### PR TITLE
Add support for declaring interfaces derived from existing interfaces

### DIFF
--- a/crates/libs/bindgen/src/delegates.rs
+++ b/crates/libs/bindgen/src/delegates.rs
@@ -96,7 +96,7 @@ fn gen_win_delegate(gen: &Gen, def: TypeDef) -> TokenStream {
         #features
         impl<#constraints #fn_constraint> #boxed<#generic_names F> {
             const VTABLE: #vtbl<#generic_names> = #vtbl::<#generic_names>{
-                base__: ::windows::core::IUnknownVtbl{QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release},
+                base__: ::windows::core::IUnknown_Vtbl{QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release},
                 Invoke: Self::Invoke,
                 #(#named_phantoms)*
             };

--- a/crates/libs/bindgen/src/gen.rs
+++ b/crates/libs/bindgen/src/gen.rs
@@ -751,7 +751,7 @@ impl<'a> Gen<'a> {
         let phantoms = self.generic_named_phantoms(generics);
 
         match self.reader.type_def_vtables(def).last() {
-            Some(Type::IUnknown) => methods.combine(&quote! { pub base__: ::windows::core::IUnknownVtbl, }),
+            Some(Type::IUnknown) => methods.combine(&quote! { pub base__: ::windows::core::IUnknown_Vtbl, }),
             Some(Type::IInspectable) => methods.combine(&quote! { pub base__: ::windows::core::IInspectableVtbl, }),
             Some(Type::TypeDef((def, _))) => {
                 let vtbl = self.type_def_vtbl_name(*def, &[]);

--- a/crates/libs/bindgen/src/implements.rs
+++ b/crates/libs/bindgen/src/implements.rs
@@ -92,7 +92,7 @@ pub fn gen(gen: &Gen, def: TypeDef) -> TokenStream {
     let mut methods = quote! {};
 
     match gen.reader.type_def_vtables(def).last() {
-        Some(Type::IUnknown) => methods.combine(&quote! { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), }),
+        Some(Type::IUnknown) => methods.combine(&quote! { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), }),
         Some(Type::IInspectable) => methods.combine(&quote! { base__: ::windows::core::IInspectableVtbl::new::<Identity, #type_ident, OFFSET>(), }),
         Some(Type::TypeDef((def, generics))) => {
             let name = gen.type_def_name_imp(*def, generics, "_Vtbl");

--- a/crates/libs/interface/src/lib.rs
+++ b/crates/libs/interface/src/lib.rs
@@ -68,7 +68,7 @@ impl Interface {
         let name = &self.name;
         let docs = &self.docs;
         let parent = self.parent();
-        let vtable_name = quote::format_ident!("{}Vtbl", name);
+        let vtable_name = quote::format_ident!("{}_Vtbl", name);
         let guid = guid.to_tokens()?;
         let implementation = self.gen_implementation();
         let com_trait = self.get_com_trait();
@@ -269,7 +269,7 @@ impl Interface {
 
     fn parent_vtable(&self) -> proc_macro2::TokenStream {
         let i = self.parent_ident();
-        let i = quote::format_ident!("{}Vtbl", i);
+        let i = quote::format_ident!("{}_Vtbl", i);
         quote!(#i)
     }
 

--- a/crates/libs/windows/src/Windows/ApplicationModel/Background/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Background/mod.rs
@@ -9969,7 +9969,7 @@ struct BackgroundTaskCanceledEventHandlerBox<F: FnMut(&::core::option::Option<IB
 }
 impl<F: FnMut(&::core::option::Option<IBackgroundTaskInstance>, BackgroundTaskCancellationReason) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> BackgroundTaskCanceledEventHandlerBox<F> {
     const VTABLE: BackgroundTaskCanceledEventHandler_Vtbl = BackgroundTaskCanceledEventHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -10029,7 +10029,7 @@ unsafe impl ::windows::core::RuntimeType for BackgroundTaskCanceledEventHandler 
 #[repr(C)]
 #[doc(hidden)]
 pub struct BackgroundTaskCanceledEventHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sender: *mut ::core::ffi::c_void, reason: BackgroundTaskCancellationReason) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"ApplicationModel_Background\"`*"]
@@ -10057,7 +10057,7 @@ struct BackgroundTaskCompletedEventHandlerBox<F: FnMut(&::core::option::Option<B
 }
 impl<F: FnMut(&::core::option::Option<BackgroundTaskRegistration>, &::core::option::Option<BackgroundTaskCompletedEventArgs>) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> BackgroundTaskCompletedEventHandlerBox<F> {
     const VTABLE: BackgroundTaskCompletedEventHandler_Vtbl = BackgroundTaskCompletedEventHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -10117,7 +10117,7 @@ unsafe impl ::windows::core::RuntimeType for BackgroundTaskCompletedEventHandler
 #[repr(C)]
 #[doc(hidden)]
 pub struct BackgroundTaskCompletedEventHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sender: *mut ::core::ffi::c_void, args: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"ApplicationModel_Background\"`*"]
@@ -10145,7 +10145,7 @@ struct BackgroundTaskProgressEventHandlerBox<F: FnMut(&::core::option::Option<Ba
 }
 impl<F: FnMut(&::core::option::Option<BackgroundTaskRegistration>, &::core::option::Option<BackgroundTaskProgressEventArgs>) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> BackgroundTaskProgressEventHandlerBox<F> {
     const VTABLE: BackgroundTaskProgressEventHandler_Vtbl = BackgroundTaskProgressEventHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -10205,7 +10205,7 @@ unsafe impl ::windows::core::RuntimeType for BackgroundTaskProgressEventHandler 
 #[repr(C)]
 #[doc(hidden)]
 pub struct BackgroundTaskProgressEventHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sender: *mut ::core::ffi::c_void, args: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/ApplicationModel/DataTransfer/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/DataTransfer/mod.rs
@@ -4263,7 +4263,7 @@ struct DataProviderHandlerBox<F: FnMut(&::core::option::Option<DataProviderReque
 }
 impl<F: FnMut(&::core::option::Option<DataProviderRequest>) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> DataProviderHandlerBox<F> {
     const VTABLE: DataProviderHandler_Vtbl = DataProviderHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -4323,7 +4323,7 @@ unsafe impl ::windows::core::RuntimeType for DataProviderHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct DataProviderHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, request: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"ApplicationModel_DataTransfer\"`*"]
@@ -4350,7 +4350,7 @@ struct ShareProviderHandlerBox<F: FnMut(&::core::option::Option<ShareProviderOpe
 }
 impl<F: FnMut(&::core::option::Option<ShareProviderOperation>) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> ShareProviderHandlerBox<F> {
     const VTABLE: ShareProviderHandler_Vtbl = ShareProviderHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -4410,7 +4410,7 @@ unsafe impl ::windows::core::RuntimeType for ShareProviderHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ShareProviderHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, operation: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/ApplicationModel/Payments/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Payments/mod.rs
@@ -2972,7 +2972,7 @@ struct PaymentRequestChangedHandlerBox<F: FnMut(&::core::option::Option<PaymentR
 }
 impl<F: FnMut(&::core::option::Option<PaymentRequest>, &::core::option::Option<PaymentRequestChangedArgs>) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> PaymentRequestChangedHandlerBox<F> {
     const VTABLE: PaymentRequestChangedHandler_Vtbl = PaymentRequestChangedHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -3032,7 +3032,7 @@ unsafe impl ::windows::core::RuntimeType for PaymentRequestChangedHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct PaymentRequestChangedHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, paymentrequest: *mut ::core::ffi::c_void, args: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/ApplicationModel/Store/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Store/mod.rs
@@ -1762,7 +1762,7 @@ struct LicenseChangedEventHandlerBox<F: FnMut() -> ::windows::core::Result<()> +
 }
 impl<F: FnMut() -> ::windows::core::Result<()> + ::core::marker::Send + 'static> LicenseChangedEventHandlerBox<F> {
     const VTABLE: LicenseChangedEventHandler_Vtbl = LicenseChangedEventHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1822,7 +1822,7 @@ unsafe impl ::windows::core::RuntimeType for LicenseChangedEventHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct LicenseChangedEventHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/Data/Text/mod.rs
+++ b/crates/libs/windows/src/Windows/Data/Text/mod.rs
@@ -1750,7 +1750,7 @@ struct SelectableWordSegmentsTokenizingHandlerBox<F: FnMut(&::core::option::Opti
 #[cfg(feature = "Foundation_Collections")]
 impl<F: FnMut(&::core::option::Option<super::super::Foundation::Collections::IIterable<SelectableWordSegment>>, &::core::option::Option<super::super::Foundation::Collections::IIterable<SelectableWordSegment>>) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> SelectableWordSegmentsTokenizingHandlerBox<F> {
     const VTABLE: SelectableWordSegmentsTokenizingHandler_Vtbl = SelectableWordSegmentsTokenizingHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1817,7 +1817,7 @@ unsafe impl ::windows::core::RuntimeType for SelectableWordSegmentsTokenizingHan
 #[repr(C)]
 #[doc(hidden)]
 pub struct SelectableWordSegmentsTokenizingHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Foundation_Collections")]
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, precedingwords: *mut ::core::ffi::c_void, words: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Foundation_Collections"))]
@@ -1856,7 +1856,7 @@ struct WordSegmentsTokenizingHandlerBox<F: FnMut(&::core::option::Option<super::
 #[cfg(feature = "Foundation_Collections")]
 impl<F: FnMut(&::core::option::Option<super::super::Foundation::Collections::IIterable<WordSegment>>, &::core::option::Option<super::super::Foundation::Collections::IIterable<WordSegment>>) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> WordSegmentsTokenizingHandlerBox<F> {
     const VTABLE: WordSegmentsTokenizingHandler_Vtbl = WordSegmentsTokenizingHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1923,7 +1923,7 @@ unsafe impl ::windows::core::RuntimeType for WordSegmentsTokenizingHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct WordSegmentsTokenizingHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Foundation_Collections")]
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, precedingwords: *mut ::core::ffi::c_void, words: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Foundation_Collections"))]

--- a/crates/libs/windows/src/Windows/Devices/Perception/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Perception/Provider/mod.rs
@@ -1915,7 +1915,7 @@ struct PerceptionStartFaceAuthenticationHandlerBox<F: FnMut(&::core::option::Opt
 #[cfg(feature = "deprecated")]
 impl<F: FnMut(&::core::option::Option<PerceptionFaceAuthenticationGroup>) -> ::windows::core::Result<bool> + ::core::marker::Send + 'static> PerceptionStartFaceAuthenticationHandlerBox<F> {
     const VTABLE: PerceptionStartFaceAuthenticationHandler_Vtbl = PerceptionStartFaceAuthenticationHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1989,7 +1989,7 @@ unsafe impl ::windows::core::RuntimeType for PerceptionStartFaceAuthenticationHa
 #[repr(C)]
 #[doc(hidden)]
 pub struct PerceptionStartFaceAuthenticationHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "deprecated")]
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sender: *mut ::core::ffi::c_void, result__: *mut bool) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "deprecated"))]
@@ -2025,7 +2025,7 @@ struct PerceptionStopFaceAuthenticationHandlerBox<F: FnMut(&::core::option::Opti
 #[cfg(feature = "deprecated")]
 impl<F: FnMut(&::core::option::Option<PerceptionFaceAuthenticationGroup>) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> PerceptionStopFaceAuthenticationHandlerBox<F> {
     const VTABLE: PerceptionStopFaceAuthenticationHandler_Vtbl = PerceptionStopFaceAuthenticationHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2092,7 +2092,7 @@ unsafe impl ::windows::core::RuntimeType for PerceptionStopFaceAuthenticationHan
 #[repr(C)]
 #[doc(hidden)]
 pub struct PerceptionStopFaceAuthenticationHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "deprecated")]
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sender: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "deprecated"))]

--- a/crates/libs/windows/src/Windows/Devices/SmartCards/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/SmartCards/mod.rs
@@ -5818,7 +5818,7 @@ struct SmartCardPinResetHandlerBox<F: FnMut(&::core::option::Option<SmartCardPro
 }
 impl<F: FnMut(&::core::option::Option<SmartCardProvisioning>, &::core::option::Option<SmartCardPinResetRequest>) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> SmartCardPinResetHandlerBox<F> {
     const VTABLE: SmartCardPinResetHandler_Vtbl = SmartCardPinResetHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -5878,7 +5878,7 @@ unsafe impl ::windows::core::RuntimeType for SmartCardPinResetHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct SmartCardPinResetHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sender: *mut ::core::ffi::c_void, request: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/Devices/Sms/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Sms/mod.rs
@@ -6326,7 +6326,7 @@ struct SmsDeviceStatusChangedEventHandlerBox<F: FnMut(&::core::option::Option<Sm
 #[cfg(feature = "deprecated")]
 impl<F: FnMut(&::core::option::Option<SmsDevice>) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> SmsDeviceStatusChangedEventHandlerBox<F> {
     const VTABLE: SmsDeviceStatusChangedEventHandler_Vtbl = SmsDeviceStatusChangedEventHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -6393,7 +6393,7 @@ unsafe impl ::windows::core::RuntimeType for SmsDeviceStatusChangedEventHandler 
 #[repr(C)]
 #[doc(hidden)]
 pub struct SmsDeviceStatusChangedEventHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "deprecated")]
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sender: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "deprecated"))]
@@ -6430,7 +6430,7 @@ struct SmsMessageReceivedEventHandlerBox<F: FnMut(&::core::option::Option<SmsDev
 #[cfg(feature = "deprecated")]
 impl<F: FnMut(&::core::option::Option<SmsDevice>, &::core::option::Option<SmsMessageReceivedEventArgs>) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> SmsMessageReceivedEventHandlerBox<F> {
     const VTABLE: SmsMessageReceivedEventHandler_Vtbl = SmsMessageReceivedEventHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -6497,7 +6497,7 @@ unsafe impl ::windows::core::RuntimeType for SmsMessageReceivedEventHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct SmsMessageReceivedEventHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "deprecated")]
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sender: *mut ::core::ffi::c_void, e: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "deprecated"))]

--- a/crates/libs/windows/src/Windows/Foundation/Collections/mod.rs
+++ b/crates/libs/windows/src/Windows/Foundation/Collections/mod.rs
@@ -2562,7 +2562,7 @@ where
 }
 impl<K: ::windows::core::RuntimeType + 'static, V: ::windows::core::RuntimeType + 'static, F: FnMut(&::core::option::Option<IObservableMap<K, V>>, &::core::option::Option<IMapChangedEventArgs<K>>) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> MapChangedEventHandlerBox<K, V, F> {
     const VTABLE: MapChangedEventHandler_Vtbl<K, V> = MapChangedEventHandler_Vtbl::<K, V> {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
         K: ::core::marker::PhantomData::<K>,
         V: ::core::marker::PhantomData::<V>,
@@ -2628,7 +2628,7 @@ where
     K: ::windows::core::RuntimeType + 'static,
     V: ::windows::core::RuntimeType + 'static,
 {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sender: *mut ::core::ffi::c_void, event: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub K: ::core::marker::PhantomData<K>,
     pub V: ::core::marker::PhantomData<V>,
@@ -2665,7 +2665,7 @@ where
 }
 impl<T: ::windows::core::RuntimeType + 'static, F: FnMut(&::core::option::Option<IObservableVector<T>>, &::core::option::Option<IVectorChangedEventArgs>) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> VectorChangedEventHandlerBox<T, F> {
     const VTABLE: VectorChangedEventHandler_Vtbl<T> = VectorChangedEventHandler_Vtbl::<T> {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
         T: ::core::marker::PhantomData::<T>,
     };
@@ -2729,7 +2729,7 @@ pub struct VectorChangedEventHandler_Vtbl<T>
 where
     T: ::windows::core::RuntimeType + 'static,
 {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sender: *mut ::core::ffi::c_void, event: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub T: ::core::marker::PhantomData<T>,
 }

--- a/crates/libs/windows/src/Windows/Foundation/mod.rs
+++ b/crates/libs/windows/src/Windows/Foundation/mod.rs
@@ -3949,7 +3949,7 @@ struct AsyncActionCompletedHandlerBox<F: FnMut(&::core::option::Option<IAsyncAct
 }
 impl<F: FnMut(&::core::option::Option<IAsyncAction>, AsyncStatus) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> AsyncActionCompletedHandlerBox<F> {
     const VTABLE: AsyncActionCompletedHandler_Vtbl = AsyncActionCompletedHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -4009,7 +4009,7 @@ unsafe impl ::windows::core::RuntimeType for AsyncActionCompletedHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct AsyncActionCompletedHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, asyncinfo: *mut ::core::ffi::c_void, asyncstatus: AsyncStatus) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Foundation\"`*"]
@@ -4043,7 +4043,7 @@ where
 }
 impl<TProgress: ::windows::core::RuntimeType + 'static, F: FnMut(&::core::option::Option<IAsyncActionWithProgress<TProgress>>, &<TProgress as ::windows::core::RuntimeType>::DefaultType) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> AsyncActionProgressHandlerBox<TProgress, F> {
     const VTABLE: AsyncActionProgressHandler_Vtbl<TProgress> = AsyncActionProgressHandler_Vtbl::<TProgress> {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
         TProgress: ::core::marker::PhantomData::<TProgress>,
     };
@@ -4107,7 +4107,7 @@ pub struct AsyncActionProgressHandler_Vtbl<TProgress>
 where
     TProgress: ::windows::core::RuntimeType + 'static,
 {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, asyncinfo: *mut ::core::ffi::c_void, progressinfo: <TProgress as ::windows::core::Abi>::Abi) -> ::windows::core::HRESULT,
     pub TProgress: ::core::marker::PhantomData<TProgress>,
 }
@@ -4141,7 +4141,7 @@ where
 }
 impl<TProgress: ::windows::core::RuntimeType + 'static, F: FnMut(&::core::option::Option<IAsyncActionWithProgress<TProgress>>, AsyncStatus) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> AsyncActionWithProgressCompletedHandlerBox<TProgress, F> {
     const VTABLE: AsyncActionWithProgressCompletedHandler_Vtbl<TProgress> = AsyncActionWithProgressCompletedHandler_Vtbl::<TProgress> {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
         TProgress: ::core::marker::PhantomData::<TProgress>,
     };
@@ -4205,7 +4205,7 @@ pub struct AsyncActionWithProgressCompletedHandler_Vtbl<TProgress>
 where
     TProgress: ::windows::core::RuntimeType + 'static,
 {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, asyncinfo: *mut ::core::ffi::c_void, asyncstatus: AsyncStatus) -> ::windows::core::HRESULT,
     pub TProgress: ::core::marker::PhantomData<TProgress>,
 }
@@ -4239,7 +4239,7 @@ where
 }
 impl<TResult: ::windows::core::RuntimeType + 'static, F: FnMut(&::core::option::Option<IAsyncOperation<TResult>>, AsyncStatus) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> AsyncOperationCompletedHandlerBox<TResult, F> {
     const VTABLE: AsyncOperationCompletedHandler_Vtbl<TResult> = AsyncOperationCompletedHandler_Vtbl::<TResult> {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
         TResult: ::core::marker::PhantomData::<TResult>,
     };
@@ -4303,7 +4303,7 @@ pub struct AsyncOperationCompletedHandler_Vtbl<TResult>
 where
     TResult: ::windows::core::RuntimeType + 'static,
 {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, asyncinfo: *mut ::core::ffi::c_void, asyncstatus: AsyncStatus) -> ::windows::core::HRESULT,
     pub TResult: ::core::marker::PhantomData<TResult>,
 }
@@ -4340,7 +4340,7 @@ where
 }
 impl<TResult: ::windows::core::RuntimeType + 'static, TProgress: ::windows::core::RuntimeType + 'static, F: FnMut(&::core::option::Option<IAsyncOperationWithProgress<TResult, TProgress>>, &<TProgress as ::windows::core::RuntimeType>::DefaultType) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> AsyncOperationProgressHandlerBox<TResult, TProgress, F> {
     const VTABLE: AsyncOperationProgressHandler_Vtbl<TResult, TProgress> = AsyncOperationProgressHandler_Vtbl::<TResult, TProgress> {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
         TResult: ::core::marker::PhantomData::<TResult>,
         TProgress: ::core::marker::PhantomData::<TProgress>,
@@ -4406,7 +4406,7 @@ where
     TResult: ::windows::core::RuntimeType + 'static,
     TProgress: ::windows::core::RuntimeType + 'static,
 {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, asyncinfo: *mut ::core::ffi::c_void, progressinfo: <TProgress as ::windows::core::Abi>::Abi) -> ::windows::core::HRESULT,
     pub TResult: ::core::marker::PhantomData<TResult>,
     pub TProgress: ::core::marker::PhantomData<TProgress>,
@@ -4443,7 +4443,7 @@ where
 }
 impl<TResult: ::windows::core::RuntimeType + 'static, TProgress: ::windows::core::RuntimeType + 'static, F: FnMut(&::core::option::Option<IAsyncOperationWithProgress<TResult, TProgress>>, AsyncStatus) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> AsyncOperationWithProgressCompletedHandlerBox<TResult, TProgress, F> {
     const VTABLE: AsyncOperationWithProgressCompletedHandler_Vtbl<TResult, TProgress> = AsyncOperationWithProgressCompletedHandler_Vtbl::<TResult, TProgress> {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
         TResult: ::core::marker::PhantomData::<TResult>,
         TProgress: ::core::marker::PhantomData::<TProgress>,
@@ -4509,7 +4509,7 @@ where
     TResult: ::windows::core::RuntimeType + 'static,
     TProgress: ::windows::core::RuntimeType + 'static,
 {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, asyncinfo: *mut ::core::ffi::c_void, asyncstatus: AsyncStatus) -> ::windows::core::HRESULT,
     pub TResult: ::core::marker::PhantomData<TResult>,
     pub TProgress: ::core::marker::PhantomData<TProgress>,
@@ -4535,7 +4535,7 @@ struct DeferralCompletedHandlerBox<F: FnMut() -> ::windows::core::Result<()> + :
 }
 impl<F: FnMut() -> ::windows::core::Result<()> + ::core::marker::Send + 'static> DeferralCompletedHandlerBox<F> {
     const VTABLE: DeferralCompletedHandler_Vtbl = DeferralCompletedHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -4595,7 +4595,7 @@ unsafe impl ::windows::core::RuntimeType for DeferralCompletedHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct DeferralCompletedHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Foundation\"`*"]
@@ -4628,7 +4628,7 @@ where
 }
 impl<T: ::windows::core::RuntimeType + 'static, F: FnMut(&::core::option::Option<::windows::core::IInspectable>, &<T as ::windows::core::RuntimeType>::DefaultType) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> EventHandlerBox<T, F> {
     const VTABLE: EventHandler_Vtbl<T> = EventHandler_Vtbl::<T> {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
         T: ::core::marker::PhantomData::<T>,
     };
@@ -4692,7 +4692,7 @@ pub struct EventHandler_Vtbl<T>
 where
     T: ::windows::core::RuntimeType + 'static,
 {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sender: *mut ::core::ffi::c_void, args: <T as ::windows::core::Abi>::Abi) -> ::windows::core::HRESULT,
     pub T: ::core::marker::PhantomData<T>,
 }
@@ -4728,7 +4728,7 @@ where
 }
 impl<TSender: ::windows::core::RuntimeType + 'static, TResult: ::windows::core::RuntimeType + 'static, F: FnMut(&<TSender as ::windows::core::RuntimeType>::DefaultType, &<TResult as ::windows::core::RuntimeType>::DefaultType) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> TypedEventHandlerBox<TSender, TResult, F> {
     const VTABLE: TypedEventHandler_Vtbl<TSender, TResult> = TypedEventHandler_Vtbl::<TSender, TResult> {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
         TSender: ::core::marker::PhantomData::<TSender>,
         TResult: ::core::marker::PhantomData::<TResult>,
@@ -4794,7 +4794,7 @@ where
     TSender: ::windows::core::RuntimeType + 'static,
     TResult: ::windows::core::RuntimeType + 'static,
 {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sender: <TSender as ::windows::core::Abi>::Abi, args: <TResult as ::windows::core::Abi>::Abi) -> ::windows::core::HRESULT,
     pub TSender: ::core::marker::PhantomData<TSender>,
     pub TResult: ::core::marker::PhantomData<TResult>,

--- a/crates/libs/windows/src/Windows/Gaming/Preview/GamesEnumeration/mod.rs
+++ b/crates/libs/windows/src/Windows/Gaming/Preview/GamesEnumeration/mod.rs
@@ -1043,7 +1043,7 @@ struct GameListChangedEventHandlerBox<F: FnMut(&::core::option::Option<GameListE
 }
 impl<F: FnMut(&::core::option::Option<GameListEntry>) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> GameListChangedEventHandlerBox<F> {
     const VTABLE: GameListChangedEventHandler_Vtbl = GameListChangedEventHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1103,7 +1103,7 @@ unsafe impl ::windows::core::RuntimeType for GameListChangedEventHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct GameListChangedEventHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, game: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Gaming_Preview_GamesEnumeration\"`*"]
@@ -1127,7 +1127,7 @@ struct GameListRemovedEventHandlerBox<F: FnMut(&::windows::core::HSTRING) -> ::w
 }
 impl<F: FnMut(&::windows::core::HSTRING) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> GameListRemovedEventHandlerBox<F> {
     const VTABLE: GameListRemovedEventHandler_Vtbl = GameListRemovedEventHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1187,7 +1187,7 @@ unsafe impl ::windows::core::RuntimeType for GameListRemovedEventHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct GameListRemovedEventHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, identifier: ::core::mem::ManuallyDrop<::windows::core::HSTRING>) -> ::windows::core::HRESULT,
 }
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/Graphics/Display/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Display/mod.rs
@@ -2323,7 +2323,7 @@ struct DisplayPropertiesEventHandlerBox<F: FnMut(&::core::option::Option<::windo
 #[cfg(feature = "deprecated")]
 impl<F: FnMut(&::core::option::Option<::windows::core::IInspectable>) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> DisplayPropertiesEventHandlerBox<F> {
     const VTABLE: DisplayPropertiesEventHandler_Vtbl = DisplayPropertiesEventHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2390,7 +2390,7 @@ unsafe impl ::windows::core::RuntimeType for DisplayPropertiesEventHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct DisplayPropertiesEventHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "deprecated")]
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sender: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "deprecated"))]

--- a/crates/libs/windows/src/Windows/Graphics/Printing/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Printing/mod.rs
@@ -3209,7 +3209,7 @@ struct PrintTaskSourceRequestedHandlerBox<F: FnMut(&::core::option::Option<Print
 }
 impl<F: FnMut(&::core::option::Option<PrintTaskSourceRequestedArgs>) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> PrintTaskSourceRequestedHandlerBox<F> {
     const VTABLE: PrintTaskSourceRequestedHandler_Vtbl = PrintTaskSourceRequestedHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -3269,7 +3269,7 @@ unsafe impl ::windows::core::RuntimeType for PrintTaskSourceRequestedHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct PrintTaskSourceRequestedHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, args: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/Graphics/Printing3D/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Printing3D/mod.rs
@@ -4225,7 +4225,7 @@ struct Print3DTaskSourceRequestedHandlerBox<F: FnMut(&::core::option::Option<Pri
 }
 impl<F: FnMut(&::core::option::Option<Print3DTaskSourceRequestedArgs>) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> Print3DTaskSourceRequestedHandlerBox<F> {
     const VTABLE: Print3DTaskSourceRequestedHandler_Vtbl = Print3DTaskSourceRequestedHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -4285,7 +4285,7 @@ unsafe impl ::windows::core::RuntimeType for Print3DTaskSourceRequestedHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct Print3DTaskSourceRequestedHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, args: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/Media/Capture/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Capture/mod.rs
@@ -14135,7 +14135,7 @@ struct MediaCaptureFailedEventHandlerBox<F: FnMut(&::core::option::Option<MediaC
 }
 impl<F: FnMut(&::core::option::Option<MediaCapture>, &::core::option::Option<MediaCaptureFailedEventArgs>) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> MediaCaptureFailedEventHandlerBox<F> {
     const VTABLE: MediaCaptureFailedEventHandler_Vtbl = MediaCaptureFailedEventHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -14195,7 +14195,7 @@ unsafe impl ::windows::core::RuntimeType for MediaCaptureFailedEventHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct MediaCaptureFailedEventHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sender: *mut ::core::ffi::c_void, erroreventargs: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Media_Capture\"`*"]
@@ -14222,7 +14222,7 @@ struct RecordLimitationExceededEventHandlerBox<F: FnMut(&::core::option::Option<
 }
 impl<F: FnMut(&::core::option::Option<MediaCapture>) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> RecordLimitationExceededEventHandlerBox<F> {
     const VTABLE: RecordLimitationExceededEventHandler_Vtbl = RecordLimitationExceededEventHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -14282,7 +14282,7 @@ unsafe impl ::windows::core::RuntimeType for RecordLimitationExceededEventHandle
 #[repr(C)]
 #[doc(hidden)]
 pub struct RecordLimitationExceededEventHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sender: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/Media/Devices/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Devices/mod.rs
@@ -8003,7 +8003,7 @@ struct CallControlEventHandlerBox<F: FnMut(&::core::option::Option<CallControl>)
 }
 impl<F: FnMut(&::core::option::Option<CallControl>) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> CallControlEventHandlerBox<F> {
     const VTABLE: CallControlEventHandler_Vtbl = CallControlEventHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -8063,7 +8063,7 @@ unsafe impl ::windows::core::RuntimeType for CallControlEventHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct CallControlEventHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sender: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Media_Devices\"`*"]
@@ -8091,7 +8091,7 @@ struct DialRequestedEventHandlerBox<F: FnMut(&::core::option::Option<CallControl
 }
 impl<F: FnMut(&::core::option::Option<CallControl>, &::core::option::Option<DialRequestedEventArgs>) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> DialRequestedEventHandlerBox<F> {
     const VTABLE: DialRequestedEventHandler_Vtbl = DialRequestedEventHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -8151,7 +8151,7 @@ unsafe impl ::windows::core::RuntimeType for DialRequestedEventHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct DialRequestedEventHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sender: *mut ::core::ffi::c_void, e: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Media_Devices\"`*"]
@@ -8179,7 +8179,7 @@ struct KeypadPressedEventHandlerBox<F: FnMut(&::core::option::Option<CallControl
 }
 impl<F: FnMut(&::core::option::Option<CallControl>, &::core::option::Option<KeypadPressedEventArgs>) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> KeypadPressedEventHandlerBox<F> {
     const VTABLE: KeypadPressedEventHandler_Vtbl = KeypadPressedEventHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -8239,7 +8239,7 @@ unsafe impl ::windows::core::RuntimeType for KeypadPressedEventHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct KeypadPressedEventHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sender: *mut ::core::ffi::c_void, e: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Media_Devices\"`*"]
@@ -8267,7 +8267,7 @@ struct RedialRequestedEventHandlerBox<F: FnMut(&::core::option::Option<CallContr
 }
 impl<F: FnMut(&::core::option::Option<CallControl>, &::core::option::Option<RedialRequestedEventArgs>) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> RedialRequestedEventHandlerBox<F> {
     const VTABLE: RedialRequestedEventHandler_Vtbl = RedialRequestedEventHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -8327,7 +8327,7 @@ unsafe impl ::windows::core::RuntimeType for RedialRequestedEventHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct RedialRequestedEventHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sender: *mut ::core::ffi::c_void, e: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/Media/Protection/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Protection/mod.rs
@@ -1483,7 +1483,7 @@ struct ComponentLoadFailedEventHandlerBox<F: FnMut(&::core::option::Option<Media
 }
 impl<F: FnMut(&::core::option::Option<MediaProtectionManager>, &::core::option::Option<ComponentLoadFailedEventArgs>) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> ComponentLoadFailedEventHandlerBox<F> {
     const VTABLE: ComponentLoadFailedEventHandler_Vtbl = ComponentLoadFailedEventHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1543,7 +1543,7 @@ unsafe impl ::windows::core::RuntimeType for ComponentLoadFailedEventHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ComponentLoadFailedEventHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sender: *mut ::core::ffi::c_void, e: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Media_Protection\"`*"]
@@ -1570,7 +1570,7 @@ struct RebootNeededEventHandlerBox<F: FnMut(&::core::option::Option<MediaProtect
 }
 impl<F: FnMut(&::core::option::Option<MediaProtectionManager>) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> RebootNeededEventHandlerBox<F> {
     const VTABLE: RebootNeededEventHandler_Vtbl = RebootNeededEventHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1630,7 +1630,7 @@ unsafe impl ::windows::core::RuntimeType for RebootNeededEventHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct RebootNeededEventHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sender: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Media_Protection\"`*"]
@@ -1658,7 +1658,7 @@ struct ServiceRequestedEventHandlerBox<F: FnMut(&::core::option::Option<MediaPro
 }
 impl<F: FnMut(&::core::option::Option<MediaProtectionManager>, &::core::option::Option<ServiceRequestedEventArgs>) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> ServiceRequestedEventHandlerBox<F> {
     const VTABLE: ServiceRequestedEventHandler_Vtbl = ServiceRequestedEventHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1718,7 +1718,7 @@ unsafe impl ::windows::core::RuntimeType for ServiceRequestedEventHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ServiceRequestedEventHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sender: *mut ::core::ffi::c_void, e: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/Networking/Connectivity/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/Connectivity/mod.rs
@@ -4042,7 +4042,7 @@ struct NetworkStatusChangedEventHandlerBox<F: FnMut(&::core::option::Option<::wi
 }
 impl<F: FnMut(&::core::option::Option<::windows::core::IInspectable>) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> NetworkStatusChangedEventHandlerBox<F> {
     const VTABLE: NetworkStatusChangedEventHandler_Vtbl = NetworkStatusChangedEventHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -4102,7 +4102,7 @@ unsafe impl ::windows::core::RuntimeType for NetworkStatusChangedEventHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct NetworkStatusChangedEventHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sender: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/Networking/Proximity/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/Proximity/mod.rs
@@ -1417,7 +1417,7 @@ struct DeviceArrivedEventHandlerBox<F: FnMut(&::core::option::Option<ProximityDe
 }
 impl<F: FnMut(&::core::option::Option<ProximityDevice>) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> DeviceArrivedEventHandlerBox<F> {
     const VTABLE: DeviceArrivedEventHandler_Vtbl = DeviceArrivedEventHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1477,7 +1477,7 @@ unsafe impl ::windows::core::RuntimeType for DeviceArrivedEventHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct DeviceArrivedEventHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sender: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Networking_Proximity\"`*"]
@@ -1504,7 +1504,7 @@ struct DeviceDepartedEventHandlerBox<F: FnMut(&::core::option::Option<ProximityD
 }
 impl<F: FnMut(&::core::option::Option<ProximityDevice>) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> DeviceDepartedEventHandlerBox<F> {
     const VTABLE: DeviceDepartedEventHandler_Vtbl = DeviceDepartedEventHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1564,7 +1564,7 @@ unsafe impl ::windows::core::RuntimeType for DeviceDepartedEventHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct DeviceDepartedEventHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sender: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Networking_Proximity\"`*"]
@@ -1592,7 +1592,7 @@ struct MessageReceivedHandlerBox<F: FnMut(&::core::option::Option<ProximityDevic
 }
 impl<F: FnMut(&::core::option::Option<ProximityDevice>, &::core::option::Option<ProximityMessage>) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> MessageReceivedHandlerBox<F> {
     const VTABLE: MessageReceivedHandler_Vtbl = MessageReceivedHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1652,7 +1652,7 @@ unsafe impl ::windows::core::RuntimeType for MessageReceivedHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct MessageReceivedHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sender: *mut ::core::ffi::c_void, message: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Networking_Proximity\"`*"]
@@ -1679,7 +1679,7 @@ struct MessageTransmittedHandlerBox<F: FnMut(&::core::option::Option<ProximityDe
 }
 impl<F: FnMut(&::core::option::Option<ProximityDevice>, i64) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> MessageTransmittedHandlerBox<F> {
     const VTABLE: MessageTransmittedHandler_Vtbl = MessageTransmittedHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1739,7 +1739,7 @@ unsafe impl ::windows::core::RuntimeType for MessageTransmittedHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct MessageTransmittedHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sender: *mut ::core::ffi::c_void, messageid: i64) -> ::windows::core::HRESULT,
 }
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/Security/Isolation/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Isolation/mod.rs
@@ -2915,7 +2915,7 @@ struct HostMessageReceivedCallbackBox<F: FnMut(&::windows::core::GUID, &::core::
 #[cfg(feature = "Foundation_Collections")]
 impl<F: FnMut(&::windows::core::GUID, &::core::option::Option<super::super::Foundation::Collections::IVectorView<::windows::core::IInspectable>>) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> HostMessageReceivedCallbackBox<F> {
     const VTABLE: HostMessageReceivedCallback_Vtbl = HostMessageReceivedCallback_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -2982,7 +2982,7 @@ unsafe impl ::windows::core::RuntimeType for HostMessageReceivedCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct HostMessageReceivedCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Foundation_Collections")]
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, receiverid: ::windows::core::GUID, message: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Foundation_Collections"))]
@@ -3019,7 +3019,7 @@ struct MessageReceivedCallbackBox<F: FnMut(&::windows::core::GUID, &::core::opti
 #[cfg(feature = "Foundation_Collections")]
 impl<F: FnMut(&::windows::core::GUID, &::core::option::Option<super::super::Foundation::Collections::IVectorView<::windows::core::IInspectable>>) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> MessageReceivedCallbackBox<F> {
     const VTABLE: MessageReceivedCallback_Vtbl = MessageReceivedCallback_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -3086,7 +3086,7 @@ unsafe impl ::windows::core::RuntimeType for MessageReceivedCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct MessageReceivedCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Foundation_Collections")]
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, receiverid: ::windows::core::GUID, message: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Foundation_Collections"))]

--- a/crates/libs/windows/src/Windows/Storage/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/mod.rs
@@ -9126,7 +9126,7 @@ struct ApplicationDataSetVersionHandlerBox<F: FnMut(&::core::option::Option<SetV
 }
 impl<F: FnMut(&::core::option::Option<SetVersionRequest>) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> ApplicationDataSetVersionHandlerBox<F> {
     const VTABLE: ApplicationDataSetVersionHandler_Vtbl = ApplicationDataSetVersionHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -9186,7 +9186,7 @@ unsafe impl ::windows::core::RuntimeType for ApplicationDataSetVersionHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ApplicationDataSetVersionHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, setversionrequest: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Storage\"`, `\"Storage_Streams\"`*"]
@@ -9219,7 +9219,7 @@ struct StreamedFileDataRequestedHandlerBox<F: FnMut(&::core::option::Option<Stre
 #[cfg(feature = "Storage_Streams")]
 impl<F: FnMut(&::core::option::Option<StreamedFileDataRequest>) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> StreamedFileDataRequestedHandlerBox<F> {
     const VTABLE: StreamedFileDataRequestedHandler_Vtbl = StreamedFileDataRequestedHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -9286,7 +9286,7 @@ unsafe impl ::windows::core::RuntimeType for StreamedFileDataRequestedHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct StreamedFileDataRequestedHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Storage_Streams")]
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, stream: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Storage_Streams"))]

--- a/crates/libs/windows/src/Windows/System/RemoteDesktop/Input/mod.rs
+++ b/crates/libs/windows/src/Windows/System/RemoteDesktop/Input/mod.rs
@@ -184,7 +184,7 @@ struct RemoteTextConnectionDataHandlerBox<F: FnMut(&[u8]) -> ::windows::core::Re
 }
 impl<F: FnMut(&[u8]) -> ::windows::core::Result<bool> + ::core::marker::Send + 'static> RemoteTextConnectionDataHandlerBox<F> {
     const VTABLE: RemoteTextConnectionDataHandler_Vtbl = RemoteTextConnectionDataHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -251,7 +251,7 @@ unsafe impl ::windows::core::RuntimeType for RemoteTextConnectionDataHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct RemoteTextConnectionDataHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pduData_array_size: u32, pdudata: *const u8, result__: *mut bool) -> ::windows::core::HRESULT,
 }
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/System/Threading/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Threading/Core/mod.rs
@@ -332,7 +332,7 @@ struct SignalHandlerBox<F: FnMut(&::core::option::Option<SignalNotifier>, bool) 
 }
 impl<F: FnMut(&::core::option::Option<SignalNotifier>, bool) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> SignalHandlerBox<F> {
     const VTABLE: SignalHandler_Vtbl = SignalHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -392,7 +392,7 @@ unsafe impl ::windows::core::RuntimeType for SignalHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct SignalHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, signalnotifier: *mut ::core::ffi::c_void, timedout: bool) -> ::windows::core::HRESULT,
 }
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/System/Threading/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Threading/mod.rs
@@ -379,7 +379,7 @@ struct TimerDestroyedHandlerBox<F: FnMut(&::core::option::Option<ThreadPoolTimer
 }
 impl<F: FnMut(&::core::option::Option<ThreadPoolTimer>) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> TimerDestroyedHandlerBox<F> {
     const VTABLE: TimerDestroyedHandler_Vtbl = TimerDestroyedHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -439,7 +439,7 @@ unsafe impl ::windows::core::RuntimeType for TimerDestroyedHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct TimerDestroyedHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, timer: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"System_Threading\"`*"]
@@ -466,7 +466,7 @@ struct TimerElapsedHandlerBox<F: FnMut(&::core::option::Option<ThreadPoolTimer>)
 }
 impl<F: FnMut(&::core::option::Option<ThreadPoolTimer>) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> TimerElapsedHandlerBox<F> {
     const VTABLE: TimerElapsedHandler_Vtbl = TimerElapsedHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -526,7 +526,7 @@ unsafe impl ::windows::core::RuntimeType for TimerElapsedHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct TimerElapsedHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, timer: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"System_Threading\"`, `\"Foundation\"`*"]
@@ -560,7 +560,7 @@ struct WorkItemHandlerBox<F: FnMut(&::core::option::Option<super::super::Foundat
 #[cfg(feature = "Foundation")]
 impl<F: FnMut(&::core::option::Option<super::super::Foundation::IAsyncAction>) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> WorkItemHandlerBox<F> {
     const VTABLE: WorkItemHandler_Vtbl = WorkItemHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -627,7 +627,7 @@ unsafe impl ::windows::core::RuntimeType for WorkItemHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct WorkItemHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Foundation")]
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, operation: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Foundation"))]

--- a/crates/libs/windows/src/Windows/System/mod.rs
+++ b/crates/libs/windows/src/Windows/System/mod.rs
@@ -7790,7 +7790,7 @@ struct DispatcherQueueHandlerBox<F: FnMut() -> ::windows::core::Result<()> + ::c
 }
 impl<F: FnMut() -> ::windows::core::Result<()> + ::core::marker::Send + 'static> DispatcherQueueHandlerBox<F> {
     const VTABLE: DispatcherQueueHandler_Vtbl = DispatcherQueueHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -7850,7 +7850,7 @@ unsafe impl ::windows::core::RuntimeType for DispatcherQueueHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct DispatcherQueueHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/UI/ApplicationSettings/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/ApplicationSettings/mod.rs
@@ -1750,7 +1750,7 @@ struct CredentialCommandCredentialDeletedHandlerBox<F: FnMut(&::core::option::Op
 }
 impl<F: FnMut(&::core::option::Option<CredentialCommand>) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> CredentialCommandCredentialDeletedHandlerBox<F> {
     const VTABLE: CredentialCommandCredentialDeletedHandler_Vtbl = CredentialCommandCredentialDeletedHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1810,7 +1810,7 @@ unsafe impl ::windows::core::RuntimeType for CredentialCommandCredentialDeletedH
 #[repr(C)]
 #[doc(hidden)]
 pub struct CredentialCommandCredentialDeletedHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, command: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"UI_ApplicationSettings\"`*"]
@@ -1838,7 +1838,7 @@ struct WebAccountCommandInvokedHandlerBox<F: FnMut(&::core::option::Option<WebAc
 }
 impl<F: FnMut(&::core::option::Option<WebAccountCommand>, &::core::option::Option<WebAccountInvokedArgs>) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> WebAccountCommandInvokedHandlerBox<F> {
     const VTABLE: WebAccountCommandInvokedHandler_Vtbl = WebAccountCommandInvokedHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1898,7 +1898,7 @@ unsafe impl ::windows::core::RuntimeType for WebAccountCommandInvokedHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct WebAccountCommandInvokedHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, command: *mut ::core::ffi::c_void, args: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"UI_ApplicationSettings\"`*"]
@@ -1925,7 +1925,7 @@ struct WebAccountProviderCommandInvokedHandlerBox<F: FnMut(&::core::option::Opti
 }
 impl<F: FnMut(&::core::option::Option<WebAccountProviderCommand>) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> WebAccountProviderCommandInvokedHandlerBox<F> {
     const VTABLE: WebAccountProviderCommandInvokedHandler_Vtbl = WebAccountProviderCommandInvokedHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1985,7 +1985,7 @@ unsafe impl ::windows::core::RuntimeType for WebAccountProviderCommandInvokedHan
 #[repr(C)]
 #[doc(hidden)]
 pub struct WebAccountProviderCommandInvokedHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, command: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/UI/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Core/mod.rs
@@ -7481,7 +7481,7 @@ struct DispatchedHandlerBox<F: FnMut() -> ::windows::core::Result<()> + ::core::
 }
 impl<F: FnMut() -> ::windows::core::Result<()> + ::core::marker::Send + 'static> DispatchedHandlerBox<F> {
     const VTABLE: DispatchedHandler_Vtbl = DispatchedHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -7541,7 +7541,7 @@ unsafe impl ::windows::core::RuntimeType for DispatchedHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct DispatchedHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"UI_Core\"`*"]
@@ -7568,7 +7568,7 @@ struct IdleDispatchedHandlerBox<F: FnMut(&::core::option::Option<IdleDispatchedH
 }
 impl<F: FnMut(&::core::option::Option<IdleDispatchedHandlerArgs>) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> IdleDispatchedHandlerBox<F> {
     const VTABLE: IdleDispatchedHandler_Vtbl = IdleDispatchedHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -7628,7 +7628,7 @@ unsafe impl ::windows::core::RuntimeType for IdleDispatchedHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IdleDispatchedHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, e: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/UI/Popups/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Popups/mod.rs
@@ -878,7 +878,7 @@ struct UICommandInvokedHandlerBox<F: FnMut(&::core::option::Option<IUICommand>) 
 }
 impl<F: FnMut(&::core::option::Option<IUICommand>) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> UICommandInvokedHandlerBox<F> {
     const VTABLE: UICommandInvokedHandler_Vtbl = UICommandInvokedHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -938,7 +938,7 @@ unsafe impl ::windows::core::RuntimeType for UICommandInvokedHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct UICommandInvokedHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, command: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/UI/WebUI/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/WebUI/Core/mod.rs
@@ -1312,7 +1312,7 @@ struct MenuClosedEventHandlerBox<F: FnMut() -> ::windows::core::Result<()> + ::c
 }
 impl<F: FnMut() -> ::windows::core::Result<()> + ::core::marker::Send + 'static> MenuClosedEventHandlerBox<F> {
     const VTABLE: MenuClosedEventHandler_Vtbl = MenuClosedEventHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1372,7 +1372,7 @@ unsafe impl ::windows::core::RuntimeType for MenuClosedEventHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct MenuClosedEventHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"UI_WebUI_Core\"`*"]
@@ -1396,7 +1396,7 @@ struct MenuOpenedEventHandlerBox<F: FnMut() -> ::windows::core::Result<()> + ::c
 }
 impl<F: FnMut() -> ::windows::core::Result<()> + ::core::marker::Send + 'static> MenuOpenedEventHandlerBox<F> {
     const VTABLE: MenuOpenedEventHandler_Vtbl = MenuOpenedEventHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1456,7 +1456,7 @@ unsafe impl ::windows::core::RuntimeType for MenuOpenedEventHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct MenuOpenedEventHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"UI_WebUI_Core\"`*"]
@@ -1483,7 +1483,7 @@ struct SizeChangedEventHandlerBox<F: FnMut(&::core::option::Option<WebUICommandB
 }
 impl<F: FnMut(&::core::option::Option<WebUICommandBarSizeChangedEventArgs>) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> SizeChangedEventHandlerBox<F> {
     const VTABLE: SizeChangedEventHandler_Vtbl = SizeChangedEventHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -1543,7 +1543,7 @@ unsafe impl ::windows::core::RuntimeType for SizeChangedEventHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct SizeChangedEventHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, eventargs: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/UI/WebUI/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/WebUI/mod.rs
@@ -13695,7 +13695,7 @@ struct ActivatedEventHandlerBox<F: FnMut(&::core::option::Option<::windows::core
 #[cfg(feature = "ApplicationModel_Activation")]
 impl<F: FnMut(&::core::option::Option<::windows::core::IInspectable>, &::core::option::Option<super::super::ApplicationModel::Activation::IActivatedEventArgs>) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> ActivatedEventHandlerBox<F> {
     const VTABLE: ActivatedEventHandler_Vtbl = ActivatedEventHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -13762,7 +13762,7 @@ unsafe impl ::windows::core::RuntimeType for ActivatedEventHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ActivatedEventHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "ApplicationModel_Activation")]
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sender: *mut ::core::ffi::c_void, eventargs: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "ApplicationModel_Activation"))]
@@ -13800,7 +13800,7 @@ struct BackgroundActivatedEventHandlerBox<F: FnMut(&::core::option::Option<::win
 #[cfg(feature = "ApplicationModel_Activation")]
 impl<F: FnMut(&::core::option::Option<::windows::core::IInspectable>, &::core::option::Option<super::super::ApplicationModel::Activation::IBackgroundActivatedEventArgs>) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> BackgroundActivatedEventHandlerBox<F> {
     const VTABLE: BackgroundActivatedEventHandler_Vtbl = BackgroundActivatedEventHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -13867,7 +13867,7 @@ unsafe impl ::windows::core::RuntimeType for BackgroundActivatedEventHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct BackgroundActivatedEventHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "ApplicationModel_Activation")]
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sender: *mut ::core::ffi::c_void, eventargs: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "ApplicationModel_Activation"))]
@@ -13905,7 +13905,7 @@ struct EnteredBackgroundEventHandlerBox<F: FnMut(&::core::option::Option<::windo
 #[cfg(feature = "ApplicationModel")]
 impl<F: FnMut(&::core::option::Option<::windows::core::IInspectable>, &::core::option::Option<super::super::ApplicationModel::IEnteredBackgroundEventArgs>) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> EnteredBackgroundEventHandlerBox<F> {
     const VTABLE: EnteredBackgroundEventHandler_Vtbl = EnteredBackgroundEventHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -13972,7 +13972,7 @@ unsafe impl ::windows::core::RuntimeType for EnteredBackgroundEventHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct EnteredBackgroundEventHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "ApplicationModel")]
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sender: *mut ::core::ffi::c_void, e: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "ApplicationModel"))]
@@ -14010,7 +14010,7 @@ struct LeavingBackgroundEventHandlerBox<F: FnMut(&::core::option::Option<::windo
 #[cfg(feature = "ApplicationModel")]
 impl<F: FnMut(&::core::option::Option<::windows::core::IInspectable>, &::core::option::Option<super::super::ApplicationModel::ILeavingBackgroundEventArgs>) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> LeavingBackgroundEventHandlerBox<F> {
     const VTABLE: LeavingBackgroundEventHandler_Vtbl = LeavingBackgroundEventHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -14077,7 +14077,7 @@ unsafe impl ::windows::core::RuntimeType for LeavingBackgroundEventHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct LeavingBackgroundEventHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "ApplicationModel")]
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sender: *mut ::core::ffi::c_void, e: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "ApplicationModel"))]
@@ -14109,7 +14109,7 @@ struct NavigatedEventHandlerBox<F: FnMut(&::core::option::Option<::windows::core
 }
 impl<F: FnMut(&::core::option::Option<::windows::core::IInspectable>, &::core::option::Option<IWebUINavigatedEventArgs>) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> NavigatedEventHandlerBox<F> {
     const VTABLE: NavigatedEventHandler_Vtbl = NavigatedEventHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -14169,7 +14169,7 @@ unsafe impl ::windows::core::RuntimeType for NavigatedEventHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct NavigatedEventHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sender: *mut ::core::ffi::c_void, e: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"UI_WebUI\"`*"]
@@ -14196,7 +14196,7 @@ struct ResumingEventHandlerBox<F: FnMut(&::core::option::Option<::windows::core:
 }
 impl<F: FnMut(&::core::option::Option<::windows::core::IInspectable>) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> ResumingEventHandlerBox<F> {
     const VTABLE: ResumingEventHandler_Vtbl = ResumingEventHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -14256,7 +14256,7 @@ unsafe impl ::windows::core::RuntimeType for ResumingEventHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ResumingEventHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sender: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"UI_WebUI\"`, `\"ApplicationModel\"`*"]
@@ -14291,7 +14291,7 @@ struct SuspendingEventHandlerBox<F: FnMut(&::core::option::Option<::windows::cor
 #[cfg(feature = "ApplicationModel")]
 impl<F: FnMut(&::core::option::Option<::windows::core::IInspectable>, &::core::option::Option<super::super::ApplicationModel::ISuspendingEventArgs>) -> ::windows::core::Result<()> + ::core::marker::Send + 'static> SuspendingEventHandlerBox<F> {
     const VTABLE: SuspendingEventHandler_Vtbl = SuspendingEventHandler_Vtbl {
-        base__: ::windows::core::IUnknownVtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
+        base__: ::windows::core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
     };
     unsafe extern "system" fn QueryInterface(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
@@ -14358,7 +14358,7 @@ unsafe impl ::windows::core::RuntimeType for SuspendingEventHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct SuspendingEventHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "ApplicationModel")]
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sender: *mut ::core::ffi::c_void, e: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "ApplicationModel"))]

--- a/crates/libs/windows/src/Windows/Win32/AI/MachineLearning/DirectML/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/AI/MachineLearning/DirectML/impl.rs
@@ -93,7 +93,7 @@ impl IDMLDebugDevice_Vtbl {
             let this = (*this).get_impl();
             this.SetMuteDebugOutput(::core::mem::transmute_copy(&mute))
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SetMuteDebugOutput: SetMuteDebugOutput::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SetMuteDebugOutput: SetMuteDebugOutput::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDMLDebugDevice as ::windows::core::Interface>::IID
@@ -269,7 +269,7 @@ impl IDMLObject_Vtbl {
             this.SetName(::core::mem::transmute(&name)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetPrivateData: GetPrivateData::<Identity, Impl, OFFSET>,
             SetPrivateData: SetPrivateData::<Identity, Impl, OFFSET>,
             SetPrivateDataInterface: SetPrivateDataInterface::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/AI/MachineLearning/DirectML/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/AI/MachineLearning/DirectML/mod.rs
@@ -451,7 +451,7 @@ unsafe impl ::windows::core::Interface for IDMLDebugDevice {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDMLDebugDevice_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub SetMuteDebugOutput: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, mute: super::super::super::Foundation::BOOL),
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -1026,7 +1026,7 @@ unsafe impl ::windows::core::Interface for IDMLObject {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDMLObject_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetPrivateData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, guid: *const ::windows::core::GUID, datasize: *mut u32, data: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetPrivateData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, guid: *const ::windows::core::GUID, datasize: u32, data: *const ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetPrivateDataInterface: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, guid: *const ::windows::core::GUID, data: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/AI/MachineLearning/WinML/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/AI/MachineLearning/WinML/impl.rs
@@ -40,7 +40,7 @@ impl IMLOperatorAttributes_Vtbl {
             this.GetStringAttributeElement(::core::mem::transmute(&name), ::core::mem::transmute_copy(&elementindex), ::core::mem::transmute_copy(&attributeelementbytesize), ::core::mem::transmute_copy(&attributeelement)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetAttributeElementCount: GetAttributeElementCount::<Identity, Impl, OFFSET>,
             GetAttribute: GetAttribute::<Identity, Impl, OFFSET>,
             GetStringAttributeElementLength: GetStringAttributeElementLength::<Identity, Impl, OFFSET>,
@@ -62,7 +62,7 @@ impl IMLOperatorKernel_Vtbl {
             let this = (*this).get_impl();
             this.Compute(::core::mem::transmute(&context)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Compute: Compute::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Compute: Compute::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMLOperatorKernel as ::windows::core::Interface>::IID
@@ -128,7 +128,7 @@ impl IMLOperatorKernelContext_Vtbl {
             this.GetExecutionInterface(::core::mem::transmute_copy(&executionobject))
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetInputTensor: GetInputTensor::<Identity, Impl, OFFSET>,
             GetOutputTensor: GetOutputTensor::<Identity, Impl, OFFSET>,
             GetOutputTensor2: GetOutputTensor2::<Identity, Impl, OFFSET>,
@@ -251,7 +251,7 @@ impl IMLOperatorKernelFactory_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CreateKernel: CreateKernel::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CreateKernel: CreateKernel::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMLOperatorKernelFactory as ::windows::core::Interface>::IID
@@ -275,7 +275,7 @@ impl IMLOperatorRegistry_Vtbl {
             this.RegisterOperatorKernel(::core::mem::transmute_copy(&operatorkernel), ::core::mem::transmute(&operatorkernelfactory), ::core::mem::transmute(&shapeinferrer)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RegisterOperatorSetSchema: RegisterOperatorSetSchema::<Identity, Impl, OFFSET>,
             RegisterOperatorKernel: RegisterOperatorKernel::<Identity, Impl, OFFSET>,
         }
@@ -376,7 +376,7 @@ impl IMLOperatorShapeInferrer_Vtbl {
             let this = (*this).get_impl();
             this.InferOutputShapes(::core::mem::transmute(&context)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), InferOutputShapes: InferOutputShapes::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), InferOutputShapes: InferOutputShapes::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMLOperatorShapeInferrer as ::windows::core::Interface>::IID
@@ -430,7 +430,7 @@ impl IMLOperatorTensor_Vtbl {
             this.GetDataInterface(::core::mem::transmute_copy(&datainterface))
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDimensionCount: GetDimensionCount::<Identity, Impl, OFFSET>,
             GetShape: GetShape::<Identity, Impl, OFFSET>,
             GetTensorDataType: GetTensorDataType::<Identity, Impl, OFFSET>,
@@ -492,7 +492,7 @@ impl IMLOperatorTensorShapeDescription_Vtbl {
             this.GetOutputTensorShape(::core::mem::transmute_copy(&outputindex), ::core::mem::transmute_copy(&dimensioncount), ::core::mem::transmute_copy(&dimensions)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetInputTensorDimensionCount: GetInputTensorDimensionCount::<Identity, Impl, OFFSET>,
             GetInputTensorShape: GetInputTensorShape::<Identity, Impl, OFFSET>,
             HasOutputShapeDescription: HasOutputShapeDescription::<Identity, Impl, OFFSET>,
@@ -576,7 +576,7 @@ impl IMLOperatorTypeInferrer_Vtbl {
             let this = (*this).get_impl();
             this.InferOutputTypes(::core::mem::transmute(&context)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), InferOutputTypes: InferOutputTypes::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), InferOutputTypes: InferOutputTypes::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMLOperatorTypeInferrer as ::windows::core::Interface>::IID
@@ -615,7 +615,7 @@ impl IWinMLEvaluationContext_Vtbl {
             this.Clear().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             BindValue: BindValue::<Identity, Impl, OFFSET>,
             GetValueByName: GetValueByName::<Identity, Impl, OFFSET>,
             Clear: Clear::<Identity, Impl, OFFSET>,
@@ -676,7 +676,7 @@ impl IWinMLModel_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDescription: GetDescription::<Identity, Impl, OFFSET>,
             EnumerateMetadata: EnumerateMetadata::<Identity, Impl, OFFSET>,
             EnumerateModelInputs: EnumerateModelInputs::<Identity, Impl, OFFSET>,
@@ -726,7 +726,7 @@ impl IWinMLRuntime_Vtbl {
             this.EvaluateModel(::core::mem::transmute(&pcontext)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             LoadModel: LoadModel::<Identity, Impl, OFFSET>,
             CreateEvaluationContext: CreateEvaluationContext::<Identity, Impl, OFFSET>,
             EvaluateModel: EvaluateModel::<Identity, Impl, OFFSET>,
@@ -753,7 +753,7 @@ impl IWinMLRuntimeFactory_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CreateRuntime: CreateRuntime::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CreateRuntime: CreateRuntime::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWinMLRuntimeFactory as ::windows::core::Interface>::IID

--- a/crates/libs/windows/src/Windows/Win32/AI/MachineLearning/WinML/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/AI/MachineLearning/WinML/mod.rs
@@ -87,7 +87,7 @@ unsafe impl ::windows::core::Interface for IMLOperatorAttributes {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMLOperatorAttributes_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetAttributeElementCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, name: ::windows::core::PCSTR, r#type: MLOperatorAttributeType, elementcount: *mut u32) -> ::windows::core::HRESULT,
     pub GetAttribute: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, name: ::windows::core::PCSTR, r#type: MLOperatorAttributeType, elementcount: u32, elementbytesize: usize, value: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetStringAttributeElementLength: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, name: ::windows::core::PCSTR, elementindex: u32, attributeelementbytesize: *mut u32) -> ::windows::core::HRESULT,
@@ -142,7 +142,7 @@ unsafe impl ::windows::core::Interface for IMLOperatorKernel {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMLOperatorKernel_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Compute: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, context: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_AI_MachineLearning_WinML\"`*"]
@@ -207,7 +207,7 @@ unsafe impl ::windows::core::Interface for IMLOperatorKernelContext {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMLOperatorKernelContext_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetInputTensor: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, inputindex: u32, tensor: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetOutputTensor: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, outputindex: u32, dimensioncount: u32, dimensionsizes: *const u32, tensor: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetOutputTensor2: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, outputindex: u32, tensor: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -389,7 +389,7 @@ unsafe impl ::windows::core::Interface for IMLOperatorKernelFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMLOperatorKernelFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateKernel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, context: *mut ::core::ffi::c_void, kernel: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_AI_MachineLearning_WinML\"`*"]
@@ -449,7 +449,7 @@ unsafe impl ::windows::core::Interface for IMLOperatorRegistry {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMLOperatorRegistry_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub RegisterOperatorSetSchema: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, operatorsetid: *const MLOperatorSetId, baselineversion: i32, schema: *const *const MLOperatorSchemaDescription, schemacount: u32, typeinferrer: *mut ::core::ffi::c_void, shapeinferrer: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub RegisterOperatorKernel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, operatorkernel: *const MLOperatorKernelDescription, operatorkernelfactory: *mut ::core::ffi::c_void, shapeinferrer: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -622,7 +622,7 @@ unsafe impl ::windows::core::Interface for IMLOperatorShapeInferrer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMLOperatorShapeInferrer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub InferOutputShapes: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, context: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_AI_MachineLearning_WinML\"`*"]
@@ -689,7 +689,7 @@ unsafe impl ::windows::core::Interface for IMLOperatorTensor {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMLOperatorTensor_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDimensionCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32,
     pub GetShape: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dimensioncount: u32, dimensions: *mut u32) -> ::windows::core::HRESULT,
     pub GetTensorDataType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> MLOperatorTensorDataType,
@@ -758,7 +758,7 @@ unsafe impl ::windows::core::Interface for IMLOperatorTensorShapeDescription {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMLOperatorTensorShapeDescription_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetInputTensorDimensionCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, inputindex: u32, dimensioncount: *mut u32) -> ::windows::core::HRESULT,
     pub GetInputTensorShape: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, inputindex: u32, dimensioncount: u32, dimensions: *mut u32) -> ::windows::core::HRESULT,
     pub HasOutputShapeDescription: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> bool,
@@ -925,7 +925,7 @@ unsafe impl ::windows::core::Interface for IMLOperatorTypeInferrer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMLOperatorTypeInferrer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub InferOutputTypes: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, context: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_AI_MachineLearning_WinML\"`*"]
@@ -988,7 +988,7 @@ unsafe impl ::windows::core::Interface for IWinMLEvaluationContext {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWinMLEvaluationContext_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Graphics_Direct3D12")]
     pub BindValue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdescriptor: *const WINML_BINDING_DESC) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Graphics_Direct3D12"))]
@@ -1061,7 +1061,7 @@ unsafe impl ::windows::core::Interface for IWinMLModel {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWinMLModel_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDescription: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppdescription: *mut *mut WINML_MODEL_DESC) -> ::windows::core::HRESULT,
     pub EnumerateMetadata: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: u32, pkey: *mut ::windows::core::PWSTR, pvalue: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -1138,7 +1138,7 @@ unsafe impl ::windows::core::Interface for IWinMLRuntime {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWinMLRuntime_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub LoadModel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, path: ::windows::core::PCWSTR, ppmodel: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Graphics_Direct3D12")]
     pub CreateEvaluationContext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, device: *mut ::core::ffi::c_void, ppcontext: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1193,7 +1193,7 @@ unsafe impl ::windows::core::Interface for IWinMLRuntimeFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWinMLRuntimeFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateRuntime: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, runtimetype: WINML_RUNTIME_TYPE, ppruntime: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_AI_MachineLearning_WinML\"`*"]

--- a/crates/libs/windows/src/Windows/Win32/Data/HtmlHelp/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Data/HtmlHelp/impl.rs
@@ -37,7 +37,7 @@ impl IITDatabase_Vtbl {
             this.GetObjectPersistence(::core::mem::transmute(&lpwszobject), ::core::mem::transmute_copy(&dwobjinstance), ::core::mem::transmute_copy(&ppvpersistence), ::core::mem::transmute_copy(&fstream)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Open: Open::<Identity, Impl, OFFSET>,
             Close: Close::<Identity, Impl, OFFSET>,
             CreateObject: CreateObject::<Identity, Impl, OFFSET>,
@@ -380,7 +380,7 @@ impl IITResultSet_Vtbl {
             this.GetColumnStatus(::core::mem::transmute_copy(&lpcolstatus)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetColumnPriority: SetColumnPriority::<Identity, Impl, OFFSET>,
             SetColumnHeap: SetColumnHeap::<Identity, Impl, OFFSET>,
             SetKeyProp: SetKeyProp::<Identity, Impl, OFFSET>,
@@ -504,7 +504,7 @@ impl IITWordWheel_Vtbl {
             this.GetDataColumns(::core::mem::transmute(&prs)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Open: Open::<Identity, Impl, OFFSET>,
             Close: Close::<Identity, Impl, OFFSET>,
             GetLocaleInfo: GetLocaleInfo::<Identity, Impl, OFFSET>,
@@ -542,7 +542,7 @@ impl IStemSink_Vtbl {
             this.PutWord(::core::mem::transmute(&pwcinbuf), ::core::mem::transmute_copy(&cwc)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             PutAltWord: PutAltWord::<Identity, Impl, OFFSET>,
             PutWord: PutWord::<Identity, Impl, OFFSET>,
         }
@@ -590,7 +590,7 @@ impl IStemmerConfig_Vtbl {
             this.LoadExternalStemmerData(::core::mem::transmute(&pstream), ::core::mem::transmute_copy(&dwextdatatype)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetLocaleInfo: SetLocaleInfo::<Identity, Impl, OFFSET>,
             GetLocaleInfo: GetLocaleInfo::<Identity, Impl, OFFSET>,
             SetControlInfo: SetControlInfo::<Identity, Impl, OFFSET>,
@@ -671,7 +671,7 @@ impl IWordBreakerConfig_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetLocaleInfo: SetLocaleInfo::<Identity, Impl, OFFSET>,
             GetLocaleInfo: GetLocaleInfo::<Identity, Impl, OFFSET>,
             SetBreakWordType: SetBreakWordType::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/Data/HtmlHelp/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Data/HtmlHelp/mod.rs
@@ -66,7 +66,7 @@ unsafe impl ::windows::core::Interface for IITDatabase {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IITDatabase_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Open: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lpszhost: ::windows::core::PCWSTR, lpszmoniker: ::windows::core::PCWSTR, dwflags: u32) -> ::windows::core::HRESULT,
     pub Close: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CreateObject: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, rclsid: *const ::windows::core::GUID, pdwobjinstance: *mut u32) -> ::windows::core::HRESULT,
@@ -478,7 +478,7 @@ unsafe impl ::windows::core::Interface for IITResultSet {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IITResultSet_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetColumnPriority: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lcolumnindex: i32, columnpriority: PRIORITY) -> ::windows::core::HRESULT,
     pub SetColumnHeap: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lcolumnindex: i32, lpvheap: *mut ::core::ffi::c_void, pfncolheapfree: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetKeyProp: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, propid: u32) -> ::windows::core::HRESULT,
@@ -616,7 +616,7 @@ unsafe impl ::windows::core::Interface for IITWordWheel {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IITWordWheel_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Open: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lpitdb: *mut ::core::ffi::c_void, lpszmoniker: ::windows::core::PCWSTR, dwflags: WORD_WHEEL_OPEN_FLAGS) -> ::windows::core::HRESULT,
     pub Close: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetLocaleInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwcodepageid: *mut u32, plcid: *mut u32) -> ::windows::core::HRESULT,
@@ -689,7 +689,7 @@ unsafe impl ::windows::core::Interface for IStemSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IStemSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub PutAltWord: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwcinbuf: ::windows::core::PCWSTR, cwc: u32) -> ::windows::core::HRESULT,
     pub PutWord: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwcinbuf: ::windows::core::PCWSTR, cwc: u32) -> ::windows::core::HRESULT,
 }
@@ -756,7 +756,7 @@ unsafe impl ::windows::core::Interface for IStemmerConfig {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IStemmerConfig_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetLocaleInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwcodepageid: u32, lcid: u32) -> ::windows::core::HRESULT,
     pub GetLocaleInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwcodepageid: *mut u32, plcid: *mut u32) -> ::windows::core::HRESULT,
     pub SetControlInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, grfstemflags: u32, dwreserved: u32) -> ::windows::core::HRESULT,
@@ -849,7 +849,7 @@ unsafe impl ::windows::core::Interface for IWordBreakerConfig {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWordBreakerConfig_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetLocaleInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwcodepageid: u32, lcid: u32) -> ::windows::core::HRESULT,
     pub GetLocaleInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwcodepageid: *mut u32, plcid: *mut u32) -> ::windows::core::HRESULT,
     pub SetBreakWordType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwbreakwordtype: u32) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/Data/Xml/MsXml/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Data/Xml/MsXml/impl.rs
@@ -166,7 +166,7 @@ impl IMXNamespaceManager_Vtbl {
             this.getURI(::core::mem::transmute(&pwchprefix), ::core::mem::transmute(&pcontextnode), ::core::mem::transmute_copy(&pwchuri), ::core::mem::transmute_copy(&pcchuri)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             putAllowOverride: putAllowOverride::<Identity, Impl, OFFSET>,
             getAllowOverride: getAllowOverride::<Identity, Impl, OFFSET>,
             reset: reset::<Identity, Impl, OFFSET>,
@@ -719,7 +719,7 @@ impl ISAXAttributes_Vtbl {
             this.getValueFromQName(::core::mem::transmute(&pwchqname), ::core::mem::transmute_copy(&cchqname), ::core::mem::transmute_copy(&ppwchvalue), ::core::mem::transmute_copy(&pcchvalue)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             getLength: getLength::<Identity, Impl, OFFSET>,
             getURI: getURI::<Identity, Impl, OFFSET>,
             getLocalName: getLocalName::<Identity, Impl, OFFSET>,
@@ -811,7 +811,7 @@ impl ISAXContentHandler_Vtbl {
             this.skippedEntity(::core::mem::transmute(&pwchname), ::core::mem::transmute_copy(&cchname)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             putDocumentLocator: putDocumentLocator::<Identity, Impl, OFFSET>,
             startDocument: startDocument::<Identity, Impl, OFFSET>,
             endDocument: endDocument::<Identity, Impl, OFFSET>,
@@ -847,7 +847,7 @@ impl ISAXDTDHandler_Vtbl {
             this.unparsedEntityDecl(::core::mem::transmute(&pwchname), ::core::mem::transmute_copy(&cchname), ::core::mem::transmute(&pwchpublicid), ::core::mem::transmute_copy(&cchpublicid), ::core::mem::transmute(&pwchsystemid), ::core::mem::transmute_copy(&cchsystemid), ::core::mem::transmute(&pwchnotationname), ::core::mem::transmute_copy(&cchnotationname)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             notationDecl: notationDecl::<Identity, Impl, OFFSET>,
             unparsedEntityDecl: unparsedEntityDecl::<Identity, Impl, OFFSET>,
         }
@@ -886,7 +886,7 @@ impl ISAXDeclHandler_Vtbl {
             this.externalEntityDecl(::core::mem::transmute(&pwchname), ::core::mem::transmute_copy(&cchname), ::core::mem::transmute(&pwchpublicid), ::core::mem::transmute_copy(&cchpublicid), ::core::mem::transmute(&pwchsystemid), ::core::mem::transmute_copy(&cchsystemid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             elementDecl: elementDecl::<Identity, Impl, OFFSET>,
             attributeDecl: attributeDecl::<Identity, Impl, OFFSET>,
             internalEntityDecl: internalEntityDecl::<Identity, Impl, OFFSET>,
@@ -917,7 +917,7 @@ impl ISAXEntityResolver_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), resolveEntity: resolveEntity::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), resolveEntity: resolveEntity::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ISAXEntityResolver as ::windows::core::Interface>::IID
@@ -947,7 +947,7 @@ impl ISAXErrorHandler_Vtbl {
             this.ignorableWarning(::core::mem::transmute(&plocator), ::core::mem::transmute(&pwcherrormessage), ::core::mem::transmute_copy(&hrerrorcode)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             error: error::<Identity, Impl, OFFSET>,
             fatalError: fatalError::<Identity, Impl, OFFSET>,
             ignorableWarning: ignorableWarning::<Identity, Impl, OFFSET>,
@@ -1005,7 +1005,7 @@ impl ISAXLexicalHandler_Vtbl {
             this.comment(::core::mem::transmute(&pwchchars), ::core::mem::transmute_copy(&cchchars)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             startDTD: startDTD::<Identity, Impl, OFFSET>,
             endDTD: endDTD::<Identity, Impl, OFFSET>,
             startEntity: startEntity::<Identity, Impl, OFFSET>,
@@ -1073,7 +1073,7 @@ impl ISAXLocator_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             getColumnNumber: getColumnNumber::<Identity, Impl, OFFSET>,
             getLineNumber: getLineNumber::<Identity, Impl, OFFSET>,
             getPublicId: getPublicId::<Identity, Impl, OFFSET>,
@@ -1285,7 +1285,7 @@ impl ISAXXMLReader_Vtbl {
             this.parseURL(::core::mem::transmute(&pwchurl)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             getFeature: getFeature::<Identity, Impl, OFFSET>,
             putFeature: putFeature::<Identity, Impl, OFFSET>,
             getProperty: getProperty::<Identity, Impl, OFFSET>,
@@ -6327,7 +6327,7 @@ impl IXMLError_Vtbl {
             let this = (*this).get_impl();
             this.GetErrorInfo(::core::mem::transmute_copy(&perrorreturn)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetErrorInfo: GetErrorInfo::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetErrorInfo: GetErrorInfo::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IXMLError as ::windows::core::Interface>::IID
@@ -6588,7 +6588,7 @@ impl IXMLHTTPRequest2_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Open: Open::<Identity, Impl, OFFSET>,
             Send: Send::<Identity, Impl, OFFSET>,
             Abort: Abort::<Identity, Impl, OFFSET>,
@@ -6644,7 +6644,7 @@ impl IXMLHTTPRequest2Callback_Vtbl {
             this.OnError(::core::mem::transmute(&pxhr), ::core::mem::transmute_copy(&hrerror)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnRedirect: OnRedirect::<Identity, Impl, OFFSET>,
             OnHeadersAvailable: OnHeadersAvailable::<Identity, Impl, OFFSET>,
             OnDataAvailable: OnDataAvailable::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/Data/Xml/MsXml/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Data/Xml/MsXml/mod.rs
@@ -224,7 +224,7 @@ unsafe impl ::windows::core::Interface for IMXNamespaceManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMXNamespaceManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub putAllowOverride: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, foverride: i16) -> ::windows::core::HRESULT,
     pub getAllowOverride: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, foverride: *mut i16) -> ::windows::core::HRESULT,
     pub reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -925,7 +925,7 @@ unsafe impl ::windows::core::Interface for ISAXAttributes {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISAXAttributes_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub getLength: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pnlength: *mut i32) -> ::windows::core::HRESULT,
     pub getURI: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, nindex: i32, ppwchuri: *mut *mut u16, pcchuri: *mut i32) -> ::windows::core::HRESULT,
     pub getLocalName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, nindex: i32, ppwchlocalname: *mut *mut u16, pcchlocalname: *mut i32) -> ::windows::core::HRESULT,
@@ -1050,7 +1050,7 @@ unsafe impl ::windows::core::Interface for ISAXContentHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISAXContentHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub putDocumentLocator: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, plocator: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub startDocument: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub endDocument: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1123,7 +1123,7 @@ unsafe impl ::windows::core::Interface for ISAXDTDHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISAXDTDHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub notationDecl: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwchname: ::windows::core::PCWSTR, cchname: i32, pwchpublicid: ::windows::core::PCWSTR, cchpublicid: i32, pwchsystemid: ::windows::core::PCWSTR, cchsystemid: i32) -> ::windows::core::HRESULT,
     pub unparsedEntityDecl: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwchname: ::windows::core::PCWSTR, cchname: i32, pwchpublicid: ::windows::core::PCWSTR, cchpublicid: i32, pwchsystemid: ::windows::core::PCWSTR, cchsystemid: i32, pwchnotationname: ::windows::core::PCWSTR, cchnotationname: i32) -> ::windows::core::HRESULT,
 }
@@ -1202,7 +1202,7 @@ unsafe impl ::windows::core::Interface for ISAXDeclHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISAXDeclHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub elementDecl: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwchname: ::windows::core::PCWSTR, cchname: i32, pwchmodel: ::windows::core::PCWSTR, cchmodel: i32) -> ::windows::core::HRESULT,
     pub attributeDecl: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwchelementname: ::windows::core::PCWSTR, cchelementname: i32, pwchattributename: ::windows::core::PCWSTR, cchattributename: i32, pwchtype: ::windows::core::PCWSTR, cchtype: i32, pwchvaluedefault: ::windows::core::PCWSTR, cchvaluedefault: i32, pwchvalue: ::windows::core::PCWSTR, cchvalue: i32) -> ::windows::core::HRESULT,
     pub internalEntityDecl: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwchname: ::windows::core::PCWSTR, cchname: i32, pwchvalue: ::windows::core::PCWSTR, cchvalue: i32) -> ::windows::core::HRESULT,
@@ -1261,7 +1261,7 @@ unsafe impl ::windows::core::Interface for ISAXEntityResolver {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISAXEntityResolver_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub resolveEntity: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwchpublicid: ::windows::core::PCWSTR, pwchsystemid: ::windows::core::PCWSTR, pvarinput: *mut super::super::super::System::Com::VARIANT) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole")))]
@@ -1331,7 +1331,7 @@ unsafe impl ::windows::core::Interface for ISAXErrorHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISAXErrorHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub error: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, plocator: *mut ::core::ffi::c_void, pwcherrormessage: ::windows::core::PCWSTR, hrerrorcode: ::windows::core::HRESULT) -> ::windows::core::HRESULT,
     pub fatalError: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, plocator: *mut ::core::ffi::c_void, pwcherrormessage: ::windows::core::PCWSTR, hrerrorcode: ::windows::core::HRESULT) -> ::windows::core::HRESULT,
     pub ignorableWarning: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, plocator: *mut ::core::ffi::c_void, pwcherrormessage: ::windows::core::PCWSTR, hrerrorcode: ::windows::core::HRESULT) -> ::windows::core::HRESULT,
@@ -1414,7 +1414,7 @@ unsafe impl ::windows::core::Interface for ISAXLexicalHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISAXLexicalHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub startDTD: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwchname: ::windows::core::PCWSTR, cchname: i32, pwchpublicid: ::windows::core::PCWSTR, cchpublicid: i32, pwchsystemid: ::windows::core::PCWSTR, cchsystemid: i32) -> ::windows::core::HRESULT,
     pub endDTD: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub startEntity: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwchname: ::windows::core::PCWSTR, cchname: i32) -> ::windows::core::HRESULT,
@@ -1482,7 +1482,7 @@ unsafe impl ::windows::core::Interface for ISAXLocator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISAXLocator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub getColumnNumber: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pncolumn: *mut i32) -> ::windows::core::HRESULT,
     pub getLineNumber: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pnline: *mut i32) -> ::windows::core::HRESULT,
     pub getPublicId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppwchpublicid: *mut *mut u16) -> ::windows::core::HRESULT,
@@ -1813,7 +1813,7 @@ unsafe impl ::windows::core::Interface for ISAXXMLReader {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISAXXMLReader_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub getFeature: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwchname: ::windows::core::PCWSTR, pvfvalue: *mut i16) -> ::windows::core::HRESULT,
     pub putFeature: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwchname: ::windows::core::PCWSTR, vfvalue: i16) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -14070,7 +14070,7 @@ unsafe impl ::windows::core::Interface for IXMLError {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXMLError_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetErrorInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, perrorreturn: *mut XML_ERROR) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_System_Com\"`*"]
@@ -14363,7 +14363,7 @@ unsafe impl ::windows::core::Interface for IXMLHTTPRequest2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXMLHTTPRequest2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Open: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszmethod: ::windows::core::PCWSTR, pwszurl: ::windows::core::PCWSTR, pstatuscallback: *mut ::core::ffi::c_void, pwszusername: ::windows::core::PCWSTR, pwszpassword: ::windows::core::PCWSTR, pwszproxyusername: ::windows::core::PCWSTR, pwszproxypassword: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
     pub Send: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbody: *mut ::core::ffi::c_void, cbbody: u64) -> ::windows::core::HRESULT,
@@ -14468,7 +14468,7 @@ unsafe impl ::windows::core::Interface for IXMLHTTPRequest2Callback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXMLHTTPRequest2Callback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnRedirect: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pxhr: *mut ::core::ffi::c_void, pwszredirecturl: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub OnHeadersAvailable: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pxhr: *mut ::core::ffi::c_void, dwstatus: u32, pwszstatus: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]

--- a/crates/libs/windows/src/Windows/Win32/Data/Xml/XmlLite/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Data/Xml/XmlLite/impl.rs
@@ -181,7 +181,7 @@ impl IXmlReader_Vtbl {
             this.IsEOF()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetInput: SetInput::<Identity, Impl, OFFSET>,
             GetProperty: GetProperty::<Identity, Impl, OFFSET>,
             SetProperty: SetProperty::<Identity, Impl, OFFSET>,
@@ -228,7 +228,7 @@ impl IXmlResolver_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), ResolveUri: ResolveUri::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), ResolveUri: ResolveUri::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IXmlResolver as ::windows::core::Interface>::IID
@@ -423,7 +423,7 @@ impl IXmlWriter_Vtbl {
             this.Flush().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetOutput: SetOutput::<Identity, Impl, OFFSET>,
             GetProperty: GetProperty::<Identity, Impl, OFFSET>,
             SetProperty: SetProperty::<Identity, Impl, OFFSET>,
@@ -642,7 +642,7 @@ impl IXmlWriterLite_Vtbl {
             this.Flush().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetOutput: SetOutput::<Identity, Impl, OFFSET>,
             GetProperty: GetProperty::<Identity, Impl, OFFSET>,
             SetProperty: SetProperty::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/Data/Xml/XmlLite/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Data/Xml/XmlLite/mod.rs
@@ -221,7 +221,7 @@ unsafe impl ::windows::core::Interface for IXmlReader {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXmlReader_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetInput: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinput: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetProperty: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, nproperty: u32, ppvalue: *mut isize) -> ::windows::core::HRESULT,
     pub SetProperty: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, nproperty: u32, pvalue: isize) -> ::windows::core::HRESULT,
@@ -307,7 +307,7 @@ unsafe impl ::windows::core::Interface for IXmlResolver {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXmlResolver_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ResolveUri: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszbaseuri: ::windows::core::PCWSTR, pwszpublicidentifier: ::windows::core::PCWSTR, pwszsystemidentifier: ::windows::core::PCWSTR, ppresolvedinput: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Data_Xml_XmlLite\"`*"]
@@ -517,7 +517,7 @@ unsafe impl ::windows::core::Interface for IXmlWriter {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXmlWriter_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetOutput: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, poutput: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetProperty: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, nproperty: u32, ppvalue: *mut isize) -> ::windows::core::HRESULT,
     pub SetProperty: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, nproperty: u32, pvalue: isize) -> ::windows::core::HRESULT,
@@ -743,7 +743,7 @@ unsafe impl ::windows::core::Interface for IXmlWriterLite {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXmlWriterLite_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetOutput: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, poutput: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetProperty: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, nproperty: u32, ppvalue: *mut isize) -> ::windows::core::HRESULT,
     pub SetProperty: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, nproperty: u32, pvalue: isize) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/Devices/DeviceAccess/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/DeviceAccess/impl.rs
@@ -28,7 +28,7 @@ impl ICreateDeviceAccessAsync_Vtbl {
             this.GetResult(::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&deviceaccess)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Cancel: Cancel::<Identity, Impl, OFFSET>,
             Wait: Wait::<Identity, Impl, OFFSET>,
             Close: Close::<Identity, Impl, OFFSET>,
@@ -63,7 +63,7 @@ impl IDeviceIoControl_Vtbl {
             this.CancelOperation(::core::mem::transmute_copy(&cancelcontext)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             DeviceIoControlSync: DeviceIoControlSync::<Identity, Impl, OFFSET>,
             DeviceIoControlAsync: DeviceIoControlAsync::<Identity, Impl, OFFSET>,
             CancelOperation: CancelOperation::<Identity, Impl, OFFSET>,
@@ -84,7 +84,7 @@ impl IDeviceRequestCompletionCallback_Vtbl {
             let this = (*this).get_impl();
             this.Invoke(::core::mem::transmute_copy(&requestresult), ::core::mem::transmute_copy(&bytesreturned)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Invoke: Invoke::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Invoke: Invoke::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDeviceRequestCompletionCallback as ::windows::core::Interface>::IID

--- a/crates/libs/windows/src/Windows/Win32/Devices/DeviceAccess/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/DeviceAccess/mod.rs
@@ -70,7 +70,7 @@ unsafe impl ::windows::core::Interface for ICreateDeviceAccessAsync {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICreateDeviceAccessAsync_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Cancel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Wait: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, timeout: u32) -> ::windows::core::HRESULT,
     pub Close: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -141,7 +141,7 @@ unsafe impl ::windows::core::Interface for IDeviceIoControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDeviceIoControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub DeviceIoControlSync: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, iocontrolcode: u32, inputbuffer: *const u8, inputbuffersize: u32, outputbuffer: *mut u8, outputbuffersize: u32, bytesreturned: *mut u32) -> ::windows::core::HRESULT,
     pub DeviceIoControlAsync: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, iocontrolcode: u32, inputbuffer: *const u8, inputbuffersize: u32, outputbuffer: *mut u8, outputbuffersize: u32, requestcompletioncallback: *mut ::core::ffi::c_void, cancelcontext: *mut usize) -> ::windows::core::HRESULT,
     pub CancelOperation: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cancelcontext: usize) -> ::windows::core::HRESULT,
@@ -192,7 +192,7 @@ unsafe impl ::windows::core::Interface for IDeviceRequestCompletionCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDeviceRequestCompletionCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, requestresult: ::windows::core::HRESULT, bytesreturned: u32) -> ::windows::core::HRESULT,
 }
 pub const CLSID_DeviceIoControl: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x12d3e372_874b_457d_9fdf_73977778686c);

--- a/crates/libs/windows/src/Windows/Win32/Devices/Display/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Display/impl.rs
@@ -31,7 +31,7 @@ impl ICloneViewHelper_Vtbl {
             this.Commit(::core::mem::transmute_copy(&ffinalcall)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetConnectedIDs: GetConnectedIDs::<Identity, Impl, OFFSET>,
             GetActiveTopology: GetActiveTopology::<Identity, Impl, OFFSET>,
             SetActiveTopology: SetActiveTopology::<Identity, Impl, OFFSET>,
@@ -93,7 +93,7 @@ impl IViewHelper_Vtbl {
             this.GetProceedOnNewConfiguration().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetConnectedIDs: GetConnectedIDs::<Identity, Impl, OFFSET>,
             GetActiveTopology: GetActiveTopology::<Identity, Impl, OFFSET>,
             SetActiveTopology: SetActiveTopology::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/Devices/Display/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Display/mod.rs
@@ -1388,7 +1388,7 @@ unsafe impl ::windows::core::Interface for ICloneViewHelper {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICloneViewHelper_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetConnectedIDs: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wszadaptorname: ::windows::core::PCWSTR, pulcount: *mut u32, pulid: *mut u32, ulflags: u32) -> ::windows::core::HRESULT,
     pub GetActiveTopology: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wszadaptorname: ::windows::core::PCWSTR, ulsourceid: u32, pulcount: *mut u32, pultargetid: *mut u32) -> ::windows::core::HRESULT,
     pub SetActiveTopology: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wszadaptorname: ::windows::core::PCWSTR, ulsourceid: u32, ulcount: u32, pultargetid: *const u32) -> ::windows::core::HRESULT,
@@ -1473,7 +1473,7 @@ unsafe impl ::windows::core::Interface for IViewHelper {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IViewHelper_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetConnectedIDs: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wszadaptorname: ::windows::core::PCWSTR, pulcount: *mut u32, pulid: *mut u32, ulflags: u32) -> ::windows::core::HRESULT,
     pub GetActiveTopology: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wszadaptorname: ::windows::core::PCWSTR, ulsourceid: u32, pulcount: *mut u32, pultargetid: *mut u32) -> ::windows::core::HRESULT,
     pub SetActiveTopology: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wszadaptorname: ::windows::core::PCWSTR, ulsourceid: u32, ulcount: u32, pultargetid: *const u32) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/Devices/Enumeration/Pnp/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Enumeration/Pnp/impl.rs
@@ -22,7 +22,7 @@ impl IUPnPAddressFamilyControl_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetAddressFamily: SetAddressFamily::<Identity, Impl, OFFSET>,
             GetAddressFamily: GetAddressFamily::<Identity, Impl, OFFSET>,
         }
@@ -42,7 +42,7 @@ impl IUPnPAsyncResult_Vtbl {
             let this = (*this).get_impl();
             this.AsyncOperationComplete(::core::mem::transmute_copy(&ullrequestid)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), AsyncOperationComplete: AsyncOperationComplete::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), AsyncOperationComplete: AsyncOperationComplete::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IUPnPAsyncResult as ::windows::core::Interface>::IID
@@ -148,7 +148,7 @@ impl IUPnPDescriptionDocumentCallback_Vtbl {
             let this = (*this).get_impl();
             this.LoadComplete(::core::mem::transmute_copy(&hrloadresult)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), LoadComplete: LoadComplete::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), LoadComplete: LoadComplete::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IUPnPDescriptionDocumentCallback as ::windows::core::Interface>::IID
@@ -444,7 +444,7 @@ impl IUPnPDeviceControl_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             GetServiceObject: GetServiceObject::<Identity, Impl, OFFSET>,
         }
@@ -471,7 +471,7 @@ impl IUPnPDeviceControlHttpHeaders_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetAdditionalResponseHeaders: GetAdditionalResponseHeaders::<Identity, Impl, OFFSET>,
         }
     }
@@ -496,7 +496,7 @@ impl IUPnPDeviceDocumentAccess_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetDocumentURL: GetDocumentURL::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetDocumentURL: GetDocumentURL::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IUPnPDeviceDocumentAccess as ::windows::core::Interface>::IID
@@ -519,7 +519,7 @@ impl IUPnPDeviceDocumentAccessEx_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetDocument: GetDocument::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetDocument: GetDocument::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IUPnPDeviceDocumentAccessEx as ::windows::core::Interface>::IID
@@ -608,7 +608,7 @@ impl IUPnPDeviceFinderAddCallbackWithInterface_Vtbl {
             let this = (*this).get_impl();
             this.DeviceAddedWithInterface(::core::mem::transmute_copy(&lfinddata), ::core::mem::transmute(&pdevice), ::core::mem::transmute_copy(&pguidinterface)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), DeviceAddedWithInterface: DeviceAddedWithInterface::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), DeviceAddedWithInterface: DeviceAddedWithInterface::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IUPnPDeviceFinderAddCallbackWithInterface as ::windows::core::Interface>::IID
@@ -641,7 +641,7 @@ impl IUPnPDeviceFinderCallback_Vtbl {
             this.SearchComplete(::core::mem::transmute_copy(&lfinddata)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             DeviceAdded: DeviceAdded::<Identity, Impl, OFFSET>,
             DeviceRemoved: DeviceRemoved::<Identity, Impl, OFFSET>,
             SearchComplete: SearchComplete::<Identity, Impl, OFFSET>,
@@ -668,7 +668,7 @@ impl IUPnPDeviceProvider_Vtbl {
             let this = (*this).get_impl();
             this.Stop().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Start: Start::<Identity, Impl, OFFSET>, Stop: Stop::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Start: Start::<Identity, Impl, OFFSET>, Stop: Stop::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IUPnPDeviceProvider as ::windows::core::Interface>::IID
@@ -750,7 +750,7 @@ impl IUPnPEventSink_Vtbl {
             this.OnStateChangedSafe(::core::mem::transmute(&varsadispidchanges)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnStateChanged: OnStateChanged::<Identity, Impl, OFFSET>,
             OnStateChangedSafe: OnStateChangedSafe::<Identity, Impl, OFFSET>,
         }
@@ -777,7 +777,7 @@ impl IUPnPEventSource_Vtbl {
             this.Unadvise(::core::mem::transmute(&pessubscriber)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Advise: Advise::<Identity, Impl, OFFSET>,
             Unadvise: Unadvise::<Identity, Impl, OFFSET>,
         }
@@ -797,7 +797,7 @@ impl IUPnPHttpHeaderControl_Vtbl {
             let this = (*this).get_impl();
             this.AddRequestHeaders(::core::mem::transmute(&bstrhttpheaders)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), AddRequestHeaders: AddRequestHeaders::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), AddRequestHeaders: AddRequestHeaders::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IUPnPHttpHeaderControl as ::windows::core::Interface>::IID
@@ -866,7 +866,7 @@ impl IUPnPRegistrar_Vtbl {
             this.UnregisterDeviceProvider(::core::mem::transmute(&bstrprovidername)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RegisterDevice: RegisterDevice::<Identity, Impl, OFFSET>,
             RegisterRunningDevice: RegisterRunningDevice::<Identity, Impl, OFFSET>,
             RegisterDeviceProvider: RegisterDeviceProvider::<Identity, Impl, OFFSET>,
@@ -921,7 +921,7 @@ impl IUPnPRemoteEndpointInfo_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDwordValue: GetDwordValue::<Identity, Impl, OFFSET>,
             GetStringValue: GetStringValue::<Identity, Impl, OFFSET>,
             GetGuidValue: GetGuidValue::<Identity, Impl, OFFSET>,
@@ -949,7 +949,7 @@ impl IUPnPReregistrar_Vtbl {
             this.ReregisterRunningDevice(::core::mem::transmute(&bstrdeviceidentifier), ::core::mem::transmute(&bstrxmldesc), ::core::mem::transmute(&punkdevicecontrol), ::core::mem::transmute(&bstrinitstring), ::core::mem::transmute(&bstrresourcepath), ::core::mem::transmute_copy(&nlifetime)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ReregisterDevice: ReregisterDevice::<Identity, Impl, OFFSET>,
             ReregisterRunningDevice: ReregisterRunningDevice::<Identity, Impl, OFFSET>,
         }
@@ -1133,7 +1133,7 @@ impl IUPnPServiceAsync_Vtbl {
             this.CancelAsyncOperation(::core::mem::transmute_copy(&ullrequestid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             BeginInvokeAction: BeginInvokeAction::<Identity, Impl, OFFSET>,
             EndInvokeAction: EndInvokeAction::<Identity, Impl, OFFSET>,
             BeginQueryStateVariable: BeginQueryStateVariable::<Identity, Impl, OFFSET>,
@@ -1170,7 +1170,7 @@ impl IUPnPServiceCallback_Vtbl {
             this.ServiceInstanceDied(::core::mem::transmute(&pus)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             StateVariableChanged: StateVariableChanged::<Identity, Impl, OFFSET>,
             ServiceInstanceDied: ServiceInstanceDied::<Identity, Impl, OFFSET>,
         }
@@ -1209,7 +1209,7 @@ impl IUPnPServiceDocumentAccess_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDocumentURL: GetDocumentURL::<Identity, Impl, OFFSET>,
             GetDocument: GetDocument::<Identity, Impl, OFFSET>,
         }
@@ -1229,7 +1229,7 @@ impl IUPnPServiceEnumProperty_Vtbl {
             let this = (*this).get_impl();
             this.SetServiceEnumProperty(::core::mem::transmute_copy(&dwmask)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SetServiceEnumProperty: SetServiceEnumProperty::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SetServiceEnumProperty: SetServiceEnumProperty::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IUPnPServiceEnumProperty as ::windows::core::Interface>::IID

--- a/crates/libs/windows/src/Windows/Win32/Devices/Enumeration/Pnp/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Enumeration/Pnp/mod.rs
@@ -167,7 +167,7 @@ unsafe impl ::windows::core::Interface for IUPnPAddressFamilyControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUPnPAddressFamilyControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetAddressFamily: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwflags: i32) -> ::windows::core::HRESULT,
     pub GetAddressFamily: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwflags: *mut i32) -> ::windows::core::HRESULT,
 }
@@ -217,7 +217,7 @@ unsafe impl ::windows::core::Interface for IUPnPAsyncResult {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUPnPAsyncResult_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AsyncOperationComplete: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ullrequestid: u64) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Devices_Enumeration_Pnp\"`, `\"Win32_System_Com\"`*"]
@@ -385,7 +385,7 @@ unsafe impl ::windows::core::Interface for IUPnPDescriptionDocumentCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUPnPDescriptionDocumentCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub LoadComplete: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hrloadresult: ::windows::core::HRESULT) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Devices_Enumeration_Pnp\"`, `\"Win32_System_Com\"`*"]
@@ -629,7 +629,7 @@ unsafe impl ::windows::core::Interface for IUPnPDeviceControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUPnPDeviceControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrxmldesc: ::core::mem::ManuallyDrop<::windows::core::BSTR>, bstrdeviceidentifier: ::core::mem::ManuallyDrop<::windows::core::BSTR>, bstrinitstring: ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
     pub GetServiceObject: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrudn: ::core::mem::ManuallyDrop<::windows::core::BSTR>, bstrserviceid: ::core::mem::ManuallyDrop<::windows::core::BSTR>, ppdispservice: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -683,7 +683,7 @@ unsafe impl ::windows::core::Interface for IUPnPDeviceControlHttpHeaders {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUPnPDeviceControlHttpHeaders_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetAdditionalResponseHeaders: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrhttpresponseheaders: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Devices_Enumeration_Pnp\"`*"]
@@ -733,7 +733,7 @@ unsafe impl ::windows::core::Interface for IUPnPDeviceDocumentAccess {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUPnPDeviceDocumentAccess_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDocumentURL: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstrdocument: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Devices_Enumeration_Pnp\"`*"]
@@ -783,7 +783,7 @@ unsafe impl ::windows::core::Interface for IUPnPDeviceDocumentAccessEx {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUPnPDeviceDocumentAccessEx_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDocument: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstrdocument: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Devices_Enumeration_Pnp\"`, `\"Win32_System_Com\"`*"]
@@ -947,7 +947,7 @@ unsafe impl ::windows::core::Interface for IUPnPDeviceFinderAddCallbackWithInter
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUPnPDeviceFinderAddCallbackWithInterface_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub DeviceAddedWithInterface: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lfinddata: i32, pdevice: *mut ::core::ffi::c_void, pguidinterface: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -1010,7 +1010,7 @@ unsafe impl ::windows::core::Interface for IUPnPDeviceFinderCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUPnPDeviceFinderCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub DeviceAdded: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lfinddata: i32, pdevice: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -1067,7 +1067,7 @@ unsafe impl ::windows::core::Interface for IUPnPDeviceProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUPnPDeviceProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Start: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrinitstring: ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub Stop: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -1219,7 +1219,7 @@ unsafe impl ::windows::core::Interface for IUPnPEventSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUPnPEventSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnStateChanged: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cchanges: u32, rgdispidchanges: *const i32) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub OnStateChangedSafe: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, varsadispidchanges: ::core::mem::ManuallyDrop<super::super::super::System::Com::VARIANT>) -> ::windows::core::HRESULT,
@@ -1281,7 +1281,7 @@ unsafe impl ::windows::core::Interface for IUPnPEventSource {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUPnPEventSource_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Advise: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pessubscriber: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Unadvise: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pessubscriber: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -1331,7 +1331,7 @@ unsafe impl ::windows::core::Interface for IUPnPHttpHeaderControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUPnPHttpHeaderControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddRequestHeaders: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrhttpheaders: ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Devices_Enumeration_Pnp\"`*"]
@@ -1406,7 +1406,7 @@ unsafe impl ::windows::core::Interface for IUPnPRegistrar {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUPnPRegistrar_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub RegisterDevice: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrxmldesc: ::core::mem::ManuallyDrop<::windows::core::BSTR>, bstrprogiddevicecontrolclass: ::core::mem::ManuallyDrop<::windows::core::BSTR>, bstrinitstring: ::core::mem::ManuallyDrop<::windows::core::BSTR>, bstrcontainerid: ::core::mem::ManuallyDrop<::windows::core::BSTR>, bstrresourcepath: ::core::mem::ManuallyDrop<::windows::core::BSTR>, nlifetime: i32, pbstrdeviceidentifier: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub RegisterRunningDevice: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrxmldesc: ::core::mem::ManuallyDrop<::windows::core::BSTR>, punkdevicecontrol: *mut ::core::ffi::c_void, bstrinitstring: ::core::mem::ManuallyDrop<::windows::core::BSTR>, bstrresourcepath: ::core::mem::ManuallyDrop<::windows::core::BSTR>, nlifetime: i32, pbstrdeviceidentifier: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub RegisterDeviceProvider: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrprovidername: ::core::mem::ManuallyDrop<::windows::core::BSTR>, bstrprogidproviderclass: ::core::mem::ManuallyDrop<::windows::core::BSTR>, bstrinitstring: ::core::mem::ManuallyDrop<::windows::core::BSTR>, bstrcontainerid: ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
@@ -1472,7 +1472,7 @@ unsafe impl ::windows::core::Interface for IUPnPRemoteEndpointInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUPnPRemoteEndpointInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDwordValue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrvaluename: ::core::mem::ManuallyDrop<::windows::core::BSTR>, pdwvalue: *mut u32) -> ::windows::core::HRESULT,
     pub GetStringValue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrvaluename: ::core::mem::ManuallyDrop<::windows::core::BSTR>, pbstrvalue: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub GetGuidValue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrvaluename: ::core::mem::ManuallyDrop<::windows::core::BSTR>, pguidvalue: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
@@ -1529,7 +1529,7 @@ unsafe impl ::windows::core::Interface for IUPnPReregistrar {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUPnPReregistrar_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ReregisterDevice: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrdeviceidentifier: ::core::mem::ManuallyDrop<::windows::core::BSTR>, bstrxmldesc: ::core::mem::ManuallyDrop<::windows::core::BSTR>, bstrprogiddevicecontrolclass: ::core::mem::ManuallyDrop<::windows::core::BSTR>, bstrinitstring: ::core::mem::ManuallyDrop<::windows::core::BSTR>, bstrcontainerid: ::core::mem::ManuallyDrop<::windows::core::BSTR>, bstrresourcepath: ::core::mem::ManuallyDrop<::windows::core::BSTR>, nlifetime: i32) -> ::windows::core::HRESULT,
     pub ReregisterRunningDevice: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrdeviceidentifier: ::core::mem::ManuallyDrop<::windows::core::BSTR>, bstrxmldesc: ::core::mem::ManuallyDrop<::windows::core::BSTR>, punkdevicecontrol: *mut ::core::ffi::c_void, bstrinitstring: ::core::mem::ManuallyDrop<::windows::core::BSTR>, bstrresourcepath: ::core::mem::ManuallyDrop<::windows::core::BSTR>, nlifetime: i32) -> ::windows::core::HRESULT,
 }
@@ -1746,7 +1746,7 @@ unsafe impl ::windows::core::Interface for IUPnPServiceAsync {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUPnPServiceAsync_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub BeginInvokeAction: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstractionname: ::core::mem::ManuallyDrop<::windows::core::BSTR>, vinactionargs: ::core::mem::ManuallyDrop<super::super::super::System::Com::VARIANT>, pasyncresult: *mut ::core::ffi::c_void, pullrequestid: *mut u64) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole")))]
@@ -1827,7 +1827,7 @@ unsafe impl ::windows::core::Interface for IUPnPServiceCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUPnPServiceCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub StateVariableChanged: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pus: *mut ::core::ffi::c_void, pcwszstatevarname: ::windows::core::PCWSTR, vavalue: ::core::mem::ManuallyDrop<super::super::super::System::Com::VARIANT>) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole")))]
@@ -1888,7 +1888,7 @@ unsafe impl ::windows::core::Interface for IUPnPServiceDocumentAccess {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUPnPServiceDocumentAccess_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDocumentURL: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstrdocurl: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub GetDocument: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstrdoc: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
 }
@@ -1938,7 +1938,7 @@ unsafe impl ::windows::core::Interface for IUPnPServiceEnumProperty {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUPnPServiceEnumProperty_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetServiceEnumProperty: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwmask: u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Devices_Enumeration_Pnp\"`, `\"Win32_System_Com\"`*"]

--- a/crates/libs/windows/src/Windows/Win32/Devices/Fax/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Fax/impl.rs
@@ -7192,7 +7192,7 @@ impl IStiDevice_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             GetCapabilities: GetCapabilities::<Identity, Impl, OFFSET>,
             GetStatus: GetStatus::<Identity, Impl, OFFSET>,
@@ -7291,7 +7291,7 @@ impl IStiDeviceControl_Vtbl {
             this.WriteToErrorLog(::core::mem::transmute_copy(&dwmessagetype), ::core::mem::transmute(&pszmessage), ::core::mem::transmute_copy(&dwerrorcode)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             RawReadData: RawReadData::<Identity, Impl, OFFSET>,
             RawWriteData: RawWriteData::<Identity, Impl, OFFSET>,
@@ -7438,7 +7438,7 @@ impl IStiUSD_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             GetCapabilities: GetCapabilities::<Identity, Impl, OFFSET>,
             GetStatus: GetStatus::<Identity, Impl, OFFSET>,
@@ -7566,7 +7566,7 @@ impl IStillImageW_Vtbl {
             this.WriteToErrorLog(::core::mem::transmute_copy(&dwmessagetype), ::core::mem::transmute(&pszmessage)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             GetDeviceList: GetDeviceList::<Identity, Impl, OFFSET>,
             GetDeviceInfo: GetDeviceInfo::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/Devices/Fax/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Fax/mod.rs
@@ -8898,7 +8898,7 @@ unsafe impl ::windows::core::Interface for IStiDevice {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IStiDevice_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hinst: super::super::Foundation::HINSTANCE, pwszdevicename: ::windows::core::PCWSTR, dwversion: u32, dwmode: u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -9027,7 +9027,7 @@ unsafe impl ::windows::core::Interface for IStiDeviceControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IStiDeviceControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwdevicetype: u32, dwmode: u32, pwszportname: ::windows::core::PCWSTR, dwflags: u32) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
     pub RawReadData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lpbuffer: *mut ::core::ffi::c_void, lpdwnumberofbytes: *mut u32, lpoverlapped: *mut super::super::System::IO::OVERLAPPED) -> ::windows::core::HRESULT,
@@ -9169,7 +9169,7 @@ unsafe impl ::windows::core::Interface for IStiUSD {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IStiUSD_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Registry")]
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pheldcb: *mut ::core::ffi::c_void, dwstiversion: u32, hparameterskey: super::super::System::Registry::HKEY) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Registry"))]
@@ -9342,7 +9342,7 @@ unsafe impl ::windows::core::Interface for IStillImageW {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IStillImageW_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hinst: super::super::Foundation::HINSTANCE, dwversion: u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]

--- a/crates/libs/windows/src/Windows/Win32/Devices/FunctionDiscovery/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/FunctionDiscovery/impl.rs
@@ -61,7 +61,7 @@ impl IFunctionDiscovery_Vtbl {
             this.RemoveInstance(::core::mem::transmute_copy(&enumsystemvisibility), ::core::mem::transmute(&pszcategory), ::core::mem::transmute(&pszsubcategory), ::core::mem::transmute(&pszcategoryidentity)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetInstanceCollection: GetInstanceCollection::<Identity, Impl, OFFSET>,
             GetInstance: GetInstance::<Identity, Impl, OFFSET>,
             CreateInstanceCollectionQuery: CreateInstanceCollectionQuery::<Identity, Impl, OFFSET>,
@@ -101,7 +101,7 @@ impl IFunctionDiscoveryNotification_Vtbl {
             this.OnEvent(::core::mem::transmute_copy(&dweventid), ::core::mem::transmute_copy(&fdqcquerycontext), ::core::mem::transmute(&pszprovider)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnUpdate: OnUpdate::<Identity, Impl, OFFSET>,
             OnError: OnError::<Identity, Impl, OFFSET>,
             OnEvent: OnEvent::<Identity, Impl, OFFSET>,
@@ -192,7 +192,7 @@ impl IFunctionDiscoveryProvider_Vtbl {
             this.InstanceReleased(::core::mem::transmute(&pifunctioninstance), ::core::mem::transmute_copy(&iproviderinstancecontext)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             Query: Query::<Identity, Impl, OFFSET>,
             EndQuery: EndQuery::<Identity, Impl, OFFSET>,
@@ -252,7 +252,7 @@ impl IFunctionDiscoveryProviderFactory_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreatePropertyStore: CreatePropertyStore::<Identity, Impl, OFFSET>,
             CreateInstance: CreateInstance::<Identity, Impl, OFFSET>,
             CreateFunctionInstanceCollection: CreateFunctionInstanceCollection::<Identity, Impl, OFFSET>,
@@ -307,7 +307,7 @@ impl IFunctionDiscoveryProviderQuery_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             IsInstanceQuery: IsInstanceQuery::<Identity, Impl, OFFSET>,
             IsSubcategoryQuery: IsSubcategoryQuery::<Identity, Impl, OFFSET>,
             GetQueryConstraints: GetQueryConstraints::<Identity, Impl, OFFSET>,
@@ -332,7 +332,7 @@ impl IFunctionDiscoveryServiceProvider_Vtbl {
             let this = (*this).get_impl();
             this.Initialize(::core::mem::transmute(&pifunctioninstance), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppv)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Initialize: Initialize::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Initialize: Initialize::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IFunctionDiscoveryServiceProvider as ::windows::core::Interface>::IID
@@ -469,7 +469,7 @@ impl IFunctionInstanceCollection_Vtbl {
             this.DeleteAll().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCount: GetCount::<Identity, Impl, OFFSET>,
             Get: Get::<Identity, Impl, OFFSET>,
             Item: Item::<Identity, Impl, OFFSET>,
@@ -516,7 +516,7 @@ impl IFunctionInstanceCollectionQuery_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddQueryConstraint: AddQueryConstraint::<Identity, Impl, OFFSET>,
             AddPropertyConstraint: AddPropertyConstraint::<Identity, Impl, OFFSET>,
             Execute: Execute::<Identity, Impl, OFFSET>,
@@ -546,7 +546,7 @@ impl IFunctionInstanceQuery_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Execute: Execute::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Execute: Execute::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IFunctionInstanceQuery as ::windows::core::Interface>::IID
@@ -576,7 +576,7 @@ impl IPNPXAssociation_Vtbl {
             this.Delete(::core::mem::transmute(&pszsubcategory)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Associate: Associate::<Identity, Impl, OFFSET>,
             Unassociate: Unassociate::<Identity, Impl, OFFSET>,
             Delete: Delete::<Identity, Impl, OFFSET>,
@@ -610,7 +610,7 @@ impl IPNPXDeviceAssociation_Vtbl {
             this.Delete(::core::mem::transmute(&pszsubcategory), ::core::mem::transmute(&pifunctiondiscoverynotification)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Associate: Associate::<Identity, Impl, OFFSET>,
             Unassociate: Unassociate::<Identity, Impl, OFFSET>,
             Delete: Delete::<Identity, Impl, OFFSET>,
@@ -689,7 +689,7 @@ impl IPropertyStoreCollection_Vtbl {
             this.DeleteAll().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCount: GetCount::<Identity, Impl, OFFSET>,
             Get: Get::<Identity, Impl, OFFSET>,
             Item: Item::<Identity, Impl, OFFSET>,
@@ -754,7 +754,7 @@ impl IProviderProperties_Vtbl {
             this.SetValue(::core::mem::transmute(&pifunctioninstance), ::core::mem::transmute_copy(&iproviderinstancecontext), ::core::mem::transmute_copy(&key), ::core::mem::transmute_copy(&ppropvar)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCount: GetCount::<Identity, Impl, OFFSET>,
             GetAt: GetAt::<Identity, Impl, OFFSET>,
             GetValue: GetValue::<Identity, Impl, OFFSET>,
@@ -816,7 +816,7 @@ impl IProviderPropertyConstraintCollection_Vtbl {
             this.Reset().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCount: GetCount::<Identity, Impl, OFFSET>,
             Get: Get::<Identity, Impl, OFFSET>,
             Item: Item::<Identity, Impl, OFFSET>,
@@ -856,7 +856,7 @@ impl IProviderPublishing_Vtbl {
             this.RemoveInstance(::core::mem::transmute_copy(&enumvisibilityflags), ::core::mem::transmute(&pszsubcategory), ::core::mem::transmute(&pszproviderinstanceidentity)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateInstance: CreateInstance::<Identity, Impl, OFFSET>,
             RemoveInstance: RemoveInstance::<Identity, Impl, OFFSET>,
         }
@@ -919,7 +919,7 @@ impl IProviderQueryConstraintCollection_Vtbl {
             this.Reset().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCount: GetCount::<Identity, Impl, OFFSET>,
             Get: Get::<Identity, Impl, OFFSET>,
             Item: Item::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/Devices/FunctionDiscovery/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/FunctionDiscovery/mod.rs
@@ -98,7 +98,7 @@ unsafe impl ::windows::core::Interface for IFunctionDiscovery {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IFunctionDiscovery_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetInstanceCollection: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszcategory: ::windows::core::PCWSTR, pszsubcategory: ::windows::core::PCWSTR, fincludeallsubcategories: super::super::Foundation::BOOL, ppifunctioninstancecollection: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -181,7 +181,7 @@ unsafe impl ::windows::core::Interface for IFunctionDiscoveryNotification {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IFunctionDiscoveryNotification_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub OnUpdate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, enumqueryupdateaction: QueryUpdateAction, fdqcquerycontext: u64, pifunctioninstance: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -292,7 +292,7 @@ unsafe impl ::windows::core::Interface for IFunctionDiscoveryProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IFunctionDiscoveryProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pifunctiondiscoveryproviderfactory: *mut ::core::ffi::c_void, pifunctiondiscoverynotification: *mut ::core::ffi::c_void, lciduserdefault: u32, pdwstgaccesscapabilities: *mut u32) -> ::windows::core::HRESULT,
     pub Query: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pifunctiondiscoveryproviderquery: *mut ::core::ffi::c_void, ppifunctioninstancecollection: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub EndQuery: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -382,7 +382,7 @@ unsafe impl ::windows::core::Interface for IFunctionDiscoveryProviderFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IFunctionDiscoveryProviderFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
     pub CreatePropertyStore: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppipropertystore: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_UI_Shell_PropertiesSystem"))]
@@ -454,7 +454,7 @@ unsafe impl ::windows::core::Interface for IFunctionDiscoveryProviderQuery {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IFunctionDiscoveryProviderQuery_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub IsInstanceQuery: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pisinstancequery: *mut super::super::Foundation::BOOL, ppszconstraintvalue: *mut *mut u16) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -519,7 +519,7 @@ unsafe impl ::windows::core::Interface for IFunctionDiscoveryServiceProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IFunctionDiscoveryServiceProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pifunctioninstance: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -709,7 +709,7 @@ unsafe impl ::windows::core::Interface for IFunctionInstanceCollection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IFunctionInstanceCollection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwcount: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
     pub Get: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszinstanceidentity: ::windows::core::PCWSTR, pdwindex: *mut u32, ppifunctioninstance: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -789,7 +789,7 @@ unsafe impl ::windows::core::Interface for IFunctionInstanceCollectionQuery {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IFunctionInstanceCollectionQuery_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddQueryConstraint: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszconstraintname: ::windows::core::PCWSTR, pszconstraintvalue: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
     pub AddPropertyConstraint: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, key: *const super::super::UI::Shell::PropertiesSystem::PROPERTYKEY, pv: *const super::super::System::Com::StructuredStorage::PROPVARIANT, enumpropertyconstraint: PropertyConstraint) -> ::windows::core::HRESULT,
@@ -846,7 +846,7 @@ unsafe impl ::windows::core::Interface for IFunctionInstanceQuery {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IFunctionInstanceQuery_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub Execute: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppifunctioninstance: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -913,7 +913,7 @@ unsafe impl ::windows::core::Interface for IPNPXAssociation {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPNPXAssociation_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Associate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszsubcategory: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub Unassociate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszsubcategory: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub Delete: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszsubcategory: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
@@ -982,7 +982,7 @@ unsafe impl ::windows::core::Interface for IPNPXDeviceAssociation {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPNPXDeviceAssociation_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Associate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszsubcategory: ::windows::core::PCWSTR, pifunctiondiscoverynotification: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Unassociate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszsubcategory: ::windows::core::PCWSTR, pifunctiondiscoverynotification: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Delete: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszsubcategory: ::windows::core::PCWSTR, pifunctiondiscoverynotification: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1068,7 +1068,7 @@ unsafe impl ::windows::core::Interface for IPropertyStoreCollection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPropertyStoreCollection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwcount: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
     pub Get: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszinstanceidentity: ::windows::core::PCWSTR, pdwindex: *mut u32, ppipropertystore: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1167,7 +1167,7 @@ unsafe impl ::windows::core::Interface for IProviderProperties {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IProviderProperties_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub GetCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pifunctioninstance: *mut ::core::ffi::c_void, iproviderinstancecontext: isize, pdwcount: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -1253,7 +1253,7 @@ unsafe impl ::windows::core::Interface for IProviderPropertyConstraintCollection
 #[repr(C)]
 #[doc(hidden)]
 pub struct IProviderPropertyConstraintCollection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwcount: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
     pub Get: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, key: *const super::super::UI::Shell::PropertiesSystem::PROPERTYKEY, ppropvar: *mut super::super::System::Com::StructuredStorage::PROPVARIANT, pdwpropertyconstraint: *mut u32) -> ::windows::core::HRESULT,
@@ -1330,7 +1330,7 @@ unsafe impl ::windows::core::Interface for IProviderPublishing {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IProviderPublishing_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub CreateInstance: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, enumvisibilityflags: SystemVisibilityFlags, pszsubcategory: ::windows::core::PCWSTR, pszproviderinstanceidentity: ::windows::core::PCWSTR, ppifunctioninstance: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -1403,7 +1403,7 @@ unsafe impl ::windows::core::Interface for IProviderQueryConstraintCollection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IProviderQueryConstraintCollection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwcount: *mut u32) -> ::windows::core::HRESULT,
     pub Get: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszconstraintname: ::windows::core::PCWSTR, ppszconstraintvalue: *mut *mut u16) -> ::windows::core::HRESULT,
     pub Item: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwindex: u32, ppszconstraintname: *mut *mut u16, ppszconstraintvalue: *mut *mut u16) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/Devices/Geolocation/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Geolocation/impl.rs
@@ -155,7 +155,7 @@ impl IDefaultLocation_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetReport: SetReport::<Identity, Impl, OFFSET>,
             GetReport: GetReport::<Identity, Impl, OFFSET>,
         }
@@ -572,7 +572,7 @@ impl ILocation_Vtbl {
             this.RequestPermissions(::core::mem::transmute_copy(&hparent), ::core::mem::transmute_copy(&preporttypes), ::core::mem::transmute_copy(&count), ::core::mem::transmute_copy(&fmodal)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RegisterForReport: RegisterForReport::<Identity, Impl, OFFSET>,
             UnregisterForReport: UnregisterForReport::<Identity, Impl, OFFSET>,
             GetReport: GetReport::<Identity, Impl, OFFSET>,
@@ -606,7 +606,7 @@ impl ILocationEvents_Vtbl {
             this.OnStatusChanged(::core::mem::transmute_copy(&reporttype), ::core::mem::transmute_copy(&newstatus)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnLocationChanged: OnLocationChanged::<Identity, Impl, OFFSET>,
             OnStatusChanged: OnStatusChanged::<Identity, Impl, OFFSET>,
         }
@@ -633,7 +633,7 @@ impl ILocationPower_Vtbl {
             this.Disconnect().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Connect: Connect::<Identity, Impl, OFFSET>,
             Disconnect: Disconnect::<Identity, Impl, OFFSET>,
         }
@@ -687,7 +687,7 @@ impl ILocationReport_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSensorID: GetSensorID::<Identity, Impl, OFFSET>,
             GetTimestamp: GetTimestamp::<Identity, Impl, OFFSET>,
             GetValue: GetValue::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/Devices/Geolocation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Geolocation/mod.rs
@@ -291,7 +291,7 @@ unsafe impl ::windows::core::Interface for IDefaultLocation {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDefaultLocation_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetReport: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, reporttype: *const ::windows::core::GUID, plocationreport: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetReport: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, reporttype: *const ::windows::core::GUID, pplocationreport: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -830,7 +830,7 @@ unsafe impl ::windows::core::Interface for ILocation {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ILocation_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub RegisterForReport: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pevents: *mut ::core::ffi::c_void, reporttype: *const ::windows::core::GUID, dwrequestedreportinterval: u32) -> ::windows::core::HRESULT,
     pub UnregisterForReport: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, reporttype: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub GetReport: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, reporttype: *const ::windows::core::GUID, pplocationreport: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -902,7 +902,7 @@ unsafe impl ::windows::core::Interface for ILocationEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ILocationEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnLocationChanged: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, reporttype: *const ::windows::core::GUID, plocationreport: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub OnStatusChanged: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, reporttype: *const ::windows::core::GUID, newstatus: LOCATION_REPORT_STATUS) -> ::windows::core::HRESULT,
 }
@@ -955,7 +955,7 @@ unsafe impl ::windows::core::Interface for ILocationPower {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ILocationPower_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Connect: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Disconnect: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -1018,7 +1018,7 @@ unsafe impl ::windows::core::Interface for ILocationReport {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ILocationReport_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetSensorID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psensorid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub GetTimestamp: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcreationtime: *mut super::super::Foundation::SYSTEMTIME) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/Devices/HumanInterfaceDevice/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/HumanInterfaceDevice/impl.rs
@@ -135,7 +135,7 @@ impl IDirectInput8A_Vtbl {
             this.ConfigureDevices(::core::mem::transmute(&param0), ::core::mem::transmute_copy(&param1), ::core::mem::transmute_copy(&param2), ::core::mem::transmute_copy(&param3)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateDevice: CreateDevice::<Identity, Impl, OFFSET>,
             EnumDevices: EnumDevices::<Identity, Impl, OFFSET>,
             GetDeviceStatus: GetDeviceStatus::<Identity, Impl, OFFSET>,
@@ -207,7 +207,7 @@ impl IDirectInput8W_Vtbl {
             this.ConfigureDevices(::core::mem::transmute(&param0), ::core::mem::transmute_copy(&param1), ::core::mem::transmute_copy(&param2), ::core::mem::transmute_copy(&param3)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateDevice: CreateDevice::<Identity, Impl, OFFSET>,
             EnumDevices: EnumDevices::<Identity, Impl, OFFSET>,
             GetDeviceStatus: GetDeviceStatus::<Identity, Impl, OFFSET>,
@@ -261,7 +261,7 @@ impl IDirectInputA_Vtbl {
             this.Initialize(::core::mem::transmute_copy(&param0), ::core::mem::transmute_copy(&param1)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateDevice: CreateDevice::<Identity, Impl, OFFSET>,
             EnumDevices: EnumDevices::<Identity, Impl, OFFSET>,
             GetDeviceStatus: GetDeviceStatus::<Identity, Impl, OFFSET>,
@@ -674,7 +674,7 @@ impl IDirectInputDevice8A_Vtbl {
             this.GetImageInfo(::core::mem::transmute_copy(&param0)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCapabilities: GetCapabilities::<Identity, Impl, OFFSET>,
             EnumObjects: EnumObjects::<Identity, Impl, OFFSET>,
             GetProperty: GetProperty::<Identity, Impl, OFFSET>,
@@ -893,7 +893,7 @@ impl IDirectInputDevice8W_Vtbl {
             this.GetImageInfo(::core::mem::transmute_copy(&param0)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCapabilities: GetCapabilities::<Identity, Impl, OFFSET>,
             EnumObjects: EnumObjects::<Identity, Impl, OFFSET>,
             GetProperty: GetProperty::<Identity, Impl, OFFSET>,
@@ -1028,7 +1028,7 @@ impl IDirectInputDeviceA_Vtbl {
             this.Initialize(::core::mem::transmute_copy(&param0), ::core::mem::transmute_copy(&param1), ::core::mem::transmute_copy(&param2)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCapabilities: GetCapabilities::<Identity, Impl, OFFSET>,
             EnumObjects: EnumObjects::<Identity, Impl, OFFSET>,
             GetProperty: GetProperty::<Identity, Impl, OFFSET>,
@@ -1149,7 +1149,7 @@ impl IDirectInputDeviceW_Vtbl {
             this.Initialize(::core::mem::transmute_copy(&param0), ::core::mem::transmute_copy(&param1), ::core::mem::transmute_copy(&param2)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCapabilities: GetCapabilities::<Identity, Impl, OFFSET>,
             EnumObjects: EnumObjects::<Identity, Impl, OFFSET>,
             GetProperty: GetProperty::<Identity, Impl, OFFSET>,
@@ -1240,7 +1240,7 @@ impl IDirectInputEffect_Vtbl {
             this.Escape(::core::mem::transmute_copy(&param0)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             GetEffectGuid: GetEffectGuid::<Identity, Impl, OFFSET>,
             GetParameters: GetParameters::<Identity, Impl, OFFSET>,
@@ -1329,7 +1329,7 @@ impl IDirectInputEffectDriver_Vtbl {
             this.GetEffectStatus(::core::mem::transmute_copy(&param0), ::core::mem::transmute_copy(&param1), ::core::mem::transmute_copy(&param2)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             DeviceID: DeviceID::<Identity, Impl, OFFSET>,
             GetVersions: GetVersions::<Identity, Impl, OFFSET>,
             Escape: Escape::<Identity, Impl, OFFSET>,
@@ -1452,7 +1452,7 @@ impl IDirectInputJoyConfig_Vtbl {
             this.OpenConfigKey(::core::mem::transmute_copy(&param0), ::core::mem::transmute_copy(&param1), ::core::mem::transmute_copy(&param2)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Acquire: Acquire::<Identity, Impl, OFFSET>,
             Unacquire: Unacquire::<Identity, Impl, OFFSET>,
             SetCooperativeLevel: SetCooperativeLevel::<Identity, Impl, OFFSET>,
@@ -1580,7 +1580,7 @@ impl IDirectInputJoyConfig8_Vtbl {
             this.OpenAppStatusKey(::core::mem::transmute_copy(&param0)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Acquire: Acquire::<Identity, Impl, OFFSET>,
             Unacquire: Unacquire::<Identity, Impl, OFFSET>,
             SetCooperativeLevel: SetCooperativeLevel::<Identity, Impl, OFFSET>,
@@ -1642,7 +1642,7 @@ impl IDirectInputW_Vtbl {
             this.Initialize(::core::mem::transmute_copy(&param0), ::core::mem::transmute_copy(&param1)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateDevice: CreateDevice::<Identity, Impl, OFFSET>,
             EnumDevices: EnumDevices::<Identity, Impl, OFFSET>,
             GetDeviceStatus: GetDeviceStatus::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/Devices/HumanInterfaceDevice/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/HumanInterfaceDevice/mod.rs
@@ -1041,7 +1041,7 @@ unsafe impl ::windows::core::Interface for IDirectInput8A {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectInput8A_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateDevice: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: *const ::windows::core::GUID, param1: *mut *mut ::core::ffi::c_void, param2: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub EnumDevices: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: u32, param1: *mut ::core::ffi::c_void, param2: *mut ::core::ffi::c_void, param3: u32) -> ::windows::core::HRESULT,
@@ -1158,7 +1158,7 @@ unsafe impl ::windows::core::Interface for IDirectInput8W {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectInput8W_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateDevice: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: *const ::windows::core::GUID, param1: *mut *mut ::core::ffi::c_void, param2: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub EnumDevices: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: u32, param1: *mut ::core::ffi::c_void, param2: *mut ::core::ffi::c_void, param3: u32) -> ::windows::core::HRESULT,
@@ -1256,7 +1256,7 @@ unsafe impl ::windows::core::Interface for IDirectInputA {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectInputA_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateDevice: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: *const ::windows::core::GUID, param1: *mut *mut ::core::ffi::c_void, param2: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub EnumDevices: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: u32, param1: *mut ::core::ffi::c_void, param2: *mut ::core::ffi::c_void, param3: u32) -> ::windows::core::HRESULT,
@@ -2226,7 +2226,7 @@ unsafe impl ::windows::core::Interface for IDirectInputDevice8A {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectInputDevice8A_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCapabilities: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: *mut DIDEVCAPS) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub EnumObjects: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: *mut ::core::ffi::c_void, param1: *mut ::core::ffi::c_void, param2: u32) -> ::windows::core::HRESULT,
@@ -2483,7 +2483,7 @@ unsafe impl ::windows::core::Interface for IDirectInputDevice8W {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectInputDevice8W_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCapabilities: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: *mut DIDEVCAPS) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub EnumObjects: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: *mut ::core::ffi::c_void, param1: *mut ::core::ffi::c_void, param2: u32) -> ::windows::core::HRESULT,
@@ -2664,7 +2664,7 @@ unsafe impl ::windows::core::Interface for IDirectInputDeviceA {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectInputDeviceA_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCapabilities: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: *mut DIDEVCAPS) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub EnumObjects: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: *mut ::core::ffi::c_void, param1: *mut ::core::ffi::c_void, param2: u32) -> ::windows::core::HRESULT,
@@ -2812,7 +2812,7 @@ unsafe impl ::windows::core::Interface for IDirectInputDeviceW {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectInputDeviceW_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCapabilities: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: *mut DIDEVCAPS) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub EnumObjects: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: *mut ::core::ffi::c_void, param1: *mut ::core::ffi::c_void, param2: u32) -> ::windows::core::HRESULT,
@@ -2922,7 +2922,7 @@ unsafe impl ::windows::core::Interface for IDirectInputEffect {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectInputEffect_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: super::super::Foundation::HINSTANCE, param1: u32, param2: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -3013,7 +3013,7 @@ unsafe impl ::windows::core::Interface for IDirectInputEffectDriver {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectInputEffectDriver_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub DeviceID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: u32, param1: u32, param2: u32, param3: u32, param4: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetVersions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: *mut DIDRIVERVERSIONS) -> ::windows::core::HRESULT,
     pub Escape: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: u32, param1: u32, param2: *mut DIEFFESCAPE) -> ::windows::core::HRESULT,
@@ -3145,7 +3145,7 @@ unsafe impl ::windows::core::Interface for IDirectInputJoyConfig {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectInputJoyConfig_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Acquire: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Unacquire: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -3298,7 +3298,7 @@ unsafe impl ::windows::core::Interface for IDirectInputJoyConfig8 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectInputJoyConfig8_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Acquire: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Unacquire: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -3404,7 +3404,7 @@ unsafe impl ::windows::core::Interface for IDirectInputW {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectInputW_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateDevice: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: *const ::windows::core::GUID, param1: *mut *mut ::core::ffi::c_void, param2: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub EnumDevices: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: u32, param1: *mut ::core::ffi::c_void, param2: *mut ::core::ffi::c_void, param3: u32) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/Devices/ImageAcquisition/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/ImageAcquisition/impl.rs
@@ -46,7 +46,7 @@ impl IEnumWIA_DEV_CAPS_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -106,7 +106,7 @@ impl IEnumWIA_DEV_INFO_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -166,7 +166,7 @@ impl IEnumWIA_FORMAT_INFO_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -226,7 +226,7 @@ impl IEnumWiaItem_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -286,7 +286,7 @@ impl IEnumWiaItem2_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -325,7 +325,7 @@ impl IWiaAppErrorHandler_Vtbl {
             this.ReportStatus(::core::mem::transmute_copy(&lflags), ::core::mem::transmute(&pwiaitem2), ::core::mem::transmute_copy(&hrstatus), ::core::mem::transmute_copy(&lpercentcomplete)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetWindow: GetWindow::<Identity, Impl, OFFSET>,
             ReportStatus: ReportStatus::<Identity, Impl, OFFSET>,
         }
@@ -345,7 +345,7 @@ impl IWiaDataCallback_Vtbl {
             let this = (*this).get_impl();
             this.BandedDataCallback(::core::mem::transmute_copy(&lmessage), ::core::mem::transmute_copy(&lstatus), ::core::mem::transmute_copy(&lpercentcomplete), ::core::mem::transmute_copy(&loffset), ::core::mem::transmute_copy(&llength), ::core::mem::transmute_copy(&lreserved), ::core::mem::transmute_copy(&lreslength), ::core::mem::transmute_copy(&pbbuffer)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), BandedDataCallback: BandedDataCallback::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), BandedDataCallback: BandedDataCallback::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWiaDataCallback as ::windows::core::Interface>::IID
@@ -402,7 +402,7 @@ impl IWiaDataTransfer_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             idtGetData: idtGetData::<Identity, Impl, OFFSET>,
             idtGetBandedData: idtGetBandedData::<Identity, Impl, OFFSET>,
             idtQueryGetData: idtQueryGetData::<Identity, Impl, OFFSET>,
@@ -495,7 +495,7 @@ impl IWiaDevMgr_Vtbl {
             this.AddDeviceDlg(::core::mem::transmute_copy(&hwndparent), ::core::mem::transmute_copy(&lflags)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             EnumDeviceInfo: EnumDeviceInfo::<Identity, Impl, OFFSET>,
             CreateDevice: CreateDevice::<Identity, Impl, OFFSET>,
             SelectDeviceDlg: SelectDeviceDlg::<Identity, Impl, OFFSET>,
@@ -586,7 +586,7 @@ impl IWiaDevMgr2_Vtbl {
             this.GetImageDlg(::core::mem::transmute_copy(&lflags), ::core::mem::transmute(&bstrdeviceid), ::core::mem::transmute_copy(&hwndparent), ::core::mem::transmute(&bstrfoldername), ::core::mem::transmute(&bstrfilename), ::core::mem::transmute_copy(&plnumfiles), ::core::mem::transmute_copy(&ppbstrfilepaths), ::core::mem::transmute_copy(&ppitem)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             EnumDeviceInfo: EnumDeviceInfo::<Identity, Impl, OFFSET>,
             CreateDevice: CreateDevice::<Identity, Impl, OFFSET>,
             SelectDeviceDlg: SelectDeviceDlg::<Identity, Impl, OFFSET>,
@@ -745,7 +745,7 @@ impl IWiaDrvItem_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetItemFlags: GetItemFlags::<Identity, Impl, OFFSET>,
             GetDeviceSpecContext: GetDeviceSpecContext::<Identity, Impl, OFFSET>,
             GetFullItemName: GetFullItemName::<Identity, Impl, OFFSET>,
@@ -792,7 +792,7 @@ impl IWiaErrorHandler_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ReportStatus: ReportStatus::<Identity, Impl, OFFSET>,
             GetStatusDescription: GetStatusDescription::<Identity, Impl, OFFSET>,
         }
@@ -812,7 +812,7 @@ impl IWiaEventCallback_Vtbl {
             let this = (*this).get_impl();
             this.ImageEventCallback(::core::mem::transmute_copy(&peventguid), ::core::mem::transmute(&bstreventdescription), ::core::mem::transmute(&bstrdeviceid), ::core::mem::transmute(&bstrdevicedescription), ::core::mem::transmute_copy(&dwdevicetype), ::core::mem::transmute(&bstrfullitemname), ::core::mem::transmute_copy(&puleventtype), ::core::mem::transmute_copy(&ulreserved)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), ImageEventCallback: ImageEventCallback::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), ImageEventCallback: ImageEventCallback::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWiaEventCallback as ::windows::core::Interface>::IID
@@ -851,7 +851,7 @@ impl IWiaImageFilter_Vtbl {
             this.ApplyProperties(::core::mem::transmute(&pwiapropertystorage)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             InitializeFilter: InitializeFilter::<Identity, Impl, OFFSET>,
             SetNewCallback: SetNewCallback::<Identity, Impl, OFFSET>,
             FilterPreviewImage: FilterPreviewImage::<Identity, Impl, OFFSET>,
@@ -1021,7 +1021,7 @@ impl IWiaItem_Vtbl {
             this.Diagnostic(::core::mem::transmute_copy(&ulsize), ::core::mem::transmute_copy(&pbuffer)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetItemType: GetItemType::<Identity, Impl, OFFSET>,
             AnalyzeItem: AnalyzeItem::<Identity, Impl, OFFSET>,
             EnumChildItems: EnumChildItems::<Identity, Impl, OFFSET>,
@@ -1208,7 +1208,7 @@ impl IWiaItem2_Vtbl {
             this.Diagnostic(::core::mem::transmute_copy(&ulsize), ::core::mem::transmute_copy(&pbuffer)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateChildItem: CreateChildItem::<Identity, Impl, OFFSET>,
             DeleteItem: DeleteItem::<Identity, Impl, OFFSET>,
             EnumChildItems: EnumChildItems::<Identity, Impl, OFFSET>,
@@ -1261,7 +1261,7 @@ impl IWiaItemExtras_Vtbl {
             this.CancelPendingIO().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetExtendedErrorInfo: GetExtendedErrorInfo::<Identity, Impl, OFFSET>,
             Escape: Escape::<Identity, Impl, OFFSET>,
             CancelPendingIO: CancelPendingIO::<Identity, Impl, OFFSET>,
@@ -1295,7 +1295,7 @@ impl IWiaLog_Vtbl {
             this.Log(::core::mem::transmute_copy(&lflags), ::core::mem::transmute_copy(&lresid), ::core::mem::transmute_copy(&ldetail), ::core::mem::transmute(&bstrtext)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             InitializeLog: InitializeLog::<Identity, Impl, OFFSET>,
             hResult: hResult::<Identity, Impl, OFFSET>,
             Log: Log::<Identity, Impl, OFFSET>,
@@ -1341,7 +1341,7 @@ impl IWiaLogEx_Vtbl {
             this.LogEx(::core::mem::transmute_copy(&lmethodid), ::core::mem::transmute_copy(&lflags), ::core::mem::transmute_copy(&lresid), ::core::mem::transmute_copy(&ldetail), ::core::mem::transmute(&bstrtext)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             InitializeLogEx: InitializeLogEx::<Identity, Impl, OFFSET>,
             hResult: hResult::<Identity, Impl, OFFSET>,
             Log: Log::<Identity, Impl, OFFSET>,
@@ -1513,7 +1513,7 @@ impl IWiaMiniDrv_Vtbl {
             this.drvUnInitializeWia(::core::mem::transmute_copy(&__midl__iwiaminidrv0064)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             drvInitializeWia: drvInitializeWia::<Identity, Impl, OFFSET>,
             drvAcquireItemData: drvAcquireItemData::<Identity, Impl, OFFSET>,
             drvInitItemProperties: drvInitItemProperties::<Identity, Impl, OFFSET>,
@@ -1551,7 +1551,7 @@ impl IWiaMiniDrvCallBack_Vtbl {
             let this = (*this).get_impl();
             this.MiniDrvCallback(::core::mem::transmute_copy(&lreason), ::core::mem::transmute_copy(&lstatus), ::core::mem::transmute_copy(&lpercentcomplete), ::core::mem::transmute_copy(&loffset), ::core::mem::transmute_copy(&llength), ::core::mem::transmute_copy(&ptranctx), ::core::mem::transmute_copy(&lreserved)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), MiniDrvCallback: MiniDrvCallback::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), MiniDrvCallback: MiniDrvCallback::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWiaMiniDrvCallBack as ::windows::core::Interface>::IID
@@ -1584,7 +1584,7 @@ impl IWiaMiniDrvTransferCallback_Vtbl {
             this.SendMessage(::core::mem::transmute_copy(&lflags), ::core::mem::transmute_copy(&pwiatransferparams)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetNextStream: GetNextStream::<Identity, Impl, OFFSET>,
             SendMessage: SendMessage::<Identity, Impl, OFFSET>,
         }
@@ -1604,7 +1604,7 @@ impl IWiaNotifyDevMgr_Vtbl {
             let this = (*this).get_impl();
             this.NewDeviceArrival().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), NewDeviceArrival: NewDeviceArrival::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), NewDeviceArrival: NewDeviceArrival::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWiaNotifyDevMgr as ::windows::core::Interface>::IID
@@ -1640,7 +1640,7 @@ impl IWiaPreview_Vtbl {
             this.Clear().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetNewPreview: GetNewPreview::<Identity, Impl, OFFSET>,
             UpdatePreview: UpdatePreview::<Identity, Impl, OFFSET>,
             DetectRegions: DetectRegions::<Identity, Impl, OFFSET>,
@@ -1786,7 +1786,7 @@ impl IWiaPropertyStorage_Vtbl {
             this.SetPropertyStream(::core::mem::transmute_copy(&pcompatibilityid), ::core::mem::transmute(&pistream)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ReadMultiple: ReadMultiple::<Identity, Impl, OFFSET>,
             WriteMultiple: WriteMultiple::<Identity, Impl, OFFSET>,
             DeleteMultiple: DeleteMultiple::<Identity, Impl, OFFSET>,
@@ -1823,7 +1823,7 @@ impl IWiaSegmentationFilter_Vtbl {
             let this = (*this).get_impl();
             this.DetectRegions(::core::mem::transmute_copy(&lflags), ::core::mem::transmute(&pinputstream), ::core::mem::transmute(&pwiaitem2)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), DetectRegions: DetectRegions::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), DetectRegions: DetectRegions::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWiaSegmentationFilter as ::windows::core::Interface>::IID
@@ -1868,7 +1868,7 @@ impl IWiaTransfer_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Download: Download::<Identity, Impl, OFFSET>,
             Upload: Upload::<Identity, Impl, OFFSET>,
             Cancel: Cancel::<Identity, Impl, OFFSET>,
@@ -1906,7 +1906,7 @@ impl IWiaTransferCallback_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             TransferCallback: TransferCallback::<Identity, Impl, OFFSET>,
             GetNextStream: GetNextStream::<Identity, Impl, OFFSET>,
         }
@@ -1942,7 +1942,7 @@ impl IWiaUIExtension_Vtbl {
             this.GetDeviceBitmapLogo(::core::mem::transmute(&bstrdeviceid), ::core::mem::transmute_copy(&phbitmap), ::core::mem::transmute_copy(&nmaxwidth), ::core::mem::transmute_copy(&nmaxheight)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             DeviceDialog: DeviceDialog::<Identity, Impl, OFFSET>,
             GetDeviceIcon: GetDeviceIcon::<Identity, Impl, OFFSET>,
             GetDeviceBitmapLogo: GetDeviceBitmapLogo::<Identity, Impl, OFFSET>,
@@ -1973,7 +1973,7 @@ impl IWiaUIExtension2_Vtbl {
             this.GetDeviceIcon(::core::mem::transmute(&bstrdeviceid), ::core::mem::transmute_copy(&phicon), ::core::mem::transmute_copy(&nsize)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             DeviceDialog: DeviceDialog::<Identity, Impl, OFFSET>,
             GetDeviceIcon: GetDeviceIcon::<Identity, Impl, OFFSET>,
         }
@@ -2093,7 +2093,7 @@ impl IWiaVideo_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             PreviewVisible: PreviewVisible::<Identity, Impl, OFFSET>,
             SetPreviewVisible: SetPreviewVisible::<Identity, Impl, OFFSET>,
             ImagesDirectory: ImagesDirectory::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/Devices/ImageAcquisition/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/ImageAcquisition/mod.rs
@@ -58,7 +58,7 @@ unsafe impl ::windows::core::Interface for IEnumWIA_DEV_CAPS {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumWIA_DEV_CAPS_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut WIA_DEV_CAP, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -125,7 +125,7 @@ unsafe impl ::windows::core::Interface for IEnumWIA_DEV_INFO {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumWIA_DEV_INFO_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -192,7 +192,7 @@ unsafe impl ::windows::core::Interface for IEnumWIA_FORMAT_INFO {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumWIA_FORMAT_INFO_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut WIA_FORMAT_INFO, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -259,7 +259,7 @@ unsafe impl ::windows::core::Interface for IEnumWiaItem {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumWiaItem_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, ppiwiaitem: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -326,7 +326,7 @@ unsafe impl ::windows::core::Interface for IEnumWiaItem2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumWiaItem2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, ppiwiaitem2: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -388,7 +388,7 @@ unsafe impl ::windows::core::Interface for IWiaAppErrorHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWiaAppErrorHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetWindow: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, phwnd: *mut super::super::Foundation::HWND) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -441,7 +441,7 @@ unsafe impl ::windows::core::Interface for IWiaDataCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWiaDataCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub BandedDataCallback: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lmessage: i32, lstatus: i32, lpercentcomplete: i32, loffset: i32, llength: i32, lreserved: i32, lreslength: i32, pbbuffer: *mut u8) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Devices_ImageAcquisition\"`*"]
@@ -514,7 +514,7 @@ unsafe impl ::windows::core::Interface for IWiaDataTransfer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWiaDataTransfer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
     pub idtGetData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pmedium: *mut super::super::System::Com::STGMEDIUM, piwiadatacallback: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage")))]
@@ -624,7 +624,7 @@ unsafe impl ::windows::core::Interface for IWiaDevMgr {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWiaDevMgr_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub EnumDeviceInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lflag: i32, ppienum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CreateDevice: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrdeviceid: ::core::mem::ManuallyDrop<::windows::core::BSTR>, ppwiaitemroot: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -735,7 +735,7 @@ unsafe impl ::windows::core::Interface for IWiaDevMgr2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWiaDevMgr2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub EnumDeviceInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lflags: i32, ppienum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CreateDevice: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lflags: i32, bstrdeviceid: ::core::mem::ManuallyDrop<::windows::core::BSTR>, ppwiaitem2root: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -849,7 +849,7 @@ unsafe impl ::windows::core::Interface for IWiaDrvItem {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWiaDrvItem_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetItemFlags: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, __midl__iwiadrvitem0000: *mut i32) -> ::windows::core::HRESULT,
     pub GetDeviceSpecContext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, __midl__iwiadrvitem0001: *mut *mut u8) -> ::windows::core::HRESULT,
     pub GetFullItemName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, __midl__iwiadrvitem0002: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
@@ -923,7 +923,7 @@ unsafe impl ::windows::core::Interface for IWiaErrorHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWiaErrorHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub ReportStatus: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lflags: i32, hwndparent: super::super::Foundation::HWND, pwiaitem2: *mut ::core::ffi::c_void, hrstatus: ::windows::core::HRESULT, lpercentcomplete: i32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -976,7 +976,7 @@ unsafe impl ::windows::core::Interface for IWiaEventCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWiaEventCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ImageEventCallback: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, peventguid: *const ::windows::core::GUID, bstreventdescription: ::core::mem::ManuallyDrop<::windows::core::BSTR>, bstrdeviceid: ::core::mem::ManuallyDrop<::windows::core::BSTR>, bstrdevicedescription: ::core::mem::ManuallyDrop<::windows::core::BSTR>, dwdevicetype: u32, bstrfullitemname: ::core::mem::ManuallyDrop<::windows::core::BSTR>, puleventtype: *mut u32, ulreserved: u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Devices_ImageAcquisition\"`*"]
@@ -1050,7 +1050,7 @@ unsafe impl ::windows::core::Interface for IWiaImageFilter {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWiaImageFilter_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub InitializeFilter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwiaitem2: *mut ::core::ffi::c_void, pwiatransfercallback: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetNewCallback: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwiatransfercallback: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
@@ -1162,7 +1162,7 @@ unsafe impl ::windows::core::Interface for IWiaItem {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWiaItem_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetItemType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pitemtype: *mut i32) -> ::windows::core::HRESULT,
     pub AnalyzeItem: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lflags: i32) -> ::windows::core::HRESULT,
     pub EnumChildItems: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppienumwiaitem: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1290,7 +1290,7 @@ unsafe impl ::windows::core::Interface for IWiaItem2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWiaItem2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateChildItem: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, litemflags: i32, lcreationflags: i32, bstritemname: ::core::mem::ManuallyDrop<::windows::core::BSTR>, ppiwiaitem2: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub DeleteItem: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lflags: i32) -> ::windows::core::HRESULT,
     pub EnumChildItems: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcategoryguid: *const ::windows::core::GUID, ppienumwiaitem2: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1367,7 +1367,7 @@ unsafe impl ::windows::core::Interface for IWiaItemExtras {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWiaItemExtras_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetExtendedErrorInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrerrortext: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub Escape: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwescapecode: u32, lpindata: *const u8, cbindatasize: u32, poutdata: *mut u8, dwoutdatasize: u32, pdwactualdatasize: *mut u32) -> ::windows::core::HRESULT,
     pub CancelPendingIO: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1424,7 +1424,7 @@ unsafe impl ::windows::core::Interface for IWiaLog {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWiaLog_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub InitializeLog: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hinstance: i32) -> ::windows::core::HRESULT,
     pub hResult: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hresult: ::windows::core::HRESULT) -> ::windows::core::HRESULT,
     pub Log: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lflags: i32, lresid: i32, ldetail: i32, bstrtext: ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
@@ -1487,7 +1487,7 @@ unsafe impl ::windows::core::Interface for IWiaLogEx {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWiaLogEx_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub InitializeLogEx: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hinstance: *const u8) -> ::windows::core::HRESULT,
     pub hResult: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hresult: ::windows::core::HRESULT) -> ::windows::core::HRESULT,
     pub Log: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lflags: i32, lresid: i32, ldetail: i32, bstrtext: ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
@@ -1608,7 +1608,7 @@ unsafe impl ::windows::core::Interface for IWiaMiniDrv {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWiaMiniDrv_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub drvInitializeWia: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, __midl__iwiaminidrv0000: *const u8, __midl__iwiaminidrv0001: i32, __midl__iwiaminidrv0002: ::core::mem::ManuallyDrop<::windows::core::BSTR>, __midl__iwiaminidrv0003: ::core::mem::ManuallyDrop<::windows::core::BSTR>, __midl__iwiaminidrv0004: *mut ::core::ffi::c_void, __midl__iwiaminidrv0005: *mut ::core::ffi::c_void, __midl__iwiaminidrv0006: *mut *mut ::core::ffi::c_void, __midl__iwiaminidrv0007: *mut *mut ::core::ffi::c_void, __midl__iwiaminidrv0008: *mut i32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub drvAcquireItemData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, __midl__iwiaminidrv0009: *const u8, __midl__iwiaminidrv0010: i32, __midl__iwiaminidrv0011: *mut MINIDRV_TRANSFER_CONTEXT, __midl__iwiaminidrv0012: *mut i32) -> ::windows::core::HRESULT,
@@ -1687,7 +1687,7 @@ unsafe impl ::windows::core::Interface for IWiaMiniDrvCallBack {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWiaMiniDrvCallBack_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub MiniDrvCallback: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lreason: i32, lstatus: i32, lpercentcomplete: i32, loffset: i32, llength: i32, ptranctx: *const MINIDRV_TRANSFER_CONTEXT, lreserved: i32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -1745,7 +1745,7 @@ unsafe impl ::windows::core::Interface for IWiaMiniDrvTransferCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWiaMiniDrvTransferCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub GetNextStream: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lflags: i32, bstritemname: ::core::mem::ManuallyDrop<::windows::core::BSTR>, bstrfullitemname: ::core::mem::ManuallyDrop<::windows::core::BSTR>, ppistream: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -1798,7 +1798,7 @@ unsafe impl ::windows::core::Interface for IWiaNotifyDevMgr {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWiaNotifyDevMgr_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub NewDeviceArrival: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Devices_ImageAcquisition\"`*"]
@@ -1864,7 +1864,7 @@ unsafe impl ::windows::core::Interface for IWiaPreview {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWiaPreview_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetNewPreview: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lflags: i32, pwiaitem2: *mut ::core::ffi::c_void, pwiatransfercallback: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub UpdatePreview: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lflags: i32, pchildwiaitem2: *mut ::core::ffi::c_void, pwiatransfercallback: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub DetectRegions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lflags: i32) -> ::windows::core::HRESULT,
@@ -1987,7 +1987,7 @@ unsafe impl ::windows::core::Interface for IWiaPropertyStorage {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWiaPropertyStorage_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
     pub ReadMultiple: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cpspec: u32, rgpspec: *const super::super::System::Com::StructuredStorage::PROPSPEC, rgpropvar: *mut super::super::System::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage")))]
@@ -2084,7 +2084,7 @@ unsafe impl ::windows::core::Interface for IWiaSegmentationFilter {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWiaSegmentationFilter_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub DetectRegions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lflags: i32, pinputstream: *mut ::core::ffi::c_void, pwiaitem2: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -2155,7 +2155,7 @@ unsafe impl ::windows::core::Interface for IWiaTransfer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWiaTransfer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Download: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lflags: i32, piwiatransfercallback: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
     pub Upload: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lflags: i32, psource: *mut ::core::ffi::c_void, piwiatransfercallback: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -2216,7 +2216,7 @@ unsafe impl ::windows::core::Interface for IWiaTransferCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWiaTransferCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub TransferCallback: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lflags: i32, pwiatransferparams: *const WiaTransferParams) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
     pub GetNextStream: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lflags: i32, bstritemname: ::core::mem::ManuallyDrop<::windows::core::BSTR>, bstrfullitemname: ::core::mem::ManuallyDrop<::windows::core::BSTR>, ppdestination: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -2281,7 +2281,7 @@ unsafe impl ::windows::core::Interface for IWiaUIExtension {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWiaUIExtension_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub DeviceDialog: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdevicedialogdata: *const DEVICEDIALOGDATA) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -2348,7 +2348,7 @@ unsafe impl ::windows::core::Interface for IWiaUIExtension2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWiaUIExtension2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub DeviceDialog: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdevicedialogdata: *const DEVICEDIALOGDATA2) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -2477,7 +2477,7 @@ unsafe impl ::windows::core::Interface for IWiaVideo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWiaVideo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub PreviewVisible: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbpreviewvisible: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]

--- a/crates/libs/windows/src/Windows/Win32/Devices/PortableDevices/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/PortableDevices/impl.rs
@@ -9,7 +9,7 @@ impl IConnectionRequestCallback_Vtbl {
             let this = (*this).get_impl();
             this.OnComplete(::core::mem::transmute_copy(&hrstatus)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnComplete: OnComplete::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnComplete: OnComplete::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IConnectionRequestCallback as ::windows::core::Interface>::IID
@@ -51,7 +51,7 @@ impl IEnumPortableDeviceConnectors_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -104,7 +104,7 @@ impl IEnumPortableDeviceObjectIDs_Vtbl {
             this.Cancel().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -140,7 +140,7 @@ impl IMediaRadioManager_Vtbl {
             this.OnSystemRadioStateChange(::core::mem::transmute_copy(&sysradiostate), ::core::mem::transmute_copy(&utimeoutsec)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetRadioInstances: GetRadioInstances::<Identity, Impl, OFFSET>,
             OnSystemRadioStateChange: OnSystemRadioStateChange::<Identity, Impl, OFFSET>,
         }
@@ -173,7 +173,7 @@ impl IMediaRadioManagerNotifySink_Vtbl {
             this.OnInstanceRadioChange(::core::mem::transmute(&bstrradioinstanceid), ::core::mem::transmute_copy(&radiostate)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnInstanceAdd: OnInstanceAdd::<Identity, Impl, OFFSET>,
             OnInstanceRemove: OnInstanceRemove::<Identity, Impl, OFFSET>,
             OnInstanceRadioChange: OnInstanceRadioChange::<Identity, Impl, OFFSET>,
@@ -273,7 +273,7 @@ impl IPortableDevice_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Open: Open::<Identity, Impl, OFFSET>,
             SendCommand: SendCommand::<Identity, Impl, OFFSET>,
             Content: Content::<Identity, Impl, OFFSET>,
@@ -424,7 +424,7 @@ impl IPortableDeviceCapabilities_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSupportedCommands: GetSupportedCommands::<Identity, Impl, OFFSET>,
             GetCommandOptions: GetCommandOptions::<Identity, Impl, OFFSET>,
             GetFunctionalCategories: GetFunctionalCategories::<Identity, Impl, OFFSET>,
@@ -493,7 +493,7 @@ impl IPortableDeviceConnector_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Connect: Connect::<Identity, Impl, OFFSET>,
             Disconnect: Disconnect::<Identity, Impl, OFFSET>,
             Cancel: Cancel::<Identity, Impl, OFFSET>,
@@ -599,7 +599,7 @@ impl IPortableDeviceContent_Vtbl {
             this.Copy(::core::mem::transmute(&pobjectids), ::core::mem::transmute(&pszdestinationfolderobjectid), ::core::mem::transmute_copy(&ppresults)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             EnumObjects: EnumObjects::<Identity, Impl, OFFSET>,
             Properties: Properties::<Identity, Impl, OFFSET>,
             Transfer: Transfer::<Identity, Impl, OFFSET>,
@@ -695,7 +695,7 @@ impl IPortableDeviceDispatchFactory_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetDeviceDispatch: GetDeviceDispatch::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetDeviceDispatch: GetDeviceDispatch::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IPortableDeviceDispatchFactory as ::windows::core::Interface>::IID
@@ -712,7 +712,7 @@ impl IPortableDeviceEventCallback_Vtbl {
             let this = (*this).get_impl();
             this.OnEvent(::core::mem::transmute(&peventparameters)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnEvent: OnEvent::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnEvent: OnEvent::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IPortableDeviceEventCallback as ::windows::core::Interface>::IID
@@ -757,7 +757,7 @@ impl IPortableDeviceKeyCollection_Vtbl {
             this.RemoveAt(::core::mem::transmute_copy(&dwindex)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCount: GetCount::<Identity, Impl, OFFSET>,
             GetAt: GetAt::<Identity, Impl, OFFSET>,
             Add: Add::<Identity, Impl, OFFSET>,
@@ -817,7 +817,7 @@ impl IPortableDeviceManager_Vtbl {
             this.GetPrivateDevices(::core::mem::transmute_copy(&ppnpdeviceids), ::core::mem::transmute_copy(&pcpnpdeviceids)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDevices: GetDevices::<Identity, Impl, OFFSET>,
             RefreshDeviceList: RefreshDeviceList::<Identity, Impl, OFFSET>,
             GetDeviceFriendlyName: GetDeviceFriendlyName::<Identity, Impl, OFFSET>,
@@ -888,7 +888,7 @@ impl IPortableDevicePropVariantCollection_Vtbl {
             this.RemoveAt(::core::mem::transmute_copy(&dwindex)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCount: GetCount::<Identity, Impl, OFFSET>,
             GetAt: GetAt::<Identity, Impl, OFFSET>,
             Add: Add::<Identity, Impl, OFFSET>,
@@ -971,7 +971,7 @@ impl IPortableDeviceProperties_Vtbl {
             this.Cancel().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSupportedProperties: GetSupportedProperties::<Identity, Impl, OFFSET>,
             GetPropertyAttributes: GetPropertyAttributes::<Identity, Impl, OFFSET>,
             GetValues: GetValues::<Identity, Impl, OFFSET>,
@@ -1038,7 +1038,7 @@ impl IPortableDevicePropertiesBulk_Vtbl {
             this.Cancel(::core::mem::transmute_copy(&pcontext)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             QueueGetValuesByObjectList: QueueGetValuesByObjectList::<Identity, Impl, OFFSET>,
             QueueGetValuesByObjectFormat: QueueGetValuesByObjectFormat::<Identity, Impl, OFFSET>,
             QueueSetValuesByObjectList: QueueSetValuesByObjectList::<Identity, Impl, OFFSET>,
@@ -1074,7 +1074,7 @@ impl IPortableDevicePropertiesBulkCallback_Vtbl {
             this.OnEnd(::core::mem::transmute_copy(&pcontext), ::core::mem::transmute_copy(&hrstatus)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnStart: OnStart::<Identity, Impl, OFFSET>,
             OnProgress: OnProgress::<Identity, Impl, OFFSET>,
             OnEnd: OnEnd::<Identity, Impl, OFFSET>,
@@ -1141,7 +1141,7 @@ impl IPortableDeviceResources_Vtbl {
             this.CreateResource(::core::mem::transmute(&presourceattributes), ::core::mem::transmute_copy(&ppdata), ::core::mem::transmute_copy(&pdwoptimalwritebuffersize), ::core::mem::transmute_copy(&ppszcookie)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSupportedResources: GetSupportedResources::<Identity, Impl, OFFSET>,
             GetResourceAttributes: GetResourceAttributes::<Identity, Impl, OFFSET>,
             GetStream: GetStream::<Identity, Impl, OFFSET>,
@@ -1268,7 +1268,7 @@ impl IPortableDeviceService_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Open: Open::<Identity, Impl, OFFSET>,
             Capabilities: Capabilities::<Identity, Impl, OFFSET>,
             Content: Content::<Identity, Impl, OFFSET>,
@@ -1304,7 +1304,7 @@ impl IPortableDeviceServiceActivation_Vtbl {
             this.CancelOpenAsync().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OpenAsync: OpenAsync::<Identity, Impl, OFFSET>,
             CancelOpenAsync: CancelOpenAsync::<Identity, Impl, OFFSET>,
         }
@@ -1508,7 +1508,7 @@ impl IPortableDeviceServiceCapabilities_Vtbl {
             this.Cancel().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSupportedMethods: GetSupportedMethods::<Identity, Impl, OFFSET>,
             GetSupportedMethodsByFormat: GetSupportedMethodsByFormat::<Identity, Impl, OFFSET>,
             GetMethodAttributes: GetMethodAttributes::<Identity, Impl, OFFSET>,
@@ -1555,7 +1555,7 @@ impl IPortableDeviceServiceManager_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDeviceServices: GetDeviceServices::<Identity, Impl, OFFSET>,
             GetDeviceForService: GetDeviceForService::<Identity, Impl, OFFSET>,
         }
@@ -1575,7 +1575,7 @@ impl IPortableDeviceServiceMethodCallback_Vtbl {
             let this = (*this).get_impl();
             this.OnComplete(::core::mem::transmute_copy(&hrstatus), ::core::mem::transmute(&presults)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnComplete: OnComplete::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnComplete: OnComplete::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IPortableDeviceServiceMethodCallback as ::windows::core::Interface>::IID
@@ -1605,7 +1605,7 @@ impl IPortableDeviceServiceMethods_Vtbl {
             this.Cancel(::core::mem::transmute(&pcallback)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Invoke: Invoke::<Identity, Impl, OFFSET>,
             InvokeAsync: InvokeAsync::<Identity, Impl, OFFSET>,
             Cancel: Cancel::<Identity, Impl, OFFSET>,
@@ -1626,7 +1626,7 @@ impl IPortableDeviceServiceOpenCallback_Vtbl {
             let this = (*this).get_impl();
             this.OnComplete(::core::mem::transmute_copy(&hrstatus)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnComplete: OnComplete::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnComplete: OnComplete::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IPortableDeviceServiceOpenCallback as ::windows::core::Interface>::IID
@@ -1656,7 +1656,7 @@ impl IPortableDeviceUnitsStream_Vtbl {
             this.Cancel().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SeekInUnits: SeekInUnits::<Identity, Impl, OFFSET>,
             Cancel: Cancel::<Identity, Impl, OFFSET>,
         }
@@ -2010,7 +2010,7 @@ impl IPortableDeviceValues_Vtbl {
             this.Clear().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCount: GetCount::<Identity, Impl, OFFSET>,
             GetAt: GetAt::<Identity, Impl, OFFSET>,
             SetValue: SetValue::<Identity, Impl, OFFSET>,
@@ -2099,7 +2099,7 @@ impl IPortableDeviceValuesCollection_Vtbl {
             this.RemoveAt(::core::mem::transmute_copy(&dwindex)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCount: GetCount::<Identity, Impl, OFFSET>,
             GetAt: GetAt::<Identity, Impl, OFFSET>,
             Add: Add::<Identity, Impl, OFFSET>,
@@ -2222,7 +2222,7 @@ impl IRadioInstance_Vtbl {
             this.IsAssociatingDevice()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetRadioManagerSignature: GetRadioManagerSignature::<Identity, Impl, OFFSET>,
             GetInstanceSignature: GetInstanceSignature::<Identity, Impl, OFFSET>,
             GetFriendlyName: GetFriendlyName::<Identity, Impl, OFFSET>,
@@ -2266,7 +2266,7 @@ impl IRadioInstanceCollection_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCount: GetCount::<Identity, Impl, OFFSET>,
             GetAt: GetAt::<Identity, Impl, OFFSET>,
         }
@@ -2317,7 +2317,7 @@ impl IWpdSerializer_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetIPortableDeviceValuesFromBuffer: GetIPortableDeviceValuesFromBuffer::<Identity, Impl, OFFSET>,
             WriteIPortableDeviceValuesToBuffer: WriteIPortableDeviceValuesToBuffer::<Identity, Impl, OFFSET>,
             GetBufferFromIPortableDeviceValues: GetBufferFromIPortableDeviceValues::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/Devices/PortableDevices/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/PortableDevices/mod.rs
@@ -57,7 +57,7 @@ unsafe impl ::windows::core::Interface for IConnectionRequestCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IConnectionRequestCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnComplete: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hrstatus: ::windows::core::HRESULT) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Devices_PortableDevices\"`*"]
@@ -116,7 +116,7 @@ unsafe impl ::windows::core::Interface for IEnumPortableDeviceConnectors {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumPortableDeviceConnectors_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, crequested: u32, pconnectors: *mut *mut ::core::ffi::c_void, pcfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cconnectors: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -181,7 +181,7 @@ unsafe impl ::windows::core::Interface for IEnumPortableDeviceObjectIDs {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumPortableDeviceObjectIDs_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cobjects: u32, pobjids: *mut ::windows::core::PWSTR, pcfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cobjects: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -238,7 +238,7 @@ unsafe impl ::windows::core::Interface for IMediaRadioManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMediaRadioManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetRadioInstances: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppcollection: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub OnSystemRadioStateChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sysradiostate: SYSTEM_RADIO_STATE, utimeoutsec: u32) -> ::windows::core::HRESULT,
 }
@@ -297,7 +297,7 @@ unsafe impl ::windows::core::Interface for IMediaRadioManagerNotifySink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMediaRadioManagerNotifySink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnInstanceAdd: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pradioinstance: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub OnInstanceRemove: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrradioinstanceid: ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub OnInstanceRadioChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrradioinstanceid: ::core::mem::ManuallyDrop<::windows::core::BSTR>, radiostate: DEVICE_RADIO_STATE) -> ::windows::core::HRESULT,
@@ -391,7 +391,7 @@ unsafe impl ::windows::core::Interface for IPortableDevice {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPortableDevice_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Open: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszpnpdeviceid: ::windows::core::PCWSTR, pclientinfo: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SendCommand: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwflags: u32, pparameters: *mut ::core::ffi::c_void, ppresults: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Content: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppcontent: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -492,7 +492,7 @@ unsafe impl ::windows::core::Interface for IPortableDeviceCapabilities {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPortableDeviceCapabilities_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetSupportedCommands: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppcommands: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
     pub GetCommandOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, command: *const super::super::UI::Shell::PropertiesSystem::PROPERTYKEY, ppoptions: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -586,7 +586,7 @@ unsafe impl ::windows::core::Interface for IPortableDeviceConnector {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPortableDeviceConnector_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Connect: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcallback: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Disconnect: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcallback: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Cancel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcallback: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -703,7 +703,7 @@ unsafe impl ::windows::core::Interface for IPortableDeviceContent {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPortableDeviceContent_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub EnumObjects: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwflags: u32, pszparentobjectid: ::windows::core::PCWSTR, pfilter: *mut ::core::ffi::c_void, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Properties: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppproperties: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Transfer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppresources: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1064,7 +1064,7 @@ unsafe impl ::windows::core::Interface for IPortableDeviceDispatchFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPortableDeviceDispatchFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub GetDeviceDispatch: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszpnpdeviceid: ::windows::core::PCWSTR, ppdevicedispatch: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -1119,7 +1119,7 @@ unsafe impl ::windows::core::Interface for IPortableDeviceEventCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPortableDeviceEventCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnEvent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, peventparameters: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Devices_PortableDevices\"`*"]
@@ -1184,7 +1184,7 @@ unsafe impl ::windows::core::Interface for IPortableDeviceKeyCollection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPortableDeviceKeyCollection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcelems: *const u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
     pub GetAt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwindex: u32, pkey: *const super::super::UI::Shell::PropertiesSystem::PROPERTYKEY) -> ::windows::core::HRESULT,
@@ -1274,7 +1274,7 @@ unsafe impl ::windows::core::Interface for IPortableDeviceManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPortableDeviceManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDevices: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppnpdeviceids: *mut ::windows::core::PWSTR, pcpnpdeviceids: *mut u32) -> ::windows::core::HRESULT,
     pub RefreshDeviceList: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetDeviceFriendlyName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszpnpdeviceid: ::windows::core::PCWSTR, pdevicefriendlyname: ::windows::core::PWSTR, pcchdevicefriendlyname: *mut u32) -> ::windows::core::HRESULT,
@@ -1352,7 +1352,7 @@ unsafe impl ::windows::core::Interface for IPortableDevicePropVariantCollection 
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPortableDevicePropVariantCollection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcelems: *const u32) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
     pub GetAt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwindex: u32, pvalue: *const super::super::System::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::HRESULT,
@@ -1452,7 +1452,7 @@ unsafe impl ::windows::core::Interface for IPortableDeviceProperties {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPortableDeviceProperties_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetSupportedProperties: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszobjectid: ::windows::core::PCWSTR, ppkeys: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
     pub GetPropertyAttributes: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszobjectid: ::windows::core::PCWSTR, key: *const super::super::UI::Shell::PropertiesSystem::PROPERTYKEY, ppattributes: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1538,7 +1538,7 @@ unsafe impl ::windows::core::Interface for IPortableDevicePropertiesBulk {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPortableDevicePropertiesBulk_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub QueueGetValuesByObjectList: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pobjectids: *mut ::core::ffi::c_void, pkeys: *mut ::core::ffi::c_void, pcallback: *mut ::core::ffi::c_void, pcontext: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub QueueGetValuesByObjectFormat: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pguidobjectformat: *const ::windows::core::GUID, pszparentobjectid: ::windows::core::PCWSTR, dwdepth: u32, pkeys: *mut ::core::ffi::c_void, pcallback: *mut ::core::ffi::c_void, pcontext: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub QueueSetValuesByObjectList: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pobjectvalues: *mut ::core::ffi::c_void, pcallback: *mut ::core::ffi::c_void, pcontext: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
@@ -1600,7 +1600,7 @@ unsafe impl ::windows::core::Interface for IPortableDevicePropertiesBulkCallback
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPortableDevicePropertiesBulkCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnStart: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcontext: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub OnProgress: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcontext: *const ::windows::core::GUID, presults: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub OnEnd: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcontext: *const ::windows::core::GUID, hrstatus: ::windows::core::HRESULT) -> ::windows::core::HRESULT,
@@ -1690,7 +1690,7 @@ unsafe impl ::windows::core::Interface for IPortableDeviceResources {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPortableDeviceResources_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetSupportedResources: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszobjectid: ::windows::core::PCWSTR, ppkeys: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
     pub GetResourceAttributes: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszobjectid: ::windows::core::PCWSTR, key: *const super::super::UI::Shell::PropertiesSystem::PROPERTYKEY, ppresourceattributes: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1804,7 +1804,7 @@ unsafe impl ::windows::core::Interface for IPortableDeviceService {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPortableDeviceService_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Open: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszpnpserviceid: ::windows::core::PCWSTR, pclientinfo: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Capabilities: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppcapabilities: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Content: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppcontent: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1871,7 +1871,7 @@ unsafe impl ::windows::core::Interface for IPortableDeviceServiceActivation {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPortableDeviceServiceActivation_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OpenAsync: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszpnpserviceid: ::windows::core::PCWSTR, pclientinfo: *mut ::core::ffi::c_void, pcallback: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CancelOpenAsync: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -1989,7 +1989,7 @@ unsafe impl ::windows::core::Interface for IPortableDeviceServiceCapabilities {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPortableDeviceServiceCapabilities_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetSupportedMethods: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppmethods: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetSupportedMethodsByFormat: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, format: *const ::windows::core::GUID, ppmethods: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetMethodAttributes: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, method: *const ::windows::core::GUID, ppattributes: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -2075,7 +2075,7 @@ unsafe impl ::windows::core::Interface for IPortableDeviceServiceManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPortableDeviceServiceManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDeviceServices: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszpnpdeviceid: ::windows::core::PCWSTR, guidservicecategory: *const ::windows::core::GUID, pservices: *mut ::windows::core::PWSTR, pcservices: *mut u32) -> ::windows::core::HRESULT,
     pub GetDeviceForService: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszpnpserviceid: ::windows::core::PCWSTR, ppszpnpdeviceid: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
 }
@@ -2128,7 +2128,7 @@ unsafe impl ::windows::core::Interface for IPortableDeviceServiceMethodCallback 
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPortableDeviceServiceMethodCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnComplete: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hrstatus: ::windows::core::HRESULT, presults: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Devices_PortableDevices\"`*"]
@@ -2193,7 +2193,7 @@ unsafe impl ::windows::core::Interface for IPortableDeviceServiceMethods {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPortableDeviceServiceMethods_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, method: *const ::windows::core::GUID, pparameters: *mut ::core::ffi::c_void, ppresults: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub InvokeAsync: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, method: *const ::windows::core::GUID, pparameters: *mut ::core::ffi::c_void, pcallback: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Cancel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcallback: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -2244,7 +2244,7 @@ unsafe impl ::windows::core::Interface for IPortableDeviceServiceOpenCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPortableDeviceServiceOpenCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnComplete: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hrstatus: ::windows::core::HRESULT) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Devices_PortableDevices\"`*"]
@@ -2297,7 +2297,7 @@ unsafe impl ::windows::core::Interface for IPortableDeviceUnitsStream {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPortableDeviceUnitsStream_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SeekInUnits: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dlibmove: i64, units: WPD_STREAM_UNITS, dworigin: u32, plibnewposition: *mut u64) -> ::windows::core::HRESULT,
     pub Cancel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -2583,7 +2583,7 @@ unsafe impl ::windows::core::Interface for IPortableDeviceValues {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPortableDeviceValues_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcelt: *const u32) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
     pub GetAt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: u32, pkey: *mut super::super::UI::Shell::PropertiesSystem::PROPERTYKEY, pvalue: *mut super::super::System::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::HRESULT,
@@ -2801,7 +2801,7 @@ unsafe impl ::windows::core::Interface for IPortableDeviceValuesCollection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPortableDeviceValuesCollection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcelems: *const u32) -> ::windows::core::HRESULT,
     pub GetAt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwindex: u32, ppvalues: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Add: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pvalues: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -2977,7 +2977,7 @@ unsafe impl ::windows::core::Interface for IRadioInstance {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRadioInstance_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetRadioManagerSignature: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pguidsignature: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub GetInstanceSignature: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstrid: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub GetFriendlyName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lcid: u32, pbstrname: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
@@ -3043,7 +3043,7 @@ unsafe impl ::windows::core::Interface for IRadioInstanceCollection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRadioInstanceCollection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcinstance: *mut u32) -> ::windows::core::HRESULT,
     pub GetAt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, uindex: u32, ppradioinstance: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -3113,7 +3113,7 @@ unsafe impl ::windows::core::Interface for IWpdSerializer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWpdSerializer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetIPortableDeviceValuesFromBuffer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbuffer: *const u8, dwinputbufferlength: u32, ppparams: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub WriteIPortableDeviceValuesToBuffer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwoutputbufferlength: u32, presults: *mut ::core::ffi::c_void, pbuffer: *mut u8, pdwbyteswritten: *mut u32) -> ::windows::core::HRESULT,
     pub GetBufferFromIPortableDeviceValues: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psource: *mut ::core::ffi::c_void, ppbuffer: *mut *mut u8, pdwbuffersize: *mut u32) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/Devices/Sensors/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Sensors/impl.rs
@@ -25,7 +25,7 @@ impl ILocationPermissions_Vtbl {
             this.CheckLocationCapability(::core::mem::transmute_copy(&dwclientthreadid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetGlobalLocationPermission: GetGlobalLocationPermission::<Identity, Impl, OFFSET>,
             CheckLocationCapability: CheckLocationCapability::<Identity, Impl, OFFSET>,
         }
@@ -205,7 +205,7 @@ impl ISensor_Vtbl {
             this.SetEventSink(::core::mem::transmute(&pevents)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetID: GetID::<Identity, Impl, OFFSET>,
             GetCategory: GetCategory::<Identity, Impl, OFFSET>,
             GetType: GetType::<Identity, Impl, OFFSET>,
@@ -281,7 +281,7 @@ impl ISensorCollection_Vtbl {
             this.Clear().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetAt: GetAt::<Identity, Impl, OFFSET>,
             GetCount: GetCount::<Identity, Impl, OFFSET>,
             Add: Add::<Identity, Impl, OFFSET>,
@@ -339,7 +339,7 @@ impl ISensorDataReport_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTimestamp: GetTimestamp::<Identity, Impl, OFFSET>,
             GetSensorValue: GetSensorValue::<Identity, Impl, OFFSET>,
             GetSensorValues: GetSensorValues::<Identity, Impl, OFFSET>,
@@ -382,7 +382,7 @@ impl ISensorEvents_Vtbl {
             this.OnLeave(::core::mem::transmute_copy(&id)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnStateChanged: OnStateChanged::<Identity, Impl, OFFSET>,
             OnDataUpdated: OnDataUpdated::<Identity, Impl, OFFSET>,
             OnEvent: OnEvent::<Identity, Impl, OFFSET>,
@@ -450,7 +450,7 @@ impl ISensorManager_Vtbl {
             this.RequestPermissions(::core::mem::transmute_copy(&hparent), ::core::mem::transmute(&psensors), ::core::mem::transmute_copy(&fmodal)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSensorsByCategory: GetSensorsByCategory::<Identity, Impl, OFFSET>,
             GetSensorsByType: GetSensorsByType::<Identity, Impl, OFFSET>,
             GetSensorByID: GetSensorByID::<Identity, Impl, OFFSET>,
@@ -473,7 +473,7 @@ impl ISensorManagerEvents_Vtbl {
             let this = (*this).get_impl();
             this.OnSensorEnter(::core::mem::transmute(&psensor), ::core::mem::transmute_copy(&state)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnSensorEnter: OnSensorEnter::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnSensorEnter: OnSensorEnter::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ISensorManagerEvents as ::windows::core::Interface>::IID

--- a/crates/libs/windows/src/Windows/Win32/Devices/Sensors/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Sensors/mod.rs
@@ -455,7 +455,7 @@ unsafe impl ::windows::core::Interface for ILocationPermissions {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ILocationPermissions_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetGlobalLocationPermission: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfenabled: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -581,7 +581,7 @@ unsafe impl ::windows::core::Interface for ISensor {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISensor_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub GetCategory: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psensorcategory: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub GetType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psensortype: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
@@ -682,7 +682,7 @@ unsafe impl ::windows::core::Interface for ISensorCollection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISensorCollection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetAt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ulindex: u32, ppsensor: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcount: *mut u32) -> ::windows::core::HRESULT,
     pub Add: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psensor: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -754,7 +754,7 @@ unsafe impl ::windows::core::Interface for ISensorDataReport {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISensorDataReport_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetTimestamp: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptimestamp: *mut super::super::Foundation::SYSTEMTIME) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -836,7 +836,7 @@ unsafe impl ::windows::core::Interface for ISensorEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISensorEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnStateChanged: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psensor: *mut ::core::ffi::c_void, state: SensorState) -> ::windows::core::HRESULT,
     pub OnDataUpdated: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psensor: *mut ::core::ffi::c_void, pnewdata: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Devices_PortableDevices")]
@@ -916,7 +916,7 @@ unsafe impl ::windows::core::Interface for ISensorManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISensorManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetSensorsByCategory: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sensorcategory: *const ::windows::core::GUID, ppsensorsfound: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetSensorsByType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sensortype: *const ::windows::core::GUID, ppsensorsfound: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetSensorByID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sensorid: *const ::windows::core::GUID, ppsensor: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -975,7 +975,7 @@ unsafe impl ::windows::core::Interface for ISensorManagerEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISensorManagerEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnSensorEnter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psensor: *mut ::core::ffi::c_void, state: SensorState) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Devices_Sensors\"`*"]

--- a/crates/libs/windows/src/Windows/Win32/Devices/Tapi/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Tapi/impl.rs
@@ -37,7 +37,7 @@ impl IEnumACDGroup_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
@@ -87,7 +87,7 @@ impl IEnumAddress_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
@@ -137,7 +137,7 @@ impl IEnumAgent_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
@@ -187,7 +187,7 @@ impl IEnumAgentHandler_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
@@ -237,7 +237,7 @@ impl IEnumAgentSession_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
@@ -284,7 +284,7 @@ impl IEnumBstr_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
@@ -334,7 +334,7 @@ impl IEnumCall_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
@@ -384,7 +384,7 @@ impl IEnumCallHub_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
@@ -434,7 +434,7 @@ impl IEnumCallingCard_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
@@ -481,7 +481,7 @@ impl IEnumDialableAddrs_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
@@ -531,7 +531,7 @@ impl IEnumDirectory_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
@@ -581,7 +581,7 @@ impl IEnumDirectoryObject_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
@@ -631,7 +631,7 @@ impl IEnumLocation_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
@@ -681,7 +681,7 @@ impl IEnumMcastScope_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
@@ -731,7 +731,7 @@ impl IEnumPhone_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
@@ -781,7 +781,7 @@ impl IEnumPluggableSuperclassInfo_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
@@ -831,7 +831,7 @@ impl IEnumPluggableTerminalClassInfo_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
@@ -881,7 +881,7 @@ impl IEnumQueue_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
@@ -931,7 +931,7 @@ impl IEnumStream_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
@@ -981,7 +981,7 @@ impl IEnumSubStream_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
@@ -1031,7 +1031,7 @@ impl IEnumTerminal_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
@@ -1078,7 +1078,7 @@ impl IEnumTerminalClass_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
@@ -1529,7 +1529,7 @@ impl ITAMMediaFormat_Vtbl {
             this.SetMediaFormat(::core::mem::transmute_copy(&pmt)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             MediaFormat: MediaFormat::<Identity, Impl, OFFSET>,
             SetMediaFormat: SetMediaFormat::<Identity, Impl, OFFSET>,
         }
@@ -3091,7 +3091,7 @@ impl ITAllocatorProperties_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetAllocatorProperties: SetAllocatorProperties::<Identity, Impl, OFFSET>,
             GetAllocatorProperties: GetAllocatorProperties::<Identity, Impl, OFFSET>,
             SetAllocateBuffers: SetAllocateBuffers::<Identity, Impl, OFFSET>,
@@ -5712,7 +5712,7 @@ impl ITLegacyAddressMediaControl_Vtbl {
             this.SetDevConfig(::core::mem::transmute(&pdeviceclass), ::core::mem::transmute_copy(&dwsize), ::core::mem::transmute_copy(&pdeviceconfig)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetID: GetID::<Identity, Impl, OFFSET>,
             GetDevConfig: GetDevConfig::<Identity, Impl, OFFSET>,
             SetDevConfig: SetDevConfig::<Identity, Impl, OFFSET>,
@@ -6140,7 +6140,7 @@ impl ITMSPAddress_Vtbl {
             this.GetEvent(::core::mem::transmute_copy(&pdwsize), ::core::mem::transmute_copy(&peventbuffer)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             Shutdown: Shutdown::<Identity, Impl, OFFSET>,
             CreateMSPCall: CreateMSPCall::<Identity, Impl, OFFSET>,
@@ -7094,7 +7094,7 @@ impl ITPluggableTerminalEventSink_Vtbl {
             let this = (*this).get_impl();
             this.FireEvent(::core::mem::transmute_copy(&pmspeventinfo)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), FireEvent: FireEvent::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), FireEvent: FireEvent::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ITPluggableTerminalEventSink as ::windows::core::Interface>::IID
@@ -7118,7 +7118,7 @@ impl ITPluggableTerminalEventSinkRegistration_Vtbl {
             this.UnregisterSink().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RegisterSink: RegisterSink::<Identity, Impl, OFFSET>,
             UnregisterSink: UnregisterSink::<Identity, Impl, OFFSET>,
         }
@@ -8487,7 +8487,7 @@ impl ITTAPIEventNotification_Vtbl {
             let this = (*this).get_impl();
             this.Event(::core::mem::transmute_copy(&tapievent), ::core::mem::transmute(&pevent)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Event: Event::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Event: Event::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ITTAPIEventNotification as ::windows::core::Interface>::IID
@@ -9078,7 +9078,7 @@ impl ITnef_Vtbl {
             this.FinishComponent(::core::mem::transmute_copy(&ulflags), ::core::mem::transmute_copy(&ulcomponentid), ::core::mem::transmute_copy(&lpcustomproplist), ::core::mem::transmute_copy(&lpcustomprops), ::core::mem::transmute_copy(&lpproplist), ::core::mem::transmute_copy(&lpproblems)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddProps: AddProps::<Identity, Impl, OFFSET>,
             ExtractProps: ExtractProps::<Identity, Impl, OFFSET>,
             Finish: Finish::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/Devices/Tapi/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Tapi/mod.rs
@@ -2736,7 +2736,7 @@ unsafe impl ::windows::core::Interface for IEnumACDGroup {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumACDGroup_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, ppelements: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -2803,7 +2803,7 @@ unsafe impl ::windows::core::Interface for IEnumAddress {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumAddress_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, ppelements: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -2870,7 +2870,7 @@ unsafe impl ::windows::core::Interface for IEnumAgent {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumAgent_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, ppelements: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -2937,7 +2937,7 @@ unsafe impl ::windows::core::Interface for IEnumAgentHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumAgentHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, ppelements: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -3004,7 +3004,7 @@ unsafe impl ::windows::core::Interface for IEnumAgentSession {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumAgentSession_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, ppelements: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -3069,7 +3069,7 @@ unsafe impl ::windows::core::Interface for IEnumBstr {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumBstr_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, ppstrings: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
@@ -3133,7 +3133,7 @@ unsafe impl ::windows::core::Interface for IEnumCall {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumCall_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, ppelements: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -3200,7 +3200,7 @@ unsafe impl ::windows::core::Interface for IEnumCallHub {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumCallHub_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, ppelements: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -3267,7 +3267,7 @@ unsafe impl ::windows::core::Interface for IEnumCallingCard {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumCallingCard_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, ppelements: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -3332,7 +3332,7 @@ unsafe impl ::windows::core::Interface for IEnumDialableAddrs {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumDialableAddrs_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, ppelements: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>, pcfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
@@ -3396,7 +3396,7 @@ unsafe impl ::windows::core::Interface for IEnumDirectory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumDirectory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, ppelements: *mut *mut ::core::ffi::c_void, pcfetched: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -3463,7 +3463,7 @@ unsafe impl ::windows::core::Interface for IEnumDirectoryObject {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumDirectoryObject_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, pval: *mut *mut ::core::ffi::c_void, pcfetched: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -3530,7 +3530,7 @@ unsafe impl ::windows::core::Interface for IEnumLocation {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumLocation_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, ppelements: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -3597,7 +3597,7 @@ unsafe impl ::windows::core::Interface for IEnumMcastScope {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumMcastScope_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, ppscopes: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -3664,7 +3664,7 @@ unsafe impl ::windows::core::Interface for IEnumPhone {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumPhone_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, ppelements: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -3731,7 +3731,7 @@ unsafe impl ::windows::core::Interface for IEnumPluggableSuperclassInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumPluggableSuperclassInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, ppelements: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -3798,7 +3798,7 @@ unsafe impl ::windows::core::Interface for IEnumPluggableTerminalClassInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumPluggableTerminalClassInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, ppelements: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -3865,7 +3865,7 @@ unsafe impl ::windows::core::Interface for IEnumQueue {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumQueue_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, ppelements: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -3932,7 +3932,7 @@ unsafe impl ::windows::core::Interface for IEnumStream {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumStream_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, ppelements: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -3999,7 +3999,7 @@ unsafe impl ::windows::core::Interface for IEnumSubStream {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumSubStream_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, ppelements: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -4066,7 +4066,7 @@ unsafe impl ::windows::core::Interface for IEnumTerminal {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumTerminal_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, ppelements: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -4131,7 +4131,7 @@ unsafe impl ::windows::core::Interface for IEnumTerminalClass {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumTerminalClass_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, pelements: *mut ::windows::core::GUID, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
@@ -4754,7 +4754,7 @@ unsafe impl ::windows::core::Interface for ITAMMediaFormat {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITAMMediaFormat_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_MediaFoundation"))]
     pub MediaFormat: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppmt: *mut *mut super::super::Media::MediaFoundation::AM_MEDIA_TYPE) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_Media_MediaFoundation")))]
@@ -6678,7 +6678,7 @@ unsafe impl ::windows::core::Interface for ITAllocatorProperties {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITAllocatorProperties_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Media_DirectShow")]
     pub SetAllocatorProperties: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pallocproperties: *const super::super::Media::DirectShow::ALLOCATOR_PROPERTIES) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Media_DirectShow"))]
@@ -10395,7 +10395,7 @@ unsafe impl ::windows::core::Interface for ITLegacyAddressMediaControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITLegacyAddressMediaControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdeviceclass: ::core::mem::ManuallyDrop<::windows::core::BSTR>, pdwsize: *mut u32, ppdeviceid: *mut *mut u8) -> ::windows::core::HRESULT,
     pub GetDevConfig: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdeviceclass: ::core::mem::ManuallyDrop<::windows::core::BSTR>, pdwsize: *mut u32, ppdeviceconfig: *mut *mut u8) -> ::windows::core::HRESULT,
     pub SetDevConfig: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdeviceclass: ::core::mem::ManuallyDrop<::windows::core::BSTR>, dwsize: u32, pdeviceconfig: *const u8) -> ::windows::core::HRESULT,
@@ -11047,7 +11047,7 @@ unsafe impl ::windows::core::Interface for ITMSPAddress {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITMSPAddress_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hevent: *const i32) -> ::windows::core::HRESULT,
     pub Shutdown: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CreateMSPCall: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hcall: *const i32, dwreserved: u32, dwmediatype: u32, pouterunknown: *mut ::core::ffi::c_void, ppstreamcontrol: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -12180,7 +12180,7 @@ unsafe impl ::windows::core::Interface for ITPluggableTerminalEventSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITPluggableTerminalEventSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub FireEvent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pmspeventinfo: *const MSP_EVENT_INFO) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -12238,7 +12238,7 @@ unsafe impl ::windows::core::Interface for ITPluggableTerminalEventSinkRegistrat
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITPluggableTerminalEventSinkRegistration_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub RegisterSink: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, peventsink: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub UnregisterSink: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -14342,7 +14342,7 @@ unsafe impl ::windows::core::Interface for ITTAPIEventNotification {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITTAPIEventNotification_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub Event: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, tapievent: TAPI_EVENT, pevent: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -15336,7 +15336,7 @@ unsafe impl ::windows::core::Interface for ITnef {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITnef_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_AddressBook")]
     pub AddProps: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ulflags: u32, ulelemid: u32, lpvdata: *mut ::core::ffi::c_void, lpproplist: *mut super::super::System::AddressBook::SPropTagArray) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_AddressBook"))]

--- a/crates/libs/windows/src/Windows/Win32/Devices/WebServicesOnDevices/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/WebServicesOnDevices/impl.rs
@@ -19,7 +19,7 @@ impl IWSDAddress_Vtbl {
             this.Deserialize(::core::mem::transmute(&pszbuffer)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Serialize: Serialize::<Identity, Impl, OFFSET>,
             Deserialize: Deserialize::<Identity, Impl, OFFSET>,
         }
@@ -39,7 +39,7 @@ impl IWSDAsyncCallback_Vtbl {
             let this = (*this).get_impl();
             this.AsyncOperationComplete(::core::mem::transmute(&pasyncresult), ::core::mem::transmute(&pasyncstate)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), AsyncOperationComplete: AsyncOperationComplete::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), AsyncOperationComplete: AsyncOperationComplete::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWSDAsyncCallback as ::windows::core::Interface>::IID
@@ -114,7 +114,7 @@ impl IWSDAsyncResult_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetCallback: SetCallback::<Identity, Impl, OFFSET>,
             SetWaitHandle: SetWaitHandle::<Identity, Impl, OFFSET>,
             HasCompleted: HasCompleted::<Identity, Impl, OFFSET>,
@@ -132,7 +132,7 @@ pub trait IWSDAttachment_Impl: Sized {}
 impl ::windows::core::RuntimeName for IWSDAttachment {}
 impl IWSDAttachment_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IWSDAttachment_Impl, const OFFSET: isize>() -> IWSDAttachment_Vtbl {
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>() }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>() }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWSDAttachment as ::windows::core::Interface>::IID
@@ -219,7 +219,7 @@ impl IWSDDeviceHost_Vtbl {
             this.SignalEvent(::core::mem::transmute(&pszserviceid), ::core::mem::transmute_copy(&pbody), ::core::mem::transmute_copy(&poperation)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Init: Init::<Identity, Impl, OFFSET>,
             Start: Start::<Identity, Impl, OFFSET>,
             Stop: Stop::<Identity, Impl, OFFSET>,
@@ -255,7 +255,7 @@ impl IWSDDeviceHostNotify_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetService: GetService::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetService: GetService::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWSDDeviceHostNotify as ::windows::core::Interface>::IID
@@ -375,7 +375,7 @@ impl IWSDDeviceProxy_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Init: Init::<Identity, Impl, OFFSET>,
             BeginGetMetadata: BeginGetMetadata::<Identity, Impl, OFFSET>,
             EndGetMetadata: EndGetMetadata::<Identity, Impl, OFFSET>,
@@ -461,7 +461,7 @@ impl IWSDEndpointProxy_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SendOneWayRequest: SendOneWayRequest::<Identity, Impl, OFFSET>,
             SendTwoWayRequest: SendTwoWayRequest::<Identity, Impl, OFFSET>,
             SendTwoWayRequestAsync: SendTwoWayRequestAsync::<Identity, Impl, OFFSET>,
@@ -499,7 +499,7 @@ impl IWSDEventingStatus_Vtbl {
             this.SubscriptionEnded(::core::mem::transmute(&pszsubscriptionaction))
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SubscriptionRenewed: SubscriptionRenewed::<Identity, Impl, OFFSET>,
             SubscriptionRenewalFailed: SubscriptionRenewalFailed::<Identity, Impl, OFFSET>,
             SubscriptionEnded: SubscriptionEnded::<Identity, Impl, OFFSET>,
@@ -592,7 +592,7 @@ impl IWSDHttpAuthParameters_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetClientAccessToken: GetClientAccessToken::<Identity, Impl, OFFSET>,
             GetAuthType: GetAuthType::<Identity, Impl, OFFSET>,
         }
@@ -778,7 +778,7 @@ impl IWSDMessageParameters_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetLocalAddress: GetLocalAddress::<Identity, Impl, OFFSET>,
             SetLocalAddress: SetLocalAddress::<Identity, Impl, OFFSET>,
             GetRemoteAddress: GetRemoteAddress::<Identity, Impl, OFFSET>,
@@ -807,7 +807,7 @@ impl IWSDMetadataExchange_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetMetadata: GetMetadata::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetMetadata: GetMetadata::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWSDMetadataExchange as ::windows::core::Interface>::IID
@@ -886,7 +886,7 @@ impl IWSDSSLClientCertificate_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetClientCertificate: GetClientCertificate::<Identity, Impl, OFFSET>,
             GetMappedAccessToken: GetMappedAccessToken::<Identity, Impl, OFFSET>,
         }
@@ -928,7 +928,7 @@ impl IWSDScopeMatchingRule_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetScopeRule: GetScopeRule::<Identity, Impl, OFFSET>,
             MatchScopes: MatchScopes::<Identity, Impl, OFFSET>,
         }
@@ -955,7 +955,7 @@ impl IWSDServiceMessaging_Vtbl {
             this.FaultRequest(::core::mem::transmute_copy(&prequestheader), ::core::mem::transmute(&pmessageparameters), ::core::mem::transmute_copy(&pfault)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SendResponse: SendResponse::<Identity, Impl, OFFSET>,
             FaultRequest: FaultRequest::<Identity, Impl, OFFSET>,
         }
@@ -1231,7 +1231,7 @@ impl IWSDSignatureProperty_Vtbl {
             this.GetSignedInfoHash(::core::mem::transmute_copy(&pbsignedinfohash), ::core::mem::transmute_copy(&pdwhashsize)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             IsMessageSigned: IsMessageSigned::<Identity, Impl, OFFSET>,
             IsMessageSignatureTrusted: IsMessageSignatureTrusted::<Identity, Impl, OFFSET>,
             GetKeyInfo: GetKeyInfo::<Identity, Impl, OFFSET>,
@@ -1497,7 +1497,7 @@ impl IWSDXMLContext_Vtbl {
             this.SetTypes(::core::mem::transmute_copy(&ptypes), ::core::mem::transmute_copy(&dwtypescount), ::core::mem::transmute_copy(&blayernumber)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddNamespace: AddNamespace::<Identity, Impl, OFFSET>,
             AddNameToNamespace: AddNameToNamespace::<Identity, Impl, OFFSET>,
             SetNamespaces: SetNamespaces::<Identity, Impl, OFFSET>,
@@ -1640,7 +1640,7 @@ impl IWSDiscoveredService_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetEndpointReference: GetEndpointReference::<Identity, Impl, OFFSET>,
             GetTypes: GetTypes::<Identity, Impl, OFFSET>,
             GetScopes: GetScopes::<Identity, Impl, OFFSET>,
@@ -1712,7 +1712,7 @@ impl IWSDiscoveryProvider_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetAddressFamily: SetAddressFamily::<Identity, Impl, OFFSET>,
             Attach: Attach::<Identity, Impl, OFFSET>,
             Detach: Detach::<Identity, Impl, OFFSET>,
@@ -1756,7 +1756,7 @@ impl IWSDiscoveryProviderNotify_Vtbl {
             this.SearchComplete(::core::mem::transmute(&psztag)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Add: Add::<Identity, Impl, OFFSET>,
             Remove: Remove::<Identity, Impl, OFFSET>,
             SearchFailed: SearchFailed::<Identity, Impl, OFFSET>,
@@ -1906,7 +1906,7 @@ impl IWSDiscoveryPublisher_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetAddressFamily: SetAddressFamily::<Identity, Impl, OFFSET>,
             RegisterNotificationSink: RegisterNotificationSink::<Identity, Impl, OFFSET>,
             UnRegisterNotificationSink: UnRegisterNotificationSink::<Identity, Impl, OFFSET>,
@@ -1944,7 +1944,7 @@ impl IWSDiscoveryPublisherNotify_Vtbl {
             this.ResolveHandler(::core::mem::transmute_copy(&psoap), ::core::mem::transmute(&pmessageparameters)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ProbeHandler: ProbeHandler::<Identity, Impl, OFFSET>,
             ResolveHandler: ResolveHandler::<Identity, Impl, OFFSET>,
         }

--- a/crates/libs/windows/src/Windows/Win32/Devices/WebServicesOnDevices/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/WebServicesOnDevices/mod.rs
@@ -423,7 +423,7 @@ unsafe impl ::windows::core::Interface for IWSDAddress {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWSDAddress_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Serialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszbuffer: ::windows::core::PWSTR, cchlength: u32, fsafe: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -480,7 +480,7 @@ unsafe impl ::windows::core::Interface for IWSDAsyncCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWSDAsyncCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AsyncOperationComplete: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pasyncresult: *mut ::core::ffi::c_void, pasyncstate: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Devices_WebServicesOnDevices\"`*"]
@@ -559,7 +559,7 @@ unsafe impl ::windows::core::Interface for IWSDAsyncResult {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWSDAsyncResult_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetCallback: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcallback: *mut ::core::ffi::c_void, pasyncstate: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub SetWaitHandle: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hwaithandle: super::super::Foundation::HANDLE) -> ::windows::core::HRESULT,
@@ -613,7 +613,7 @@ unsafe impl ::windows::core::Interface for IWSDAttachment {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWSDAttachment_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
 }
 #[doc = "*Required features: `\"Win32_Devices_WebServicesOnDevices\"`*"]
 #[repr(transparent)]
@@ -725,7 +725,7 @@ unsafe impl ::windows::core::Interface for IWSDDeviceHost {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWSDDeviceHost_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Init: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszlocalid: ::windows::core::PCWSTR, pcontext: *mut ::core::ffi::c_void, pphostaddresses: *const *mut ::core::ffi::c_void, dwhostaddresscount: u32) -> ::windows::core::HRESULT,
     pub Start: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ullinstanceid: u64, pscopelist: *const WSD_URI_LIST, pnotificationsink: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Stop: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -792,7 +792,7 @@ unsafe impl ::windows::core::Interface for IWSDDeviceHostNotify {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWSDDeviceHostNotify_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetService: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszserviceid: ::windows::core::PCWSTR, ppservice: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Devices_WebServicesOnDevices\"`*"]
@@ -889,7 +889,7 @@ unsafe impl ::windows::core::Interface for IWSDDeviceProxy {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWSDDeviceProxy_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Init: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszdeviceid: ::windows::core::PCWSTR, pdeviceaddress: *mut ::core::ffi::c_void, pszlocalid: ::windows::core::PCWSTR, pcontext: *mut ::core::ffi::c_void, psponsor: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub BeginGetMetadata: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppresult: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub EndGetMetadata: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, presult: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -977,7 +977,7 @@ unsafe impl ::windows::core::Interface for IWSDEndpointProxy {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWSDEndpointProxy_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SendOneWayRequest: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbody: *const ::core::ffi::c_void, poperation: *const WSD_OPERATION) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub SendTwoWayRequest: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbody: *const ::core::ffi::c_void, poperation: *const WSD_OPERATION, presponsecontext: *const WSD_SYNCHRONOUS_RESPONSE_CONTEXT) -> ::windows::core::HRESULT,
@@ -1050,7 +1050,7 @@ unsafe impl ::windows::core::Interface for IWSDEventingStatus {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWSDEventingStatus_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SubscriptionRenewed: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszsubscriptionaction: ::windows::core::PCWSTR),
     pub SubscriptionRenewalFailed: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszsubscriptionaction: ::windows::core::PCWSTR, hr: ::windows::core::HRESULT),
     pub SubscriptionEnded: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszsubscriptionaction: ::windows::core::PCWSTR),
@@ -1251,7 +1251,7 @@ unsafe impl ::windows::core::Interface for IWSDHttpAuthParameters {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWSDHttpAuthParameters_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetClientAccessToken: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, phtoken: *mut super::super::Foundation::HANDLE) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -1529,7 +1529,7 @@ unsafe impl ::windows::core::Interface for IWSDMessageParameters {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWSDMessageParameters_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetLocalAddress: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppaddress: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetLocalAddress: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, paddress: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetRemoteAddress: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppaddress: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1583,7 +1583,7 @@ unsafe impl ::windows::core::Interface for IWSDMetadataExchange {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWSDMetadataExchange_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetMetadata: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, metadataout: *mut *mut WSD_METADATA_SECTION_LIST) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Devices_WebServicesOnDevices\"`*"]
@@ -1714,7 +1714,7 @@ unsafe impl ::windows::core::Interface for IWSDSSLClientCertificate {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWSDSSLClientCertificate_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
     pub GetClientCertificate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppcertcontext: *mut *mut super::super::Security::Cryptography::CERT_CONTEXT) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography")))]
@@ -1781,7 +1781,7 @@ unsafe impl ::windows::core::Interface for IWSDScopeMatchingRule {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWSDScopeMatchingRule_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetScopeRule: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppszscopematchingrule: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub MatchScopes: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszscope1: ::windows::core::PCWSTR, pszscope2: ::windows::core::PCWSTR, pfmatch: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -1843,7 +1843,7 @@ unsafe impl ::windows::core::Interface for IWSDServiceMessaging {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWSDServiceMessaging_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SendResponse: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbody: *const ::core::ffi::c_void, poperation: *const WSD_OPERATION, pmessageparameters: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub FaultRequest: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, prequestheader: *const WSD_SOAP_HEADER, pmessageparameters: *mut ::core::ffi::c_void, pfault: *const WSD_SOAP_FAULT) -> ::windows::core::HRESULT,
 }
@@ -2255,7 +2255,7 @@ unsafe impl ::windows::core::Interface for IWSDSignatureProperty {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWSDSignatureProperty_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub IsMessageSigned: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbsigned: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -2711,7 +2711,7 @@ unsafe impl ::windows::core::Interface for IWSDXMLContext {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWSDXMLContext_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddNamespace: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszuri: ::windows::core::PCWSTR, pszsuggestedprefix: ::windows::core::PCWSTR, ppnamespace: *mut *mut WSDXML_NAMESPACE) -> ::windows::core::HRESULT,
     pub AddNameToNamespace: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszuri: ::windows::core::PCWSTR, pszname: ::windows::core::PCWSTR, ppname: *mut *mut WSDXML_NAME) -> ::windows::core::HRESULT,
     pub SetNamespaces: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pnamespaces: *const *const WSDXML_NAMESPACE, wnamespacescount: u16, blayernumber: u8) -> ::windows::core::HRESULT,
@@ -2803,7 +2803,7 @@ unsafe impl ::windows::core::Interface for IWSDiscoveredService {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWSDiscoveredService_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetEndpointReference: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppendpointreference: *mut *mut WSD_ENDPOINT_REFERENCE) -> ::windows::core::HRESULT,
     pub GetTypes: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pptypeslist: *mut *mut WSD_NAME_LIST) -> ::windows::core::HRESULT,
     pub GetScopes: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppscopeslist: *mut *mut WSD_URI_LIST) -> ::windows::core::HRESULT,
@@ -2896,7 +2896,7 @@ unsafe impl ::windows::core::Interface for IWSDiscoveryProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWSDiscoveryProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetAddressFamily: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwaddressfamily: u32) -> ::windows::core::HRESULT,
     pub Attach: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psink: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Detach: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -2972,7 +2972,7 @@ unsafe impl ::windows::core::Interface for IWSDiscoveryProviderNotify {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWSDiscoveryProviderNotify_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Add: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pservice: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Remove: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pservice: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SearchFailed: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hr: ::windows::core::HRESULT, psztag: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
@@ -3157,7 +3157,7 @@ unsafe impl ::windows::core::Interface for IWSDiscoveryPublisher {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWSDiscoveryPublisher_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetAddressFamily: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwaddressfamily: u32) -> ::windows::core::HRESULT,
     pub RegisterNotificationSink: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psink: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub UnRegisterNotificationSink: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psink: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -3227,7 +3227,7 @@ unsafe impl ::windows::core::Interface for IWSDiscoveryPublisherNotify {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWSDiscoveryPublisherNotify_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ProbeHandler: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psoap: *const WSD_SOAP_MESSAGE, pmessageparameters: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub ResolveHandler: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psoap: *const WSD_SOAP_MESSAGE, pmessageparameters: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }

--- a/crates/libs/windows/src/Windows/Win32/Gaming/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Gaming/impl.rs
@@ -37,7 +37,7 @@ impl IGameExplorer_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddGame: AddGame::<Identity, Impl, OFFSET>,
             RemoveGame: RemoveGame::<Identity, Impl, OFFSET>,
             UpdateGame: UpdateGame::<Identity, Impl, OFFSET>,
@@ -81,7 +81,7 @@ impl IGameExplorer2_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             InstallGame: InstallGame::<Identity, Impl, OFFSET>,
             UninstallGame: UninstallGame::<Identity, Impl, OFFSET>,
             CheckAccess: CheckAccess::<Identity, Impl, OFFSET>,
@@ -214,7 +214,7 @@ impl IGameStatistics_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetMaxCategoryLength: GetMaxCategoryLength::<Identity, Impl, OFFSET>,
             GetMaxNameLength: GetMaxNameLength::<Identity, Impl, OFFSET>,
             GetMaxValueLength: GetMaxValueLength::<Identity, Impl, OFFSET>,
@@ -251,7 +251,7 @@ impl IGameStatisticsMgr_Vtbl {
             this.RemoveGameStatistics(::core::mem::transmute(&gdfbinarypath)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetGameStatistics: GetGameStatistics::<Identity, Impl, OFFSET>,
             RemoveGameStatistics: RemoveGameStatistics::<Identity, Impl, OFFSET>,
         }
@@ -323,7 +323,7 @@ impl IXblIdpAuthManager_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetGamerAccount: SetGamerAccount::<Identity, Impl, OFFSET>,
             GetGamerAccount: GetGamerAccount::<Identity, Impl, OFFSET>,
             SetAppViewInitialized: SetAppViewInitialized::<Identity, Impl, OFFSET>,
@@ -582,7 +582,7 @@ impl IXblIdpAuthTokenResult_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetStatus: GetStatus::<Identity, Impl, OFFSET>,
             GetErrorCode: GetErrorCode::<Identity, Impl, OFFSET>,
             GetToken: GetToken::<Identity, Impl, OFFSET>,
@@ -651,7 +651,7 @@ impl IXblIdpAuthTokenResult2_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetModernGamertag: GetModernGamertag::<Identity, Impl, OFFSET>,
             GetModernGamertagSuffix: GetModernGamertagSuffix::<Identity, Impl, OFFSET>,
             GetUniqueModernGamertag: GetUniqueModernGamertag::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/Gaming/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Gaming/mod.rs
@@ -375,7 +375,7 @@ unsafe impl ::windows::core::Interface for IGameExplorer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IGameExplorer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddGame: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrgdfbinarypath: ::core::mem::ManuallyDrop<::windows::core::BSTR>, bstrgameinstalldirectory: ::core::mem::ManuallyDrop<::windows::core::BSTR>, installscope: GAME_INSTALL_SCOPE, pguidinstanceid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub RemoveGame: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, guidinstanceid: ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub UpdateGame: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, guidinstanceid: ::windows::core::GUID) -> ::windows::core::HRESULT,
@@ -449,7 +449,7 @@ unsafe impl ::windows::core::Interface for IGameExplorer2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IGameExplorer2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub InstallGame: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, binarygdfpath: ::windows::core::PCWSTR, installdirectory: ::windows::core::PCWSTR, installscope: GAME_INSTALL_SCOPE) -> ::windows::core::HRESULT,
     pub UninstallGame: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, binarygdfpath: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -555,7 +555,7 @@ unsafe impl ::windows::core::Interface for IGameStatistics {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IGameStatistics_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetMaxCategoryLength: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cch: *mut u32) -> ::windows::core::HRESULT,
     pub GetMaxNameLength: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cch: *mut u32) -> ::windows::core::HRESULT,
     pub GetMaxValueLength: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cch: *mut u32) -> ::windows::core::HRESULT,
@@ -627,7 +627,7 @@ unsafe impl ::windows::core::Interface for IGameStatisticsMgr {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IGameStatisticsMgr_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetGameStatistics: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, gdfbinarypath: ::windows::core::PCWSTR, opentype: GAMESTATS_OPEN_TYPE, popenresult: *mut GAMESTATS_OPEN_RESULT, ppistats: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub RemoveGameStatistics: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, gdfbinarypath: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
 }
@@ -715,7 +715,7 @@ unsafe impl ::windows::core::Interface for IXblIdpAuthManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXblIdpAuthManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetGamerAccount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, msaaccountid: ::windows::core::PCWSTR, xuid: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub GetGamerAccount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, msaaccountid: *mut ::windows::core::PWSTR, xuid: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub SetAppViewInitialized: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, appsid: ::windows::core::PCWSTR, msaaccountid: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
@@ -849,7 +849,7 @@ unsafe impl ::windows::core::Interface for IXblIdpAuthTokenResult {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXblIdpAuthTokenResult_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetStatus: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, status: *mut XBL_IDP_AUTH_TOKEN_STATUS) -> ::windows::core::HRESULT,
     pub GetErrorCode: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, errorcode: *mut ::windows::core::HRESULT) -> ::windows::core::HRESULT,
     pub GetToken: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, token: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
@@ -926,7 +926,7 @@ unsafe impl ::windows::core::Interface for IXblIdpAuthTokenResult2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXblIdpAuthTokenResult2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetModernGamertag: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetModernGamertagSuffix: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetUniqueModernGamertag: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/Globalization/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Globalization/impl.rs
@@ -15,7 +15,7 @@ impl IComprehensiveSpellCheckProvider_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), ComprehensiveCheck: ComprehensiveCheck::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), ComprehensiveCheck: ComprehensiveCheck::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IComprehensiveSpellCheckProvider as ::windows::core::Interface>::IID
@@ -57,7 +57,7 @@ impl IEnumCodePage_Vtbl {
             this.Skip(::core::mem::transmute_copy(&celt)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Clone: Clone::<Identity, Impl, OFFSET>,
             Next: Next::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -104,7 +104,7 @@ impl IEnumRfc1766_Vtbl {
             this.Skip(::core::mem::transmute_copy(&celt)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Clone: Clone::<Identity, Impl, OFFSET>,
             Next: Next::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -151,7 +151,7 @@ impl IEnumScript_Vtbl {
             this.Skip(::core::mem::transmute_copy(&celt)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Clone: Clone::<Identity, Impl, OFFSET>,
             Next: Next::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -179,7 +179,7 @@ impl IEnumSpellingError_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Next: Next::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Next: Next::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IEnumSpellingError as ::windows::core::Interface>::IID
@@ -233,7 +233,7 @@ impl IMLangCodePages_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCharCodePages: GetCharCodePages::<Identity, Impl, OFFSET>,
             GetStrCodePages: GetStrCodePages::<Identity, Impl, OFFSET>,
             CodePageToCodePages: CodePageToCodePages::<Identity, Impl, OFFSET>,
@@ -310,7 +310,7 @@ impl IMLangConvertCharset_Vtbl {
             this.DoConversionFromUnicode(::core::mem::transmute(&psrcstr), ::core::mem::transmute_copy(&pcsrcsize), ::core::mem::transmute_copy(&pdststr), ::core::mem::transmute_copy(&pcdstsize)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             GetSourceCodePage: GetSourceCodePage::<Identity, Impl, OFFSET>,
             GetDestinationCodePage: GetDestinationCodePage::<Identity, Impl, OFFSET>,
@@ -493,7 +493,7 @@ impl IMLangLineBreakConsole_Vtbl {
             this.BreakLineA(::core::mem::transmute_copy(&locale), ::core::mem::transmute_copy(&ucodepage), ::core::mem::transmute(&pszsrc), ::core::mem::transmute_copy(&cchsrc), ::core::mem::transmute_copy(&cmaxcolumns), ::core::mem::transmute_copy(&pcchline), ::core::mem::transmute_copy(&pcchskip)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             BreakLineML: BreakLineML::<Identity, Impl, OFFSET>,
             BreakLineW: BreakLineW::<Identity, Impl, OFFSET>,
             BreakLineA: BreakLineA::<Identity, Impl, OFFSET>,
@@ -542,7 +542,7 @@ impl IMLangString_Vtbl {
             this.GetMLStr(::core::mem::transmute_copy(&lsrcpos), ::core::mem::transmute_copy(&lsrclen), ::core::mem::transmute(&punkouter), ::core::mem::transmute_copy(&dwclscontext), ::core::mem::transmute_copy(&piid), ::core::mem::transmute_copy(&ppdestmlstr), ::core::mem::transmute_copy(&pldestpos), ::core::mem::transmute_copy(&pldestlen)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Sync: Sync::<Identity, Impl, OFFSET>,
             GetLength: GetLength::<Identity, Impl, OFFSET>,
             SetMLStr: SetMLStr::<Identity, Impl, OFFSET>,
@@ -670,7 +670,7 @@ impl IMLangStringBufA_Vtbl {
             this.Delete(::core::mem::transmute_copy(&cchoffset), ::core::mem::transmute_copy(&cchdelete)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetStatus: GetStatus::<Identity, Impl, OFFSET>,
             LockBuf: LockBuf::<Identity, Impl, OFFSET>,
             UnlockBuf: UnlockBuf::<Identity, Impl, OFFSET>,
@@ -724,7 +724,7 @@ impl IMLangStringBufW_Vtbl {
             this.Delete(::core::mem::transmute_copy(&cchoffset), ::core::mem::transmute_copy(&cchdelete)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetStatus: GetStatus::<Identity, Impl, OFFSET>,
             LockBuf: LockBuf::<Identity, Impl, OFFSET>,
             UnlockBuf: UnlockBuf::<Identity, Impl, OFFSET>,
@@ -958,7 +958,7 @@ impl IMultiLanguage_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetNumberOfCodePageInfo: GetNumberOfCodePageInfo::<Identity, Impl, OFFSET>,
             GetCodePageInfo: GetCodePageInfo::<Identity, Impl, OFFSET>,
             GetFamilyCodePage: GetFamilyCodePage::<Identity, Impl, OFFSET>,
@@ -1217,7 +1217,7 @@ impl IMultiLanguage2_Vtbl {
             this.ValidateCodePageEx(::core::mem::transmute_copy(&uicodepage), ::core::mem::transmute_copy(&hwnd), ::core::mem::transmute_copy(&dwfiodcontrol)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetNumberOfCodePageInfo: GetNumberOfCodePageInfo::<Identity, Impl, OFFSET>,
             GetCodePageInfo: GetCodePageInfo::<Identity, Impl, OFFSET>,
             GetFamilyCodePage: GetFamilyCodePage::<Identity, Impl, OFFSET>,
@@ -1338,7 +1338,7 @@ impl IOptionDescription_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Id: Id::<Identity, Impl, OFFSET>,
             Heading: Heading::<Identity, Impl, OFFSET>,
             Description: Description::<Identity, Impl, OFFSET>,
@@ -1466,7 +1466,7 @@ impl ISpellCheckProvider_Vtbl {
             this.InitializeWordlist(::core::mem::transmute_copy(&wordlisttype), ::core::mem::transmute(&words)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             LanguageTag: LanguageTag::<Identity, Impl, OFFSET>,
             Check: Check::<Identity, Impl, OFFSET>,
             Suggest: Suggest::<Identity, Impl, OFFSET>,
@@ -1528,7 +1528,7 @@ impl ISpellCheckProviderFactory_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SupportedLanguages: SupportedLanguages::<Identity, Impl, OFFSET>,
             IsSupported: IsSupported::<Identity, Impl, OFFSET>,
             CreateSpellCheckProvider: CreateSpellCheckProvider::<Identity, Impl, OFFSET>,
@@ -1691,7 +1691,7 @@ impl ISpellChecker_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             LanguageTag: LanguageTag::<Identity, Impl, OFFSET>,
             Check: Check::<Identity, Impl, OFFSET>,
             Suggest: Suggest::<Identity, Impl, OFFSET>,
@@ -1743,7 +1743,7 @@ impl ISpellCheckerChangedEventHandler_Vtbl {
             let this = (*this).get_impl();
             this.Invoke(::core::mem::transmute(&sender)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Invoke: Invoke::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Invoke: Invoke::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ISpellCheckerChangedEventHandler as ::windows::core::Interface>::IID
@@ -1794,7 +1794,7 @@ impl ISpellCheckerFactory_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SupportedLanguages: SupportedLanguages::<Identity, Impl, OFFSET>,
             IsSupported: IsSupported::<Identity, Impl, OFFSET>,
             CreateSpellChecker: CreateSpellChecker::<Identity, Impl, OFFSET>,
@@ -1858,7 +1858,7 @@ impl ISpellingError_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             StartIndex: StartIndex::<Identity, Impl, OFFSET>,
             Length: Length::<Identity, Impl, OFFSET>,
             CorrectiveAction: CorrectiveAction::<Identity, Impl, OFFSET>,
@@ -1887,7 +1887,7 @@ impl IUserDictionariesRegistrar_Vtbl {
             this.UnregisterUserDictionary(::core::mem::transmute(&dictionarypath), ::core::mem::transmute(&languagetag)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RegisterUserDictionary: RegisterUserDictionary::<Identity, Impl, OFFSET>,
             UnregisterUserDictionary: UnregisterUserDictionary::<Identity, Impl, OFFSET>,
         }

--- a/crates/libs/windows/src/Windows/Win32/Globalization/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Globalization/mod.rs
@@ -12034,7 +12034,7 @@ unsafe impl ::windows::core::Interface for IComprehensiveSpellCheckProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IComprehensiveSpellCheckProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ComprehensiveCheck: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, text: ::windows::core::PCWSTR, value: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Globalization\"`*"]
@@ -12093,7 +12093,7 @@ unsafe impl ::windows::core::Interface for IEnumCodePage {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumCodePage_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Clone: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut MIMECPINFO, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -12155,7 +12155,7 @@ unsafe impl ::windows::core::Interface for IEnumRfc1766 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumRfc1766_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Clone: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut RFC1766INFO, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -12217,7 +12217,7 @@ unsafe impl ::windows::core::Interface for IEnumScript {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumScript_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Clone: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut SCRIPTINFO, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -12270,7 +12270,7 @@ unsafe impl ::windows::core::Interface for IEnumSpellingError {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumSpellingError_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Globalization\"`*"]
@@ -12331,7 +12331,7 @@ unsafe impl ::windows::core::Interface for IMLangCodePages {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMLangCodePages_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCharCodePages: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, chsrc: u16, pdwcodepages: *mut u32) -> ::windows::core::HRESULT,
     pub GetStrCodePages: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszsrc: ::windows::core::PCWSTR, cchsrc: i32, dwprioritycodepages: u32, pdwcodepages: *mut u32, pcchcodepages: *mut i32) -> ::windows::core::HRESULT,
     pub CodePageToCodePages: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ucodepage: u32, pdwcodepages: *mut u32) -> ::windows::core::HRESULT,
@@ -12410,7 +12410,7 @@ unsafe impl ::windows::core::Interface for IMLangConvertCharset {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMLangConvertCharset_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, uisrccodepage: u32, uidstcodepage: u32, dwproperty: u32) -> ::windows::core::HRESULT,
     pub GetSourceCodePage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, puisrccodepage: *mut u32) -> ::windows::core::HRESULT,
     pub GetDestinationCodePage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, puidstcodepage: *mut u32) -> ::windows::core::HRESULT,
@@ -12733,7 +12733,7 @@ unsafe impl ::windows::core::Interface for IMLangLineBreakConsole {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMLangLineBreakConsole_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub BreakLineML: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psrcmlstr: *mut ::core::ffi::c_void, lsrcpos: i32, lsrclen: i32, cmincolumns: i32, cmaxcolumns: i32, pllinelen: *mut i32, plskiplen: *mut i32) -> ::windows::core::HRESULT,
     pub BreakLineW: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, locale: u32, pszsrc: ::windows::core::PCWSTR, cchsrc: i32, cmaxcolumns: i32, pcchline: *mut i32, pcchskip: *mut i32) -> ::windows::core::HRESULT,
     pub BreakLineA: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, locale: u32, ucodepage: u32, pszsrc: ::windows::core::PCSTR, cchsrc: i32, cmaxcolumns: i32, pcchline: *mut i32, pcchskip: *mut i32) -> ::windows::core::HRESULT,
@@ -12805,7 +12805,7 @@ unsafe impl ::windows::core::Interface for IMLangString {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMLangString_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Sync: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fnoaccess: super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -12997,7 +12997,7 @@ unsafe impl ::windows::core::Interface for IMLangStringBufA {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMLangStringBufA_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetStatus: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, plflags: *mut i32, pcchbuf: *mut i32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub LockBuf: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cchoffset: i32, cchmaxlock: i32, ppszbuf: *mut *mut super::Foundation::CHAR, pcchbuf: *mut i32) -> ::windows::core::HRESULT,
@@ -13069,7 +13069,7 @@ unsafe impl ::windows::core::Interface for IMLangStringBufW {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMLangStringBufW_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetStatus: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, plflags: *mut i32, pcchbuf: *mut i32) -> ::windows::core::HRESULT,
     pub LockBuf: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cchoffset: i32, cchmaxlock: i32, ppszbuf: *mut *mut u16, pcchbuf: *mut i32) -> ::windows::core::HRESULT,
     pub UnlockBuf: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszbuf: ::windows::core::PCWSTR, cchoffset: i32, cchwrite: i32) -> ::windows::core::HRESULT,
@@ -13298,7 +13298,7 @@ unsafe impl ::windows::core::Interface for IMultiLanguage {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMultiLanguage_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetNumberOfCodePageInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pccodepage: *mut u32) -> ::windows::core::HRESULT,
     pub GetCodePageInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, uicodepage: u32, pcodepageinfo: *mut MIMECPINFO) -> ::windows::core::HRESULT,
     pub GetFamilyCodePage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, uicodepage: u32, puifamilycodepage: *mut u32) -> ::windows::core::HRESULT,
@@ -13489,7 +13489,7 @@ unsafe impl ::windows::core::Interface for IMultiLanguage2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMultiLanguage2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetNumberOfCodePageInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pccodepage: *mut u32) -> ::windows::core::HRESULT,
     pub GetCodePageInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, uicodepage: u32, langid: u16, pcodepageinfo: *mut MIMECPINFO) -> ::windows::core::HRESULT,
     pub GetFamilyCodePage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, uicodepage: u32, puifamilycodepage: *mut u32) -> ::windows::core::HRESULT,
@@ -13802,7 +13802,7 @@ unsafe impl ::windows::core::Interface for IOptionDescription {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOptionDescription_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Id: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub Heading: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub Description: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
@@ -13916,7 +13916,7 @@ unsafe impl ::windows::core::Interface for ISpellCheckProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISpellCheckProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub LanguageTag: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub Check: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, text: ::windows::core::PCWSTR, value: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
@@ -14002,7 +14002,7 @@ unsafe impl ::windows::core::Interface for ISpellCheckProviderFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISpellCheckProviderFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub SupportedLanguages: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -14140,7 +14140,7 @@ unsafe impl ::windows::core::Interface for ISpellChecker {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISpellChecker_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub LanguageTag: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub Check: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, text: ::windows::core::PCWSTR, value: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
@@ -14362,7 +14362,7 @@ unsafe impl ::windows::core::Interface for ISpellCheckerChangedEventHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISpellCheckerChangedEventHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sender: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Globalization\"`*"]
@@ -14430,7 +14430,7 @@ unsafe impl ::windows::core::Interface for ISpellCheckerFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISpellCheckerFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub SupportedLanguages: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -14500,7 +14500,7 @@ unsafe impl ::windows::core::Interface for ISpellingError {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISpellingError_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub StartIndex: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: *mut u32) -> ::windows::core::HRESULT,
     pub Length: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: *mut u32) -> ::windows::core::HRESULT,
     pub CorrectiveAction: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: *mut CORRECTIVE_ACTION) -> ::windows::core::HRESULT,
@@ -14563,7 +14563,7 @@ unsafe impl ::windows::core::Interface for IUserDictionariesRegistrar {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUserDictionariesRegistrar_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub RegisterUserDictionary: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dictionarypath: ::windows::core::PCWSTR, languagetag: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub UnregisterUserDictionary: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dictionarypath: ::windows::core::PCWSTR, languagetag: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
 }

--- a/crates/libs/windows/src/Windows/Win32/Graphics/CompositionSwapchain/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/CompositionSwapchain/impl.rs
@@ -104,7 +104,7 @@ impl IPresentStatistics_Vtbl {
             this.GetKind()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetPresentId: GetPresentId::<Identity, Impl, OFFSET>,
             GetKind: GetKind::<Identity, Impl, OFFSET>,
         }
@@ -173,7 +173,7 @@ impl IPresentationBuffer_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetAvailableEvent: GetAvailableEvent::<Identity, Impl, OFFSET>,
             IsAvailable: IsAvailable::<Identity, Impl, OFFSET>,
         }
@@ -193,7 +193,7 @@ impl IPresentationContent_Vtbl {
             let this = (*this).get_impl();
             this.SetTag(::core::mem::transmute_copy(&tag))
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SetTag: SetTag::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SetTag: SetTag::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IPresentationContent as ::windows::core::Interface>::IID
@@ -229,7 +229,7 @@ impl IPresentationFactory_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             IsPresentationSupported: IsPresentationSupported::<Identity, Impl, OFFSET>,
             IsPresentationSupportedWithIndependentFlip: IsPresentationSupportedWithIndependentFlip::<Identity, Impl, OFFSET>,
             CreatePresentationManager: CreatePresentationManager::<Identity, Impl, OFFSET>,
@@ -362,7 +362,7 @@ impl IPresentationManager_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddBufferFromResource: AddBufferFromResource::<Identity, Impl, OFFSET>,
             CreatePresentationSurface: CreatePresentationSurface::<Identity, Impl, OFFSET>,
             GetNextPresentId: GetNextPresentId::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/Graphics/CompositionSwapchain/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/CompositionSwapchain/mod.rs
@@ -239,7 +239,7 @@ unsafe impl ::windows::core::Interface for IPresentStatistics {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPresentStatistics_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetPresentId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u64,
     pub GetKind: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> PresentStatisticsKind,
 }
@@ -370,7 +370,7 @@ unsafe impl ::windows::core::Interface for IPresentationBuffer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPresentationBuffer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetAvailableEvent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, availableeventhandle: *mut super::super::Foundation::HANDLE) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -423,7 +423,7 @@ unsafe impl ::windows::core::Interface for IPresentationContent {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPresentationContent_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetTag: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, tag: usize),
 }
 #[doc = "*Required features: `\"Win32_Graphics_CompositionSwapchain\"`*"]
@@ -479,7 +479,7 @@ unsafe impl ::windows::core::Interface for IPresentationFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPresentationFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub IsPresentationSupported: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u8,
     pub IsPresentationSupportedWithIndependentFlip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u8,
     pub CreatePresentationManager: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pppresentationmanager: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -584,7 +584,7 @@ unsafe impl ::windows::core::Interface for IPresentationManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPresentationManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddBufferFromResource: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, resource: *mut ::core::ffi::c_void, presentationbuffer: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub CreatePresentationSurface: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, compositionsurfacehandle: super::super::Foundation::HANDLE, presentationsurface: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/Graphics/DXCore/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/DXCore/impl.rs
@@ -70,7 +70,7 @@ impl IDXCoreAdapter_Vtbl {
             this.GetFactory(::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppvfactory)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             IsValid: IsValid::<Identity, Impl, OFFSET>,
             IsAttributeSupported: IsAttributeSupported::<Identity, Impl, OFFSET>,
             IsPropertySupported: IsPropertySupported::<Identity, Impl, OFFSET>,
@@ -132,7 +132,7 @@ impl IDXCoreAdapterFactory_Vtbl {
             this.UnregisterEventNotification(::core::mem::transmute_copy(&eventcookie)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateAdapterList: CreateAdapterList::<Identity, Impl, OFFSET>,
             GetAdapterByLuid: GetAdapterByLuid::<Identity, Impl, OFFSET>,
             IsNotificationTypeSupported: IsNotificationTypeSupported::<Identity, Impl, OFFSET>,
@@ -186,7 +186,7 @@ impl IDXCoreAdapterList_Vtbl {
             this.IsAdapterPreferenceSupported(::core::mem::transmute_copy(&preference))
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetAdapter: GetAdapter::<Identity, Impl, OFFSET>,
             GetAdapterCount: GetAdapterCount::<Identity, Impl, OFFSET>,
             IsStale: IsStale::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/Graphics/DXCore/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/DXCore/mod.rs
@@ -89,7 +89,7 @@ unsafe impl ::windows::core::Interface for IDXCoreAdapter {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDXCoreAdapter_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub IsValid: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> bool,
     pub IsAttributeSupported: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, attributeguid: *const ::windows::core::GUID) -> bool,
     pub IsPropertySupported: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, property: DXCoreAdapterProperty) -> bool,
@@ -173,7 +173,7 @@ unsafe impl ::windows::core::Interface for IDXCoreAdapterFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDXCoreAdapterFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateAdapterList: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, numattributes: u32, filterattributes: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, ppvadapterlist: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub GetAdapterByLuid: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, adapterluid: *const super::super::Foundation::LUID, riid: *const ::windows::core::GUID, ppvadapter: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -252,7 +252,7 @@ unsafe impl ::windows::core::Interface for IDXCoreAdapterList {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDXCoreAdapterList_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetAdapter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: u32, riid: *const ::windows::core::GUID, ppvadapter: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetAdapterCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32,
     pub IsStale: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> bool,

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct2D/Common/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct2D/Common/impl.rs
@@ -46,7 +46,7 @@ impl ID2D1SimplifiedGeometrySink_Vtbl {
             this.Close().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetFillMode: SetFillMode::<Identity, Impl, OFFSET>,
             SetSegmentFlags: SetSegmentFlags::<Identity, Impl, OFFSET>,
             BeginFigure: BeginFigure::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct2D/Common/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct2D/Common/mod.rs
@@ -64,7 +64,7 @@ unsafe impl ::windows::core::Interface for ID2D1SimplifiedGeometrySink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID2D1SimplifiedGeometrySink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetFillMode: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fillmode: D2D1_FILL_MODE),
     pub SetSegmentFlags: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, vertexflags: D2D1_PATH_SEGMENT),
     pub BeginFigure: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, startpoint: D2D_POINT_2F, figurebegin: D2D1_FIGURE_BEGIN),

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct2D/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct2D/impl.rs
@@ -9,7 +9,7 @@ impl ID2D1AnalysisTransform_Vtbl {
             let this = (*this).get_impl();
             this.ProcessAnalysisResults(::core::mem::transmute_copy(&analysisdata), ::core::mem::transmute_copy(&analysisdatacount)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), ProcessAnalysisResults: ProcessAnalysisResults::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), ProcessAnalysisResults: ProcessAnalysisResults::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ID2D1AnalysisTransform as ::windows::core::Interface>::IID
@@ -678,7 +678,7 @@ impl ID2D1CommandSink_Vtbl {
             this.PopLayer().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             BeginDraw: BeginDraw::<Identity, Impl, OFFSET>,
             EndDraw: EndDraw::<Identity, Impl, OFFSET>,
             SetAntialiasMode: SetAntialiasMode::<Identity, Impl, OFFSET>,
@@ -2367,7 +2367,7 @@ impl ID2D1EffectContext_Vtbl {
             this.IsBufferPrecisionSupported(::core::mem::transmute_copy(&bufferprecision))
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDpi: GetDpi::<Identity, Impl, OFFSET>,
             CreateEffect: CreateEffect::<Identity, Impl, OFFSET>,
             GetMaximumSupportedFeatureLevel: GetMaximumSupportedFeatureLevel::<Identity, Impl, OFFSET>,
@@ -2487,7 +2487,7 @@ impl ID2D1EffectImpl_Vtbl {
             this.SetGraph(::core::mem::transmute(&transformgraph)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             PrepareForRender: PrepareForRender::<Identity, Impl, OFFSET>,
             SetGraph: SetGraph::<Identity, Impl, OFFSET>,
@@ -2682,7 +2682,7 @@ impl ID2D1Factory_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ReloadSystemMetrics: ReloadSystemMetrics::<Identity, Impl, OFFSET>,
             GetDesktopDpi: GetDesktopDpi::<Identity, Impl, OFFSET>,
             CreateRectangleGeometry: CreateRectangleGeometry::<Identity, Impl, OFFSET>,
@@ -3008,7 +3008,7 @@ impl ID2D1GdiInteropRenderTarget_Vtbl {
             this.ReleaseDC(::core::mem::transmute_copy(&update)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDC: GetDC::<Identity, Impl, OFFSET>,
             ReleaseDC: ReleaseDC::<Identity, Impl, OFFSET>,
         }
@@ -3100,7 +3100,7 @@ impl ID2D1GdiMetafileSink_Vtbl {
             let this = (*this).get_impl();
             this.ProcessRecord(::core::mem::transmute_copy(&recordtype), ::core::mem::transmute_copy(&recorddata), ::core::mem::transmute_copy(&recorddatasize)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), ProcessRecord: ProcessRecord::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), ProcessRecord: ProcessRecord::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ID2D1GdiMetafileSink as ::windows::core::Interface>::IID
@@ -3968,7 +3968,7 @@ impl ID2D1Multithread_Vtbl {
             this.Leave()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetMultithreadProtected: GetMultithreadProtected::<Identity, Impl, OFFSET>,
             Enter: Enter::<Identity, Impl, OFFSET>,
             Leave: Leave::<Identity, Impl, OFFSET>,
@@ -4120,7 +4120,7 @@ impl ID2D1PrintControl_Vtbl {
             this.Close().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddPage: AddPage::<Identity, Impl, OFFSET>,
             Close: Close::<Identity, Impl, OFFSET>,
         }
@@ -4207,7 +4207,7 @@ impl ID2D1Properties_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetPropertyCount: GetPropertyCount::<Identity, Impl, OFFSET>,
             GetPropertyName: GetPropertyName::<Identity, Impl, OFFSET>,
             GetPropertyNameLength: GetPropertyNameLength::<Identity, Impl, OFFSET>,
@@ -4357,7 +4357,7 @@ impl ID2D1RenderInfo_Vtbl {
             this.SetInstructionCountHint(::core::mem::transmute_copy(&instructioncount))
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetInputDescription: SetInputDescription::<Identity, Impl, OFFSET>,
             SetOutputBuffer: SetOutputBuffer::<Identity, Impl, OFFSET>,
             SetCached: SetCached::<Identity, Impl, OFFSET>,
@@ -4826,7 +4826,7 @@ impl ID2D1Resource_Vtbl {
             let this = (*this).get_impl();
             this.GetFactory(::core::mem::transmute_copy(&factory))
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetFactory: GetFactory::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetFactory: GetFactory::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ID2D1Resource as ::windows::core::Interface>::IID
@@ -4843,7 +4843,7 @@ impl ID2D1ResourceTexture_Vtbl {
             let this = (*this).get_impl();
             this.Update(::core::mem::transmute_copy(&minimumextents), ::core::mem::transmute_copy(&maximimumextents), ::core::mem::transmute_copy(&strides), ::core::mem::transmute_copy(&dimensions), ::core::mem::transmute_copy(&data), ::core::mem::transmute_copy(&datacount)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Update: Update::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Update: Update::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ID2D1ResourceTexture as ::windows::core::Interface>::IID
@@ -5804,7 +5804,7 @@ impl ID2D1TessellationSink_Vtbl {
             this.Close().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddTriangles: AddTriangles::<Identity, Impl, OFFSET>,
             Close: Close::<Identity, Impl, OFFSET>,
         }
@@ -5916,7 +5916,7 @@ impl ID2D1TransformGraph_Vtbl {
             this.SetPassthroughGraph(::core::mem::transmute_copy(&effectinputindex)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetInputCount: GetInputCount::<Identity, Impl, OFFSET>,
             SetSingleTransformNode: SetSingleTransformNode::<Identity, Impl, OFFSET>,
             AddNode: AddNode::<Identity, Impl, OFFSET>,
@@ -5943,7 +5943,7 @@ impl ID2D1TransformNode_Vtbl {
             let this = (*this).get_impl();
             this.GetInputCount()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetInputCount: GetInputCount::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetInputCount: GetInputCount::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ID2D1TransformNode as ::windows::core::Interface>::IID
@@ -6023,7 +6023,7 @@ impl ID2D1VertexBuffer_Vtbl {
             let this = (*this).get_impl();
             this.Unmap().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Map: Map::<Identity, Impl, OFFSET>, Unmap: Unmap::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Map: Map::<Identity, Impl, OFFSET>, Unmap: Unmap::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ID2D1VertexBuffer as ::windows::core::Interface>::IID

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct2D/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct2D/mod.rs
@@ -203,7 +203,7 @@ unsafe impl ::windows::core::Interface for ID2D1AnalysisTransform {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID2D1AnalysisTransform_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ProcessAnalysisResults: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, analysisdata: *const u8, analysisdatacount: u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`*"]
@@ -2060,7 +2060,7 @@ unsafe impl ::windows::core::Interface for ID2D1CommandSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID2D1CommandSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub BeginDraw: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub EndDraw: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetAntialiasMode: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, antialiasmode: D2D1_ANTIALIAS_MODE) -> ::windows::core::HRESULT,
@@ -11696,7 +11696,7 @@ unsafe impl ::windows::core::Interface for ID2D1EffectContext {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID2D1EffectContext_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDpi: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dpix: *mut f32, dpiy: *mut f32),
     pub CreateEffect: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, effectid: *const ::windows::core::GUID, effect: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Graphics_Direct3D")]
@@ -12169,7 +12169,7 @@ unsafe impl ::windows::core::Interface for ID2D1EffectImpl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID2D1EffectImpl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, effectcontext: *mut ::core::ffi::c_void, transformgraph: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub PrepareForRender: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, changetype: D2D1_CHANGE_TYPE) -> ::windows::core::HRESULT,
     pub SetGraph: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, transformgraph: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -12492,7 +12492,7 @@ unsafe impl ::windows::core::Interface for ID2D1Factory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID2D1Factory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ReloadSystemMetrics: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetDesktopDpi: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dpix: *mut f32, dpiy: *mut f32),
     #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
@@ -14593,7 +14593,7 @@ unsafe impl ::windows::core::Interface for ID2D1GdiInteropRenderTarget {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID2D1GdiInteropRenderTarget_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Graphics_Gdi")]
     pub GetDC: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, mode: D2D1_DC_INITIALIZE_MODE, hdc: *mut super::Gdi::HDC) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Graphics_Gdi"))]
@@ -14839,7 +14839,7 @@ unsafe impl ::windows::core::Interface for ID2D1GdiMetafileSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID2D1GdiMetafileSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ProcessRecord: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, recordtype: u32, recorddata: *const ::core::ffi::c_void, recorddatasize: u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`*"]
@@ -17313,7 +17313,7 @@ unsafe impl ::windows::core::Interface for ID2D1Multithread {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID2D1Multithread_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetMultithreadProtected: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> super::super::Foundation::BOOL,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -17898,7 +17898,7 @@ unsafe impl ::windows::core::Interface for ID2D1PrintControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID2D1PrintControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_System_Com"))]
     pub AddPage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, commandlist: *mut ::core::ffi::c_void, pagesize: Common::D2D_SIZE_F, pageprintticketstream: *mut ::core::ffi::c_void, tag1: *mut u64, tag2: *mut u64) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_System_Com")))]
@@ -17993,7 +17993,7 @@ unsafe impl ::windows::core::Interface for ID2D1Properties {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID2D1Properties_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetPropertyCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32,
     pub GetPropertyName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: u32, name: ::windows::core::PWSTR, namecount: u32) -> ::windows::core::HRESULT,
     pub GetPropertyNameLength: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: u32) -> u32,
@@ -18411,7 +18411,7 @@ unsafe impl ::windows::core::Interface for ID2D1RenderInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID2D1RenderInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetInputDescription: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, inputindex: u32, inputdescription: D2D1_INPUT_DESCRIPTION) -> ::windows::core::HRESULT,
     pub SetOutputBuffer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bufferprecision: D2D1_BUFFER_PRECISION, channeldepth: D2D1_CHANNEL_DEPTH) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -19007,7 +19007,7 @@ unsafe impl ::windows::core::Interface for ID2D1Resource {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID2D1Resource_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetFactory: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, factory: *mut *mut ::core::ffi::c_void),
 }
 #[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`*"]
@@ -19058,7 +19058,7 @@ unsafe impl ::windows::core::Interface for ID2D1ResourceTexture {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID2D1ResourceTexture_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Update: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, minimumextents: *const u32, maximimumextents: *const u32, strides: *const u32, dimensions: u32, data: *const u8, datacount: u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`*"]
@@ -20920,7 +20920,7 @@ unsafe impl ::windows::core::Interface for ID2D1TessellationSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID2D1TessellationSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
     pub AddTriangles: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, triangles: *const D2D1_TRIANGLE, trianglescount: u32),
     #[cfg(not(feature = "Win32_Graphics_Direct2D_Common"))]
@@ -21111,7 +21111,7 @@ unsafe impl ::windows::core::Interface for ID2D1TransformGraph {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID2D1TransformGraph_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetInputCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32,
     pub SetSingleTransformNode: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, node: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub AddNode: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, node: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -21170,7 +21170,7 @@ unsafe impl ::windows::core::Interface for ID2D1TransformNode {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID2D1TransformNode_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetInputCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32,
 }
 #[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`*"]
@@ -21503,7 +21503,7 @@ unsafe impl ::windows::core::Interface for ID2D1VertexBuffer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID2D1VertexBuffer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Map: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, data: *mut *mut u8, buffersize: u32) -> ::windows::core::HRESULT,
     pub Unmap: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D/Dxc/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D/Dxc/impl.rs
@@ -15,7 +15,7 @@ impl IDxcAssembler_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), AssembleToContainer: AssembleToContainer::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), AssembleToContainer: AssembleToContainer::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDxcAssembler as ::windows::core::Interface>::IID
@@ -39,7 +39,7 @@ impl IDxcBlob_Vtbl {
             this.GetBufferSize()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetBufferPointer: GetBufferPointer::<Identity, Impl, OFFSET>,
             GetBufferSize: GetBufferSize::<Identity, Impl, OFFSET>,
         }
@@ -170,7 +170,7 @@ impl IDxcCompiler_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Compile: Compile::<Identity, Impl, OFFSET>,
             Preprocess: Preprocess::<Identity, Impl, OFFSET>,
             Disassemble: Disassemble::<Identity, Impl, OFFSET>,
@@ -229,7 +229,7 @@ impl IDxcCompiler3_Vtbl {
             this.Disassemble(::core::mem::transmute_copy(&pobject), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppresult)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Compile: Compile::<Identity, Impl, OFFSET>,
             Disassemble: Disassemble::<Identity, Impl, OFFSET>,
         }
@@ -274,7 +274,7 @@ impl IDxcCompilerArgs_Vtbl {
             this.AddDefines(::core::mem::transmute_copy(&pdefines), ::core::mem::transmute_copy(&definecount)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetArguments: GetArguments::<Identity, Impl, OFFSET>,
             GetCount: GetCount::<Identity, Impl, OFFSET>,
             AddArguments: AddArguments::<Identity, Impl, OFFSET>,
@@ -322,7 +322,7 @@ impl IDxcContainerBuilder_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Load: Load::<Identity, Impl, OFFSET>,
             AddPart: AddPart::<Identity, Impl, OFFSET>,
             RemovePart: RemovePart::<Identity, Impl, OFFSET>,
@@ -399,7 +399,7 @@ impl IDxcContainerReflection_Vtbl {
             this.GetPartReflection(::core::mem::transmute_copy(&idx), ::core::mem::transmute_copy(&iid), ::core::mem::transmute_copy(&ppvobject)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Load: Load::<Identity, Impl, OFFSET>,
             GetPartCount: GetPartCount::<Identity, Impl, OFFSET>,
             GetPartKind: GetPartKind::<Identity, Impl, OFFSET>,
@@ -430,7 +430,7 @@ impl IDxcExtraOutputs_Vtbl {
             this.GetOutput(::core::mem::transmute_copy(&uindex), ::core::mem::transmute_copy(&iid), ::core::mem::transmute_copy(&ppvobject), ::core::mem::transmute_copy(&ppoutputtype), ::core::mem::transmute_copy(&ppoutputname)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetOutputCount: GetOutputCount::<Identity, Impl, OFFSET>,
             GetOutput: GetOutput::<Identity, Impl, OFFSET>,
         }
@@ -456,7 +456,7 @@ impl IDxcIncludeHandler_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), LoadSource: LoadSource::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), LoadSource: LoadSource::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDxcIncludeHandler as ::windows::core::Interface>::IID
@@ -585,7 +585,7 @@ impl IDxcLibrary_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetMalloc: SetMalloc::<Identity, Impl, OFFSET>,
             CreateBlobFromBlob: CreateBlobFromBlob::<Identity, Impl, OFFSET>,
             CreateBlobFromFile: CreateBlobFromFile::<Identity, Impl, OFFSET>,
@@ -626,7 +626,7 @@ impl IDxcLinker_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RegisterLibrary: RegisterLibrary::<Identity, Impl, OFFSET>,
             Link: Link::<Identity, Impl, OFFSET>,
         }
@@ -677,7 +677,7 @@ impl IDxcOperationResult_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetStatus: GetStatus::<Identity, Impl, OFFSET>,
             GetResult: GetResult::<Identity, Impl, OFFSET>,
             GetErrorBuffer: GetErrorBuffer::<Identity, Impl, OFFSET>,
@@ -723,7 +723,7 @@ impl IDxcOptimizer_Vtbl {
             this.RunOptimizer(::core::mem::transmute(&pblob), ::core::mem::transmute_copy(&ppoptions), ::core::mem::transmute_copy(&optioncount), ::core::mem::transmute_copy(&poutputmodule), ::core::mem::transmute_copy(&ppoutputtext)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetAvailablePassCount: GetAvailablePassCount::<Identity, Impl, OFFSET>,
             GetAvailablePass: GetAvailablePass::<Identity, Impl, OFFSET>,
             RunOptimizer: RunOptimizer::<Identity, Impl, OFFSET>,
@@ -799,7 +799,7 @@ impl IDxcOptimizerPass_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetOptionName: GetOptionName::<Identity, Impl, OFFSET>,
             GetDescription: GetDescription::<Identity, Impl, OFFSET>,
             GetOptionArgCount: GetOptionArgCount::<Identity, Impl, OFFSET>,
@@ -1072,7 +1072,7 @@ impl IDxcPdbUtils_Vtbl {
             this.OverrideRootSignature(::core::mem::transmute(&prootsignature)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Load: Load::<Identity, Impl, OFFSET>,
             GetSourceCount: GetSourceCount::<Identity, Impl, OFFSET>,
             GetSource: GetSource::<Identity, Impl, OFFSET>,
@@ -1301,7 +1301,7 @@ impl IDxcUtils_Vtbl {
             this.GetPDBContents(::core::mem::transmute(&ppdbblob), ::core::mem::transmute_copy(&pphash), ::core::mem::transmute_copy(&ppcontainer)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateBlobFromBlob: CreateBlobFromBlob::<Identity, Impl, OFFSET>,
             CreateBlobFromPinned: CreateBlobFromPinned::<Identity, Impl, OFFSET>,
             MoveToBlob: MoveToBlob::<Identity, Impl, OFFSET>,
@@ -1338,7 +1338,7 @@ impl IDxcValidator_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Validate: Validate::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Validate: Validate::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDxcValidator as ::windows::core::Interface>::IID
@@ -1391,7 +1391,7 @@ impl IDxcVersionInfo_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetVersion: GetVersion::<Identity, Impl, OFFSET>,
             GetFlags: GetFlags::<Identity, Impl, OFFSET>,
         }
@@ -1434,7 +1434,7 @@ impl IDxcVersionInfo3_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetCustomVersionString: GetCustomVersionString::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetCustomVersionString: GetCustomVersionString::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDxcVersionInfo3 as ::windows::core::Interface>::IID

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D/Dxc/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D/Dxc/mod.rs
@@ -76,7 +76,7 @@ unsafe impl ::windows::core::Interface for IDxcAssembler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDxcAssembler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AssembleToContainer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pshader: *mut ::core::ffi::c_void, ppresult: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Graphics_Direct3D_Dxc\"`*"]
@@ -128,7 +128,7 @@ unsafe impl ::windows::core::Interface for IDxcBlob {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDxcBlob_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetBufferPointer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> *mut ::core::ffi::c_void,
     pub GetBufferSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> usize,
 }
@@ -465,7 +465,7 @@ unsafe impl ::windows::core::Interface for IDxcCompiler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDxcCompiler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Compile: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psource: *mut ::core::ffi::c_void, psourcename: ::windows::core::PCWSTR, pentrypoint: ::windows::core::PCWSTR, ptargetprofile: ::windows::core::PCWSTR, parguments: *const ::windows::core::PWSTR, argcount: u32, pdefines: *const DxcDefine, definecount: u32, pincludehandler: *mut ::core::ffi::c_void, ppresult: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Preprocess: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psource: *mut ::core::ffi::c_void, psourcename: ::windows::core::PCWSTR, parguments: *const ::windows::core::PWSTR, argcount: u32, pdefines: *const DxcDefine, definecount: u32, pincludehandler: *mut ::core::ffi::c_void, ppresult: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Disassemble: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psource: *mut ::core::ffi::c_void, ppdisassembly: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -635,7 +635,7 @@ unsafe impl ::windows::core::Interface for IDxcCompiler3 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDxcCompiler3_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Compile: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psource: *const DxcBuffer, parguments: *const ::windows::core::PWSTR, argcount: u32, pincludehandler: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppresult: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Disassemble: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pobject: *const DxcBuffer, riid: *const ::windows::core::GUID, ppresult: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -697,7 +697,7 @@ unsafe impl ::windows::core::Interface for IDxcCompilerArgs {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDxcCompilerArgs_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetArguments: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> *mut ::windows::core::PWSTR,
     pub GetCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32,
     pub AddArguments: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, parguments: *const ::windows::core::PWSTR, argcount: u32) -> ::windows::core::HRESULT,
@@ -766,7 +766,7 @@ unsafe impl ::windows::core::Interface for IDxcContainerBuilder {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDxcContainerBuilder_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Load: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdxilcontainerheader: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub AddPart: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fourcc: u32, psource: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub RemovePart: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fourcc: u32) -> ::windows::core::HRESULT,
@@ -840,7 +840,7 @@ unsafe impl ::windows::core::Interface for IDxcContainerReflection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDxcContainerReflection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Load: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcontainer: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetPartCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, presult: *mut u32) -> ::windows::core::HRESULT,
     pub GetPartKind: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, idx: u32, presult: *mut u32) -> ::windows::core::HRESULT,
@@ -900,7 +900,7 @@ unsafe impl ::windows::core::Interface for IDxcExtraOutputs {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDxcExtraOutputs_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetOutputCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32,
     pub GetOutput: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, uindex: u32, iid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void, ppoutputtype: *mut *mut ::core::ffi::c_void, ppoutputname: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -954,7 +954,7 @@ unsafe impl ::windows::core::Interface for IDxcIncludeHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDxcIncludeHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub LoadSource: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfilename: ::windows::core::PCWSTR, ppincludesource: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Graphics_Direct3D_Dxc\"`*"]
@@ -1066,7 +1066,7 @@ unsafe impl ::windows::core::Interface for IDxcLibrary {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDxcLibrary_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub SetMalloc: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pmalloc: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -1145,7 +1145,7 @@ unsafe impl ::windows::core::Interface for IDxcLinker {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDxcLinker_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub RegisterLibrary: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, plibname: ::windows::core::PCWSTR, plib: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Link: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pentryname: ::windows::core::PCWSTR, ptargetprofile: ::windows::core::PCWSTR, plibnames: *const ::windows::core::PWSTR, libcount: u32, parguments: *const ::windows::core::PWSTR, argcount: u32, ppresult: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -1204,7 +1204,7 @@ unsafe impl ::windows::core::Interface for IDxcOperationResult {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDxcOperationResult_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetStatus: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pstatus: *mut ::windows::core::HRESULT) -> ::windows::core::HRESULT,
     pub GetResult: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppresult: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetErrorBuffer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pperrors: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1266,7 +1266,7 @@ unsafe impl ::windows::core::Interface for IDxcOptimizer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDxcOptimizer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetAvailablePassCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcount: *mut u32) -> ::windows::core::HRESULT,
     pub GetAvailablePass: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: u32, ppresult: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub RunOptimizer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pblob: *mut ::core::ffi::c_void, ppoptions: *const ::windows::core::PWSTR, optioncount: u32, poutputmodule: *mut *mut ::core::ffi::c_void, ppoutputtext: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1334,7 +1334,7 @@ unsafe impl ::windows::core::Interface for IDxcOptimizerPass {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDxcOptimizerPass_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetOptionName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppresult: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetDescription: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppresult: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetOptionArgCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcount: *mut u32) -> ::windows::core::HRESULT,
@@ -1485,7 +1485,7 @@ unsafe impl ::windows::core::Interface for IDxcPdbUtils {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDxcPdbUtils_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Load: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppdbordxil: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetSourceCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcount: *mut u32) -> ::windows::core::HRESULT,
     pub GetSource: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, uindex: u32, ppresult: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1736,7 +1736,7 @@ unsafe impl ::windows::core::Interface for IDxcUtils {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDxcUtils_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateBlobFromBlob: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pblob: *mut ::core::ffi::c_void, offset: u32, length: u32, ppresult: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CreateBlobFromPinned: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdata: *const ::core::ffi::c_void, size: u32, codepage: DXC_CP, pblobencoding: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
@@ -1807,7 +1807,7 @@ unsafe impl ::windows::core::Interface for IDxcValidator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDxcValidator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Validate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pshader: *mut ::core::ffi::c_void, flags: u32, ppresult: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Graphics_Direct3D_Dxc\"`*"]
@@ -1935,7 +1935,7 @@ unsafe impl ::windows::core::Interface for IDxcVersionInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDxcVersionInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetVersion: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pmajor: *mut u32, pminor: *mut u32) -> ::windows::core::HRESULT,
     pub GetFlags: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pflags: *mut u32) -> ::windows::core::HRESULT,
 }
@@ -2057,7 +2057,7 @@ unsafe impl ::windows::core::Interface for IDxcVersionInfo3 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDxcVersionInfo3_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCustomVersionString: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pversionstring: *mut *mut i8) -> ::windows::core::HRESULT,
 }
 pub const CLSID_DxcAssembler: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd728db68_f903_4f80_94cd_dccf76ec7151);

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D/impl.rs
@@ -16,7 +16,7 @@ impl ID3DBlob_Vtbl {
             this.GetBufferSize()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetBufferPointer: GetBufferPointer::<Identity, Impl, OFFSET>,
             GetBufferSize: GetBufferSize::<Identity, Impl, OFFSET>,
         }
@@ -49,7 +49,7 @@ impl ID3DDestructionNotifier_Vtbl {
             this.UnregisterDestructionCallback(::core::mem::transmute_copy(&callbackid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RegisterDestructionCallback: RegisterDestructionCallback::<Identity, Impl, OFFSET>,
             UnregisterDestructionCallback: UnregisterDestructionCallback::<Identity, Impl, OFFSET>,
         }

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D/mod.rs
@@ -53,7 +53,7 @@ unsafe impl ::windows::core::Interface for ID3DBlob {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3DBlob_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetBufferPointer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> *mut ::core::ffi::c_void,
     pub GetBufferSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> usize,
 }
@@ -109,7 +109,7 @@ unsafe impl ::windows::core::Interface for ID3DDestructionNotifier {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3DDestructionNotifier_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub RegisterDestructionCallback: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, callbackfn: *mut ::core::ffi::c_void, pdata: *const ::core::ffi::c_void, pcallbackid: *mut u32) -> ::windows::core::HRESULT,
     pub UnregisterDestructionCallback: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, callbackid: u32) -> ::windows::core::HRESULT,
 }

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D10/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D10/impl.rs
@@ -187,7 +187,7 @@ impl ID3D10Debug_Vtbl {
             this.Validate().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetFeatureMask: SetFeatureMask::<Identity, Impl, OFFSET>,
             GetFeatureMask: GetFeatureMask::<Identity, Impl, OFFSET>,
             SetPresentPerRenderOpDelay: SetPresentPerRenderOpDelay::<Identity, Impl, OFFSET>,
@@ -946,7 +946,7 @@ impl ID3D10Device_Vtbl {
             this.GetTextFilterSize(::core::mem::transmute_copy(&pwidth), ::core::mem::transmute_copy(&pheight))
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             VSSetConstantBuffers: VSSetConstantBuffers::<Identity, Impl, OFFSET>,
             PSSetShaderResources: PSSetShaderResources::<Identity, Impl, OFFSET>,
             PSSetShader: PSSetShader::<Identity, Impl, OFFSET>,
@@ -1127,7 +1127,7 @@ impl ID3D10DeviceChild_Vtbl {
             this.SetPrivateDataInterface(::core::mem::transmute_copy(&guid), ::core::mem::transmute(&pdata)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDevice: GetDevice::<Identity, Impl, OFFSET>,
             GetPrivateData: GetPrivateData::<Identity, Impl, OFFSET>,
             SetPrivateData: SetPrivateData::<Identity, Impl, OFFSET>,
@@ -1237,7 +1237,7 @@ impl ID3D10Effect_Vtbl {
             this.IsOptimized()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             IsValid: IsValid::<Identity, Impl, OFFSET>,
             IsPool: IsPool::<Identity, Impl, OFFSET>,
             GetDevice: GetDevice::<Identity, Impl, OFFSET>,
@@ -1608,7 +1608,7 @@ impl ID3D10EffectPool_Vtbl {
             let this = (*this).get_impl();
             this.AsEffect()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), AsEffect: AsEffect::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), AsEffect: AsEffect::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ID3D10EffectPool as ::windows::core::Interface>::IID
@@ -2705,7 +2705,7 @@ impl ID3D10InfoQueue_Vtbl {
             this.GetMuteDebugOutput()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetMessageCountLimit: SetMessageCountLimit::<Identity, Impl, OFFSET>,
             ClearStoredMessages: ClearStoredMessages::<Identity, Impl, OFFSET>,
             GetMessage: GetMessage::<Identity, Impl, OFFSET>,
@@ -2790,7 +2790,7 @@ impl ID3D10Multithread_Vtbl {
             this.GetMultithreadProtected()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Enter: Enter::<Identity, Impl, OFFSET>,
             Leave: Leave::<Identity, Impl, OFFSET>,
             SetMultithreadProtected: SetMultithreadProtected::<Identity, Impl, OFFSET>,
@@ -2998,7 +2998,7 @@ impl ID3D10ShaderReflection_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDesc: GetDesc::<Identity, Impl, OFFSET>,
             GetConstantBufferByIndex: GetConstantBufferByIndex::<Identity, Impl, OFFSET>,
             GetConstantBufferByName: GetConstantBufferByName::<Identity, Impl, OFFSET>,
@@ -3182,7 +3182,7 @@ impl ID3D10ShaderReflection1_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDesc: GetDesc::<Identity, Impl, OFFSET>,
             GetConstantBufferByIndex: GetConstantBufferByIndex::<Identity, Impl, OFFSET>,
             GetConstantBufferByName: GetConstantBufferByName::<Identity, Impl, OFFSET>,
@@ -3394,7 +3394,7 @@ impl ID3D10StateBlock_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Capture: Capture::<Identity, Impl, OFFSET>,
             Apply: Apply::<Identity, Impl, OFFSET>,
             ReleaseAllDeviceObjects: ReleaseAllDeviceObjects::<Identity, Impl, OFFSET>,
@@ -3426,7 +3426,7 @@ impl ID3D10SwitchToRef_Vtbl {
             this.GetUseRef()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetUseRef: SetUseRef::<Identity, Impl, OFFSET>,
             GetUseRef: GetUseRef::<Identity, Impl, OFFSET>,
         }

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D10/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D10/mod.rs
@@ -929,7 +929,7 @@ unsafe impl ::windows::core::Interface for ID3D10Debug {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D10Debug_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetFeatureMask: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, mask: u32) -> ::windows::core::HRESULT,
     pub GetFeatureMask: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32,
     pub SetPresentPerRenderOpDelay: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, milliseconds: u32) -> ::windows::core::HRESULT,
@@ -1599,7 +1599,7 @@ unsafe impl ::windows::core::Interface for ID3D10Device {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D10Device_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub VSSetConstantBuffers: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, startslot: u32, numbuffers: u32, ppconstantbuffers: *const *mut ::core::ffi::c_void),
     pub PSSetShaderResources: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, startslot: u32, numviews: u32, ppshaderresourceviews: *const *mut ::core::ffi::c_void),
     pub PSSetShader: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppixelshader: *mut ::core::ffi::c_void),
@@ -2331,7 +2331,7 @@ unsafe impl ::windows::core::Interface for ID3D10DeviceChild {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D10DeviceChild_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDevice: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppdevice: *mut *mut ::core::ffi::c_void),
     pub GetPrivateData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, guid: *const ::windows::core::GUID, pdatasize: *mut u32, pdata: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetPrivateData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, guid: *const ::windows::core::GUID, datasize: u32, pdata: *const ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -2443,7 +2443,7 @@ unsafe impl ::windows::core::Interface for ID3D10Effect {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D10Effect_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub IsValid: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> super::super::Foundation::BOOL,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -3369,7 +3369,7 @@ unsafe impl ::windows::core::Interface for ID3D10EffectPool {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D10EffectPool_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AsEffect: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::core::option::Option<ID3D10Effect>,
 }
 #[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`*"]
@@ -5258,7 +5258,7 @@ unsafe impl ::windows::core::Interface for ID3D10InfoQueue {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D10InfoQueue_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetMessageCountLimit: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, messagecountlimit: u64) -> ::windows::core::HRESULT,
     pub ClearStoredMessages: unsafe extern "system" fn(this: *mut ::core::ffi::c_void),
     pub GetMessage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, messageindex: u64, pmessage: *mut D3D10_MESSAGE, pmessagebytelength: *mut usize) -> ::windows::core::HRESULT,
@@ -5460,7 +5460,7 @@ unsafe impl ::windows::core::Interface for ID3D10Multithread {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D10Multithread_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Enter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void),
     pub Leave: unsafe extern "system" fn(this: *mut ::core::ffi::c_void),
     #[cfg(feature = "Win32_Foundation")]
@@ -6217,7 +6217,7 @@ unsafe impl ::windows::core::Interface for ID3D10ShaderReflection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D10ShaderReflection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Graphics_Direct3D")]
     pub GetDesc: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdesc: *mut D3D10_SHADER_DESC) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Graphics_Direct3D"))]
@@ -6364,7 +6364,7 @@ unsafe impl ::windows::core::Interface for ID3D10ShaderReflection1 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D10ShaderReflection1_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Graphics_Direct3D")]
     pub GetDesc: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdesc: *mut D3D10_SHADER_DESC) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Graphics_Direct3D"))]
@@ -6838,7 +6838,7 @@ unsafe impl ::windows::core::Interface for ID3D10StateBlock {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D10StateBlock_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Capture: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Apply: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub ReleaseAllDeviceObjects: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -6902,7 +6902,7 @@ unsafe impl ::windows::core::Interface for ID3D10SwitchToRef {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D10SwitchToRef_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub SetUseRef: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, useref: super::super::Foundation::BOOL) -> super::super::Foundation::BOOL,
     #[cfg(not(feature = "Win32_Foundation"))]

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D11/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D11/impl.rs
@@ -368,7 +368,7 @@ impl ID3D11Debug_Vtbl {
             this.ValidateContextForDispatch(::core::mem::transmute(&pcontext)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetFeatureMask: SetFeatureMask::<Identity, Impl, OFFSET>,
             GetFeatureMask: GetFeatureMask::<Identity, Impl, OFFSET>,
             SetPresentPerRenderOpDelay: SetPresentPerRenderOpDelay::<Identity, Impl, OFFSET>,
@@ -835,7 +835,7 @@ impl ID3D11Device_Vtbl {
             this.GetExceptionMode()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateBuffer: CreateBuffer::<Identity, Impl, OFFSET>,
             CreateTexture1D: CreateTexture1D::<Identity, Impl, OFFSET>,
             CreateTexture2D: CreateTexture2D::<Identity, Impl, OFFSET>,
@@ -1258,7 +1258,7 @@ impl ID3D11DeviceChild_Vtbl {
             this.SetPrivateDataInterface(::core::mem::transmute_copy(&guid), ::core::mem::transmute(&pdata)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDevice: GetDevice::<Identity, Impl, OFFSET>,
             GetPrivateData: GetPrivateData::<Identity, Impl, OFFSET>,
             SetPrivateData: SetPrivateData::<Identity, Impl, OFFSET>,
@@ -2496,7 +2496,7 @@ impl ID3D11FunctionLinkingGraph_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateModuleInstance: CreateModuleInstance::<Identity, Impl, OFFSET>,
             SetInputSignature: SetInputSignature::<Identity, Impl, OFFSET>,
             SetOutputSignature: SetOutputSignature::<Identity, Impl, OFFSET>,
@@ -2858,7 +2858,7 @@ impl ID3D11InfoQueue_Vtbl {
             this.GetMuteDebugOutput()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetMessageCountLimit: SetMessageCountLimit::<Identity, Impl, OFFSET>,
             ClearStoredMessages: ClearStoredMessages::<Identity, Impl, OFFSET>,
             GetMessage: GetMessage::<Identity, Impl, OFFSET>,
@@ -2934,7 +2934,7 @@ impl ID3D11LibraryReflection_Vtbl {
             this.GetFunctionByIndex(::core::mem::transmute_copy(&functionindex))
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDesc: GetDesc::<Identity, Impl, OFFSET>,
             GetFunctionByIndex: GetFunctionByIndex::<Identity, Impl, OFFSET>,
         }
@@ -2970,7 +2970,7 @@ impl ID3D11Linker_Vtbl {
             this.AddClipPlaneFromCBuffer(::core::mem::transmute_copy(&ucbufferslot), ::core::mem::transmute_copy(&ucbufferentry)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Link: Link::<Identity, Impl, OFFSET>,
             UseLibrary: UseLibrary::<Identity, Impl, OFFSET>,
             AddClipPlaneFromCBuffer: AddClipPlaneFromCBuffer::<Identity, Impl, OFFSET>,
@@ -2984,7 +2984,7 @@ pub trait ID3D11LinkingNode_Impl: Sized {}
 impl ::windows::core::RuntimeName for ID3D11LinkingNode {}
 impl ID3D11LinkingNode_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D11LinkingNode_Impl, const OFFSET: isize>() -> ID3D11LinkingNode_Vtbl {
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>() }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>() }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ID3D11LinkingNode as ::windows::core::Interface>::IID
@@ -3007,7 +3007,7 @@ impl ID3D11Module_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CreateInstance: CreateInstance::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CreateInstance: CreateInstance::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ID3D11Module as ::windows::core::Interface>::IID
@@ -3079,7 +3079,7 @@ impl ID3D11ModuleInstance_Vtbl {
             this.BindResourceAsUnorderedAccessViewByName(::core::mem::transmute(&psrvname), ::core::mem::transmute_copy(&udstuavslot), ::core::mem::transmute_copy(&ucount)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             BindConstantBuffer: BindConstantBuffer::<Identity, Impl, OFFSET>,
             BindConstantBufferByName: BindConstantBufferByName::<Identity, Impl, OFFSET>,
             BindResource: BindResource::<Identity, Impl, OFFSET>,
@@ -3129,7 +3129,7 @@ impl ID3D11Multithread_Vtbl {
             this.GetMultithreadProtected()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Enter: Enter::<Identity, Impl, OFFSET>,
             Leave: Leave::<Identity, Impl, OFFSET>,
             SetMultithreadProtected: SetMultithreadProtected::<Identity, Impl, OFFSET>,
@@ -3265,7 +3265,7 @@ impl ID3D11RefDefaultTrackingOptions_Vtbl {
             let this = (*this).get_impl();
             this.SetTrackingOptions(::core::mem::transmute_copy(&resourcetypeflags), ::core::mem::transmute_copy(&options)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SetTrackingOptions: SetTrackingOptions::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SetTrackingOptions: SetTrackingOptions::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ID3D11RefDefaultTrackingOptions as ::windows::core::Interface>::IID
@@ -3282,7 +3282,7 @@ impl ID3D11RefTrackingOptions_Vtbl {
             let this = (*this).get_impl();
             this.SetTrackingOptions(::core::mem::transmute_copy(&uoptions)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SetTrackingOptions: SetTrackingOptions::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SetTrackingOptions: SetTrackingOptions::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ID3D11RefTrackingOptions as ::windows::core::Interface>::IID
@@ -3544,7 +3544,7 @@ impl ID3D11ShaderReflection_Vtbl {
             this.GetRequiresFlags()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDesc: GetDesc::<Identity, Impl, OFFSET>,
             GetConstantBufferByIndex: GetConstantBufferByIndex::<Identity, Impl, OFFSET>,
             GetConstantBufferByName: GetConstantBufferByName::<Identity, Impl, OFFSET>,
@@ -3871,7 +3871,7 @@ impl ID3D11ShaderTrace_Vtbl {
             this.GetReadRegister(::core::mem::transmute_copy(&stepindex), ::core::mem::transmute_copy(&readregisterindex), ::core::mem::transmute_copy(&pregister), ::core::mem::transmute_copy(&pvalue)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             TraceReady: TraceReady::<Identity, Impl, OFFSET>,
             ResetTrace: ResetTrace::<Identity, Impl, OFFSET>,
             GetTraceStats: GetTraceStats::<Identity, Impl, OFFSET>,
@@ -3903,7 +3903,7 @@ impl ID3D11ShaderTraceFactory_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CreateShaderTrace: CreateShaderTrace::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CreateShaderTrace: CreateShaderTrace::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ID3D11ShaderTraceFactory as ::windows::core::Interface>::IID
@@ -3930,7 +3930,7 @@ impl ID3D11SwitchToRef_Vtbl {
             this.GetUseRef()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetUseRef: SetUseRef::<Identity, Impl, OFFSET>,
             GetUseRef: GetUseRef::<Identity, Impl, OFFSET>,
         }
@@ -4057,7 +4057,7 @@ impl ID3D11TracingDevice_Vtbl {
             this.SetShaderTrackingOptions(::core::mem::transmute(&pshader), ::core::mem::transmute_copy(&options)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetShaderTrackingOptionsByType: SetShaderTrackingOptionsByType::<Identity, Impl, OFFSET>,
             SetShaderTrackingOptions: SetShaderTrackingOptions::<Identity, Impl, OFFSET>,
         }
@@ -4998,7 +4998,7 @@ impl ID3D11VideoDevice_Vtbl {
             this.SetPrivateDataInterface(::core::mem::transmute_copy(&guid), ::core::mem::transmute(&pdata)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateVideoDecoder: CreateVideoDecoder::<Identity, Impl, OFFSET>,
             CreateVideoProcessor: CreateVideoProcessor::<Identity, Impl, OFFSET>,
             CreateAuthenticatedChannel: CreateAuthenticatedChannel::<Identity, Impl, OFFSET>,
@@ -5355,7 +5355,7 @@ impl ID3DUserDefinedAnnotation_Vtbl {
             this.GetStatus()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             BeginEvent: BeginEvent::<Identity, Impl, OFFSET>,
             EndEvent: EndEvent::<Identity, Impl, OFFSET>,
             SetMarker: SetMarker::<Identity, Impl, OFFSET>,
@@ -5414,7 +5414,7 @@ impl ID3DX11FFT_Vtbl {
             this.InverseTransform(::core::mem::transmute(&pinputbuffer), ::core::mem::transmute_copy(&ppoutputbuffer)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetForwardScale: SetForwardScale::<Identity, Impl, OFFSET>,
             GetForwardScale: GetForwardScale::<Identity, Impl, OFFSET>,
             SetInverseScale: SetInverseScale::<Identity, Impl, OFFSET>,
@@ -5452,7 +5452,7 @@ impl ID3DX11Scan_Vtbl {
             this.Multiscan(::core::mem::transmute_copy(&elementtype), ::core::mem::transmute_copy(&opcode), ::core::mem::transmute_copy(&elementscansize), ::core::mem::transmute_copy(&elementscanpitch), ::core::mem::transmute_copy(&scancount), ::core::mem::transmute(&psrc), ::core::mem::transmute(&pdst)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetScanDirection: SetScanDirection::<Identity, Impl, OFFSET>,
             Scan: Scan::<Identity, Impl, OFFSET>,
             Multiscan: Multiscan::<Identity, Impl, OFFSET>,
@@ -5480,7 +5480,7 @@ impl ID3DX11SegmentedScan_Vtbl {
             this.SegScan(::core::mem::transmute_copy(&elementtype), ::core::mem::transmute_copy(&opcode), ::core::mem::transmute_copy(&elementscansize), ::core::mem::transmute(&psrc), ::core::mem::transmute(&psrcelementflags), ::core::mem::transmute(&pdst)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetScanDirection: SetScanDirection::<Identity, Impl, OFFSET>,
             SegScan: SegScan::<Identity, Impl, OFFSET>,
         }

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D11/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D11/mod.rs
@@ -1274,7 +1274,7 @@ unsafe impl ::windows::core::Interface for ID3D11Debug {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D11Debug_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetFeatureMask: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, mask: u32) -> ::windows::core::HRESULT,
     pub GetFeatureMask: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32,
     pub SetPresentPerRenderOpDelay: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, milliseconds: u32) -> ::windows::core::HRESULT,
@@ -1755,7 +1755,7 @@ unsafe impl ::windows::core::Interface for ID3D11Device {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D11Device_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateBuffer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdesc: *const D3D11_BUFFER_DESC, pinitialdata: *const D3D11_SUBRESOURCE_DATA, ppbuffer: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
     pub CreateTexture1D: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdesc: *const D3D11_TEXTURE1D_DESC, pinitialdata: *const D3D11_SUBRESOURCE_DATA, pptexture1d: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -4137,7 +4137,7 @@ unsafe impl ::windows::core::Interface for ID3D11DeviceChild {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D11DeviceChild_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDevice: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppdevice: *mut *mut ::core::ffi::c_void),
     pub GetPrivateData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, guid: *const ::windows::core::GUID, pdatasize: *mut u32, pdata: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetPrivateData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, guid: *const ::windows::core::GUID, datasize: u32, pdata: *const ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -8144,7 +8144,7 @@ unsafe impl ::windows::core::Interface for ID3D11FunctionLinkingGraph {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D11FunctionLinkingGraph_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Graphics_Direct3D")]
     pub CreateModuleInstance: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppmoduleinstance: *mut *mut ::core::ffi::c_void, pperrorbuffer: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Graphics_Direct3D"))]
@@ -8634,7 +8634,7 @@ unsafe impl ::windows::core::Interface for ID3D11InfoQueue {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D11InfoQueue_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetMessageCountLimit: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, messagecountlimit: u64) -> ::windows::core::HRESULT,
     pub ClearStoredMessages: unsafe extern "system" fn(this: *mut ::core::ffi::c_void),
     pub GetMessage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, messageindex: u64, pmessage: *mut D3D11_MESSAGE, pmessagebytelength: *mut usize) -> ::windows::core::HRESULT,
@@ -8824,7 +8824,7 @@ unsafe impl ::windows::core::Interface for ID3D11LibraryReflection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D11LibraryReflection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDesc: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdesc: *mut D3D11_LIBRARY_DESC) -> ::windows::core::HRESULT,
     pub GetFunctionByIndex: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, functionindex: i32) -> ::core::option::Option<ID3D11FunctionReflection>,
 }
@@ -8892,7 +8892,7 @@ unsafe impl ::windows::core::Interface for ID3D11Linker {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D11Linker_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Graphics_Direct3D")]
     pub Link: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pentry: *mut ::core::ffi::c_void, pentryname: ::windows::core::PCSTR, ptargetname: ::windows::core::PCSTR, uflags: u32, ppshaderblob: *mut *mut ::core::ffi::c_void, pperrorbuffer: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Graphics_Direct3D"))]
@@ -8944,7 +8944,7 @@ unsafe impl ::windows::core::Interface for ID3D11LinkingNode {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D11LinkingNode_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
 }
 #[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`*"]
 #[repr(transparent)]
@@ -8998,7 +8998,7 @@ unsafe impl ::windows::core::Interface for ID3D11Module {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D11Module_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateInstance: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pnamespace: ::windows::core::PCSTR, ppmoduleinstance: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`*"]
@@ -9091,7 +9091,7 @@ unsafe impl ::windows::core::Interface for ID3D11ModuleInstance {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D11ModuleInstance_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub BindConstantBuffer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, usrcslot: u32, udstslot: u32, cbdstoffset: u32) -> ::windows::core::HRESULT,
     pub BindConstantBufferByName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pname: ::windows::core::PCSTR, udstslot: u32, cbdstoffset: u32) -> ::windows::core::HRESULT,
     pub BindResource: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, usrcslot: u32, udstslot: u32, ucount: u32) -> ::windows::core::HRESULT,
@@ -9167,7 +9167,7 @@ unsafe impl ::windows::core::Interface for ID3D11Multithread {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D11Multithread_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Enter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void),
     pub Leave: unsafe extern "system" fn(this: *mut ::core::ffi::c_void),
     #[cfg(feature = "Win32_Foundation")]
@@ -9951,7 +9951,7 @@ unsafe impl ::windows::core::Interface for ID3D11RefDefaultTrackingOptions {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D11RefDefaultTrackingOptions_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetTrackingOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, resourcetypeflags: u32, options: u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`*"]
@@ -10002,7 +10002,7 @@ unsafe impl ::windows::core::Interface for ID3D11RefTrackingOptions {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D11RefTrackingOptions_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetTrackingOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, uoptions: u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`*"]
@@ -10539,7 +10539,7 @@ unsafe impl ::windows::core::Interface for ID3D11ShaderReflection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D11ShaderReflection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Graphics_Direct3D")]
     pub GetDesc: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdesc: *mut D3D11_SHADER_DESC) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Graphics_Direct3D"))]
@@ -11084,7 +11084,7 @@ unsafe impl ::windows::core::Interface for ID3D11ShaderTrace {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D11ShaderTrace_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub TraceReady: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptestcount: *mut u64) -> ::windows::core::HRESULT,
     pub ResetTrace: unsafe extern "system" fn(this: *mut ::core::ffi::c_void),
     #[cfg(feature = "Win32_Foundation")]
@@ -11152,7 +11152,7 @@ unsafe impl ::windows::core::Interface for ID3D11ShaderTraceFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D11ShaderTraceFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateShaderTrace: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pshader: *mut ::core::ffi::c_void, ptracedesc: *const D3D11_SHADER_TRACE_DESC, ppshadertrace: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`*"]
@@ -11213,7 +11213,7 @@ unsafe impl ::windows::core::Interface for ID3D11SwitchToRef {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D11SwitchToRef_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub SetUseRef: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, useref: super::super::Foundation::BOOL) -> super::super::Foundation::BOOL,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -11867,7 +11867,7 @@ unsafe impl ::windows::core::Interface for ID3D11TracingDevice {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D11TracingDevice_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetShaderTrackingOptionsByType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, resourcetypeflags: u32, options: u32) -> ::windows::core::HRESULT,
     pub SetShaderTrackingOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pshader: *mut ::core::ffi::c_void, options: u32) -> ::windows::core::HRESULT,
 }
@@ -15270,7 +15270,7 @@ unsafe impl ::windows::core::Interface for ID3D11VideoDevice {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D11VideoDevice_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
     pub CreateVideoDecoder: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pvideodesc: *const D3D11_VIDEO_DECODER_DESC, pconfig: *const D3D11_VIDEO_DECODER_CONFIG, ppdecoder: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Graphics_Dxgi_Common"))]
@@ -16456,7 +16456,7 @@ unsafe impl ::windows::core::Interface for ID3DUserDefinedAnnotation {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3DUserDefinedAnnotation_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub BeginEvent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, name: ::windows::core::PCWSTR) -> i32,
     pub EndEvent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> i32,
     pub SetMarker: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, name: ::windows::core::PCWSTR),
@@ -16537,7 +16537,7 @@ unsafe impl ::windows::core::Interface for ID3DX11FFT {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3DX11FFT_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetForwardScale: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, forwardscale: f32) -> ::windows::core::HRESULT,
     pub GetForwardScale: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> f32,
     pub SetInverseScale: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, inversescale: f32) -> ::windows::core::HRESULT,
@@ -16608,7 +16608,7 @@ unsafe impl ::windows::core::Interface for ID3DX11Scan {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3DX11Scan_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetScanDirection: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, direction: D3DX11_SCAN_DIRECTION) -> ::windows::core::HRESULT,
     pub Scan: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, elementtype: D3DX11_SCAN_DATA_TYPE, opcode: D3DX11_SCAN_OPCODE, elementscansize: u32, psrc: *mut ::core::ffi::c_void, pdst: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Multiscan: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, elementtype: D3DX11_SCAN_DATA_TYPE, opcode: D3DX11_SCAN_OPCODE, elementscansize: u32, elementscanpitch: u32, scancount: u32, psrc: *mut ::core::ffi::c_void, pdst: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -16669,7 +16669,7 @@ unsafe impl ::windows::core::Interface for ID3DX11SegmentedScan {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3DX11SegmentedScan_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetScanDirection: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, direction: D3DX11_SCAN_DIRECTION) -> ::windows::core::HRESULT,
     pub SegScan: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, elementtype: D3DX11_SCAN_DATA_TYPE, opcode: D3DX11_SCAN_OPCODE, elementscansize: u32, psrc: *mut ::core::ffi::c_void, psrcelementflags: *mut ::core::ffi::c_void, pdst: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D11on12/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D11on12/impl.rs
@@ -25,7 +25,7 @@ impl ID3D11On12Device_Vtbl {
             this.AcquireWrappedResources(::core::mem::transmute_copy(&ppresources), ::core::mem::transmute_copy(&numresources))
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateWrappedResource: CreateWrappedResource::<Identity, Impl, OFFSET>,
             ReleaseWrappedResources: ReleaseWrappedResources::<Identity, Impl, OFFSET>,
             AcquireWrappedResources: AcquireWrappedResources::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D11on12/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D11on12/mod.rs
@@ -87,7 +87,7 @@ unsafe impl ::windows::core::Interface for ID3D11On12Device {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D11On12Device_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Graphics_Direct3D12")]
     pub CreateWrappedResource: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, presource12: *mut ::core::ffi::c_void, pflags11: *const D3D11_RESOURCE_FLAGS, instate: super::Direct3D12::D3D12_RESOURCE_STATES, outstate: super::Direct3D12::D3D12_RESOURCE_STATES, riid: *const ::windows::core::GUID, ppresource11: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Graphics_Direct3D12"))]

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D12/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D12/impl.rs
@@ -152,7 +152,7 @@ impl ID3D12Debug_Vtbl {
             let this = (*this).get_impl();
             this.EnableDebugLayer()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), EnableDebugLayer: EnableDebugLayer::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), EnableDebugLayer: EnableDebugLayer::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ID3D12Debug as ::windows::core::Interface>::IID
@@ -185,7 +185,7 @@ impl ID3D12Debug1_Vtbl {
             this.SetEnableSynchronizedCommandQueueValidation(::core::mem::transmute_copy(&enable))
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             EnableDebugLayer: EnableDebugLayer::<Identity, Impl, OFFSET>,
             SetEnableGPUBasedValidation: SetEnableGPUBasedValidation::<Identity, Impl, OFFSET>,
             SetEnableSynchronizedCommandQueueValidation: SetEnableSynchronizedCommandQueueValidation::<Identity, Impl, OFFSET>,
@@ -207,7 +207,7 @@ impl ID3D12Debug2_Vtbl {
             this.SetGPUBasedValidationFlags(::core::mem::transmute_copy(&flags))
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetGPUBasedValidationFlags: SetGPUBasedValidationFlags::<Identity, Impl, OFFSET>,
         }
     }
@@ -319,7 +319,7 @@ impl ID3D12DebugCommandList_Vtbl {
             this.GetFeatureMask()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AssertResourceState: AssertResourceState::<Identity, Impl, OFFSET>,
             SetFeatureMask: SetFeatureMask::<Identity, Impl, OFFSET>,
             GetFeatureMask: GetFeatureMask::<Identity, Impl, OFFSET>,
@@ -356,7 +356,7 @@ impl ID3D12DebugCommandList1_Vtbl {
             this.GetDebugParameter(::core::mem::transmute_copy(&r#type), ::core::mem::transmute_copy(&pdata), ::core::mem::transmute_copy(&datasize)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AssertResourceState: AssertResourceState::<Identity, Impl, OFFSET>,
             SetDebugParameter: SetDebugParameter::<Identity, Impl, OFFSET>,
             GetDebugParameter: GetDebugParameter::<Identity, Impl, OFFSET>,
@@ -410,7 +410,7 @@ impl ID3D12DebugCommandQueue_Vtbl {
             let this = (*this).get_impl();
             this.AssertResourceState(::core::mem::transmute(&presource), ::core::mem::transmute_copy(&subresource), ::core::mem::transmute_copy(&state))
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), AssertResourceState: AssertResourceState::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), AssertResourceState: AssertResourceState::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ID3D12DebugCommandQueue as ::windows::core::Interface>::IID
@@ -440,7 +440,7 @@ impl ID3D12DebugDevice_Vtbl {
             this.ReportLiveDeviceObjects(::core::mem::transmute_copy(&flags)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetFeatureMask: SetFeatureMask::<Identity, Impl, OFFSET>,
             GetFeatureMask: GetFeatureMask::<Identity, Impl, OFFSET>,
             ReportLiveDeviceObjects: ReportLiveDeviceObjects::<Identity, Impl, OFFSET>,
@@ -474,7 +474,7 @@ impl ID3D12DebugDevice1_Vtbl {
             this.ReportLiveDeviceObjects(::core::mem::transmute_copy(&flags)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetDebugParameter: SetDebugParameter::<Identity, Impl, OFFSET>,
             GetDebugParameter: GetDebugParameter::<Identity, Impl, OFFSET>,
             ReportLiveDeviceObjects: ReportLiveDeviceObjects::<Identity, Impl, OFFSET>,
@@ -1247,7 +1247,7 @@ impl ID3D12DeviceRemovedExtendedData_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetAutoBreadcrumbsOutput: GetAutoBreadcrumbsOutput::<Identity, Impl, OFFSET>,
             GetPageFaultAllocationOutput: GetPageFaultAllocationOutput::<Identity, Impl, OFFSET>,
         }
@@ -1352,7 +1352,7 @@ impl ID3D12DeviceRemovedExtendedDataSettings_Vtbl {
             this.SetWatsonDumpEnablement(::core::mem::transmute_copy(&enablement))
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetAutoBreadcrumbsEnablement: SetAutoBreadcrumbsEnablement::<Identity, Impl, OFFSET>,
             SetPageFaultEnablement: SetPageFaultEnablement::<Identity, Impl, OFFSET>,
             SetWatsonDumpEnablement: SetWatsonDumpEnablement::<Identity, Impl, OFFSET>,
@@ -2403,7 +2403,7 @@ impl ID3D12InfoQueue_Vtbl {
             this.GetMuteDebugOutput()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetMessageCountLimit: SetMessageCountLimit::<Identity, Impl, OFFSET>,
             ClearStoredMessages: ClearStoredMessages::<Identity, Impl, OFFSET>,
             GetMessage: GetMessage::<Identity, Impl, OFFSET>,
@@ -2499,7 +2499,7 @@ impl ID3D12LibraryReflection_Vtbl {
             this.GetFunctionByIndex(::core::mem::transmute_copy(&functionindex))
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDesc: GetDesc::<Identity, Impl, OFFSET>,
             GetFunctionByIndex: GetFunctionByIndex::<Identity, Impl, OFFSET>,
         }
@@ -2519,7 +2519,7 @@ impl ID3D12LifetimeOwner_Vtbl {
             let this = (*this).get_impl();
             this.LifetimeStateUpdated(::core::mem::transmute_copy(&newstate))
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), LifetimeStateUpdated: LifetimeStateUpdated::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), LifetimeStateUpdated: LifetimeStateUpdated::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ID3D12LifetimeOwner as ::windows::core::Interface>::IID
@@ -2592,7 +2592,7 @@ impl ID3D12Object_Vtbl {
             this.SetName(::core::mem::transmute(&name)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetPrivateData: GetPrivateData::<Identity, Impl, OFFSET>,
             SetPrivateData: SetPrivateData::<Identity, Impl, OFFSET>,
             SetPrivateDataInterface: SetPrivateDataInterface::<Identity, Impl, OFFSET>,
@@ -2907,7 +2907,7 @@ impl ID3D12RootSignatureDeserializer_Vtbl {
             let this = (*this).get_impl();
             this.GetRootSignatureDesc()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetRootSignatureDesc: GetRootSignatureDesc::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetRootSignatureDesc: GetRootSignatureDesc::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ID3D12RootSignatureDeserializer as ::windows::core::Interface>::IID
@@ -2924,7 +2924,7 @@ impl ID3D12SDKConfiguration_Vtbl {
             let this = (*this).get_impl();
             this.SetSDKVersion(::core::mem::transmute_copy(&sdkversion), ::core::mem::transmute(&sdkpath)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SetSDKVersion: SetSDKVersion::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SetSDKVersion: SetSDKVersion::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ID3D12SDKConfiguration as ::windows::core::Interface>::IID
@@ -3136,7 +3136,7 @@ impl ID3D12ShaderReflection_Vtbl {
             this.GetRequiresFlags()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDesc: GetDesc::<Identity, Impl, OFFSET>,
             GetConstantBufferByIndex: GetConstantBufferByIndex::<Identity, Impl, OFFSET>,
             GetConstantBufferByName: GetConstantBufferByName::<Identity, Impl, OFFSET>,
@@ -3375,7 +3375,7 @@ impl ID3D12SharingContract_Vtbl {
             this.EndCapturableWork(::core::mem::transmute_copy(&guid))
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Present: Present::<Identity, Impl, OFFSET>,
             SharedFenceSignal: SharedFenceSignal::<Identity, Impl, OFFSET>,
             BeginCapturableWork: BeginCapturableWork::<Identity, Impl, OFFSET>,
@@ -3426,7 +3426,7 @@ impl ID3D12StateObjectProperties_Vtbl {
             this.SetPipelineStackSize(::core::mem::transmute_copy(&pipelinestacksizeinbytes))
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetShaderIdentifier: GetShaderIdentifier::<Identity, Impl, OFFSET>,
             GetShaderStackSize: GetShaderStackSize::<Identity, Impl, OFFSET>,
             GetPipelineStackSize: GetPipelineStackSize::<Identity, Impl, OFFSET>,
@@ -3470,7 +3470,7 @@ impl ID3D12SwapChainAssistant_Vtbl {
             this.InsertImplicitSync().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetLUID: GetLUID::<Identity, Impl, OFFSET>,
             GetSwapChainObject: GetSwapChainObject::<Identity, Impl, OFFSET>,
             GetCurrentResourceAndCommandQueue: GetCurrentResourceAndCommandQueue::<Identity, Impl, OFFSET>,
@@ -3502,7 +3502,7 @@ impl ID3D12Tools_Vtbl {
             this.ShaderInstrumentationEnabled()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             EnableShaderInstrumentation: EnableShaderInstrumentation::<Identity, Impl, OFFSET>,
             ShaderInstrumentationEnabled: ShaderInstrumentationEnabled::<Identity, Impl, OFFSET>,
         }
@@ -3535,7 +3535,7 @@ impl ID3D12VersionedRootSignatureDeserializer_Vtbl {
             this.GetUnconvertedRootSignatureDesc()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetRootSignatureDescAtVersion: GetRootSignatureDescAtVersion::<Identity, Impl, OFFSET>,
             GetUnconvertedRootSignatureDesc: GetUnconvertedRootSignatureDesc::<Identity, Impl, OFFSET>,
         }

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D12/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D12/mod.rs
@@ -671,7 +671,7 @@ unsafe impl ::windows::core::Interface for ID3D12Debug {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D12Debug_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub EnableDebugLayer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void),
 }
 #[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`*"]
@@ -738,7 +738,7 @@ unsafe impl ::windows::core::Interface for ID3D12Debug1 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D12Debug1_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub EnableDebugLayer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void),
     #[cfg(feature = "Win32_Foundation")]
     pub SetEnableGPUBasedValidation: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, enable: super::super::Foundation::BOOL),
@@ -797,7 +797,7 @@ unsafe impl ::windows::core::Interface for ID3D12Debug2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D12Debug2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetGPUBasedValidationFlags: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, flags: D3D12_GPU_BASED_VALIDATION_FLAGS),
 }
 #[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`*"]
@@ -1184,7 +1184,7 @@ unsafe impl ::windows::core::Interface for ID3D12DebugCommandList {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D12DebugCommandList_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub AssertResourceState: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, presource: *mut ::core::ffi::c_void, subresource: u32, state: u32) -> super::super::Foundation::BOOL,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -1251,7 +1251,7 @@ unsafe impl ::windows::core::Interface for ID3D12DebugCommandList1 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D12DebugCommandList1_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub AssertResourceState: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, presource: *mut ::core::ffi::c_void, subresource: u32, state: u32) -> super::super::Foundation::BOOL,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -1396,7 +1396,7 @@ unsafe impl ::windows::core::Interface for ID3D12DebugCommandQueue {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D12DebugCommandQueue_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub AssertResourceState: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, presource: *mut ::core::ffi::c_void, subresource: u32, state: u32) -> super::super::Foundation::BOOL,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -1456,7 +1456,7 @@ unsafe impl ::windows::core::Interface for ID3D12DebugDevice {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D12DebugDevice_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetFeatureMask: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, mask: D3D12_DEBUG_FEATURE) -> ::windows::core::HRESULT,
     pub GetFeatureMask: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> D3D12_DEBUG_FEATURE,
     pub ReportLiveDeviceObjects: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, flags: D3D12_RLDO_FLAGS) -> ::windows::core::HRESULT,
@@ -1515,7 +1515,7 @@ unsafe impl ::windows::core::Interface for ID3D12DebugDevice1 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D12DebugDevice1_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetDebugParameter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, r#type: D3D12_DEBUG_DEVICE_PARAMETER_TYPE, pdata: *const ::core::ffi::c_void, datasize: u32) -> ::windows::core::HRESULT,
     pub GetDebugParameter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, r#type: D3D12_DEBUG_DEVICE_PARAMETER_TYPE, pdata: *mut ::core::ffi::c_void, datasize: u32) -> ::windows::core::HRESULT,
     pub ReportLiveDeviceObjects: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, flags: D3D12_RLDO_FLAGS) -> ::windows::core::HRESULT,
@@ -6936,7 +6936,7 @@ unsafe impl ::windows::core::Interface for ID3D12DeviceRemovedExtendedData {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D12DeviceRemovedExtendedData_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetAutoBreadcrumbsOutput: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, poutput: *mut D3D12_DRED_AUTO_BREADCRUMBS_OUTPUT) -> ::windows::core::HRESULT,
     pub GetPageFaultAllocationOutput: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, poutput: *mut D3D12_DRED_PAGE_FAULT_OUTPUT) -> ::windows::core::HRESULT,
 }
@@ -7176,7 +7176,7 @@ unsafe impl ::windows::core::Interface for ID3D12DeviceRemovedExtendedDataSettin
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D12DeviceRemovedExtendedDataSettings_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetAutoBreadcrumbsEnablement: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, enablement: D3D12_DRED_ENABLEMENT),
     pub SetPageFaultEnablement: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, enablement: D3D12_DRED_ENABLEMENT),
     pub SetWatsonDumpEnablement: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, enablement: D3D12_DRED_ENABLEMENT),
@@ -11447,7 +11447,7 @@ unsafe impl ::windows::core::Interface for ID3D12InfoQueue {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D12InfoQueue_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetMessageCountLimit: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, messagecountlimit: u64) -> ::windows::core::HRESULT,
     pub ClearStoredMessages: unsafe extern "system" fn(this: *mut ::core::ffi::c_void),
     pub GetMessage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, messageindex: u64, pmessage: *mut D3D12_MESSAGE, pmessagebytelength: *mut usize) -> ::windows::core::HRESULT,
@@ -11769,7 +11769,7 @@ unsafe impl ::windows::core::Interface for ID3D12LibraryReflection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D12LibraryReflection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDesc: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdesc: *mut D3D12_LIBRARY_DESC) -> ::windows::core::HRESULT,
     pub GetFunctionByIndex: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, functionindex: i32) -> ::core::option::Option<ID3D12FunctionReflection>,
 }
@@ -11821,7 +11821,7 @@ unsafe impl ::windows::core::Interface for ID3D12LifetimeOwner {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D12LifetimeOwner_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub LifetimeStateUpdated: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, newstate: D3D12_LIFETIME_STATE),
 }
 #[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`*"]
@@ -12115,7 +12115,7 @@ unsafe impl ::windows::core::Interface for ID3D12Object {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D12Object_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetPrivateData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, guid: *const ::windows::core::GUID, pdatasize: *mut u32, pdata: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetPrivateData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, guid: *const ::windows::core::GUID, datasize: u32, pdata: *const ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetPrivateDataInterface: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, guid: *const ::windows::core::GUID, pdata: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -13805,7 +13805,7 @@ unsafe impl ::windows::core::Interface for ID3D12RootSignatureDeserializer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D12RootSignatureDeserializer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetRootSignatureDesc: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> *mut D3D12_ROOT_SIGNATURE_DESC,
 }
 #[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`*"]
@@ -13859,7 +13859,7 @@ unsafe impl ::windows::core::Interface for ID3D12SDKConfiguration {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D12SDKConfiguration_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetSDKVersion: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sdkversion: u32, sdkpath: ::windows::core::PCSTR) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`*"]
@@ -14117,7 +14117,7 @@ unsafe impl ::windows::core::Interface for ID3D12ShaderReflection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D12ShaderReflection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Graphics_Direct3D")]
     pub GetDesc: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdesc: *mut D3D12_SHADER_DESC) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Graphics_Direct3D"))]
@@ -14423,7 +14423,7 @@ unsafe impl ::windows::core::Interface for ID3D12SharingContract {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D12SharingContract_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Present: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, presource: *mut ::core::ffi::c_void, subresource: u32, window: super::super::Foundation::HWND),
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -14611,7 +14611,7 @@ unsafe impl ::windows::core::Interface for ID3D12StateObjectProperties {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D12StateObjectProperties_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetShaderIdentifier: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pexportname: ::windows::core::PCWSTR) -> *mut ::core::ffi::c_void,
     pub GetShaderStackSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pexportname: ::windows::core::PCWSTR) -> u64,
     pub GetPipelineStackSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u64,
@@ -14686,7 +14686,7 @@ unsafe impl ::windows::core::Interface for ID3D12SwapChainAssistant {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D12SwapChainAssistant_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetLUID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, result__: *mut super::super::Foundation::LUID),
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -14753,7 +14753,7 @@ unsafe impl ::windows::core::Interface for ID3D12Tools {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D12Tools_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub EnableShaderInstrumentation: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, benable: super::super::Foundation::BOOL),
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -14815,7 +14815,7 @@ unsafe impl ::windows::core::Interface for ID3D12VersionedRootSignatureDeseriali
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D12VersionedRootSignatureDeserializer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetRootSignatureDescAtVersion: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, converttoversion: D3D_ROOT_SIGNATURE_VERSION, ppdesc: *mut *mut D3D12_VERSIONED_ROOT_SIGNATURE_DESC) -> ::windows::core::HRESULT,
     pub GetUnconvertedRootSignatureDesc: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> *mut D3D12_VERSIONED_ROOT_SIGNATURE_DESC,
 }

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D9/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D9/impl.rs
@@ -91,7 +91,7 @@ impl IDirect3D9_Vtbl {
             this.CreateDevice(::core::mem::transmute_copy(&adapter), ::core::mem::transmute_copy(&devicetype), ::core::mem::transmute_copy(&hfocuswindow), ::core::mem::transmute_copy(&behaviorflags), ::core::mem::transmute_copy(&ppresentationparameters), ::core::mem::transmute_copy(&ppreturneddeviceinterface)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RegisterSoftwareDevice: RegisterSoftwareDevice::<Identity, Impl, OFFSET>,
             GetAdapterCount: GetAdapterCount::<Identity, Impl, OFFSET>,
             GetAdapterIdentifier: GetAdapterIdentifier::<Identity, Impl, OFFSET>,
@@ -1076,7 +1076,7 @@ impl IDirect3DDevice9_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             TestCooperativeLevel: TestCooperativeLevel::<Identity, Impl, OFFSET>,
             GetAvailableTextureMem: GetAvailableTextureMem::<Identity, Impl, OFFSET>,
             EvictManagedResources: EvictManagedResources::<Identity, Impl, OFFSET>,
@@ -1378,7 +1378,7 @@ impl IDirect3DPixelShader9_Vtbl {
             this.GetFunction(::core::mem::transmute_copy(&param0), ::core::mem::transmute_copy(&psizeofdata)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDevice: GetDevice::<Identity, Impl, OFFSET>,
             GetFunction: GetFunction::<Identity, Impl, OFFSET>,
         }
@@ -1429,7 +1429,7 @@ impl IDirect3DQuery9_Vtbl {
             this.GetData(::core::mem::transmute_copy(&pdata), ::core::mem::transmute_copy(&dwsize), ::core::mem::transmute_copy(&dwgetdataflags)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDevice: GetDevice::<Identity, Impl, OFFSET>,
             GetType: GetType::<Identity, Impl, OFFSET>,
             GetDataSize: GetDataSize::<Identity, Impl, OFFSET>,
@@ -1501,7 +1501,7 @@ impl IDirect3DResource9_Vtbl {
             this.GetType()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDevice: GetDevice::<Identity, Impl, OFFSET>,
             SetPrivateData: SetPrivateData::<Identity, Impl, OFFSET>,
             GetPrivateData: GetPrivateData::<Identity, Impl, OFFSET>,
@@ -1546,7 +1546,7 @@ impl IDirect3DStateBlock9_Vtbl {
             this.Apply().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDevice: GetDevice::<Identity, Impl, OFFSET>,
             Capture: Capture::<Identity, Impl, OFFSET>,
             Apply: Apply::<Identity, Impl, OFFSET>,
@@ -1677,7 +1677,7 @@ impl IDirect3DSwapChain9_Vtbl {
             this.GetPresentParameters(::core::mem::transmute_copy(&ppresentationparameters)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Present: Present::<Identity, Impl, OFFSET>,
             GetFrontBufferData: GetFrontBufferData::<Identity, Impl, OFFSET>,
             GetBackBuffer: GetBackBuffer::<Identity, Impl, OFFSET>,
@@ -1843,7 +1843,7 @@ impl IDirect3DVertexDeclaration9_Vtbl {
             this.GetDeclaration(::core::mem::transmute_copy(&pelement), ::core::mem::transmute_copy(&pnumelements)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDevice: GetDevice::<Identity, Impl, OFFSET>,
             GetDeclaration: GetDeclaration::<Identity, Impl, OFFSET>,
         }
@@ -1876,7 +1876,7 @@ impl IDirect3DVertexShader9_Vtbl {
             this.GetFunction(::core::mem::transmute_copy(&param0), ::core::mem::transmute_copy(&psizeofdata)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDevice: GetDevice::<Identity, Impl, OFFSET>,
             GetFunction: GetFunction::<Identity, Impl, OFFSET>,
         }
@@ -1945,7 +1945,7 @@ impl IDirect3DVolume9_Vtbl {
             this.UnlockBox().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDevice: GetDevice::<Identity, Impl, OFFSET>,
             SetPrivateData: SetPrivateData::<Identity, Impl, OFFSET>,
             GetPrivateData: GetPrivateData::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D9/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D9/mod.rs
@@ -194,7 +194,7 @@ unsafe impl ::windows::core::Interface for IDirect3D9 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirect3D9_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub RegisterSoftwareDevice: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinitializefunction: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetAdapterCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32,
     #[cfg(feature = "Win32_Foundation")]
@@ -1188,7 +1188,7 @@ unsafe impl ::windows::core::Interface for IDirect3DDevice9 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirect3DDevice9_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub TestCooperativeLevel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetAvailableTextureMem: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32,
     pub EvictManagedResources: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -2234,7 +2234,7 @@ unsafe impl ::windows::core::Interface for IDirect3DPixelShader9 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirect3DPixelShader9_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDevice: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppdevice: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetFunction: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: *mut ::core::ffi::c_void, psizeofdata: *mut u32) -> ::windows::core::HRESULT,
 }
@@ -2297,7 +2297,7 @@ unsafe impl ::windows::core::Interface for IDirect3DQuery9 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirect3DQuery9_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDevice: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppdevice: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> D3DQUERYTYPE,
     pub GetDataSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32,
@@ -2372,7 +2372,7 @@ unsafe impl ::windows::core::Interface for IDirect3DResource9 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirect3DResource9_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDevice: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppdevice: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetPrivateData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, refguid: *const ::windows::core::GUID, pdata: *const ::core::ffi::c_void, sizeofdata: u32, flags: u32) -> ::windows::core::HRESULT,
     pub GetPrivateData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, refguid: *const ::windows::core::GUID, pdata: *mut ::core::ffi::c_void, psizeofdata: *mut u32) -> ::windows::core::HRESULT,
@@ -2435,7 +2435,7 @@ unsafe impl ::windows::core::Interface for IDirect3DStateBlock9 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirect3DStateBlock9_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDevice: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppdevice: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Capture: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Apply: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -2645,7 +2645,7 @@ unsafe impl ::windows::core::Interface for IDirect3DSwapChain9 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirect3DSwapChain9_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
     pub Present: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psourcerect: *const super::super::Foundation::RECT, pdestrect: *const super::super::Foundation::RECT, hdestwindowoverride: super::super::Foundation::HWND, pdirtyregion: *const super::Gdi::RGNDATA, dwflags: u32) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi")))]
@@ -3066,7 +3066,7 @@ unsafe impl ::windows::core::Interface for IDirect3DVertexDeclaration9 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirect3DVertexDeclaration9_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDevice: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppdevice: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetDeclaration: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pelement: *mut D3DVERTEXELEMENT9, pnumelements: *mut u32) -> ::windows::core::HRESULT,
 }
@@ -3120,7 +3120,7 @@ unsafe impl ::windows::core::Interface for IDirect3DVertexShader9 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirect3DVertexShader9_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDevice: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppdevice: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetFunction: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: *mut ::core::ffi::c_void, psizeofdata: *mut u32) -> ::windows::core::HRESULT,
 }
@@ -3192,7 +3192,7 @@ unsafe impl ::windows::core::Interface for IDirect3DVolume9 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirect3DVolume9_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDevice: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppdevice: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetPrivateData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, refguid: *const ::windows::core::GUID, pdata: *const ::core::ffi::c_void, sizeofdata: u32, flags: u32) -> ::windows::core::HRESULT,
     pub GetPrivateData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, refguid: *const ::windows::core::GUID, pdata: *mut ::core::ffi::c_void, psizeofdata: *mut u32) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D9on12/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D9on12/impl.rs
@@ -25,7 +25,7 @@ impl IDirect3DDevice9On12_Vtbl {
             this.ReturnUnderlyingResource(::core::mem::transmute(&presource), ::core::mem::transmute_copy(&numsync), ::core::mem::transmute_copy(&psignalvalues), ::core::mem::transmute_copy(&ppfences)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetD3D12Device: GetD3D12Device::<Identity, Impl, OFFSET>,
             UnwrapUnderlyingResource: UnwrapUnderlyingResource::<Identity, Impl, OFFSET>,
             ReturnUnderlyingResource: ReturnUnderlyingResource::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D9on12/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D9on12/mod.rs
@@ -81,7 +81,7 @@ unsafe impl ::windows::core::Interface for IDirect3DDevice9On12 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirect3DDevice9On12_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetD3D12Device: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppvdevice: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Direct3D9"))]
     pub UnwrapUnderlyingResource: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, presource: *mut ::core::ffi::c_void, pcommandqueue: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppvresource12: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/Graphics/DirectComposition/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/DirectComposition/impl.rs
@@ -105,7 +105,7 @@ impl IDCompositionAnimation_Vtbl {
             this.End(::core::mem::transmute_copy(&endoffset), ::core::mem::transmute_copy(&endvalue)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Reset: Reset::<Identity, Impl, OFFSET>,
             SetAbsoluteBeginTime: SetAbsoluteBeginTime::<Identity, Impl, OFFSET>,
             AddCubic: AddCubic::<Identity, Impl, OFFSET>,
@@ -314,7 +314,7 @@ pub trait IDCompositionClip_Impl: Sized {}
 impl ::windows::core::RuntimeName for IDCompositionClip {}
 impl IDCompositionClip_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IDCompositionClip_Impl, const OFFSET: isize>() -> IDCompositionClip_Vtbl {
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>() }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>() }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDCompositionClip as ::windows::core::Interface>::IID
@@ -436,7 +436,7 @@ impl IDCompositionDelegatedInkTrail_Vtbl {
             this.StartNewTrail(::core::mem::transmute_copy(&color)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddTrailPoints: AddTrailPoints::<Identity, Impl, OFFSET>,
             AddTrailPointsWithPrediction: AddTrailPointsWithPrediction::<Identity, Impl, OFFSET>,
             RemoveTrailPoints: RemoveTrailPoints::<Identity, Impl, OFFSET>,
@@ -787,7 +787,7 @@ impl IDCompositionDevice_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Commit: Commit::<Identity, Impl, OFFSET>,
             WaitForCommitCompletion: WaitForCommitCompletion::<Identity, Impl, OFFSET>,
             GetFrameStatistics: GetFrameStatistics::<Identity, Impl, OFFSET>,
@@ -1067,7 +1067,7 @@ impl IDCompositionDevice2_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Commit: Commit::<Identity, Impl, OFFSET>,
             WaitForCommitCompletion: WaitForCommitCompletion::<Identity, Impl, OFFSET>,
             GetFrameStatistics: GetFrameStatistics::<Identity, Impl, OFFSET>,
@@ -1298,7 +1298,7 @@ impl IDCompositionDeviceDebug_Vtbl {
             this.DisableDebugCounters().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             EnableDebugCounters: EnableDebugCounters::<Identity, Impl, OFFSET>,
             DisableDebugCounters: DisableDebugCounters::<Identity, Impl, OFFSET>,
         }
@@ -1311,7 +1311,7 @@ pub trait IDCompositionEffect_Impl: Sized {}
 impl ::windows::core::RuntimeName for IDCompositionEffect {}
 impl IDCompositionEffect_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IDCompositionEffect_Impl, const OFFSET: isize>() -> IDCompositionEffect_Vtbl {
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>() }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>() }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDCompositionEffect as ::windows::core::Interface>::IID
@@ -1462,7 +1462,7 @@ impl IDCompositionInkTrailDevice_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateDelegatedInkTrail: CreateDelegatedInkTrail::<Identity, Impl, OFFSET>,
             CreateDelegatedInkTrailForSwapChain: CreateDelegatedInkTrailForSwapChain::<Identity, Impl, OFFSET>,
         }
@@ -2449,7 +2449,7 @@ impl IDCompositionSurface_Vtbl {
             this.Scroll(::core::mem::transmute_copy(&scrollrect), ::core::mem::transmute_copy(&cliprect), ::core::mem::transmute_copy(&offsetx), ::core::mem::transmute_copy(&offsety)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             BeginDraw: BeginDraw::<Identity, Impl, OFFSET>,
             EndDraw: EndDraw::<Identity, Impl, OFFSET>,
             SuspendDraw: SuspendDraw::<Identity, Impl, OFFSET>,
@@ -2494,7 +2494,7 @@ impl IDCompositionSurfaceFactory_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateSurface: CreateSurface::<Identity, Impl, OFFSET>,
             CreateVirtualSurface: CreateVirtualSurface::<Identity, Impl, OFFSET>,
         }
@@ -2649,7 +2649,7 @@ impl IDCompositionTarget_Vtbl {
             let this = (*this).get_impl();
             this.SetRoot(::core::mem::transmute(&visual)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SetRoot: SetRoot::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SetRoot: SetRoot::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDCompositionTarget as ::windows::core::Interface>::IID
@@ -2977,7 +2977,7 @@ impl IDCompositionVisual_Vtbl {
             this.SetCompositeMode(::core::mem::transmute_copy(&compositemode)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetOffsetX: SetOffsetX::<Identity, Impl, OFFSET>,
             SetOffsetX2: SetOffsetX2::<Identity, Impl, OFFSET>,
             SetOffsetY: SetOffsetY::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/Graphics/DirectComposition/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/DirectComposition/mod.rs
@@ -321,7 +321,7 @@ unsafe impl ::windows::core::Interface for IDCompositionAnimation {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDCompositionAnimation_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetAbsoluteBeginTime: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, begintime: i64) -> ::windows::core::HRESULT,
     pub AddCubic: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, beginoffset: f64, constantcoefficient: f32, linearcoefficient: f32, quadraticcoefficient: f32, cubiccoefficient: f32) -> ::windows::core::HRESULT,
@@ -750,7 +750,7 @@ unsafe impl ::windows::core::Interface for IDCompositionClip {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDCompositionClip_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
 }
 #[doc = "*Required features: `\"Win32_Graphics_DirectComposition\"`*"]
 #[repr(transparent)]
@@ -1023,7 +1023,7 @@ unsafe impl ::windows::core::Interface for IDCompositionDelegatedInkTrail {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDCompositionDelegatedInkTrail_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddTrailPoints: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, inkpoints: *const DCompositionInkTrailPoint, inkpointscount: u32, generationid: *mut u32) -> ::windows::core::HRESULT,
     pub AddTrailPointsWithPrediction: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, inkpoints: *const DCompositionInkTrailPoint, inkpointscount: u32, predictedinkpoints: *const DCompositionInkTrailPoint, predictedinkpointscount: u32, generationid: *mut u32) -> ::windows::core::HRESULT,
     pub RemoveTrailPoints: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, generationid: u32) -> ::windows::core::HRESULT,
@@ -1384,7 +1384,7 @@ unsafe impl ::windows::core::Interface for IDCompositionDevice {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDCompositionDevice_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Commit: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub WaitForCommitCompletion: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -1565,7 +1565,7 @@ unsafe impl ::windows::core::Interface for IDCompositionDevice2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDCompositionDevice2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Commit: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub WaitForCommitCompletion: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -1862,7 +1862,7 @@ unsafe impl ::windows::core::Interface for IDCompositionDeviceDebug {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDCompositionDeviceDebug_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub EnableDebugCounters: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub DisableDebugCounters: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -1908,7 +1908,7 @@ unsafe impl ::windows::core::Interface for IDCompositionEffect {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDCompositionEffect_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
 }
 #[doc = "*Required features: `\"Win32_Graphics_DirectComposition\"`*"]
 #[repr(transparent)]
@@ -2302,7 +2302,7 @@ unsafe impl ::windows::core::Interface for IDCompositionInkTrailDevice {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDCompositionInkTrailDevice_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateDelegatedInkTrail: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, inktrail: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CreateDelegatedInkTrailForSwapChain: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, swapchain: *mut ::core::ffi::c_void, inktrail: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -3915,7 +3915,7 @@ unsafe impl ::windows::core::Interface for IDCompositionSurface {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDCompositionSurface_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub BeginDraw: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, updaterect: *const super::super::Foundation::RECT, iid: *const ::windows::core::GUID, updateobject: *mut *mut ::core::ffi::c_void, updateoffset: *mut super::super::Foundation::POINT) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -3983,7 +3983,7 @@ unsafe impl ::windows::core::Interface for IDCompositionSurfaceFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDCompositionSurfaceFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
     pub CreateSurface: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, width: u32, height: u32, pixelformat: super::Dxgi::Common::DXGI_FORMAT, alphamode: super::Dxgi::Common::DXGI_ALPHA_MODE, surface: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Graphics_Dxgi_Common"))]
@@ -4243,7 +4243,7 @@ unsafe impl ::windows::core::Interface for IDCompositionTarget {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDCompositionTarget_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetRoot: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, visual: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Graphics_DirectComposition\"`*"]
@@ -4957,7 +4957,7 @@ unsafe impl ::windows::core::Interface for IDCompositionVisual {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDCompositionVisual_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetOffsetX: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, animation: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetOffsetX2: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, offsetx: f32) -> ::windows::core::HRESULT,
     pub SetOffsetY: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, animation: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/Graphics/DirectDraw/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/DirectDraw/impl.rs
@@ -31,7 +31,7 @@ impl IDDVideoPortContainer_Vtbl {
             this.QueryVideoPortStatus(::core::mem::transmute_copy(&param0), ::core::mem::transmute_copy(&param1)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateVideoPort: CreateVideoPort::<Identity, Impl, OFFSET>,
             EnumVideoPorts: EnumVideoPorts::<Identity, Impl, OFFSET>,
             GetVideoPortConnectInfo: GetVideoPortConnectInfo::<Identity, Impl, OFFSET>,
@@ -183,7 +183,7 @@ impl IDirectDraw_Vtbl {
             this.WaitForVerticalBlank(::core::mem::transmute_copy(&param0), ::core::mem::transmute_copy(&param1)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Compact: Compact::<Identity, Impl, OFFSET>,
             CreateClipper: CreateClipper::<Identity, Impl, OFFSET>,
             CreatePalette: CreatePalette::<Identity, Impl, OFFSET>,
@@ -357,7 +357,7 @@ impl IDirectDraw2_Vtbl {
             this.GetAvailableVidMem(::core::mem::transmute_copy(&param0), ::core::mem::transmute_copy(&param1), ::core::mem::transmute_copy(&param2)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Compact: Compact::<Identity, Impl, OFFSET>,
             CreateClipper: CreateClipper::<Identity, Impl, OFFSET>,
             CreatePalette: CreatePalette::<Identity, Impl, OFFSET>,
@@ -562,7 +562,7 @@ impl IDirectDraw4_Vtbl {
             this.GetDeviceIdentifier(::core::mem::transmute_copy(&param0), ::core::mem::transmute_copy(&param1)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Compact: Compact::<Identity, Impl, OFFSET>,
             CreateClipper: CreateClipper::<Identity, Impl, OFFSET>,
             CreatePalette: CreatePalette::<Identity, Impl, OFFSET>,
@@ -783,7 +783,7 @@ impl IDirectDraw7_Vtbl {
             this.EvaluateMode(::core::mem::transmute_copy(&param0), ::core::mem::transmute_copy(&param1)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Compact: Compact::<Identity, Impl, OFFSET>,
             CreateClipper: CreateClipper::<Identity, Impl, OFFSET>,
             CreatePalette: CreatePalette::<Identity, Impl, OFFSET>,
@@ -862,7 +862,7 @@ impl IDirectDrawClipper_Vtbl {
             this.SetHWnd(::core::mem::transmute_copy(&param0), ::core::mem::transmute_copy(&param1)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetClipList: GetClipList::<Identity, Impl, OFFSET>,
             GetHWnd: GetHWnd::<Identity, Impl, OFFSET>,
             Initialize: Initialize::<Identity, Impl, OFFSET>,
@@ -893,7 +893,7 @@ impl IDirectDrawColorControl_Vtbl {
             this.SetColorControls(::core::mem::transmute_copy(&param0)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetColorControls: GetColorControls::<Identity, Impl, OFFSET>,
             SetColorControls: SetColorControls::<Identity, Impl, OFFSET>,
         }
@@ -920,7 +920,7 @@ impl IDirectDrawGammaControl_Vtbl {
             this.SetGammaRamp(::core::mem::transmute_copy(&param0), ::core::mem::transmute_copy(&param1)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetGammaRamp: GetGammaRamp::<Identity, Impl, OFFSET>,
             SetGammaRamp: SetGammaRamp::<Identity, Impl, OFFSET>,
         }
@@ -953,7 +953,7 @@ impl IDirectDrawKernel_Vtbl {
             this.ReleaseKernelHandle().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCaps: GetCaps::<Identity, Impl, OFFSET>,
             GetKernelHandle: GetKernelHandle::<Identity, Impl, OFFSET>,
             ReleaseKernelHandle: ReleaseKernelHandle::<Identity, Impl, OFFSET>,
@@ -996,7 +996,7 @@ impl IDirectDrawPalette_Vtbl {
             this.SetEntries(::core::mem::transmute_copy(&param0), ::core::mem::transmute_copy(&param1), ::core::mem::transmute_copy(&param2), ::core::mem::transmute_copy(&param3)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCaps: GetCaps::<Identity, Impl, OFFSET>,
             GetEntries: GetEntries::<Identity, Impl, OFFSET>,
             Initialize: Initialize::<Identity, Impl, OFFSET>,
@@ -1226,7 +1226,7 @@ impl IDirectDrawSurface_Vtbl {
             this.UpdateOverlayZOrder(::core::mem::transmute_copy(&param0), ::core::mem::transmute(&param1)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddAttachedSurface: AddAttachedSurface::<Identity, Impl, OFFSET>,
             AddOverlayDirtyRect: AddOverlayDirtyRect::<Identity, Impl, OFFSET>,
             Blt: Blt::<Identity, Impl, OFFSET>,
@@ -1503,7 +1503,7 @@ impl IDirectDrawSurface2_Vtbl {
             this.PageUnlock(::core::mem::transmute_copy(&param0)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddAttachedSurface: AddAttachedSurface::<Identity, Impl, OFFSET>,
             AddOverlayDirtyRect: AddOverlayDirtyRect::<Identity, Impl, OFFSET>,
             Blt: Blt::<Identity, Impl, OFFSET>,
@@ -1789,7 +1789,7 @@ impl IDirectDrawSurface3_Vtbl {
             this.SetSurfaceDesc(::core::mem::transmute_copy(&param0), ::core::mem::transmute_copy(&param1)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddAttachedSurface: AddAttachedSurface::<Identity, Impl, OFFSET>,
             AddOverlayDirtyRect: AddOverlayDirtyRect::<Identity, Impl, OFFSET>,
             Blt: Blt::<Identity, Impl, OFFSET>,
@@ -2106,7 +2106,7 @@ impl IDirectDrawSurface4_Vtbl {
             this.ChangeUniquenessValue().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddAttachedSurface: AddAttachedSurface::<Identity, Impl, OFFSET>,
             AddOverlayDirtyRect: AddOverlayDirtyRect::<Identity, Impl, OFFSET>,
             Blt: Blt::<Identity, Impl, OFFSET>,
@@ -2452,7 +2452,7 @@ impl IDirectDrawSurface7_Vtbl {
             this.GetLOD(::core::mem::transmute_copy(&param0)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddAttachedSurface: AddAttachedSurface::<Identity, Impl, OFFSET>,
             AddOverlayDirtyRect: AddOverlayDirtyRect::<Identity, Impl, OFFSET>,
             Blt: Blt::<Identity, Impl, OFFSET>,
@@ -2523,7 +2523,7 @@ impl IDirectDrawSurfaceKernel_Vtbl {
             this.ReleaseKernelHandle().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetKernelHandle: GetKernelHandle::<Identity, Impl, OFFSET>,
             ReleaseKernelHandle: ReleaseKernelHandle::<Identity, Impl, OFFSET>,
         }
@@ -2625,7 +2625,7 @@ impl IDirectDrawVideoPort_Vtbl {
             this.WaitForSync(::core::mem::transmute_copy(&param0), ::core::mem::transmute_copy(&param1), ::core::mem::transmute_copy(&param2)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Flip: Flip::<Identity, Impl, OFFSET>,
             GetBandwidthInfo: GetBandwidthInfo::<Identity, Impl, OFFSET>,
             GetColorControls: GetColorControls::<Identity, Impl, OFFSET>,
@@ -2667,7 +2667,7 @@ impl IDirectDrawVideoPortNotify_Vtbl {
             this.ReleaseNotification(::core::mem::transmute_copy(&param0)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AcquireNotification: AcquireNotification::<Identity, Impl, OFFSET>,
             ReleaseNotification: ReleaseNotification::<Identity, Impl, OFFSET>,
         }

--- a/crates/libs/windows/src/Windows/Win32/Graphics/DirectDraw/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/DirectDraw/mod.rs
@@ -134,7 +134,7 @@ unsafe impl ::windows::core::Interface for IDDVideoPortContainer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDDVideoPortContainer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateVideoPort: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: u32, param1: *mut DDVIDEOPORTDESC, param2: *mut *mut ::core::ffi::c_void, param3: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub EnumVideoPorts: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: u32, param1: *mut DDVIDEOPORTCAPS, param2: *mut ::core::ffi::c_void, param3: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetVideoPortConnectInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: u32, pcinfo: *mut u32, param2: *mut DDVIDEOPORTCONNECT) -> ::windows::core::HRESULT,
@@ -272,7 +272,7 @@ unsafe impl ::windows::core::Interface for IDirectDraw {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectDraw_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Compact: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CreateClipper: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: u32, param1: *mut *mut ::core::ffi::c_void, param2: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -435,7 +435,7 @@ unsafe impl ::windows::core::Interface for IDirectDraw2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectDraw2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Compact: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CreateClipper: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: u32, param1: *mut *mut ::core::ffi::c_void, param2: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -619,7 +619,7 @@ unsafe impl ::windows::core::Interface for IDirectDraw4 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectDraw4_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Compact: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CreateClipper: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: u32, param1: *mut *mut ::core::ffi::c_void, param2: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -821,7 +821,7 @@ unsafe impl ::windows::core::Interface for IDirectDraw7 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectDraw7_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Compact: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CreateClipper: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: u32, param1: *mut *mut ::core::ffi::c_void, param2: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -945,7 +945,7 @@ unsafe impl ::windows::core::Interface for IDirectDrawClipper {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectDrawClipper_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
     pub GetClipList: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: *mut super::super::Foundation::RECT, param1: *mut super::Gdi::RGNDATA, param2: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi")))]
@@ -1017,7 +1017,7 @@ unsafe impl ::windows::core::Interface for IDirectDrawColorControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectDrawColorControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetColorControls: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: *mut DDCOLORCONTROL) -> ::windows::core::HRESULT,
     pub SetColorControls: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: *mut DDCOLORCONTROL) -> ::windows::core::HRESULT,
 }
@@ -1070,7 +1070,7 @@ unsafe impl ::windows::core::Interface for IDirectDrawGammaControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectDrawGammaControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetGammaRamp: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: u32, param1: *mut DDGAMMARAMP) -> ::windows::core::HRESULT,
     pub SetGammaRamp: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: u32, param1: *mut DDGAMMARAMP) -> ::windows::core::HRESULT,
 }
@@ -1126,7 +1126,7 @@ unsafe impl ::windows::core::Interface for IDirectDrawKernel {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectDrawKernel_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCaps: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: *mut DDKERNELCAPS) -> ::windows::core::HRESULT,
     pub GetKernelHandle: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: *mut usize) -> ::windows::core::HRESULT,
     pub ReleaseKernelHandle: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1195,7 +1195,7 @@ unsafe impl ::windows::core::Interface for IDirectDrawPalette {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectDrawPalette_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCaps: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Graphics_Gdi")]
     pub GetEntries: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: u32, param1: u32, param2: u32, param3: *mut super::Gdi::PALETTEENTRY) -> ::windows::core::HRESULT,
@@ -1406,7 +1406,7 @@ unsafe impl ::windows::core::Interface for IDirectDrawSurface {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectDrawSurface_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddAttachedSurface: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub AddOverlayDirtyRect: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: *mut super::super::Foundation::RECT) -> ::windows::core::HRESULT,
@@ -1670,7 +1670,7 @@ unsafe impl ::windows::core::Interface for IDirectDrawSurface2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectDrawSurface2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddAttachedSurface: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub AddOverlayDirtyRect: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: *mut super::super::Foundation::RECT) -> ::windows::core::HRESULT,
@@ -1940,7 +1940,7 @@ unsafe impl ::windows::core::Interface for IDirectDrawSurface3 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectDrawSurface3_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddAttachedSurface: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub AddOverlayDirtyRect: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: *mut super::super::Foundation::RECT) -> ::windows::core::HRESULT,
@@ -2228,7 +2228,7 @@ unsafe impl ::windows::core::Interface for IDirectDrawSurface4 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectDrawSurface4_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddAttachedSurface: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub AddOverlayDirtyRect: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: *mut super::super::Foundation::RECT) -> ::windows::core::HRESULT,
@@ -2536,7 +2536,7 @@ unsafe impl ::windows::core::Interface for IDirectDrawSurface7 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectDrawSurface7_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddAttachedSurface: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub AddOverlayDirtyRect: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: *mut super::super::Foundation::RECT) -> ::windows::core::HRESULT,
@@ -2660,7 +2660,7 @@ unsafe impl ::windows::core::Interface for IDirectDrawSurfaceKernel {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectDrawSurfaceKernel_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetKernelHandle: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: *mut usize) -> ::windows::core::HRESULT,
     pub ReleaseKernelHandle: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -2759,7 +2759,7 @@ unsafe impl ::windows::core::Interface for IDirectDrawVideoPort {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectDrawVideoPort_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Flip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: *mut ::core::ffi::c_void, param1: u32) -> ::windows::core::HRESULT,
     pub GetBandwidthInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: *mut DDPIXELFORMAT, param1: u32, param2: u32, param3: u32, param4: *mut DDVIDEOPORTBANDWIDTH) -> ::windows::core::HRESULT,
     pub GetColorControls: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: *mut DDCOLORCONTROL) -> ::windows::core::HRESULT,
@@ -2837,7 +2837,7 @@ unsafe impl ::windows::core::Interface for IDirectDrawVideoPortNotify {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectDrawVideoPortNotify_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub AcquireNotification: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: *mut super::super::Foundation::HANDLE, param1: *mut DDVIDEOPORTNOTIFY) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]

--- a/crates/libs/windows/src/Windows/Win32/Graphics/DirectManipulation/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/DirectManipulation/impl.rs
@@ -9,7 +9,7 @@ impl IDirectManipulationAutoScrollBehavior_Vtbl {
             let this = (*this).get_impl();
             this.SetConfiguration(::core::mem::transmute_copy(&motiontypes), ::core::mem::transmute_copy(&scrollmotion)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SetConfiguration: SetConfiguration::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SetConfiguration: SetConfiguration::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDirectManipulationAutoScrollBehavior as ::windows::core::Interface>::IID
@@ -45,7 +45,7 @@ impl IDirectManipulationCompositor_Vtbl {
             this.Flush().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddContent: AddContent::<Identity, Impl, OFFSET>,
             RemoveContent: RemoveContent::<Identity, Impl, OFFSET>,
             SetUpdateManager: SetUpdateManager::<Identity, Impl, OFFSET>,
@@ -139,7 +139,7 @@ impl IDirectManipulationContent_Vtbl {
             this.SyncContentTransform(::core::mem::transmute_copy(&matrix), ::core::mem::transmute_copy(&pointcount)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetContentRect: GetContentRect::<Identity, Impl, OFFSET>,
             SetContentRect: SetContentRect::<Identity, Impl, OFFSET>,
             GetViewport: GetViewport::<Identity, Impl, OFFSET>,
@@ -178,7 +178,7 @@ impl IDirectManipulationDeferContactService_Vtbl {
             this.CancelDeferral(::core::mem::transmute_copy(&pointerid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             DeferContact: DeferContact::<Identity, Impl, OFFSET>,
             CancelContact: CancelContact::<Identity, Impl, OFFSET>,
             CancelDeferral: CancelDeferral::<Identity, Impl, OFFSET>,
@@ -212,7 +212,7 @@ impl IDirectManipulationDragDropBehavior_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetConfiguration: SetConfiguration::<Identity, Impl, OFFSET>,
             GetStatus: GetStatus::<Identity, Impl, OFFSET>,
         }
@@ -232,7 +232,7 @@ impl IDirectManipulationDragDropEventHandler_Vtbl {
             let this = (*this).get_impl();
             this.OnDragDropStatusChange(::core::mem::transmute(&viewport), ::core::mem::transmute_copy(&current), ::core::mem::transmute_copy(&previous)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnDragDropStatusChange: OnDragDropStatusChange::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnDragDropStatusChange: OnDragDropStatusChange::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDirectManipulationDragDropEventHandler as ::windows::core::Interface>::IID
@@ -249,7 +249,7 @@ impl IDirectManipulationFrameInfoProvider_Vtbl {
             let this = (*this).get_impl();
             this.GetNextFrameInfo(::core::mem::transmute_copy(&time), ::core::mem::transmute_copy(&processtime), ::core::mem::transmute_copy(&compositiontime)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetNextFrameInfo: GetNextFrameInfo::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetNextFrameInfo: GetNextFrameInfo::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDirectManipulationFrameInfoProvider as ::windows::core::Interface>::IID
@@ -266,7 +266,7 @@ impl IDirectManipulationInteractionEventHandler_Vtbl {
             let this = (*this).get_impl();
             this.OnInteraction(::core::mem::transmute(&viewport), ::core::mem::transmute_copy(&interaction)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnInteraction: OnInteraction::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnInteraction: OnInteraction::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDirectManipulationInteractionEventHandler as ::windows::core::Interface>::IID
@@ -329,7 +329,7 @@ impl IDirectManipulationManager_Vtbl {
             this.CreateContent(::core::mem::transmute(&frameinfo), ::core::mem::transmute_copy(&clsid), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&object)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Activate: Activate::<Identity, Impl, OFFSET>,
             Deactivate: Deactivate::<Identity, Impl, OFFSET>,
             RegisterHitTestTarget: RegisterHitTestTarget::<Identity, Impl, OFFSET>,
@@ -443,7 +443,7 @@ impl IDirectManipulationPrimaryContent_Vtbl {
             this.GetCenterPoint(::core::mem::transmute_copy(&centerx), ::core::mem::transmute_copy(&centery)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetSnapInterval: SetSnapInterval::<Identity, Impl, OFFSET>,
             SetSnapPoints: SetSnapPoints::<Identity, Impl, OFFSET>,
             SetSnapType: SetSnapType::<Identity, Impl, OFFSET>,
@@ -470,7 +470,7 @@ impl IDirectManipulationUpdateHandler_Vtbl {
             let this = (*this).get_impl();
             this.Update().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Update: Update::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Update: Update::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDirectManipulationUpdateHandler as ::windows::core::Interface>::IID
@@ -509,7 +509,7 @@ impl IDirectManipulationUpdateManager_Vtbl {
             this.Update(::core::mem::transmute(&frameinfo)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RegisterWaitHandleCallback: RegisterWaitHandleCallback::<Identity, Impl, OFFSET>,
             UnregisterWaitHandleCallback: UnregisterWaitHandleCallback::<Identity, Impl, OFFSET>,
             Update: Update::<Identity, Impl, OFFSET>,
@@ -714,7 +714,7 @@ impl IDirectManipulationViewport_Vtbl {
             this.Abandon().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Enable: Enable::<Identity, Impl, OFFSET>,
             Disable: Disable::<Identity, Impl, OFFSET>,
             SetContact: SetContact::<Identity, Impl, OFFSET>,
@@ -816,7 +816,7 @@ impl IDirectManipulationViewportEventHandler_Vtbl {
             this.OnContentUpdated(::core::mem::transmute(&viewport), ::core::mem::transmute(&content)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnViewportStatusChanged: OnViewportStatusChanged::<Identity, Impl, OFFSET>,
             OnViewportUpdated: OnViewportUpdated::<Identity, Impl, OFFSET>,
             OnContentUpdated: OnContentUpdated::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/Graphics/DirectManipulation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/DirectManipulation/mod.rs
@@ -44,7 +44,7 @@ unsafe impl ::windows::core::Interface for IDirectManipulationAutoScrollBehavior
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectManipulationAutoScrollBehavior_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetConfiguration: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, motiontypes: DIRECTMANIPULATION_MOTION_TYPES, scrollmotion: DIRECTMANIPULATION_AUTOSCROLL_CONFIGURATION) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Graphics_DirectManipulation\"`*"]
@@ -114,7 +114,7 @@ unsafe impl ::windows::core::Interface for IDirectManipulationCompositor {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectManipulationCompositor_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddContent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, content: *mut ::core::ffi::c_void, device: *mut ::core::ffi::c_void, parentvisual: *mut ::core::ffi::c_void, childvisual: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub RemoveContent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, content: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetUpdateManager: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, updatemanager: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -296,7 +296,7 @@ unsafe impl ::windows::core::Interface for IDirectManipulationContent {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectManipulationContent_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetContentRect: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, contentsize: *mut super::super::Foundation::RECT) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -364,7 +364,7 @@ unsafe impl ::windows::core::Interface for IDirectManipulationDeferContactServic
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectManipulationDeferContactService_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub DeferContact: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pointerid: u32, timeout: u32) -> ::windows::core::HRESULT,
     pub CancelContact: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pointerid: u32) -> ::windows::core::HRESULT,
     pub CancelDeferral: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pointerid: u32) -> ::windows::core::HRESULT,
@@ -419,7 +419,7 @@ unsafe impl ::windows::core::Interface for IDirectManipulationDragDropBehavior {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectManipulationDragDropBehavior_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetConfiguration: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, configuration: DIRECTMANIPULATION_DRAG_DROP_CONFIGURATION) -> ::windows::core::HRESULT,
     pub GetStatus: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, status: *mut DIRECTMANIPULATION_DRAG_DROP_STATUS) -> ::windows::core::HRESULT,
 }
@@ -472,7 +472,7 @@ unsafe impl ::windows::core::Interface for IDirectManipulationDragDropEventHandl
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectManipulationDragDropEventHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnDragDropStatusChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, viewport: *mut ::core::ffi::c_void, current: DIRECTMANIPULATION_DRAG_DROP_STATUS, previous: DIRECTMANIPULATION_DRAG_DROP_STATUS) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Graphics_DirectManipulation\"`*"]
@@ -521,7 +521,7 @@ unsafe impl ::windows::core::Interface for IDirectManipulationFrameInfoProvider 
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectManipulationFrameInfoProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetNextFrameInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, time: *mut u64, processtime: *mut u64, compositiontime: *mut u64) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Graphics_DirectManipulation\"`*"]
@@ -573,7 +573,7 @@ unsafe impl ::windows::core::Interface for IDirectManipulationInteractionEventHa
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectManipulationInteractionEventHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnInteraction: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, viewport: *mut ::core::ffi::c_void, interaction: DIRECTMANIPULATION_INTERACTION_TYPE) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Graphics_DirectManipulation\"`*"]
@@ -676,7 +676,7 @@ unsafe impl ::windows::core::Interface for IDirectManipulationManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectManipulationManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Activate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, window: super::super::Foundation::HWND) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -1042,7 +1042,7 @@ unsafe impl ::windows::core::Interface for IDirectManipulationPrimaryContent {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectManipulationPrimaryContent_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetSnapInterval: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, motion: DIRECTMANIPULATION_MOTION_TYPES, interval: f32, offset: f32) -> ::windows::core::HRESULT,
     pub SetSnapPoints: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, motion: DIRECTMANIPULATION_MOTION_TYPES, points: *const f32, pointcount: u32) -> ::windows::core::HRESULT,
     pub SetSnapType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, motion: DIRECTMANIPULATION_MOTION_TYPES, r#type: DIRECTMANIPULATION_SNAPPOINT_TYPE) -> ::windows::core::HRESULT,
@@ -1099,7 +1099,7 @@ unsafe impl ::windows::core::Interface for IDirectManipulationUpdateHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectManipulationUpdateHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Update: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Graphics_DirectManipulation\"`*"]
@@ -1164,7 +1164,7 @@ unsafe impl ::windows::core::Interface for IDirectManipulationUpdateManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectManipulationUpdateManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub RegisterWaitHandleCallback: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, handle: super::super::Foundation::HANDLE, eventhandler: *mut ::core::ffi::c_void, cookie: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -1333,7 +1333,7 @@ unsafe impl ::windows::core::Interface for IDirectManipulationViewport {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectManipulationViewport_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Enable: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Disable: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetContact: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pointerid: u32) -> ::windows::core::HRESULT,
@@ -1631,7 +1631,7 @@ unsafe impl ::windows::core::Interface for IDirectManipulationViewportEventHandl
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectManipulationViewportEventHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnViewportStatusChanged: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, viewport: *mut ::core::ffi::c_void, current: DIRECTMANIPULATION_STATUS, previous: DIRECTMANIPULATION_STATUS) -> ::windows::core::HRESULT,
     pub OnViewportUpdated: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, viewport: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub OnContentUpdated: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, viewport: *mut ::core::ffi::c_void, content: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/Graphics/DirectWrite/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/DirectWrite/impl.rs
@@ -19,7 +19,7 @@ impl IDWriteAsyncResult_Vtbl {
             this.GetResult().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetWaitHandle: GetWaitHandle::<Identity, Impl, OFFSET>,
             GetResult: GetResult::<Identity, Impl, OFFSET>,
         }
@@ -103,7 +103,7 @@ impl IDWriteBitmapRenderTarget_Vtbl {
             this.Resize(::core::mem::transmute_copy(&width), ::core::mem::transmute_copy(&height)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             DrawGlyphRun: DrawGlyphRun::<Identity, Impl, OFFSET>,
             GetMemoryDC: GetMemoryDC::<Identity, Impl, OFFSET>,
             GetPixelsPerDip: GetPixelsPerDip::<Identity, Impl, OFFSET>,
@@ -181,7 +181,7 @@ impl IDWriteColorGlyphRunEnumerator_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             MoveNext: MoveNext::<Identity, Impl, OFFSET>,
             GetCurrentRun: GetCurrentRun::<Identity, Impl, OFFSET>,
         }
@@ -447,7 +447,7 @@ impl IDWriteFactory_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSystemFontCollection: GetSystemFontCollection::<Identity, Impl, OFFSET>,
             CreateCustomFontCollection: CreateCustomFontCollection::<Identity, Impl, OFFSET>,
             RegisterFontCollectionLoader: RegisterFontCollectionLoader::<Identity, Impl, OFFSET>,
@@ -1097,7 +1097,7 @@ impl IDWriteFont_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetFontFamily: GetFontFamily::<Identity, Impl, OFFSET>,
             GetWeight: GetWeight::<Identity, Impl, OFFSET>,
             GetStretch: GetStretch::<Identity, Impl, OFFSET>,
@@ -1287,7 +1287,7 @@ impl IDWriteFontCollection_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetFontFamilyCount: GetFontFamilyCount::<Identity, Impl, OFFSET>,
             GetFontFamily: GetFontFamily::<Identity, Impl, OFFSET>,
             FindFamilyName: FindFamilyName::<Identity, Impl, OFFSET>,
@@ -1439,7 +1439,7 @@ impl IDWriteFontCollectionLoader_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CreateEnumeratorFromKey: CreateEnumeratorFromKey::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CreateEnumeratorFromKey: CreateEnumeratorFromKey::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDWriteFontCollectionLoader as ::windows::core::Interface>::IID
@@ -1456,7 +1456,7 @@ impl IDWriteFontDownloadListener_Vtbl {
             let this = (*this).get_impl();
             this.DownloadCompleted(::core::mem::transmute(&downloadqueue), ::core::mem::transmute(&context), ::core::mem::transmute_copy(&downloadresult))
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), DownloadCompleted: DownloadCompleted::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), DownloadCompleted: DownloadCompleted::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDWriteFontDownloadListener as ::windows::core::Interface>::IID
@@ -1513,7 +1513,7 @@ impl IDWriteFontDownloadQueue_Vtbl {
             this.GetGenerationCount()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddListener: AddListener::<Identity, Impl, OFFSET>,
             RemoveListener: RemoveListener::<Identity, Impl, OFFSET>,
             IsEmpty: IsEmpty::<Identity, Impl, OFFSET>,
@@ -1643,7 +1643,7 @@ impl IDWriteFontFace_Vtbl {
             this.GetGdiCompatibleGlyphMetrics(::core::mem::transmute_copy(&emsize), ::core::mem::transmute_copy(&pixelsperdip), ::core::mem::transmute_copy(&transform), ::core::mem::transmute_copy(&usegdinatural), ::core::mem::transmute_copy(&glyphindices), ::core::mem::transmute_copy(&glyphcount), ::core::mem::transmute_copy(&glyphmetrics), ::core::mem::transmute_copy(&issideways)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetType: GetType::<Identity, Impl, OFFSET>,
             GetFiles: GetFiles::<Identity, Impl, OFFSET>,
             GetIndex: GetIndex::<Identity, Impl, OFFSET>,
@@ -2256,7 +2256,7 @@ impl IDWriteFontFaceReference_Vtbl {
             this.EnqueueFileFragmentDownloadRequest(::core::mem::transmute_copy(&fileoffset), ::core::mem::transmute_copy(&fragmentsize)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateFontFace: CreateFontFace::<Identity, Impl, OFFSET>,
             CreateFontFaceWithSimulations: CreateFontFaceWithSimulations::<Identity, Impl, OFFSET>,
             Equals: Equals::<Identity, Impl, OFFSET>,
@@ -2332,7 +2332,7 @@ impl IDWriteFontFallback_Vtbl {
             this.MapCharacters(::core::mem::transmute(&analysissource), ::core::mem::transmute_copy(&textposition), ::core::mem::transmute_copy(&textlength), ::core::mem::transmute(&basefontcollection), ::core::mem::transmute(&basefamilyname), ::core::mem::transmute_copy(&baseweight), ::core::mem::transmute_copy(&basestyle), ::core::mem::transmute_copy(&basestretch), ::core::mem::transmute_copy(&mappedlength), ::core::mem::transmute_copy(&mappedfont), ::core::mem::transmute_copy(&scale))
                 .into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), MapCharacters: MapCharacters::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), MapCharacters: MapCharacters::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDWriteFontFallback as ::windows::core::Interface>::IID
@@ -2385,7 +2385,7 @@ impl IDWriteFontFallbackBuilder_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddMapping: AddMapping::<Identity, Impl, OFFSET>,
             AddMappings: AddMappings::<Identity, Impl, OFFSET>,
             CreateFontFallback: CreateFontFallback::<Identity, Impl, OFFSET>,
@@ -2565,7 +2565,7 @@ impl IDWriteFontFile_Vtbl {
             this.Analyze(::core::mem::transmute_copy(&issupportedfonttype), ::core::mem::transmute_copy(&fontfiletype), ::core::mem::transmute_copy(&fontfacetype), ::core::mem::transmute_copy(&numberoffaces)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetReferenceKey: GetReferenceKey::<Identity, Impl, OFFSET>,
             GetLoader: GetLoader::<Identity, Impl, OFFSET>,
             Analyze: Analyze::<Identity, Impl, OFFSET>,
@@ -2608,7 +2608,7 @@ impl IDWriteFontFileEnumerator_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             MoveNext: MoveNext::<Identity, Impl, OFFSET>,
             GetCurrentFontFile: GetCurrentFontFile::<Identity, Impl, OFFSET>,
         }
@@ -2634,7 +2634,7 @@ impl IDWriteFontFileLoader_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CreateStreamFromKey: CreateStreamFromKey::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CreateStreamFromKey: CreateStreamFromKey::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDWriteFontFileLoader as ::windows::core::Interface>::IID
@@ -2682,7 +2682,7 @@ impl IDWriteFontFileStream_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ReadFileFragment: ReadFileFragment::<Identity, Impl, OFFSET>,
             ReleaseFileFragment: ReleaseFileFragment::<Identity, Impl, OFFSET>,
             GetFileSize: GetFileSize::<Identity, Impl, OFFSET>,
@@ -2729,7 +2729,7 @@ impl IDWriteFontList_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetFontCollection: GetFontCollection::<Identity, Impl, OFFSET>,
             GetFontCount: GetFontCount::<Identity, Impl, OFFSET>,
             GetFont: GetFont::<Identity, Impl, OFFSET>,
@@ -2913,7 +2913,7 @@ impl IDWriteFontResource_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetFontFile: GetFontFile::<Identity, Impl, OFFSET>,
             GetFontFaceIndex: GetFontFaceIndex::<Identity, Impl, OFFSET>,
             GetFontAxisCount: GetFontAxisCount::<Identity, Impl, OFFSET>,
@@ -3037,7 +3037,7 @@ impl IDWriteFontSet_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetFontCount: GetFontCount::<Identity, Impl, OFFSET>,
             GetFontFaceReference: GetFontFaceReference::<Identity, Impl, OFFSET>,
             FindFontFaceReference: FindFontFaceReference::<Identity, Impl, OFFSET>,
@@ -3302,7 +3302,7 @@ impl IDWriteFontSetBuilder_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddFontFaceReference: AddFontFaceReference::<Identity, Impl, OFFSET>,
             AddFontFaceReference2: AddFontFaceReference2::<Identity, Impl, OFFSET>,
             AddFontSet: AddFontSet::<Identity, Impl, OFFSET>,
@@ -3420,7 +3420,7 @@ impl IDWriteGdiInterop_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateFontFromLOGFONT: CreateFontFromLOGFONT::<Identity, Impl, OFFSET>,
             ConvertFontToLOGFONT: ConvertFontToLOGFONT::<Identity, Impl, OFFSET>,
             ConvertFontFaceToLOGFONT: ConvertFontFaceToLOGFONT::<Identity, Impl, OFFSET>,
@@ -3533,7 +3533,7 @@ impl IDWriteGlyphRunAnalysis_Vtbl {
             this.GetAlphaBlendParams(::core::mem::transmute(&renderingparams), ::core::mem::transmute_copy(&blendgamma), ::core::mem::transmute_copy(&blendenhancedcontrast), ::core::mem::transmute_copy(&blendcleartypelevel)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetAlphaTextureBounds: GetAlphaTextureBounds::<Identity, Impl, OFFSET>,
             CreateAlphaTexture: CreateAlphaTexture::<Identity, Impl, OFFSET>,
             GetAlphaBlendParams: GetAlphaBlendParams::<Identity, Impl, OFFSET>,
@@ -3621,7 +3621,7 @@ impl IDWriteInlineObject_Vtbl {
             this.GetBreakConditions(::core::mem::transmute_copy(&breakconditionbefore), ::core::mem::transmute_copy(&breakconditionafter)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Draw: Draw::<Identity, Impl, OFFSET>,
             GetMetrics: GetMetrics::<Identity, Impl, OFFSET>,
             GetOverhangMetrics: GetOverhangMetrics::<Identity, Impl, OFFSET>,
@@ -3738,7 +3738,7 @@ impl IDWriteLocalizedStrings_Vtbl {
             this.GetString(::core::mem::transmute_copy(&index), ::core::mem::transmute_copy(&stringbuffer), ::core::mem::transmute_copy(&size)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCount: GetCount::<Identity, Impl, OFFSET>,
             FindLocaleName: FindLocaleName::<Identity, Impl, OFFSET>,
             GetLocaleNameLength: GetLocaleNameLength::<Identity, Impl, OFFSET>,
@@ -3755,7 +3755,7 @@ pub trait IDWriteNumberSubstitution_Impl: Sized {}
 impl ::windows::core::RuntimeName for IDWriteNumberSubstitution {}
 impl IDWriteNumberSubstitution_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IDWriteNumberSubstitution_Impl, const OFFSET: isize>() -> IDWriteNumberSubstitution_Vtbl {
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>() }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>() }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDWriteNumberSubstitution as ::windows::core::Interface>::IID
@@ -3806,7 +3806,7 @@ impl IDWritePixelSnapping_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             IsPixelSnappingDisabled: IsPixelSnappingDisabled::<Identity, Impl, OFFSET>,
             GetCurrentTransform: GetCurrentTransform::<Identity, Impl, OFFSET>,
             GetPixelsPerDip: GetPixelsPerDip::<Identity, Impl, OFFSET>,
@@ -3960,7 +3960,7 @@ impl IDWriteRenderingParams_Vtbl {
             this.GetRenderingMode()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetGamma: GetGamma::<Identity, Impl, OFFSET>,
             GetEnhancedContrast: GetEnhancedContrast::<Identity, Impl, OFFSET>,
             GetClearTypeLevel: GetClearTypeLevel::<Identity, Impl, OFFSET>,
@@ -4074,7 +4074,7 @@ impl IDWriteStringList_Vtbl {
             this.GetString(::core::mem::transmute_copy(&listindex), ::core::mem::transmute_copy(&stringbuffer), ::core::mem::transmute_copy(&stringbuffersize)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCount: GetCount::<Identity, Impl, OFFSET>,
             GetLocaleNameLength: GetLocaleNameLength::<Identity, Impl, OFFSET>,
             GetLocaleName: GetLocaleName::<Identity, Impl, OFFSET>,
@@ -4116,7 +4116,7 @@ impl IDWriteTextAnalysisSink_Vtbl {
             this.SetNumberSubstitution(::core::mem::transmute_copy(&textposition), ::core::mem::transmute_copy(&textlength), ::core::mem::transmute(&numbersubstitution)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetScriptAnalysis: SetScriptAnalysis::<Identity, Impl, OFFSET>,
             SetLineBreakpoints: SetLineBreakpoints::<Identity, Impl, OFFSET>,
             SetBidiLevel: SetBidiLevel::<Identity, Impl, OFFSET>,
@@ -4183,7 +4183,7 @@ impl IDWriteTextAnalysisSource_Vtbl {
             this.GetNumberSubstitution(::core::mem::transmute_copy(&textposition), ::core::mem::transmute_copy(&textlength), ::core::mem::transmute_copy(&numbersubstitution)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTextAtPosition: GetTextAtPosition::<Identity, Impl, OFFSET>,
             GetTextBeforePosition: GetTextBeforePosition::<Identity, Impl, OFFSET>,
             GetParagraphReadingDirection: GetParagraphReadingDirection::<Identity, Impl, OFFSET>,
@@ -4413,7 +4413,7 @@ impl IDWriteTextAnalyzer_Vtbl {
             .into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AnalyzeScript: AnalyzeScript::<Identity, Impl, OFFSET>,
             AnalyzeBidi: AnalyzeBidi::<Identity, Impl, OFFSET>,
             AnalyzeNumberSubstitution: AnalyzeNumberSubstitution::<Identity, Impl, OFFSET>,
@@ -4767,7 +4767,7 @@ impl IDWriteTextFormat_Vtbl {
             this.GetLocaleName(::core::mem::transmute_copy(&localename), ::core::mem::transmute_copy(&namesize)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetTextAlignment: SetTextAlignment::<Identity, Impl, OFFSET>,
             SetParagraphAlignment: SetParagraphAlignment::<Identity, Impl, OFFSET>,
             SetWordWrapping: SetWordWrapping::<Identity, Impl, OFFSET>,
@@ -5625,7 +5625,7 @@ impl IDWriteTypography_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddFontFeature: AddFontFeature::<Identity, Impl, OFFSET>,
             GetFontFeatureCount: GetFontFeatureCount::<Identity, Impl, OFFSET>,
             GetFontFeature: GetFontFeature::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/Graphics/DirectWrite/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/DirectWrite/mod.rs
@@ -59,7 +59,7 @@ unsafe impl ::windows::core::Interface for IDWriteAsyncResult {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDWriteAsyncResult_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetWaitHandle: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> super::super::Foundation::HANDLE,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -146,7 +146,7 @@ unsafe impl ::windows::core::Interface for IDWriteBitmapRenderTarget {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDWriteBitmapRenderTarget_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub DrawGlyphRun: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, baselineoriginx: f32, baselineoriginy: f32, measuringmode: DWRITE_MEASURING_MODE, glyphrun: *const DWRITE_GLYPH_RUN, renderingparams: *mut ::core::ffi::c_void, textcolor: super::super::Foundation::COLORREF, blackboxrect: *mut super::super::Foundation::RECT) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -325,7 +325,7 @@ unsafe impl ::windows::core::Interface for IDWriteColorGlyphRunEnumerator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDWriteColorGlyphRunEnumerator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub MoveNext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hasrun: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -597,7 +597,7 @@ unsafe impl ::windows::core::Interface for IDWriteFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDWriteFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetSystemFontCollection: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fontcollection: *mut *mut ::core::ffi::c_void, checkforupdates: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -3251,7 +3251,7 @@ unsafe impl ::windows::core::Interface for IDWriteFont {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDWriteFont_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetFontFamily: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fontfamily: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetWeight: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> DWRITE_FONT_WEIGHT,
     pub GetStretch: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> DWRITE_FONT_STRETCH,
@@ -3799,7 +3799,7 @@ unsafe impl ::windows::core::Interface for IDWriteFontCollection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDWriteFontCollection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetFontFamilyCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32,
     pub GetFontFamily: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: u32, fontfamily: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -4224,7 +4224,7 @@ unsafe impl ::windows::core::Interface for IDWriteFontCollectionLoader {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDWriteFontCollectionLoader_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateEnumeratorFromKey: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, factory: *mut ::core::ffi::c_void, collectionkey: *const ::core::ffi::c_void, collectionkeysize: u32, fontfileenumerator: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`*"]
@@ -4277,7 +4277,7 @@ unsafe impl ::windows::core::Interface for IDWriteFontDownloadListener {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDWriteFontDownloadListener_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub DownloadCompleted: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, downloadqueue: *mut ::core::ffi::c_void, context: *mut ::core::ffi::c_void, downloadresult: ::windows::core::HRESULT),
 }
 #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`*"]
@@ -4350,7 +4350,7 @@ unsafe impl ::windows::core::Interface for IDWriteFontDownloadQueue {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDWriteFontDownloadQueue_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddListener: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, listener: *mut ::core::ffi::c_void, token: *mut u32) -> ::windows::core::HRESULT,
     pub RemoveListener: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, token: u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -4477,7 +4477,7 @@ unsafe impl ::windows::core::Interface for IDWriteFontFace {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDWriteFontFace_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> DWRITE_FONT_FACE_TYPE,
     pub GetFiles: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, numberoffiles: *mut u32, fontfiles: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetIndex: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32,
@@ -6630,7 +6630,7 @@ unsafe impl ::windows::core::Interface for IDWriteFontFaceReference {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDWriteFontFaceReference_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateFontFace: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fontface: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CreateFontFaceWithSimulations: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fontfacesimulationflags: DWRITE_FONT_SIMULATIONS, fontface: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -6829,7 +6829,7 @@ unsafe impl ::windows::core::Interface for IDWriteFontFallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDWriteFontFallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub MapCharacters: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, analysissource: *mut ::core::ffi::c_void, textposition: u32, textlength: u32, basefontcollection: *mut ::core::ffi::c_void, basefamilyname: ::windows::core::PCWSTR, baseweight: DWRITE_FONT_WEIGHT, basestyle: DWRITE_FONT_STYLE, basestretch: DWRITE_FONT_STRETCH, mappedlength: *mut u32, mappedfont: *mut *mut ::core::ffi::c_void, scale: *mut f32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`*"]
@@ -6970,7 +6970,7 @@ unsafe impl ::windows::core::Interface for IDWriteFontFallbackBuilder {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDWriteFontFallbackBuilder_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddMapping: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ranges: *const DWRITE_UNICODE_RANGE, rangescount: u32, targetfamilynames: *const *const u16, targetfamilynamescount: u32, fontcollection: *mut ::core::ffi::c_void, localename: ::windows::core::PCWSTR, basefamilyname: ::windows::core::PCWSTR, scale: f32) -> ::windows::core::HRESULT,
     pub AddMappings: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fontfallback: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CreateFontFallback: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fontfallback: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -7362,7 +7362,7 @@ unsafe impl ::windows::core::Interface for IDWriteFontFile {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDWriteFontFile_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetReferenceKey: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fontfilereferencekey: *mut *mut ::core::ffi::c_void, fontfilereferencekeysize: *mut u32) -> ::windows::core::HRESULT,
     pub GetLoader: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fontfileloader: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -7423,7 +7423,7 @@ unsafe impl ::windows::core::Interface for IDWriteFontFileEnumerator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDWriteFontFileEnumerator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub MoveNext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hascurrentfile: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -7477,7 +7477,7 @@ unsafe impl ::windows::core::Interface for IDWriteFontFileLoader {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDWriteFontFileLoader_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateStreamFromKey: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fontfilereferencekey: *const ::core::ffi::c_void, fontfilereferencekeysize: u32, fontfilestream: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`*"]
@@ -7537,7 +7537,7 @@ unsafe impl ::windows::core::Interface for IDWriteFontFileStream {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDWriteFontFileStream_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ReadFileFragment: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fragmentstart: *mut *mut ::core::ffi::c_void, fileoffset: u64, fragmentsize: u64, fragmentcontext: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub ReleaseFileFragment: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fragmentcontext: *mut ::core::ffi::c_void),
     pub GetFileSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, filesize: *mut u64) -> ::windows::core::HRESULT,
@@ -7597,7 +7597,7 @@ unsafe impl ::windows::core::Interface for IDWriteFontList {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDWriteFontList_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetFontCollection: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fontcollection: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetFontCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32,
     pub GetFont: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: u32, font: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -7874,7 +7874,7 @@ unsafe impl ::windows::core::Interface for IDWriteFontResource {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDWriteFontResource_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetFontFile: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fontfile: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetFontFaceIndex: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32,
     pub GetFontAxisCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32,
@@ -7988,7 +7988,7 @@ unsafe impl ::windows::core::Interface for IDWriteFontSet {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDWriteFontSet_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetFontCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32,
     pub GetFontFaceReference: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, listindex: u32, fontfacereference: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -8713,7 +8713,7 @@ unsafe impl ::windows::core::Interface for IDWriteFontSetBuilder {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDWriteFontSetBuilder_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddFontFaceReference: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fontfacereference: *mut ::core::ffi::c_void, properties: *const DWRITE_FONT_PROPERTY, propertycount: u32) -> ::windows::core::HRESULT,
     pub AddFontFaceReference2: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fontfacereference: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub AddFontSet: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fontset: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -9009,7 +9009,7 @@ unsafe impl ::windows::core::Interface for IDWriteGdiInterop {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDWriteGdiInterop_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Graphics_Gdi")]
     pub CreateFontFromLOGFONT: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, logfont: *const super::Gdi::LOGFONTW, font: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Graphics_Gdi"))]
@@ -9244,7 +9244,7 @@ unsafe impl ::windows::core::Interface for IDWriteGlyphRunAnalysis {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDWriteGlyphRunAnalysis_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetAlphaTextureBounds: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, texturetype: DWRITE_TEXTURE_TYPE, texturebounds: *mut super::super::Foundation::RECT) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -9399,7 +9399,7 @@ unsafe impl ::windows::core::Interface for IDWriteInlineObject {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDWriteInlineObject_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Draw: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, clientdrawingcontext: *const ::core::ffi::c_void, renderer: *mut ::core::ffi::c_void, originx: f32, originy: f32, issideways: super::super::Foundation::BOOL, isrighttoleft: super::super::Foundation::BOOL, clientdrawingeffect: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -9562,7 +9562,7 @@ unsafe impl ::windows::core::Interface for IDWriteLocalizedStrings {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDWriteLocalizedStrings_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32,
     #[cfg(feature = "Win32_Foundation")]
     pub FindLocaleName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, localename: ::windows::core::PCWSTR, index: *mut u32, exists: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -9615,7 +9615,7 @@ unsafe impl ::windows::core::Interface for IDWriteNumberSubstitution {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDWriteNumberSubstitution_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
 }
 #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`*"]
 #[repr(transparent)]
@@ -9674,7 +9674,7 @@ unsafe impl ::windows::core::Interface for IDWritePixelSnapping {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDWritePixelSnapping_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub IsPixelSnappingDisabled: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, clientdrawingcontext: *const ::core::ffi::c_void, isdisabled: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -9921,7 +9921,7 @@ unsafe impl ::windows::core::Interface for IDWriteRenderingParams {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDWriteRenderingParams_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetGamma: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> f32,
     pub GetEnhancedContrast: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> f32,
     pub GetClearTypeLevel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> f32,
@@ -10279,7 +10279,7 @@ unsafe impl ::windows::core::Interface for IDWriteStringList {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDWriteStringList_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32,
     pub GetLocaleNameLength: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, listindex: u32, length: *mut u32) -> ::windows::core::HRESULT,
     pub GetLocaleName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, listindex: u32, localename: ::windows::core::PWSTR, size: u32) -> ::windows::core::HRESULT,
@@ -10344,7 +10344,7 @@ unsafe impl ::windows::core::Interface for IDWriteTextAnalysisSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDWriteTextAnalysisSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetScriptAnalysis: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, textposition: u32, textlength: u32, scriptanalysis: *const DWRITE_SCRIPT_ANALYSIS) -> ::windows::core::HRESULT,
     pub SetLineBreakpoints: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, textposition: u32, textlength: u32, linebreakpoints: *const DWRITE_LINE_BREAKPOINT) -> ::windows::core::HRESULT,
     pub SetBidiLevel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, textposition: u32, textlength: u32, explicitlevel: u8, resolvedlevel: u8) -> ::windows::core::HRESULT,
@@ -10496,7 +10496,7 @@ unsafe impl ::windows::core::Interface for IDWriteTextAnalysisSource {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDWriteTextAnalysisSource_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetTextAtPosition: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, textposition: u32, textstring: *mut *mut u16, textlength: *mut u32) -> ::windows::core::HRESULT,
     pub GetTextBeforePosition: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, textposition: u32, textstring: *mut *mut u16, textlength: *mut u32) -> ::windows::core::HRESULT,
     pub GetParagraphReadingDirection: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> DWRITE_READING_DIRECTION,
@@ -10756,7 +10756,7 @@ unsafe impl ::windows::core::Interface for IDWriteTextAnalyzer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDWriteTextAnalyzer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AnalyzeScript: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, analysissource: *mut ::core::ffi::c_void, textposition: u32, textlength: u32, analysissink: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub AnalyzeBidi: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, analysissource: *mut ::core::ffi::c_void, textposition: u32, textlength: u32, analysissink: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub AnalyzeNumberSubstitution: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, analysissource: *mut ::core::ffi::c_void, textposition: u32, textlength: u32, analysissink: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -11524,7 +11524,7 @@ unsafe impl ::windows::core::Interface for IDWriteTextFormat {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDWriteTextFormat_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetTextAlignment: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, textalignment: DWRITE_TEXT_ALIGNMENT) -> ::windows::core::HRESULT,
     pub SetParagraphAlignment: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, paragraphalignment: DWRITE_PARAGRAPH_ALIGNMENT) -> ::windows::core::HRESULT,
     pub SetWordWrapping: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wordwrapping: DWRITE_WORD_WRAPPING) -> ::windows::core::HRESULT,
@@ -14510,7 +14510,7 @@ unsafe impl ::windows::core::Interface for IDWriteTypography {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDWriteTypography_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddFontFeature: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fontfeature: DWRITE_FONT_FEATURE) -> ::windows::core::HRESULT,
     pub GetFontFeatureCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32,
     pub GetFontFeature: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fontfeatureindex: u32, fontfeature: *mut DWRITE_FONT_FEATURE) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Dxgi/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Dxgi/impl.rs
@@ -218,7 +218,7 @@ impl IDXGIDebug_Vtbl {
             let this = (*this).get_impl();
             this.ReportLiveObjects(::core::mem::transmute(&apiid), ::core::mem::transmute_copy(&flags)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), ReportLiveObjects: ReportLiveObjects::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), ReportLiveObjects: ReportLiveObjects::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDXGIDebug as ::windows::core::Interface>::IID
@@ -336,7 +336,7 @@ impl IDXGIDecodeSwapChain_Vtbl {
             this.GetColorSpace()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             PresentBuffer: PresentBuffer::<Identity, Impl, OFFSET>,
             SetSourceRect: SetSourceRect::<Identity, Impl, OFFSET>,
             SetTargetRect: SetTargetRect::<Identity, Impl, OFFSET>,
@@ -588,7 +588,7 @@ impl IDXGIDisplayControl_Vtbl {
             this.SetStereoEnabled(::core::mem::transmute_copy(&enabled))
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             IsStereoEnabled: IsStereoEnabled::<Identity, Impl, OFFSET>,
             SetStereoEnabled: SetStereoEnabled::<Identity, Impl, OFFSET>,
         }
@@ -1002,7 +1002,7 @@ impl IDXGIFactoryMedia_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateSwapChainForCompositionSurfaceHandle: CreateSwapChainForCompositionSurfaceHandle::<Identity, Impl, OFFSET>,
             CreateDecodeSwapChainForCompositionSurfaceHandle: CreateDecodeSwapChainForCompositionSurfaceHandle::<Identity, Impl, OFFSET>,
         }
@@ -1242,7 +1242,7 @@ impl IDXGIInfoQueue_Vtbl {
             this.GetMuteDebugOutput(::core::mem::transmute(&producer))
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetMessageCountLimit: SetMessageCountLimit::<Identity, Impl, OFFSET>,
             ClearStoredMessages: ClearStoredMessages::<Identity, Impl, OFFSET>,
             GetMessage: GetMessage::<Identity, Impl, OFFSET>,
@@ -1343,7 +1343,7 @@ impl IDXGIObject_Vtbl {
             this.GetParent(::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppparent)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetPrivateData: SetPrivateData::<Identity, Impl, OFFSET>,
             SetPrivateDataInterface: SetPrivateDataInterface::<Identity, Impl, OFFSET>,
             GetPrivateData: GetPrivateData::<Identity, Impl, OFFSET>,
@@ -2368,7 +2368,7 @@ impl IDXGISwapChainMedia_Vtbl {
             this.CheckPresentDurationSupport(::core::mem::transmute_copy(&desiredpresentduration), ::core::mem::transmute_copy(&pclosestsmallerpresentduration), ::core::mem::transmute_copy(&pclosestlargerpresentduration)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetFrameStatisticsMedia: GetFrameStatisticsMedia::<Identity, Impl, OFFSET>,
             SetPresentDuration: SetPresentDuration::<Identity, Impl, OFFSET>,
             CheckPresentDurationSupport: CheckPresentDurationSupport::<Identity, Impl, OFFSET>,
@@ -2396,7 +2396,7 @@ impl IDXGraphicsAnalysis_Vtbl {
             this.EndCapture()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             BeginCapture: BeginCapture::<Identity, Impl, OFFSET>,
             EndCapture: EndCapture::<Identity, Impl, OFFSET>,
         }

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Dxgi/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Dxgi/mod.rs
@@ -862,7 +862,7 @@ unsafe impl ::windows::core::Interface for IDXGIDebug {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDXGIDebug_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ReportLiveObjects: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, apiid: ::windows::core::GUID, flags: DXGI_DEBUG_RLO_FLAGS) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`*"]
@@ -1025,7 +1025,7 @@ unsafe impl ::windows::core::Interface for IDXGIDecodeSwapChain {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDXGIDecodeSwapChain_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub PresentBuffer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, buffertopresent: u32, syncinterval: u32, flags: u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub SetSourceRect: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, prect: *const super::super::Foundation::RECT) -> ::windows::core::HRESULT,
@@ -1945,7 +1945,7 @@ unsafe impl ::windows::core::Interface for IDXGIDisplayControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDXGIDisplayControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub IsStereoEnabled: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> super::super::Foundation::BOOL,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -4131,7 +4131,7 @@ unsafe impl ::windows::core::Interface for IDXGIFactoryMedia {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDXGIFactoryMedia_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
     pub CreateSwapChainForCompositionSurfaceHandle: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdevice: *mut ::core::ffi::c_void, hsurface: super::super::Foundation::HANDLE, pdesc: *const DXGI_SWAP_CHAIN_DESC1, prestricttooutput: *mut ::core::ffi::c_void, ppswapchain: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common")))]
@@ -4329,7 +4329,7 @@ unsafe impl ::windows::core::Interface for IDXGIInfoQueue {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDXGIInfoQueue_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetMessageCountLimit: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, producer: ::windows::core::GUID, messagecountlimit: u64) -> ::windows::core::HRESULT,
     pub ClearStoredMessages: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, producer: ::windows::core::GUID),
     pub GetMessage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, producer: ::windows::core::GUID, messageindex: u64, pmessage: *mut DXGI_INFO_QUEUE_MESSAGE, pmessagebytelength: *mut usize) -> ::windows::core::HRESULT,
@@ -4563,7 +4563,7 @@ unsafe impl ::windows::core::Interface for IDXGIObject {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDXGIObject_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetPrivateData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, name: *const ::windows::core::GUID, datasize: u32, pdata: *const ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetPrivateDataInterface: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, name: *const ::windows::core::GUID, punknown: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetPrivateData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, name: *const ::windows::core::GUID, pdatasize: *mut u32, pdata: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -8482,7 +8482,7 @@ unsafe impl ::windows::core::Interface for IDXGISwapChainMedia {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDXGISwapChainMedia_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetFrameStatisticsMedia: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pstats: *mut DXGI_FRAME_STATISTICS_MEDIA) -> ::windows::core::HRESULT,
     pub SetPresentDuration: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, duration: u32) -> ::windows::core::HRESULT,
     pub CheckPresentDurationSupport: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, desiredpresentduration: u32, pclosestsmallerpresentduration: *mut u32, pclosestlargerpresentduration: *mut u32) -> ::windows::core::HRESULT,
@@ -8536,7 +8536,7 @@ unsafe impl ::windows::core::Interface for IDXGraphicsAnalysis {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDXGraphicsAnalysis_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub BeginCapture: unsafe extern "system" fn(this: *mut ::core::ffi::c_void),
     pub EndCapture: unsafe extern "system" fn(this: *mut ::core::ffi::c_void),
 }

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Imaging/D2D/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Imaging/D2D/impl.rs
@@ -25,7 +25,7 @@ impl IWICImageEncoder_Vtbl {
             this.WriteThumbnail(::core::mem::transmute(&pimage), ::core::mem::transmute(&pencoder), ::core::mem::transmute_copy(&pimageparameters)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             WriteFrame: WriteFrame::<Identity, Impl, OFFSET>,
             WriteFrameThumbnail: WriteFrameThumbnail::<Identity, Impl, OFFSET>,
             WriteThumbnail: WriteThumbnail::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Imaging/D2D/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Imaging/D2D/mod.rs
@@ -68,7 +68,7 @@ unsafe impl ::windows::core::Interface for IWICImageEncoder {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWICImageEncoder_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Dxgi_Common"))]
     pub WriteFrame: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pimage: *mut ::core::ffi::c_void, pframeencode: *mut ::core::ffi::c_void, pimageparameters: *const super::WICImageParameters) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Dxgi_Common")))]

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Imaging/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Imaging/impl.rs
@@ -203,7 +203,7 @@ impl IWICBitmapCodecProgressNotification_Vtbl {
             this.RegisterProgressNotification(::core::mem::transmute(&pfnprogressnotification), ::core::mem::transmute_copy(&pvdata), ::core::mem::transmute_copy(&dwprogressflags)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RegisterProgressNotification: RegisterProgressNotification::<Identity, Impl, OFFSET>,
         }
     }
@@ -334,7 +334,7 @@ impl IWICBitmapDecoder_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             QueryCapability: QueryCapability::<Identity, Impl, OFFSET>,
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             GetContainerFormat: GetContainerFormat::<Identity, Impl, OFFSET>,
@@ -488,7 +488,7 @@ impl IWICBitmapEncoder_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             GetContainerFormat: GetContainerFormat::<Identity, Impl, OFFSET>,
             GetEncoderInfo: GetEncoderInfo::<Identity, Impl, OFFSET>,
@@ -675,7 +675,7 @@ impl IWICBitmapFrameEncode_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             SetSize: SetSize::<Identity, Impl, OFFSET>,
             SetResolution: SetResolution::<Identity, Impl, OFFSET>,
@@ -735,7 +735,7 @@ impl IWICBitmapLock_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSize: GetSize::<Identity, Impl, OFFSET>,
             GetStride: GetStride::<Identity, Impl, OFFSET>,
             GetDataPointer: GetDataPointer::<Identity, Impl, OFFSET>,
@@ -805,7 +805,7 @@ impl IWICBitmapSource_Vtbl {
             this.CopyPixels(::core::mem::transmute_copy(&prc), ::core::mem::transmute_copy(&cbstride), ::core::mem::transmute_copy(&cbbuffersize), ::core::mem::transmute_copy(&pbbuffer)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSize: GetSize::<Identity, Impl, OFFSET>,
             GetPixelFormat: GetPixelFormat::<Identity, Impl, OFFSET>,
             GetResolution: GetResolution::<Identity, Impl, OFFSET>,
@@ -856,7 +856,7 @@ impl IWICBitmapSourceTransform_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CopyPixels: CopyPixels::<Identity, Impl, OFFSET>,
             GetClosestSize: GetClosestSize::<Identity, Impl, OFFSET>,
             GetClosestPixelFormat: GetClosestPixelFormat::<Identity, Impl, OFFSET>,
@@ -921,7 +921,7 @@ impl IWICColorContext_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             InitializeFromFilename: InitializeFromFilename::<Identity, Impl, OFFSET>,
             InitializeFromMemory: InitializeFromMemory::<Identity, Impl, OFFSET>,
             InitializeFromExifColorSpace: InitializeFromExifColorSpace::<Identity, Impl, OFFSET>,
@@ -1136,7 +1136,7 @@ impl IWICComponentInfo_Vtbl {
             this.GetFriendlyName(::core::mem::transmute_copy(&cchfriendlyname), ::core::mem::transmute(&wzfriendlyname), ::core::mem::transmute_copy(&pcchactual)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetComponentType: GetComponentType::<Identity, Impl, OFFSET>,
             GetCLSID: GetCLSID::<Identity, Impl, OFFSET>,
             GetSigningStatus: GetSigningStatus::<Identity, Impl, OFFSET>,
@@ -1184,7 +1184,7 @@ impl IWICDdsDecoder_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetParameters: GetParameters::<Identity, Impl, OFFSET>,
             GetFrame: GetFrame::<Identity, Impl, OFFSET>,
         }
@@ -1226,7 +1226,7 @@ impl IWICDdsEncoder_Vtbl {
             this.CreateNewFrame(::core::mem::transmute_copy(&ppiframeencode), ::core::mem::transmute_copy(&parrayindex), ::core::mem::transmute_copy(&pmiplevel), ::core::mem::transmute_copy(&psliceindex)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetParameters: SetParameters::<Identity, Impl, OFFSET>,
             GetParameters: GetParameters::<Identity, Impl, OFFSET>,
             CreateNewFrame: CreateNewFrame::<Identity, Impl, OFFSET>,
@@ -1269,7 +1269,7 @@ impl IWICDdsFrameDecode_Vtbl {
             this.CopyBlocks(::core::mem::transmute_copy(&prcboundsinblocks), ::core::mem::transmute_copy(&cbstride), ::core::mem::transmute_copy(&cbbuffersize), ::core::mem::transmute_copy(&pbbuffer)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSizeInBlocks: GetSizeInBlocks::<Identity, Impl, OFFSET>,
             GetFormatInfo: GetFormatInfo::<Identity, Impl, OFFSET>,
             CopyBlocks: CopyBlocks::<Identity, Impl, OFFSET>,
@@ -1602,7 +1602,7 @@ impl IWICDevelopRawNotificationCallback_Vtbl {
             let this = (*this).get_impl();
             this.Notify(::core::mem::transmute_copy(&notificationmask)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Notify: Notify::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Notify: Notify::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWICDevelopRawNotificationCallback as ::windows::core::Interface>::IID
@@ -1647,7 +1647,7 @@ impl IWICEnumMetadataItem_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -1682,7 +1682,7 @@ impl IWICFastMetadataEncoder_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Commit: Commit::<Identity, Impl, OFFSET>,
             GetMetadataQueryWriter: GetMetadataQueryWriter::<Identity, Impl, OFFSET>,
         }
@@ -2069,7 +2069,7 @@ impl IWICImagingFactory_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateDecoderFromFilename: CreateDecoderFromFilename::<Identity, Impl, OFFSET>,
             CreateDecoderFromStream: CreateDecoderFromStream::<Identity, Impl, OFFSET>,
             CreateDecoderFromFileHandle: CreateDecoderFromFileHandle::<Identity, Impl, OFFSET>,
@@ -2206,7 +2206,7 @@ impl IWICJpegFrameDecode_Vtbl {
             this.CopyMinimalStream(::core::mem::transmute_copy(&streamoffset), ::core::mem::transmute_copy(&cbstreamdata), ::core::mem::transmute_copy(&pbstreamdata), ::core::mem::transmute_copy(&pcbstreamdataactual)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             DoesSupportIndexing: DoesSupportIndexing::<Identity, Impl, OFFSET>,
             SetIndexing: SetIndexing::<Identity, Impl, OFFSET>,
             ClearIndexing: ClearIndexing::<Identity, Impl, OFFSET>,
@@ -2274,7 +2274,7 @@ impl IWICJpegFrameEncode_Vtbl {
             this.WriteScan(::core::mem::transmute_copy(&cbscandata), ::core::mem::transmute_copy(&pbscandata)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetAcHuffmanTable: GetAcHuffmanTable::<Identity, Impl, OFFSET>,
             GetDcHuffmanTable: GetDcHuffmanTable::<Identity, Impl, OFFSET>,
             GetQuantizationTable: GetQuantizationTable::<Identity, Impl, OFFSET>,
@@ -2342,7 +2342,7 @@ impl IWICMetadataBlockReader_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetContainerFormat: GetContainerFormat::<Identity, Impl, OFFSET>,
             GetCount: GetCount::<Identity, Impl, OFFSET>,
             GetReaderByIndex: GetReaderByIndex::<Identity, Impl, OFFSET>,
@@ -2544,7 +2544,7 @@ impl IWICMetadataQueryReader_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetContainerFormat: GetContainerFormat::<Identity, Impl, OFFSET>,
             GetLocation: GetLocation::<Identity, Impl, OFFSET>,
             GetMetadataByName: GetMetadataByName::<Identity, Impl, OFFSET>,
@@ -2654,7 +2654,7 @@ impl IWICMetadataReader_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetMetadataFormat: GetMetadataFormat::<Identity, Impl, OFFSET>,
             GetMetadataHandlerInfo: GetMetadataHandlerInfo::<Identity, Impl, OFFSET>,
             GetCount: GetCount::<Identity, Impl, OFFSET>,
@@ -2895,7 +2895,7 @@ impl IWICPalette_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             InitializePredefined: InitializePredefined::<Identity, Impl, OFFSET>,
             InitializeCustom: InitializeCustom::<Identity, Impl, OFFSET>,
             InitializeFromBitmap: InitializeFromBitmap::<Identity, Impl, OFFSET>,
@@ -3074,7 +3074,7 @@ impl IWICPlanarBitmapFrameEncode_Vtbl {
             this.WriteSource(::core::mem::transmute_copy(&ppplanes), ::core::mem::transmute_copy(&cplanes), ::core::mem::transmute_copy(&prcsource)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             WritePixels: WritePixels::<Identity, Impl, OFFSET>,
             WriteSource: WriteSource::<Identity, Impl, OFFSET>,
         }
@@ -3104,7 +3104,7 @@ impl IWICPlanarBitmapSourceTransform_Vtbl {
             this.CopyPixels(::core::mem::transmute_copy(&prcsource), ::core::mem::transmute_copy(&uiwidth), ::core::mem::transmute_copy(&uiheight), ::core::mem::transmute_copy(&dsttransform), ::core::mem::transmute_copy(&dstplanaroptions), ::core::mem::transmute_copy(&pdstplanes), ::core::mem::transmute_copy(&cplanes)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             DoesSupportTransform: DoesSupportTransform::<Identity, Impl, OFFSET>,
             CopyPixels: CopyPixels::<Identity, Impl, OFFSET>,
         }
@@ -3160,7 +3160,7 @@ impl IWICProgressCallback_Vtbl {
             let this = (*this).get_impl();
             this.Notify(::core::mem::transmute_copy(&uframenum), ::core::mem::transmute_copy(&operation), ::core::mem::transmute_copy(&dblprogress)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Notify: Notify::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Notify: Notify::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWICProgressCallback as ::windows::core::Interface>::IID
@@ -3202,7 +3202,7 @@ impl IWICProgressiveLevelControl_Vtbl {
             this.SetCurrentLevel(::core::mem::transmute_copy(&nlevel)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetLevelCount: GetLevelCount::<Identity, Impl, OFFSET>,
             GetCurrentLevel: GetCurrentLevel::<Identity, Impl, OFFSET>,
             SetCurrentLevel: SetCurrentLevel::<Identity, Impl, OFFSET>,
@@ -3307,7 +3307,7 @@ impl IWICStreamProvider_Vtbl {
             this.RefreshStream().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetStream: GetStream::<Identity, Impl, OFFSET>,
             GetPersistOptions: GetPersistOptions::<Identity, Impl, OFFSET>,
             GetPreferredVendorGUID: GetPreferredVendorGUID::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Imaging/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Imaging/mod.rs
@@ -513,7 +513,7 @@ unsafe impl ::windows::core::Interface for IWICBitmapCodecProgressNotification {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWICBitmapCodecProgressNotification_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub RegisterProgressNotification: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfnprogressnotification: *mut ::core::ffi::c_void, pvdata: *const ::core::ffi::c_void, dwprogressflags: u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Graphics_Imaging\"`*"]
@@ -613,7 +613,7 @@ unsafe impl ::windows::core::Interface for IWICBitmapDecoder {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWICBitmapDecoder_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub QueryCapability: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pistream: *mut ::core::ffi::c_void, pdwcapability: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -909,7 +909,7 @@ unsafe impl ::windows::core::Interface for IWICBitmapEncoder {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWICBitmapEncoder_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pistream: *mut ::core::ffi::c_void, cacheoption: WICBitmapEncoderCacheOption) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -1360,7 +1360,7 @@ unsafe impl ::windows::core::Interface for IWICBitmapFrameEncode {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWICBitmapFrameEncode_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com_StructuredStorage")]
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, piencoderoptions: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com_StructuredStorage"))]
@@ -1433,7 +1433,7 @@ unsafe impl ::windows::core::Interface for IWICBitmapLock {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWICBitmapLock_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, puiwidth: *mut u32, puiheight: *mut u32) -> ::windows::core::HRESULT,
     pub GetStride: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcbstride: *mut u32) -> ::windows::core::HRESULT,
     pub GetDataPointer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcbbuffersize: *mut u32, ppbdata: *mut *mut u8) -> ::windows::core::HRESULT,
@@ -1587,7 +1587,7 @@ unsafe impl ::windows::core::Interface for IWICBitmapSource {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWICBitmapSource_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, puiwidth: *mut u32, puiheight: *mut u32) -> ::windows::core::HRESULT,
     pub GetPixelFormat: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppixelformat: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub GetResolution: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdpix: *mut f64, pdpiy: *mut f64) -> ::windows::core::HRESULT,
@@ -1652,7 +1652,7 @@ unsafe impl ::windows::core::Interface for IWICBitmapSourceTransform {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWICBitmapSourceTransform_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CopyPixels: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, prc: *const WICRect, uiwidth: u32, uiheight: u32, pguiddstformat: *const ::windows::core::GUID, dsttransform: WICBitmapTransformOptions, nstride: u32, cbbuffersize: u32, pbbuffer: *mut u8) -> ::windows::core::HRESULT,
     pub GetClosestSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, puiwidth: *mut u32, puiheight: *mut u32) -> ::windows::core::HRESULT,
     pub GetClosestPixelFormat: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pguiddstformat: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
@@ -1727,7 +1727,7 @@ unsafe impl ::windows::core::Interface for IWICColorContext {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWICColorContext_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub InitializeFromFilename: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wzfilename: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub InitializeFromMemory: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbbuffer: *const u8, cbbuffersize: u32) -> ::windows::core::HRESULT,
     pub InitializeFromExifColorSpace: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: u32) -> ::windows::core::HRESULT,
@@ -2157,7 +2157,7 @@ unsafe impl ::windows::core::Interface for IWICComponentInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWICComponentInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetComponentType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptype: *mut WICComponentType) -> ::windows::core::HRESULT,
     pub GetCLSID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pclsid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub GetSigningStatus: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pstatus: *mut u32) -> ::windows::core::HRESULT,
@@ -2220,7 +2220,7 @@ unsafe impl ::windows::core::Interface for IWICDdsDecoder {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWICDdsDecoder_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
     pub GetParameters: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pparameters: *mut WICDdsParameters) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Graphics_Dxgi_Common"))]
@@ -2284,7 +2284,7 @@ unsafe impl ::windows::core::Interface for IWICDdsEncoder {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWICDdsEncoder_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
     pub SetParameters: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pparameters: *const WICDdsParameters) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Graphics_Dxgi_Common"))]
@@ -2350,7 +2350,7 @@ unsafe impl ::windows::core::Interface for IWICDdsFrameDecode {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWICDdsFrameDecode_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetSizeInBlocks: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwidthinblocks: *mut u32, pheightinblocks: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
     pub GetFormatInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pformatinfo: *mut WICDdsFormatInfo) -> ::windows::core::HRESULT,
@@ -2660,7 +2660,7 @@ unsafe impl ::windows::core::Interface for IWICDevelopRawNotificationCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWICDevelopRawNotificationCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Notify: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, notificationmask: u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Graphics_Imaging\"`*"]
@@ -2721,7 +2721,7 @@ unsafe impl ::windows::core::Interface for IWICEnumMetadataItem {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWICEnumMetadataItem_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgeltschema: *mut super::super::System::Com::StructuredStorage::PROPVARIANT, rgeltid: *mut super::super::System::Com::StructuredStorage::PROPVARIANT, rgeltvalue: *mut super::super::System::Com::StructuredStorage::PROPVARIANT, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage")))]
@@ -2780,7 +2780,7 @@ unsafe impl ::windows::core::Interface for IWICFastMetadataEncoder {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWICFastMetadataEncoder_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Commit: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetMetadataQueryWriter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppimetadataquerywriter: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -3159,7 +3159,7 @@ unsafe impl ::windows::core::Interface for IWICImagingFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWICImagingFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateDecoderFromFilename: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wzfilename: ::windows::core::PCWSTR, pguidvendor: *const ::windows::core::GUID, dwdesiredaccess: u32, metadataoptions: WICDecodeOptions, ppidecoder: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
     pub CreateDecoderFromStream: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pistream: *mut ::core::ffi::c_void, pguidvendor: *const ::windows::core::GUID, metadataoptions: WICDecodeOptions, ppidecoder: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -3288,7 +3288,7 @@ unsafe impl ::windows::core::Interface for IWICJpegFrameDecode {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWICJpegFrameDecode_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub DoesSupportIndexing: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfindexingsupported: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -3376,7 +3376,7 @@ unsafe impl ::windows::core::Interface for IWICJpegFrameEncode {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWICJpegFrameEncode_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
     pub GetAcHuffmanTable: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, scanindex: u32, tableindex: u32, pachuffmantable: *mut super::Dxgi::Common::DXGI_JPEG_AC_HUFFMAN_TABLE) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Graphics_Dxgi_Common"))]
@@ -3452,7 +3452,7 @@ unsafe impl ::windows::core::Interface for IWICMetadataBlockReader {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWICMetadataBlockReader_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetContainerFormat: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pguidcontainerformat: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub GetCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pccount: *mut u32) -> ::windows::core::HRESULT,
     pub GetReaderByIndex: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, nindex: u32, ppimetadatareader: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -3768,7 +3768,7 @@ unsafe impl ::windows::core::Interface for IWICMetadataQueryReader {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWICMetadataQueryReader_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetContainerFormat: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pguidcontainerformat: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub GetLocation: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cchmaxlength: u32, wznamespace: ::windows::core::PWSTR, pcchactuallength: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
@@ -3949,7 +3949,7 @@ unsafe impl ::windows::core::Interface for IWICMetadataReader {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWICMetadataReader_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetMetadataFormat: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pguidmetadataformat: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub GetMetadataHandlerInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppihandler: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pccount: *mut u32) -> ::windows::core::HRESULT,
@@ -4477,7 +4477,7 @@ unsafe impl ::windows::core::Interface for IWICPalette {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWICPalette_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub InitializePredefined: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, epalettetype: WICBitmapPaletteType, faddtransparentcolor: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -4953,7 +4953,7 @@ unsafe impl ::windows::core::Interface for IWICPlanarBitmapFrameEncode {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWICPlanarBitmapFrameEncode_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub WritePixels: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, linecount: u32, pplanes: *const WICBitmapPlane, cplanes: u32) -> ::windows::core::HRESULT,
     pub WriteSource: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppplanes: *const *mut ::core::ffi::c_void, cplanes: u32, prcsource: *const WICRect) -> ::windows::core::HRESULT,
 }
@@ -5008,7 +5008,7 @@ unsafe impl ::windows::core::Interface for IWICPlanarBitmapSourceTransform {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWICPlanarBitmapSourceTransform_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub DoesSupportTransform: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, puiwidth: *mut u32, puiheight: *mut u32, dsttransform: WICBitmapTransformOptions, dstplanaroptions: WICPlanarOptions, pguiddstformats: *const ::windows::core::GUID, pplanedescriptions: *mut WICBitmapPlaneDescription, cplanes: u32, pfissupported: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -5157,7 +5157,7 @@ unsafe impl ::windows::core::Interface for IWICProgressCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWICProgressCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Notify: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, uframenum: u32, operation: WICProgressOperation, dblprogress: f64) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Graphics_Imaging\"`*"]
@@ -5214,7 +5214,7 @@ unsafe impl ::windows::core::Interface for IWICProgressiveLevelControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWICProgressiveLevelControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetLevelCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pclevels: *mut u32) -> ::windows::core::HRESULT,
     pub GetCurrentLevel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pnlevel: *mut u32) -> ::windows::core::HRESULT,
     pub SetCurrentLevel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, nlevel: u32) -> ::windows::core::HRESULT,
@@ -5466,7 +5466,7 @@ unsafe impl ::windows::core::Interface for IWICStreamProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWICStreamProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub GetStream: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppistream: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Printing/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Printing/impl.rs
@@ -42,7 +42,7 @@ impl IAsyncGetSrvReferralCookie_Vtbl {
             this.FinishAsyncCallWithData(::core::mem::transmute(&param0)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             FinishAsyncCall: FinishAsyncCall::<Identity, Impl, OFFSET>,
             CancelAsyncCall: CancelAsyncCall::<Identity, Impl, OFFSET>,
             FinishAsyncCallWithData: FinishAsyncCallWithData::<Identity, Impl, OFFSET>,
@@ -148,7 +148,7 @@ impl IBidiRequest_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetSchema: SetSchema::<Identity, Impl, OFFSET>,
             SetInputData: SetInputData::<Identity, Impl, OFFSET>,
             GetResult: GetResult::<Identity, Impl, OFFSET>,
@@ -199,7 +199,7 @@ impl IBidiRequestContainer_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddRequest: AddRequest::<Identity, Impl, OFFSET>,
             GetEnumObject: GetEnumObject::<Identity, Impl, OFFSET>,
             GetRequestCount: GetRequestCount::<Identity, Impl, OFFSET>,
@@ -239,7 +239,7 @@ impl IBidiSpl_Vtbl {
             this.MultiSendRecv(::core::mem::transmute(&pszaction), ::core::mem::transmute(&prequestcontainer)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             BindDevice: BindDevice::<Identity, Impl, OFFSET>,
             UnbindDevice: UnbindDevice::<Identity, Impl, OFFSET>,
             SendRecv: SendRecv::<Identity, Impl, OFFSET>,
@@ -295,7 +295,7 @@ impl IBidiSpl2_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             BindDevice: BindDevice::<Identity, Impl, OFFSET>,
             UnbindDevice: UnbindDevice::<Identity, Impl, OFFSET>,
             SendRecvXMLString: SendRecvXMLString::<Identity, Impl, OFFSET>,
@@ -342,7 +342,7 @@ impl IFixedDocument_Vtbl {
             this.SetPrintTicket(::core::mem::transmute(&pprintticket)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetUri: GetUri::<Identity, Impl, OFFSET>,
             GetPrintTicket: GetPrintTicket::<Identity, Impl, OFFSET>,
             SetPrintTicket: SetPrintTicket::<Identity, Impl, OFFSET>,
@@ -388,7 +388,7 @@ impl IFixedDocumentSequence_Vtbl {
             this.SetPrintTicket(::core::mem::transmute(&pprintticket)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetUri: GetUri::<Identity, Impl, OFFSET>,
             GetPrintTicket: GetPrintTicket::<Identity, Impl, OFFSET>,
             SetPrintTicket: SetPrintTicket::<Identity, Impl, OFFSET>,
@@ -632,7 +632,7 @@ impl IInterFilterCommunicator_Vtbl {
             this.RequestWriter(::core::mem::transmute_copy(&ppiwriter)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RequestReader: RequestReader::<Identity, Impl, OFFSET>,
             RequestWriter: RequestWriter::<Identity, Impl, OFFSET>,
         }
@@ -689,7 +689,7 @@ impl IPartBase_Vtbl {
             this.SetPartCompression(::core::mem::transmute_copy(&compression)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetUri: GetUri::<Identity, Impl, OFFSET>,
             GetStream: GetStream::<Identity, Impl, OFFSET>,
             GetPartCompression: GetPartCompression::<Identity, Impl, OFFSET>,
@@ -721,7 +721,7 @@ impl IPartDiscardControl_Vtbl {
             let this = (*this).get_impl();
             this.GetDiscardProperties(::core::mem::transmute_copy(&urisentinelpage), ::core::mem::transmute_copy(&uriparttodiscard)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetDiscardProperties: GetDiscardProperties::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetDiscardProperties: GetDiscardProperties::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IPartDiscardControl as ::windows::core::Interface>::IID
@@ -888,7 +888,7 @@ impl IPrintAsyncCookie_Vtbl {
             this.CancelAsyncCall(::core::mem::transmute_copy(&param0)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             FinishAsyncCall: FinishAsyncCall::<Identity, Impl, OFFSET>,
             CancelAsyncCall: CancelAsyncCall::<Identity, Impl, OFFSET>,
         }
@@ -944,7 +944,7 @@ impl IPrintAsyncNotify_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreatePrintAsyncNotifyChannel: CreatePrintAsyncNotifyChannel::<Identity, Impl, OFFSET>,
             CreatePrintAsyncNotifyRegistration: CreatePrintAsyncNotifyRegistration::<Identity, Impl, OFFSET>,
         }
@@ -971,7 +971,7 @@ impl IPrintAsyncNotifyCallback_Vtbl {
             this.ChannelClosed(::core::mem::transmute(&pchannel), ::core::mem::transmute(&pdata)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnEventNotify: OnEventNotify::<Identity, Impl, OFFSET>,
             ChannelClosed: ChannelClosed::<Identity, Impl, OFFSET>,
         }
@@ -998,7 +998,7 @@ impl IPrintAsyncNotifyChannel_Vtbl {
             this.CloseChannel(::core::mem::transmute(&pdata)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SendNotification: SendNotification::<Identity, Impl, OFFSET>,
             CloseChannel: CloseChannel::<Identity, Impl, OFFSET>,
         }
@@ -1025,7 +1025,7 @@ impl IPrintAsyncNotifyDataObject_Vtbl {
             this.ReleaseData().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AcquireData: AcquireData::<Identity, Impl, OFFSET>,
             ReleaseData: ReleaseData::<Identity, Impl, OFFSET>,
         }
@@ -1052,7 +1052,7 @@ impl IPrintAsyncNotifyRegistration_Vtbl {
             this.UnregisterForNotifications().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RegisterForNotifications: RegisterForNotifications::<Identity, Impl, OFFSET>,
             UnregisterForNotifications: UnregisterForNotifications::<Identity, Impl, OFFSET>,
         }
@@ -1091,7 +1091,7 @@ impl IPrintAsyncNotifyServerReferral_Vtbl {
             this.SetServerReferral(::core::mem::transmute(&prmtserverreferral)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetServerReferral: GetServerReferral::<Identity, Impl, OFFSET>,
             AsyncGetServerReferral: AsyncGetServerReferral::<Identity, Impl, OFFSET>,
             SetServerReferral: SetServerReferral::<Identity, Impl, OFFSET>,
@@ -1129,7 +1129,7 @@ impl IPrintClassObjectFactory_Vtbl {
             let this = (*this).get_impl();
             this.GetPrintClassObject(::core::mem::transmute(&pszprintername), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppnewobject)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetPrintClassObject: GetPrintClassObject::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetPrintClassObject: GetPrintClassObject::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IPrintClassObjectFactory as ::windows::core::Interface>::IID
@@ -1204,7 +1204,7 @@ impl IPrintCoreHelper_Vtbl {
             this.CreateInstanceOfMSXMLObject(::core::mem::transmute_copy(&rclsid), ::core::mem::transmute(&punkouter), ::core::mem::transmute_copy(&dwclscontext), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppv)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetOption: GetOption::<Identity, Impl, OFFSET>,
             SetOptions: SetOptions::<Identity, Impl, OFFSET>,
             EnumConstrainedOptions: EnumConstrainedOptions::<Identity, Impl, OFFSET>,
@@ -1489,7 +1489,7 @@ impl IPrintJob_Vtbl {
             this.RequestCancel().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Name: Name::<Identity, Impl, OFFSET>,
             Id: Id::<Identity, Impl, OFFSET>,
             PrintedPages: PrintedPages::<Identity, Impl, OFFSET>,
@@ -1579,7 +1579,7 @@ impl IPrintOemCommon_Vtbl {
             this.DevMode(::core::mem::transmute_copy(&dwmode), ::core::mem::transmute_copy(&poemdmparam)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetInfo: GetInfo::<Identity, Impl, OFFSET>,
             DevMode: DevMode::<Identity, Impl, OFFSET>,
         }
@@ -1615,7 +1615,7 @@ impl IPrintOemDriverUI_Vtbl {
             this.DrvUpdateUISetting(::core::mem::transmute_copy(&pci), ::core::mem::transmute_copy(&poptitem), ::core::mem::transmute_copy(&dwpreviousselection), ::core::mem::transmute_copy(&dwmode)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             DrvGetDriverSetting: DrvGetDriverSetting::<Identity, Impl, OFFSET>,
             DrvUpgradeRegistrySetting: DrvUpgradeRegistrySetting::<Identity, Impl, OFFSET>,
             DrvUpdateUISetting: DrvUpdateUISetting::<Identity, Impl, OFFSET>,
@@ -1789,7 +1789,7 @@ impl IPrintOemUIMXDC_Vtbl {
             this.AdjustDPI(::core::mem::transmute_copy(&hprinter), ::core::mem::transmute_copy(&cbdevmode), ::core::mem::transmute_copy(&pdevmode), ::core::mem::transmute_copy(&cboemdm), ::core::mem::transmute_copy(&poemdm), ::core::mem::transmute_copy(&pdpi)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AdjustImageableArea: AdjustImageableArea::<Identity, Impl, OFFSET>,
             AdjustImageCompression: AdjustImageCompression::<Identity, Impl, OFFSET>,
             AdjustDPI: AdjustDPI::<Identity, Impl, OFFSET>,
@@ -1823,7 +1823,7 @@ impl IPrintPipelineFilter_Vtbl {
             this.StartOperation().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             InitializeFilter: InitializeFilter::<Identity, Impl, OFFSET>,
             ShutdownOperation: ShutdownOperation::<Identity, Impl, OFFSET>,
             StartOperation: StartOperation::<Identity, Impl, OFFSET>,
@@ -1854,7 +1854,7 @@ impl IPrintPipelineManagerControl_Vtbl {
             this.FilterFinished().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RequestShutdown: RequestShutdown::<Identity, Impl, OFFSET>,
             FilterFinished: FilterFinished::<Identity, Impl, OFFSET>,
         }
@@ -1874,7 +1874,7 @@ impl IPrintPipelineProgressReport_Vtbl {
             let this = (*this).get_impl();
             this.ReportProgress(::core::mem::transmute_copy(&update)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), ReportProgress: ReportProgress::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), ReportProgress: ReportProgress::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IPrintPipelineProgressReport as ::windows::core::Interface>::IID
@@ -1913,7 +1913,7 @@ impl IPrintPipelinePropertyBag_Vtbl {
             this.DeleteProperty(::core::mem::transmute(&pszname))
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddProperty: AddProperty::<Identity, Impl, OFFSET>,
             GetProperty: GetProperty::<Identity, Impl, OFFSET>,
             DeleteProperty: DeleteProperty::<Identity, Impl, OFFSET>,
@@ -1950,7 +1950,7 @@ impl IPrintPreviewDxgiPackageTarget_Vtbl {
             this.InvalidatePreview().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetJobPageCount: SetJobPageCount::<Identity, Impl, OFFSET>,
             DrawPage: DrawPage::<Identity, Impl, OFFSET>,
             InvalidatePreview: InvalidatePreview::<Identity, Impl, OFFSET>,
@@ -1987,7 +1987,7 @@ impl IPrintReadStream_Vtbl {
             this.ReadBytes(::core::mem::transmute_copy(&pvbuffer), ::core::mem::transmute_copy(&cbrequested), ::core::mem::transmute_copy(&pcbread), ::core::mem::transmute_copy(&pbendoffile)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Seek: Seek::<Identity, Impl, OFFSET>,
             ReadBytes: ReadBytes::<Identity, Impl, OFFSET>,
         }
@@ -2013,7 +2013,7 @@ impl IPrintReadStreamFactory_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetStream: GetStream::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetStream: GetStream::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IPrintReadStreamFactory as ::windows::core::Interface>::IID
@@ -2938,7 +2938,7 @@ impl IPrintTicketProvider_Vtbl {
             this.ValidatePrintTicket(::core::mem::transmute(&pbaseticket)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSupportedVersions: GetSupportedVersions::<Identity, Impl, OFFSET>,
             BindPrinter: BindPrinter::<Identity, Impl, OFFSET>,
             QueryDeviceNamespace: QueryDeviceNamespace::<Identity, Impl, OFFSET>,
@@ -3038,7 +3038,7 @@ impl IPrintWriteStream_Vtbl {
             this.Close()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             WriteBytes: WriteBytes::<Identity, Impl, OFFSET>,
             Close: Close::<Identity, Impl, OFFSET>,
         }
@@ -3058,7 +3058,7 @@ impl IPrintWriteStreamFlush_Vtbl {
             let this = (*this).get_impl();
             this.FlushData().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), FlushData: FlushData::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), FlushData: FlushData::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IPrintWriteStreamFlush as ::windows::core::Interface>::IID
@@ -3075,7 +3075,7 @@ impl IPrinterBidiSetRequestCallback_Vtbl {
             let this = (*this).get_impl();
             this.Completed(::core::mem::transmute(&bstrresponse), ::core::mem::transmute_copy(&hrstatus)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Completed: Completed::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Completed: Completed::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IPrinterBidiSetRequestCallback as ::windows::core::Interface>::IID
@@ -3092,7 +3092,7 @@ impl IPrinterExtensionAsyncOperation_Vtbl {
             let this = (*this).get_impl();
             this.Cancel().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Cancel: Cancel::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Cancel: Cancel::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IPrinterExtensionAsyncOperation as ::windows::core::Interface>::IID
@@ -3376,7 +3376,7 @@ impl IPrinterExtensionManager_Vtbl {
             this.DisableEvents().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             EnableEvents: EnableEvents::<Identity, Impl, OFFSET>,
             DisableEvents: DisableEvents::<Identity, Impl, OFFSET>,
         }
@@ -4010,7 +4010,7 @@ impl IXpsDocument_Vtbl {
             this.SetThumbnail(::core::mem::transmute(&pthumbnail)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetThumbnail: GetThumbnail::<Identity, Impl, OFFSET>,
             SetThumbnail: SetThumbnail::<Identity, Impl, OFFSET>,
         }
@@ -4067,7 +4067,7 @@ impl IXpsDocumentConsumer_Vtbl {
             this.GetNewEmptyPart(::core::mem::transmute(&uri), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppnewobject), ::core::mem::transmute_copy(&ppwritestream)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SendXpsUnknown: SendXpsUnknown::<Identity, Impl, OFFSET>,
             SendXpsDocument: SendXpsDocument::<Identity, Impl, OFFSET>,
             SendFixedDocumentSequence: SendFixedDocumentSequence::<Identity, Impl, OFFSET>,
@@ -4098,7 +4098,7 @@ impl IXpsDocumentProvider_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetXpsPart: GetXpsPart::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetXpsPart: GetXpsPart::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IXpsDocumentProvider as ::windows::core::Interface>::IID
@@ -4137,7 +4137,7 @@ impl IXpsPartIterator_Vtbl {
             this.Next()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Reset: Reset::<Identity, Impl, OFFSET>,
             Current: Current::<Identity, Impl, OFFSET>,
             IsDone: IsDone::<Identity, Impl, OFFSET>,
@@ -4168,7 +4168,7 @@ impl IXpsRasterizationFactory_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CreateRasterizer: CreateRasterizer::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CreateRasterizer: CreateRasterizer::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IXpsRasterizationFactory as ::windows::core::Interface>::IID
@@ -4194,7 +4194,7 @@ impl IXpsRasterizationFactory1_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CreateRasterizer: CreateRasterizer::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CreateRasterizer: CreateRasterizer::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IXpsRasterizationFactory1 as ::windows::core::Interface>::IID
@@ -4220,7 +4220,7 @@ impl IXpsRasterizationFactory2_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CreateRasterizer: CreateRasterizer::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CreateRasterizer: CreateRasterizer::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IXpsRasterizationFactory2 as ::windows::core::Interface>::IID
@@ -4253,7 +4253,7 @@ impl IXpsRasterizer_Vtbl {
             this.SetMinimalLineWidth(::core::mem::transmute_copy(&width)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RasterizeRect: RasterizeRect::<Identity, Impl, OFFSET>,
             SetMinimalLineWidth: SetMinimalLineWidth::<Identity, Impl, OFFSET>,
         }
@@ -4273,7 +4273,7 @@ impl IXpsRasterizerNotificationCallback_Vtbl {
             let this = (*this).get_impl();
             this.Continue().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Continue: Continue::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Continue: Continue::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IXpsRasterizerNotificationCallback as ::windows::core::Interface>::IID

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Printing/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Printing/mod.rs
@@ -3005,7 +3005,7 @@ unsafe impl ::windows::core::Interface for IAsyncGetSrvReferralCookie {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAsyncGetSrvReferralCookie_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub FinishAsyncCall: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: ::windows::core::HRESULT) -> ::windows::core::HRESULT,
     pub CancelAsyncCall: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: ::windows::core::HRESULT) -> ::windows::core::HRESULT,
     pub FinishAsyncCallWithData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
@@ -3173,7 +3173,7 @@ unsafe impl ::windows::core::Interface for IBidiRequest {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IBidiRequest_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetSchema: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszschema: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub SetInputData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwtype: u32, pdata: *const u8, usize: u32) -> ::windows::core::HRESULT,
     pub GetResult: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, phr: *mut ::windows::core::HRESULT) -> ::windows::core::HRESULT,
@@ -3239,7 +3239,7 @@ unsafe impl ::windows::core::Interface for IBidiRequestContainer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IBidiRequestContainer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddRequest: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, prequest: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
     pub GetEnumObject: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -3313,7 +3313,7 @@ unsafe impl ::windows::core::Interface for IBidiSpl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IBidiSpl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub BindDevice: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszdevicename: ::windows::core::PCWSTR, dwaccess: u32) -> ::windows::core::HRESULT,
     pub UnbindDevice: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SendRecv: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszaction: ::windows::core::PCWSTR, prequest: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -3384,7 +3384,7 @@ unsafe impl ::windows::core::Interface for IBidiSpl2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IBidiSpl2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub BindDevice: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszdevicename: ::windows::core::PCWSTR, dwaccess: u32) -> ::windows::core::HRESULT,
     pub UnbindDevice: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SendRecvXMLString: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrrequest: ::core::mem::ManuallyDrop<::windows::core::BSTR>, pbstrresponse: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
@@ -3450,7 +3450,7 @@ unsafe impl ::windows::core::Interface for IFixedDocument {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IFixedDocument_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetUri: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, uri: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub GetPrintTicket: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppprintticket: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetPrintTicket: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pprintticket: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -3512,7 +3512,7 @@ unsafe impl ::windows::core::Interface for IFixedDocumentSequence {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IFixedDocumentSequence_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetUri: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, uri: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub GetPrintTicket: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppprintticket: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetPrintTicket: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pprintticket: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -3936,7 +3936,7 @@ unsafe impl ::windows::core::Interface for IInterFilterCommunicator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IInterFilterCommunicator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub RequestReader: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppireader: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub RequestWriter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppiwriter: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -3998,7 +3998,7 @@ unsafe impl ::windows::core::Interface for IPartBase {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPartBase_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetUri: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, uri: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub GetStream: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppstream: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetPartCompression: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcompression: *mut EXpsCompressionOptions) -> ::windows::core::HRESULT,
@@ -4125,7 +4125,7 @@ unsafe impl ::windows::core::Interface for IPartDiscardControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPartDiscardControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDiscardProperties: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, urisentinelpage: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>, uriparttodiscard: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Graphics_Printing\"`*"]
@@ -4698,7 +4698,7 @@ unsafe impl ::windows::core::Interface for IPrintAsyncCookie {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPrintAsyncCookie_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub FinishAsyncCall: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: ::windows::core::HRESULT) -> ::windows::core::HRESULT,
     pub CancelAsyncCall: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: ::windows::core::HRESULT) -> ::windows::core::HRESULT,
 }
@@ -4829,7 +4829,7 @@ unsafe impl ::windows::core::Interface for IPrintAsyncNotify {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPrintAsyncNotify_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreatePrintAsyncNotifyChannel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: u32, param1: *const ::windows::core::GUID, param2: PrintAsyncNotifyUserFilter, param3: PrintAsyncNotifyConversationStyle, param4: *mut ::core::ffi::c_void, param5: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CreatePrintAsyncNotifyRegistration: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: *const ::windows::core::GUID, param1: PrintAsyncNotifyUserFilter, param2: PrintAsyncNotifyConversationStyle, param3: *mut ::core::ffi::c_void, param4: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -4890,7 +4890,7 @@ unsafe impl ::windows::core::Interface for IPrintAsyncNotifyCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPrintAsyncNotifyCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnEventNotify: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pchannel: *mut ::core::ffi::c_void, pdata: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub ChannelClosed: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pchannel: *mut ::core::ffi::c_void, pdata: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -4949,7 +4949,7 @@ unsafe impl ::windows::core::Interface for IPrintAsyncNotifyChannel {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPrintAsyncNotifyChannel_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SendNotification: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdata: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CloseChannel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdata: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -5002,7 +5002,7 @@ unsafe impl ::windows::core::Interface for IPrintAsyncNotifyDataObject {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPrintAsyncNotifyDataObject_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AcquireData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppnotificationdata: *mut *mut u8, psize: *mut u32, ppschema: *mut *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub ReleaseData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -5055,7 +5055,7 @@ unsafe impl ::windows::core::Interface for IPrintAsyncNotifyRegistration {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPrintAsyncNotifyRegistration_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub RegisterForNotifications: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub UnregisterForNotifications: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -5118,7 +5118,7 @@ unsafe impl ::windows::core::Interface for IPrintAsyncNotifyServerReferral {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPrintAsyncNotifyServerReferral_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetServerReferral: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub AsyncGetServerReferral: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetServerReferral: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, prmtserverreferral: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
@@ -5245,7 +5245,7 @@ unsafe impl ::windows::core::Interface for IPrintClassObjectFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPrintClassObjectFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetPrintClassObject: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszprintername: ::windows::core::PCWSTR, riid: *const ::windows::core::GUID, ppnewobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Graphics_Printing\"`*"]
@@ -5353,7 +5353,7 @@ unsafe impl ::windows::core::Interface for IPrintCoreHelper {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPrintCoreHelper_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
     pub GetOption: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdevmode: *const super::Gdi::DEVMODEA, cbsize: u32, pszfeaturerequested: ::windows::core::PCSTR, ppszoption: *mut ::windows::core::PSTR) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi")))]
@@ -6088,7 +6088,7 @@ unsafe impl ::windows::core::Interface for IPrintJob {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPrintJob_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Name: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstrname: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub Id: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pulid: *mut u32) -> ::windows::core::HRESULT,
     pub PrintedPages: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pulpages: *mut u32) -> ::windows::core::HRESULT,
@@ -6237,7 +6237,7 @@ unsafe impl ::windows::core::Interface for IPrintOemCommon {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPrintOemCommon_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwmode: u32, pbuffer: *mut ::core::ffi::c_void, cbsize: u32, pcbneeded: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
     pub DevMode: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwmode: u32, poemdmparam: *mut OEMDMPARAM) -> ::windows::core::HRESULT,
@@ -6306,7 +6306,7 @@ unsafe impl ::windows::core::Interface for IPrintOemDriverUI {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPrintOemDriverUI_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub DrvGetDriverSetting: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pci: *mut ::core::ffi::c_void, feature: ::windows::core::PCSTR, poutput: *mut ::core::ffi::c_void, cbsize: u32, pcbneeded: *mut u32, pdwoptionsreturned: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub DrvUpgradeRegistrySetting: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hprinter: super::super::Foundation::HANDLE, pfeature: ::windows::core::PCSTR, poption: ::windows::core::PCSTR) -> ::windows::core::HRESULT,
@@ -6781,7 +6781,7 @@ unsafe impl ::windows::core::Interface for IPrintOemUIMXDC {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPrintOemUIMXDC_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
     pub AdjustImageableArea: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hprinter: super::super::Foundation::HANDLE, cbdevmode: u32, pdevmode: *const super::Gdi::DEVMODEA, cboemdm: u32, poemdm: *const ::core::ffi::c_void, prclimageablearea: *mut super::super::Foundation::RECTL) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi")))]
@@ -6852,7 +6852,7 @@ unsafe impl ::windows::core::Interface for IPrintPipelineFilter {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPrintPipelineFilter_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub InitializeFilter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinegotiation: *mut ::core::ffi::c_void, pipropertybag: *mut ::core::ffi::c_void, pipipelinecontrol: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub ShutdownOperation: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub StartOperation: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -6911,7 +6911,7 @@ unsafe impl ::windows::core::Interface for IPrintPipelineManagerControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPrintPipelineManagerControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub RequestShutdown: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hrreason: ::windows::core::HRESULT, preason: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -6964,7 +6964,7 @@ unsafe impl ::windows::core::Interface for IPrintPipelineProgressReport {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPrintPipelineProgressReport_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ReportProgress: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, update: EXpsJobConsumption) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Graphics_Printing\"`*"]
@@ -7035,7 +7035,7 @@ unsafe impl ::windows::core::Interface for IPrintPipelinePropertyBag {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPrintPipelinePropertyBag_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub AddProperty: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszname: ::windows::core::PCWSTR, pvar: *const super::super::System::Com::VARIANT) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole")))]
@@ -7106,7 +7106,7 @@ unsafe impl ::windows::core::Interface for IPrintPreviewDxgiPackageTarget {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPrintPreviewDxgiPackageTarget_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetJobPageCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, counttype: PageCountType, count: u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Graphics_Dxgi")]
     pub DrawPage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, jobpagenumber: u32, pageimage: *mut ::core::ffi::c_void, dpix: f32, dpiy: f32) -> ::windows::core::HRESULT,
@@ -7166,7 +7166,7 @@ unsafe impl ::windows::core::Interface for IPrintReadStream {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPrintReadStream_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Seek: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dlibmove: i64, dworigin: u32, plibnewposition: *mut u64) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub ReadBytes: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pvbuffer: *mut ::core::ffi::c_void, cbrequested: u32, pcbread: *mut u32, pbendoffile: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -7220,7 +7220,7 @@ unsafe impl ::windows::core::Interface for IPrintReadStreamFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPrintReadStreamFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetStream: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppstream: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_System_Com\"`*"]
@@ -9532,7 +9532,7 @@ unsafe impl ::windows::core::Interface for IPrintTicketProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPrintTicketProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetSupportedVersions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hprinter: super::super::Foundation::HANDLE, ppversions: *mut *mut i32, cversions: *mut i32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -9821,7 +9821,7 @@ unsafe impl ::windows::core::Interface for IPrintWriteStream {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPrintWriteStream_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub WriteBytes: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pvbuffer: *const ::core::ffi::c_void, cbbuffer: u32, pcbwritten: *mut u32) -> ::windows::core::HRESULT,
     pub Close: unsafe extern "system" fn(this: *mut ::core::ffi::c_void),
 }
@@ -9871,7 +9871,7 @@ unsafe impl ::windows::core::Interface for IPrintWriteStreamFlush {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPrintWriteStreamFlush_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub FlushData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Graphics_Printing\"`*"]
@@ -9920,7 +9920,7 @@ unsafe impl ::windows::core::Interface for IPrinterBidiSetRequestCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPrinterBidiSetRequestCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Completed: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrresponse: ::core::mem::ManuallyDrop<::windows::core::BSTR>, hrstatus: ::windows::core::HRESULT) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Graphics_Printing\"`*"]
@@ -9969,7 +9969,7 @@ unsafe impl ::windows::core::Interface for IPrinterExtensionAsyncOperation {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPrinterExtensionAsyncOperation_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Cancel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_System_Com\"`*"]
@@ -10493,7 +10493,7 @@ unsafe impl ::windows::core::Interface for IPrinterExtensionManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPrinterExtensionManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub EnableEvents: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, printerdriverid: ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub DisableEvents: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -11881,7 +11881,7 @@ unsafe impl ::windows::core::Interface for IXpsDocument {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXpsDocument_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetThumbnail: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppthumbnail: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetThumbnail: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pthumbnail: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -11967,7 +11967,7 @@ unsafe impl ::windows::core::Interface for IXpsDocumentConsumer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXpsDocumentConsumer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SendXpsUnknown: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punknown: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SendXpsDocument: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pixpsdocument: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SendFixedDocumentSequence: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pifixeddocumentsequence: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -12023,7 +12023,7 @@ unsafe impl ::windows::core::Interface for IXpsDocumentProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXpsDocumentProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetXpsPart: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppixpspart: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Graphics_Printing\"`*"]
@@ -12083,7 +12083,7 @@ unsafe impl ::windows::core::Interface for IXpsPartIterator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXpsPartIterator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void),
     pub Current: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, puri: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>, ppxpspart: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -12144,7 +12144,7 @@ unsafe impl ::windows::core::Interface for IXpsRasterizationFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXpsRasterizationFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Storage_Xps")]
     pub CreateRasterizer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, xpspage: *mut ::core::ffi::c_void, dpi: f32, nontextrenderingmode: XPSRAS_RENDERING_MODE, textrenderingmode: XPSRAS_RENDERING_MODE, ppixpsrasterizer: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Storage_Xps"))]
@@ -12202,7 +12202,7 @@ unsafe impl ::windows::core::Interface for IXpsRasterizationFactory1 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXpsRasterizationFactory1_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Storage_Xps")]
     pub CreateRasterizer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, xpspage: *mut ::core::ffi::c_void, dpi: f32, nontextrenderingmode: XPSRAS_RENDERING_MODE, textrenderingmode: XPSRAS_RENDERING_MODE, pixelformat: XPSRAS_PIXEL_FORMAT, ppixpsrasterizer: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Storage_Xps"))]
@@ -12260,7 +12260,7 @@ unsafe impl ::windows::core::Interface for IXpsRasterizationFactory2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXpsRasterizationFactory2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Storage_Xps")]
     pub CreateRasterizer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, xpspage: *mut ::core::ffi::c_void, dpix: f32, dpiy: f32, nontextrenderingmode: XPSRAS_RENDERING_MODE, textrenderingmode: XPSRAS_RENDERING_MODE, pixelformat: XPSRAS_PIXEL_FORMAT, backgroundcolor: XPSRAS_BACKGROUND_COLOR, ppixpsrasterizer: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Storage_Xps"))]
@@ -12321,7 +12321,7 @@ unsafe impl ::windows::core::Interface for IXpsRasterizer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXpsRasterizer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Graphics_Imaging")]
     pub RasterizeRect: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, x: i32, y: i32, width: i32, height: i32, notificationcallback: *mut ::core::ffi::c_void, bitmap: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Graphics_Imaging"))]
@@ -12374,7 +12374,7 @@ unsafe impl ::windows::core::Interface for IXpsRasterizerNotificationCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXpsRasterizerNotificationCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Continue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Graphics_Printing\"`*"]

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/Apo/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/Apo/impl.rs
@@ -2,7 +2,7 @@ pub trait IApoAcousticEchoCancellation_Impl: Sized {}
 impl ::windows::core::RuntimeName for IApoAcousticEchoCancellation {}
 impl IApoAcousticEchoCancellation_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IApoAcousticEchoCancellation_Impl, const OFFSET: isize>() -> IApoAcousticEchoCancellation_Vtbl {
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>() }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>() }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IApoAcousticEchoCancellation as ::windows::core::Interface>::IID
@@ -38,7 +38,7 @@ impl IApoAuxiliaryInputConfiguration_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddAuxiliaryInput: AddAuxiliaryInput::<Identity, Impl, OFFSET>,
             RemoveAuxiliaryInput: RemoveAuxiliaryInput::<Identity, Impl, OFFSET>,
             IsInputFormatSupported: IsInputFormatSupported::<Identity, Impl, OFFSET>,
@@ -59,7 +59,7 @@ impl IApoAuxiliaryInputRT_Vtbl {
             let this = (*this).get_impl();
             this.AcceptInput(::core::mem::transmute_copy(&dwinputid), ::core::mem::transmute_copy(&pinputconnection))
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), AcceptInput: AcceptInput::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), AcceptInput: AcceptInput::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IApoAuxiliaryInputRT as ::windows::core::Interface>::IID
@@ -77,7 +77,7 @@ impl IAudioDeviceModulesClient_Vtbl {
             this.SetAudioDeviceModulesManager(::core::mem::transmute(&paudiodevicemodulesmanager)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetAudioDeviceModulesManager: SetAudioDeviceModulesManager::<Identity, Impl, OFFSET>,
         }
     }
@@ -136,7 +136,7 @@ impl IAudioMediaType_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             IsCompressedFormat: IsCompressedFormat::<Identity, Impl, OFFSET>,
             IsEqual: IsEqual::<Identity, Impl, OFFSET>,
             GetAudioFormat: GetAudioFormat::<Identity, Impl, OFFSET>,
@@ -225,7 +225,7 @@ impl IAudioProcessingObject_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Reset: Reset::<Identity, Impl, OFFSET>,
             GetLatency: GetLatency::<Identity, Impl, OFFSET>,
             GetRegistrationProperties: GetRegistrationProperties::<Identity, Impl, OFFSET>,
@@ -257,7 +257,7 @@ impl IAudioProcessingObjectConfiguration_Vtbl {
             this.UnlockForProcess().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             LockForProcess: LockForProcess::<Identity, Impl, OFFSET>,
             UnlockForProcess: UnlockForProcess::<Identity, Impl, OFFSET>,
         }
@@ -277,7 +277,7 @@ impl IAudioProcessingObjectLoggingService_Vtbl {
             let this = (*this).get_impl();
             this.ApoLog(::core::mem::transmute_copy(&level), ::core::mem::transmute(&format))
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), ApoLog: ApoLog::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), ApoLog: ApoLog::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IAudioProcessingObjectLoggingService as ::windows::core::Interface>::IID
@@ -304,7 +304,7 @@ impl IAudioProcessingObjectNotifications_Vtbl {
             this.HandleNotification(::core::mem::transmute_copy(&aponotification))
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetApoNotificationRegistrationInfo: GetApoNotificationRegistrationInfo::<Identity, Impl, OFFSET>,
             HandleNotification: HandleNotification::<Identity, Impl, OFFSET>,
         }
@@ -337,7 +337,7 @@ impl IAudioProcessingObjectRT_Vtbl {
             this.CalcOutputFrames(::core::mem::transmute_copy(&u32inputframecount))
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             APOProcess: APOProcess::<Identity, Impl, OFFSET>,
             CalcInputFrames: CalcInputFrames::<Identity, Impl, OFFSET>,
             CalcOutputFrames: CalcOutputFrames::<Identity, Impl, OFFSET>,
@@ -364,7 +364,7 @@ impl IAudioProcessingObjectRTQueueService_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetRealTimeWorkQueue: GetRealTimeWorkQueue::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetRealTimeWorkQueue: GetRealTimeWorkQueue::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IAudioProcessingObjectRTQueueService as ::windows::core::Interface>::IID
@@ -400,7 +400,7 @@ impl IAudioProcessingObjectVBR_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CalcMaxInputFrames: CalcMaxInputFrames::<Identity, Impl, OFFSET>,
             CalcMaxOutputFrames: CalcMaxOutputFrames::<Identity, Impl, OFFSET>,
         }
@@ -413,7 +413,7 @@ pub trait IAudioSystemEffects_Impl: Sized {}
 impl ::windows::core::RuntimeName for IAudioSystemEffects {}
 impl IAudioSystemEffects_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IAudioSystemEffects_Impl, const OFFSET: isize>() -> IAudioSystemEffects_Vtbl {
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>() }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>() }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IAudioSystemEffects as ::windows::core::Interface>::IID
@@ -511,7 +511,7 @@ impl IAudioSystemEffectsCustomFormats_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetFormatCount: GetFormatCount::<Identity, Impl, OFFSET>,
             GetFormat: GetFormat::<Identity, Impl, OFFSET>,
             GetFormatRepresentation: GetFormatRepresentation::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/Apo/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/Apo/mod.rs
@@ -40,7 +40,7 @@ unsafe impl ::windows::core::Interface for IApoAcousticEchoCancellation {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IApoAcousticEchoCancellation_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
 }
 #[doc = "*Required features: `\"Win32_Media_Audio_Apo\"`*"]
 #[repr(transparent)]
@@ -98,7 +98,7 @@ unsafe impl ::windows::core::Interface for IApoAuxiliaryInputConfiguration {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IApoAuxiliaryInputConfiguration_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddAuxiliaryInput: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwinputid: u32, cbdatasize: u32, pbydata: *const u8, pinputconnection: *const APO_CONNECTION_DESCRIPTOR) -> ::windows::core::HRESULT,
     pub RemoveAuxiliaryInput: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwinputid: u32) -> ::windows::core::HRESULT,
     pub IsInputFormatSupported: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, prequestedinputformat: *mut ::core::ffi::c_void, ppsupportedinputformat: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -149,7 +149,7 @@ unsafe impl ::windows::core::Interface for IApoAuxiliaryInputRT {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IApoAuxiliaryInputRT_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AcceptInput: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwinputid: u32, pinputconnection: *const APO_CONNECTION_PROPERTY),
 }
 #[doc = "*Required features: `\"Win32_Media_Audio_Apo\"`*"]
@@ -201,7 +201,7 @@ unsafe impl ::windows::core::Interface for IAudioDeviceModulesClient {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAudioDeviceModulesClient_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetAudioDeviceModulesManager: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, paudiodevicemodulesmanager: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_Audio_Apo\"`*"]
@@ -267,7 +267,7 @@ unsafe impl ::windows::core::Interface for IAudioMediaType {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAudioMediaType_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub IsCompressedFormat: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfcompressed: *mut super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -353,7 +353,7 @@ unsafe impl ::windows::core::Interface for IAudioProcessingObject {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAudioProcessingObject_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetLatency: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptime: *mut i64) -> ::windows::core::HRESULT,
     pub GetRegistrationProperties: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppregprops: *mut *mut APO_REG_PROPERTIES) -> ::windows::core::HRESULT,
@@ -411,7 +411,7 @@ unsafe impl ::windows::core::Interface for IAudioProcessingObjectConfiguration {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAudioProcessingObjectConfiguration_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub LockForProcess: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, u32numinputconnections: u32, ppinputconnections: *const *const APO_CONNECTION_DESCRIPTOR, u32numoutputconnections: u32, ppoutputconnections: *const *const APO_CONNECTION_DESCRIPTOR) -> ::windows::core::HRESULT,
     pub UnlockForProcess: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -464,7 +464,7 @@ unsafe impl ::windows::core::Interface for IAudioProcessingObjectLoggingService 
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAudioProcessingObjectLoggingService_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ApoLog: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, level: APO_LOG_LEVEL, format: ::windows::core::PCWSTR),
 }
 #[doc = "*Required features: `\"Win32_Media_Audio_Apo\"`*"]
@@ -518,7 +518,7 @@ unsafe impl ::windows::core::Interface for IAudioProcessingObjectNotifications {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAudioProcessingObjectNotifications_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetApoNotificationRegistrationInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, aponotifications: *mut *mut APO_NOTIFICATION_DESCRIPTOR, count: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_PropertiesSystem"))]
     pub HandleNotification: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, aponotification: *const APO_NOTIFICATION),
@@ -577,7 +577,7 @@ unsafe impl ::windows::core::Interface for IAudioProcessingObjectRT {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAudioProcessingObjectRT_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub APOProcess: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, u32numinputconnections: u32, ppinputconnections: *const *const APO_CONNECTION_PROPERTY, u32numoutputconnections: u32, ppoutputconnections: *mut *mut APO_CONNECTION_PROPERTY),
     pub CalcInputFrames: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, u32outputframecount: u32) -> u32,
     pub CalcOutputFrames: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, u32inputframecount: u32) -> u32,
@@ -629,7 +629,7 @@ unsafe impl ::windows::core::Interface for IAudioProcessingObjectRTQueueService 
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAudioProcessingObjectRTQueueService_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetRealTimeWorkQueue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, workqueueid: *mut u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_Audio_Apo\"`*"]
@@ -683,7 +683,7 @@ unsafe impl ::windows::core::Interface for IAudioProcessingObjectVBR {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAudioProcessingObjectVBR_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CalcMaxInputFrames: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, u32maxoutputframecount: u32, pu32inputframecount: *mut u32) -> ::windows::core::HRESULT,
     pub CalcMaxOutputFrames: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, u32maxinputframecount: u32, pu32outputframecount: *mut u32) -> ::windows::core::HRESULT,
 }
@@ -729,7 +729,7 @@ unsafe impl ::windows::core::Interface for IAudioSystemEffects {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAudioSystemEffects_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
 }
 #[doc = "*Required features: `\"Win32_Media_Audio_Apo\"`*"]
 #[repr(transparent)]
@@ -957,7 +957,7 @@ unsafe impl ::windows::core::Interface for IAudioSystemEffectsCustomFormats {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAudioSystemEffectsCustomFormats_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetFormatCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcformats: *mut u32) -> ::windows::core::HRESULT,
     pub GetFormat: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, nformat: u32, ppformat: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetFormatRepresentation: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, nformat: u32, ppwstrformatrep: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/DirectMusic/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/DirectMusic/impl.rs
@@ -61,7 +61,7 @@ impl IDirectMusic_Vtbl {
             this.SetDirectSound(::core::mem::transmute(&pdirectsound), ::core::mem::transmute_copy(&hwnd)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             EnumPort: EnumPort::<Identity, Impl, OFFSET>,
             CreateMusicBuffer: CreateMusicBuffer::<Identity, Impl, OFFSET>,
             CreatePort: CreatePort::<Identity, Impl, OFFSET>,
@@ -181,7 +181,7 @@ impl IDirectMusicBuffer_Vtbl {
             this.SetUsedBytes(::core::mem::transmute_copy(&cb)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Flush: Flush::<Identity, Impl, OFFSET>,
             TotalTime: TotalTime::<Identity, Impl, OFFSET>,
             PackStructured: PackStructured::<Identity, Impl, OFFSET>,
@@ -225,7 +225,7 @@ impl IDirectMusicCollection_Vtbl {
             this.EnumInstrument(::core::mem::transmute_copy(&dwindex), ::core::mem::transmute_copy(&pdwpatch), ::core::mem::transmute(&pwszname), ::core::mem::transmute_copy(&dwnamelen)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetInstrument: GetInstrument::<Identity, Impl, OFFSET>,
             EnumInstrument: EnumInstrument::<Identity, Impl, OFFSET>,
         }
@@ -245,7 +245,7 @@ impl IDirectMusicDownload_Vtbl {
             let this = (*this).get_impl();
             this.GetBuffer(::core::mem::transmute_copy(&ppvbuffer), ::core::mem::transmute_copy(&pdwsize)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetBuffer: GetBuffer::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetBuffer: GetBuffer::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDirectMusicDownload as ::windows::core::Interface>::IID
@@ -255,7 +255,7 @@ pub trait IDirectMusicDownloadedInstrument_Impl: Sized {}
 impl ::windows::core::RuntimeName for IDirectMusicDownloadedInstrument {}
 impl IDirectMusicDownloadedInstrument_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IDirectMusicDownloadedInstrument_Impl, const OFFSET: isize>() -> IDirectMusicDownloadedInstrument_Vtbl {
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>() }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>() }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDirectMusicDownloadedInstrument as ::windows::core::Interface>::IID
@@ -279,7 +279,7 @@ impl IDirectMusicInstrument_Vtbl {
             this.SetPatch(::core::mem::transmute_copy(&dwpatch)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetPatch: GetPatch::<Identity, Impl, OFFSET>,
             SetPatch: SetPatch::<Identity, Impl, OFFSET>,
         }
@@ -405,7 +405,7 @@ impl IDirectMusicPort_Vtbl {
             this.GetFormat(::core::mem::transmute_copy(&pwaveformatex), ::core::mem::transmute_copy(&pdwwaveformatexsize), ::core::mem::transmute_copy(&pdwbuffersize)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             PlayBuffer: PlayBuffer::<Identity, Impl, OFFSET>,
             SetReadNotificationHandle: SetReadNotificationHandle::<Identity, Impl, OFFSET>,
             Read: Read::<Identity, Impl, OFFSET>,
@@ -483,7 +483,7 @@ impl IDirectMusicPortDownload_Vtbl {
             this.Unload(::core::mem::transmute(&pidmdownload)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetBuffer: GetBuffer::<Identity, Impl, OFFSET>,
             AllocateBuffer: AllocateBuffer::<Identity, Impl, OFFSET>,
             GetDLId: GetDLId::<Identity, Impl, OFFSET>,
@@ -613,7 +613,7 @@ impl IDirectMusicSynth_Vtbl {
             this.GetAppend(::core::mem::transmute_copy(&pdwappend)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Open: Open::<Identity, Impl, OFFSET>,
             Close: Close::<Identity, Impl, OFFSET>,
             SetNumChannelGroups: SetNumChannelGroups::<Identity, Impl, OFFSET>,
@@ -751,7 +751,7 @@ impl IDirectMusicSynthSink_Vtbl {
             this.GetDesiredBufferSize(::core::mem::transmute_copy(&pdwbuffersizeinsamples)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Init: Init::<Identity, Impl, OFFSET>,
             SetMasterClock: SetMasterClock::<Identity, Impl, OFFSET>,
             GetLatencyClock: GetLatencyClock::<Identity, Impl, OFFSET>,
@@ -777,7 +777,7 @@ impl IDirectMusicThru_Vtbl {
             let this = (*this).get_impl();
             this.ThruChannel(::core::mem::transmute_copy(&dwsourcechannelgroup), ::core::mem::transmute_copy(&dwsourcechannel), ::core::mem::transmute_copy(&dwdestinationchannelgroup), ::core::mem::transmute_copy(&dwdestinationchannel), ::core::mem::transmute(&pdestinationport)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), ThruChannel: ThruChannel::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), ThruChannel: ThruChannel::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDirectMusicThru as ::windows::core::Interface>::IID

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/DirectMusic/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/DirectMusic/mod.rs
@@ -87,7 +87,7 @@ unsafe impl ::windows::core::Interface for IDirectMusic {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectMusic_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub EnumPort: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwindex: u32, pportcaps: *mut DMUS_PORTCAPS) -> ::windows::core::HRESULT,
     pub CreateMusicBuffer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbufferdesc: *mut DMUS_BUFFERDESC, ppbuffer: *mut *mut ::core::ffi::c_void, punkouter: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -302,7 +302,7 @@ unsafe impl ::windows::core::Interface for IDirectMusicBuffer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectMusicBuffer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Flush: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub TotalTime: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, prttime: *mut i64) -> ::windows::core::HRESULT,
     pub PackStructured: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, rt: i64, dwchannelgroup: u32, dwchannelmessage: u32) -> ::windows::core::HRESULT,
@@ -370,7 +370,7 @@ unsafe impl ::windows::core::Interface for IDirectMusicCollection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectMusicCollection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetInstrument: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwpatch: u32, ppinstrument: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub EnumInstrument: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwindex: u32, pdwpatch: *mut u32, pwszname: ::windows::core::PCWSTR, dwnamelen: u32) -> ::windows::core::HRESULT,
 }
@@ -420,7 +420,7 @@ unsafe impl ::windows::core::Interface for IDirectMusicDownload {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectMusicDownload_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetBuffer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppvbuffer: *mut *mut ::core::ffi::c_void, pdwsize: *mut u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_Audio_DirectMusic\"`*"]
@@ -465,7 +465,7 @@ unsafe impl ::windows::core::Interface for IDirectMusicDownloadedInstrument {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectMusicDownloadedInstrument_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
 }
 #[doc = "*Required features: `\"Win32_Media_Audio_DirectMusic\"`*"]
 #[repr(transparent)]
@@ -516,7 +516,7 @@ unsafe impl ::windows::core::Interface for IDirectMusicInstrument {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectMusicInstrument_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetPatch: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwpatch: *mut u32) -> ::windows::core::HRESULT,
     pub SetPatch: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwpatch: u32) -> ::windows::core::HRESULT,
 }
@@ -645,7 +645,7 @@ unsafe impl ::windows::core::Interface for IDirectMusicPort {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectMusicPort_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub PlayBuffer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbuffer: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub SetReadNotificationHandle: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hevent: super::super::super::Foundation::HANDLE) -> ::windows::core::HRESULT,
@@ -745,7 +745,7 @@ unsafe impl ::windows::core::Interface for IDirectMusicPortDownload {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectMusicPortDownload_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetBuffer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwdlid: u32, ppidmdownload: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub AllocateBuffer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwsize: u32, ppidmdownload: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetDLId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwstartdlid: *mut u32, dwcount: u32) -> ::windows::core::HRESULT,
@@ -869,7 +869,7 @@ unsafe impl ::windows::core::Interface for IDirectMusicSynth {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectMusicSynth_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Open: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pportparams: *mut DMUS_PORTPARAMS8) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -1143,7 +1143,7 @@ unsafe impl ::windows::core::Interface for IDirectMusicSynthSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectMusicSynthSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Init: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psynth: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetMasterClock: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pclock: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetLatencyClock: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppclock: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1208,7 +1208,7 @@ unsafe impl ::windows::core::Interface for IDirectMusicThru {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectMusicThru_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ThruChannel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwsourcechannelgroup: u32, dwsourcechannel: u32, dwdestinationchannelgroup: u32, dwdestinationchannel: u32, pdestinationport: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 pub const CLSID_DirectMusic: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x636b9f10_0c7d_11d1_95b2_0020afdc7421);

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/DirectSound/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/DirectSound/impl.rs
@@ -73,7 +73,7 @@ impl IDirectSound_Vtbl {
             this.Initialize(::core::mem::transmute_copy(&pcguiddevice)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateSoundBuffer: CreateSoundBuffer::<Identity, Impl, OFFSET>,
             GetCaps: GetCaps::<Identity, Impl, OFFSET>,
             DuplicateSoundBuffer: DuplicateSoundBuffer::<Identity, Impl, OFFSET>,
@@ -253,7 +253,7 @@ impl IDirectSound3DBuffer_Vtbl {
             this.SetVelocity(::core::mem::transmute_copy(&x), ::core::mem::transmute_copy(&y), ::core::mem::transmute_copy(&z), ::core::mem::transmute_copy(&dwapply)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetAllParameters: GetAllParameters::<Identity, Impl, OFFSET>,
             GetConeAngles: GetConeAngles::<Identity, Impl, OFFSET>,
             GetConeOrientation: GetConeOrientation::<Identity, Impl, OFFSET>,
@@ -413,7 +413,7 @@ impl IDirectSound3DListener_Vtbl {
             this.CommitDeferredSettings().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetAllParameters: GetAllParameters::<Identity, Impl, OFFSET>,
             GetDistanceFactor: GetDistanceFactor::<Identity, Impl, OFFSET>,
             GetDopplerFactor: GetDopplerFactor::<Identity, Impl, OFFSET>,
@@ -605,7 +605,7 @@ impl IDirectSoundBuffer_Vtbl {
             this.Restore().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCaps: GetCaps::<Identity, Impl, OFFSET>,
             GetCurrentPosition: GetCurrentPosition::<Identity, Impl, OFFSET>,
             GetFormat: GetFormat::<Identity, Impl, OFFSET>,
@@ -700,7 +700,7 @@ impl IDirectSoundCapture_Vtbl {
             this.Initialize(::core::mem::transmute_copy(&pcguiddevice)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateCaptureBuffer: CreateCaptureBuffer::<Identity, Impl, OFFSET>,
             GetCaps: GetCaps::<Identity, Impl, OFFSET>,
             Initialize: Initialize::<Identity, Impl, OFFSET>,
@@ -782,7 +782,7 @@ impl IDirectSoundCaptureBuffer_Vtbl {
             this.Unlock(::core::mem::transmute_copy(&pvaudioptr1), ::core::mem::transmute_copy(&dwaudiobytes1), ::core::mem::transmute_copy(&pvaudioptr2), ::core::mem::transmute_copy(&dwaudiobytes2)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCaps: GetCaps::<Identity, Impl, OFFSET>,
             GetCurrentPosition: GetCurrentPosition::<Identity, Impl, OFFSET>,
             GetFormat: GetFormat::<Identity, Impl, OFFSET>,
@@ -870,7 +870,7 @@ impl IDirectSoundCaptureFXAec_Vtbl {
             this.Reset().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetAllParameters: SetAllParameters::<Identity, Impl, OFFSET>,
             GetAllParameters: GetAllParameters::<Identity, Impl, OFFSET>,
             GetStatus: GetStatus::<Identity, Impl, OFFSET>,
@@ -914,7 +914,7 @@ impl IDirectSoundCaptureFXNoiseSuppress_Vtbl {
             this.Reset().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetAllParameters: SetAllParameters::<Identity, Impl, OFFSET>,
             GetAllParameters: GetAllParameters::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -948,7 +948,7 @@ impl IDirectSoundFXChorus_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetAllParameters: SetAllParameters::<Identity, Impl, OFFSET>,
             GetAllParameters: GetAllParameters::<Identity, Impl, OFFSET>,
         }
@@ -981,7 +981,7 @@ impl IDirectSoundFXCompressor_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetAllParameters: SetAllParameters::<Identity, Impl, OFFSET>,
             GetAllParameters: GetAllParameters::<Identity, Impl, OFFSET>,
         }
@@ -1014,7 +1014,7 @@ impl IDirectSoundFXDistortion_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetAllParameters: SetAllParameters::<Identity, Impl, OFFSET>,
             GetAllParameters: GetAllParameters::<Identity, Impl, OFFSET>,
         }
@@ -1047,7 +1047,7 @@ impl IDirectSoundFXEcho_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetAllParameters: SetAllParameters::<Identity, Impl, OFFSET>,
             GetAllParameters: GetAllParameters::<Identity, Impl, OFFSET>,
         }
@@ -1080,7 +1080,7 @@ impl IDirectSoundFXFlanger_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetAllParameters: SetAllParameters::<Identity, Impl, OFFSET>,
             GetAllParameters: GetAllParameters::<Identity, Impl, OFFSET>,
         }
@@ -1113,7 +1113,7 @@ impl IDirectSoundFXGargle_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetAllParameters: SetAllParameters::<Identity, Impl, OFFSET>,
             GetAllParameters: GetAllParameters::<Identity, Impl, OFFSET>,
         }
@@ -1182,7 +1182,7 @@ impl IDirectSoundFXI3DL2Reverb_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetAllParameters: SetAllParameters::<Identity, Impl, OFFSET>,
             GetAllParameters: GetAllParameters::<Identity, Impl, OFFSET>,
             SetPreset: SetPreset::<Identity, Impl, OFFSET>,
@@ -1219,7 +1219,7 @@ impl IDirectSoundFXParamEq_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetAllParameters: SetAllParameters::<Identity, Impl, OFFSET>,
             GetAllParameters: GetAllParameters::<Identity, Impl, OFFSET>,
         }
@@ -1252,7 +1252,7 @@ impl IDirectSoundFXWavesReverb_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetAllParameters: SetAllParameters::<Identity, Impl, OFFSET>,
             GetAllParameters: GetAllParameters::<Identity, Impl, OFFSET>,
         }
@@ -1275,7 +1275,7 @@ impl IDirectSoundFullDuplex_Vtbl {
             let this = (*this).get_impl();
             this.Initialize(::core::mem::transmute_copy(&pcaptureguid), ::core::mem::transmute_copy(&prenderguid), ::core::mem::transmute_copy(&lpdscbufferdesc), ::core::mem::transmute_copy(&lpdsbufferdesc), ::core::mem::transmute_copy(&hwnd), ::core::mem::transmute_copy(&dwlevel), ::core::mem::transmute_copy(&lplpdirectsoundcapturebuffer8), ::core::mem::transmute_copy(&lplpdirectsoundbuffer8)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Initialize: Initialize::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Initialize: Initialize::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDirectSoundFullDuplex as ::windows::core::Interface>::IID
@@ -1295,7 +1295,7 @@ impl IDirectSoundNotify_Vtbl {
             let this = (*this).get_impl();
             this.SetNotificationPositions(::core::mem::transmute_copy(&dwpositionnotifies), ::core::mem::transmute_copy(&pcpositionnotifies)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SetNotificationPositions: SetNotificationPositions::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SetNotificationPositions: SetNotificationPositions::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDirectSoundNotify as ::windows::core::Interface>::IID

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/DirectSound/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/DirectSound/mod.rs
@@ -191,7 +191,7 @@ unsafe impl ::windows::core::Interface for IDirectSound {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectSound_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateSoundBuffer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcdsbufferdesc: *const DSBUFFERDESC, ppdsbuffer: *mut *mut ::core::ffi::c_void, punkouter: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetCaps: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdscaps: *mut DSCAPS) -> ::windows::core::HRESULT,
     pub DuplicateSoundBuffer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdsbufferoriginal: *mut ::core::ffi::c_void, ppdsbufferduplicate: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -319,7 +319,7 @@ unsafe impl ::windows::core::Interface for IDirectSound3DBuffer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectSound3DBuffer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Graphics_Direct3D")]
     pub GetAllParameters: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pds3dbuffer: *mut DS3DBUFFER) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Graphics_Direct3D"))]
@@ -458,7 +458,7 @@ unsafe impl ::windows::core::Interface for IDirectSound3DListener {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectSound3DListener_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Graphics_Direct3D")]
     pub GetAllParameters: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, plistener: *mut DS3DLISTENER) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Graphics_Direct3D"))]
@@ -698,7 +698,7 @@ unsafe impl ::windows::core::Interface for IDirectSoundBuffer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectSoundBuffer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCaps: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdsbuffercaps: *mut DSBCAPS) -> ::windows::core::HRESULT,
     pub GetCurrentPosition: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwcurrentplaycursor: *mut u32, pdwcurrentwritecursor: *mut u32) -> ::windows::core::HRESULT,
     pub GetFormat: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwfxformat: *mut super::WAVEFORMATEX, dwsizeallocated: u32, pdwsizewritten: *mut u32) -> ::windows::core::HRESULT,
@@ -909,7 +909,7 @@ unsafe impl ::windows::core::Interface for IDirectSoundCapture {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectSoundCapture_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateCaptureBuffer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcdscbufferdesc: *const DSCBUFFERDESC, ppdscbuffer: *mut *mut ::core::ffi::c_void, punkouter: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetCaps: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdsccaps: *mut DSCCAPS) -> ::windows::core::HRESULT,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcguiddevice: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
@@ -989,7 +989,7 @@ unsafe impl ::windows::core::Interface for IDirectSoundCaptureBuffer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectSoundCaptureBuffer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCaps: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdscbcaps: *mut DSCBCAPS) -> ::windows::core::HRESULT,
     pub GetCurrentPosition: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwcaptureposition: *mut u32, pdwreadposition: *mut u32) -> ::windows::core::HRESULT,
     pub GetFormat: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwfxformat: *mut super::WAVEFORMATEX, dwsizeallocated: u32, pdwsizewritten: *mut u32) -> ::windows::core::HRESULT,
@@ -1161,7 +1161,7 @@ unsafe impl ::windows::core::Interface for IDirectSoundCaptureFXAec {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectSoundCaptureFXAec_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub SetAllParameters: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdscfxaec: *const DSCFXAec) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -1230,7 +1230,7 @@ unsafe impl ::windows::core::Interface for IDirectSoundCaptureFXNoiseSuppress {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectSoundCaptureFXNoiseSuppress_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub SetAllParameters: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcdscfxnoisesuppress: *const DSCFXNoiseSuppress) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -1291,7 +1291,7 @@ unsafe impl ::windows::core::Interface for IDirectSoundFXChorus {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectSoundFXChorus_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetAllParameters: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcdsfxchorus: *const DSFXChorus) -> ::windows::core::HRESULT,
     pub GetAllParameters: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdsfxchorus: *mut DSFXChorus) -> ::windows::core::HRESULT,
 }
@@ -1345,7 +1345,7 @@ unsafe impl ::windows::core::Interface for IDirectSoundFXCompressor {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectSoundFXCompressor_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetAllParameters: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcdsfxcompressor: *const DSFXCompressor) -> ::windows::core::HRESULT,
     pub GetAllParameters: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdsfxcompressor: *mut DSFXCompressor) -> ::windows::core::HRESULT,
 }
@@ -1399,7 +1399,7 @@ unsafe impl ::windows::core::Interface for IDirectSoundFXDistortion {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectSoundFXDistortion_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetAllParameters: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcdsfxdistortion: *const DSFXDistortion) -> ::windows::core::HRESULT,
     pub GetAllParameters: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdsfxdistortion: *mut DSFXDistortion) -> ::windows::core::HRESULT,
 }
@@ -1453,7 +1453,7 @@ unsafe impl ::windows::core::Interface for IDirectSoundFXEcho {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectSoundFXEcho_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetAllParameters: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcdsfxecho: *const DSFXEcho) -> ::windows::core::HRESULT,
     pub GetAllParameters: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdsfxecho: *mut DSFXEcho) -> ::windows::core::HRESULT,
 }
@@ -1507,7 +1507,7 @@ unsafe impl ::windows::core::Interface for IDirectSoundFXFlanger {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectSoundFXFlanger_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetAllParameters: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcdsfxflanger: *const DSFXFlanger) -> ::windows::core::HRESULT,
     pub GetAllParameters: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdsfxflanger: *mut DSFXFlanger) -> ::windows::core::HRESULT,
 }
@@ -1561,7 +1561,7 @@ unsafe impl ::windows::core::Interface for IDirectSoundFXGargle {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectSoundFXGargle_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetAllParameters: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcdsfxgargle: *const DSFXGargle) -> ::windows::core::HRESULT,
     pub GetAllParameters: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdsfxgargle: *mut DSFXGargle) -> ::windows::core::HRESULT,
 }
@@ -1629,7 +1629,7 @@ unsafe impl ::windows::core::Interface for IDirectSoundFXI3DL2Reverb {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectSoundFXI3DL2Reverb_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetAllParameters: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcdsfxi3dl2reverb: *const DSFXI3DL2Reverb) -> ::windows::core::HRESULT,
     pub GetAllParameters: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdsfxi3dl2reverb: *mut DSFXI3DL2Reverb) -> ::windows::core::HRESULT,
     pub SetPreset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwpreset: u32) -> ::windows::core::HRESULT,
@@ -1687,7 +1687,7 @@ unsafe impl ::windows::core::Interface for IDirectSoundFXParamEq {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectSoundFXParamEq_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetAllParameters: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcdsfxparameq: *const DSFXParamEq) -> ::windows::core::HRESULT,
     pub GetAllParameters: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdsfxparameq: *mut DSFXParamEq) -> ::windows::core::HRESULT,
 }
@@ -1741,7 +1741,7 @@ unsafe impl ::windows::core::Interface for IDirectSoundFXWavesReverb {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectSoundFXWavesReverb_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetAllParameters: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcdsfxwavesreverb: *const DSFXWavesReverb) -> ::windows::core::HRESULT,
     pub GetAllParameters: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdsfxwavesreverb: *mut DSFXWavesReverb) -> ::windows::core::HRESULT,
 }
@@ -1796,7 +1796,7 @@ unsafe impl ::windows::core::Interface for IDirectSoundFullDuplex {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectSoundFullDuplex_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcaptureguid: *const ::windows::core::GUID, prenderguid: *const ::windows::core::GUID, lpdscbufferdesc: *const DSCBUFFERDESC, lpdsbufferdesc: *const DSBUFFERDESC, hwnd: super::super::super::Foundation::HWND, dwlevel: u32, lplpdirectsoundcapturebuffer8: *mut *mut ::core::ffi::c_void, lplpdirectsoundbuffer8: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -1850,7 +1850,7 @@ unsafe impl ::windows::core::Interface for IDirectSoundNotify {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectSoundNotify_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub SetNotificationPositions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwpositionnotifies: u32, pcpositionnotifies: *const DSBPOSITIONNOTIFY) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/Endpoints/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/Endpoints/impl.rs
@@ -9,7 +9,7 @@ impl IAudioEndpointFormatControl_Vtbl {
             let this = (*this).get_impl();
             this.ResetToDefault(::core::mem::transmute_copy(&resetflags)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), ResetToDefault: ResetToDefault::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), ResetToDefault: ResetToDefault::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IAudioEndpointFormatControl as ::windows::core::Interface>::IID
@@ -36,7 +36,7 @@ impl IAudioEndpointLastBufferControl_Vtbl {
             this.ReleaseOutputDataPointerForLastBuffer(::core::mem::transmute_copy(&pconnectionproperty))
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             IsLastBufferControlSupported: IsLastBufferControlSupported::<Identity, Impl, OFFSET>,
             ReleaseOutputDataPointerForLastBuffer: ReleaseOutputDataPointerForLastBuffer::<Identity, Impl, OFFSET>,
         }
@@ -75,7 +75,7 @@ impl IAudioEndpointOffloadStreamMeter_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetMeterChannelCount: GetMeterChannelCount::<Identity, Impl, OFFSET>,
             GetMeteringData: GetMeteringData::<Identity, Impl, OFFSET>,
         }
@@ -108,7 +108,7 @@ impl IAudioEndpointOffloadStreamMute_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetMute: SetMute::<Identity, Impl, OFFSET>,
             GetMute: GetMute::<Identity, Impl, OFFSET>,
         }
@@ -156,7 +156,7 @@ impl IAudioEndpointOffloadStreamVolume_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetVolumeChannelCount: GetVolumeChannelCount::<Identity, Impl, OFFSET>,
             SetChannelVolumes: SetChannelVolumes::<Identity, Impl, OFFSET>,
             GetChannelVolumes: GetChannelVolumes::<Identity, Impl, OFFSET>,
@@ -325,7 +325,7 @@ impl IAudioEndpointVolume_Vtbl {
             this.GetVolumeRange(::core::mem::transmute_copy(&pflvolumemindb), ::core::mem::transmute_copy(&pflvolumemaxdb), ::core::mem::transmute_copy(&pflvolumeincrementdb)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RegisterControlChangeNotify: RegisterControlChangeNotify::<Identity, Impl, OFFSET>,
             UnregisterControlChangeNotify: UnregisterControlChangeNotify::<Identity, Impl, OFFSET>,
             GetChannelCount: GetChannelCount::<Identity, Impl, OFFSET>,
@@ -364,7 +364,7 @@ impl IAudioEndpointVolumeCallback_Vtbl {
             let this = (*this).get_impl();
             this.OnNotify(::core::mem::transmute_copy(&pnotify)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnNotify: OnNotify::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnNotify: OnNotify::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IAudioEndpointVolumeCallback as ::windows::core::Interface>::IID
@@ -417,7 +417,7 @@ impl IAudioLfxControl_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetLocalEffectsState: SetLocalEffectsState::<Identity, Impl, OFFSET>,
             GetLocalEffectsState: GetLocalEffectsState::<Identity, Impl, OFFSET>,
         }
@@ -474,7 +474,7 @@ impl IAudioMeterInformation_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetPeakValue: GetPeakValue::<Identity, Impl, OFFSET>,
             GetMeteringChannelCount: GetMeteringChannelCount::<Identity, Impl, OFFSET>,
             GetChannelsPeakValues: GetChannelsPeakValues::<Identity, Impl, OFFSET>,
@@ -536,7 +536,7 @@ impl IHardwareAudioEngineBase_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetAvailableOffloadConnectorCount: GetAvailableOffloadConnectorCount::<Identity, Impl, OFFSET>,
             GetEngineFormat: GetEngineFormat::<Identity, Impl, OFFSET>,
             SetEngineDeviceFormat: SetEngineDeviceFormat::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/Endpoints/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/Endpoints/mod.rs
@@ -44,7 +44,7 @@ unsafe impl ::windows::core::Interface for IAudioEndpointFormatControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAudioEndpointFormatControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ResetToDefault: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, resetflags: u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_Audio_Endpoints\"`*"]
@@ -100,7 +100,7 @@ unsafe impl ::windows::core::Interface for IAudioEndpointLastBufferControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAudioEndpointLastBufferControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub IsLastBufferControlSupported: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> super::super::super::Foundation::BOOL,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -161,7 +161,7 @@ unsafe impl ::windows::core::Interface for IAudioEndpointOffloadStreamMeter {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAudioEndpointOffloadStreamMeter_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetMeterChannelCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pu32channelcount: *mut u32) -> ::windows::core::HRESULT,
     pub GetMeteringData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, u32channelcount: u32, pf32peakvalues: *mut f32) -> ::windows::core::HRESULT,
 }
@@ -215,7 +215,7 @@ unsafe impl ::windows::core::Interface for IAudioEndpointOffloadStreamMute {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAudioEndpointOffloadStreamMute_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetMute: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bmuted: u8) -> ::windows::core::HRESULT,
     pub GetMute: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbmuted: *mut u8) -> ::windows::core::HRESULT,
 }
@@ -275,7 +275,7 @@ unsafe impl ::windows::core::Interface for IAudioEndpointOffloadStreamVolume {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAudioEndpointOffloadStreamVolume_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetVolumeChannelCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pu32channelcount: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Media_KernelStreaming")]
     pub SetChannelVolumes: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, u32channelcount: u32, pf32volumes: *const f32, u32curvetype: super::super::KernelStreaming::AUDIO_CURVE_TYPE, pcurveduration: *const i64) -> ::windows::core::HRESULT,
@@ -400,7 +400,7 @@ unsafe impl ::windows::core::Interface for IAudioEndpointVolume {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAudioEndpointVolume_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub RegisterControlChangeNotify: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pnotify: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub UnregisterControlChangeNotify: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pnotify: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetChannelCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pnchannelcount: *mut u32) -> ::windows::core::HRESULT,
@@ -474,7 +474,7 @@ unsafe impl ::windows::core::Interface for IAudioEndpointVolumeCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAudioEndpointVolumeCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub OnNotify: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pnotify: *mut super::AUDIO_VOLUME_NOTIFICATION_DATA) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -675,7 +675,7 @@ unsafe impl ::windows::core::Interface for IAudioLfxControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAudioLfxControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub SetLocalEffectsState: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, benabled: super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -743,7 +743,7 @@ unsafe impl ::windows::core::Interface for IAudioMeterInformation {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAudioMeterInformation_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetPeakValue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfpeak: *mut f32) -> ::windows::core::HRESULT,
     pub GetMeteringChannelCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pnchannelcount: *mut u32) -> ::windows::core::HRESULT,
     pub GetChannelsPeakValues: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, u32channelcount: u32, afpeakvalues: *mut f32) -> ::windows::core::HRESULT,
@@ -832,7 +832,7 @@ unsafe impl ::windows::core::Interface for IHardwareAudioEngineBase {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IHardwareAudioEngineBase_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetAvailableOffloadConnectorCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, _pwstrdeviceid: ::windows::core::PCWSTR, _uconnectorid: u32, _pavailableconnectorinstancecount: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub GetEngineFormat: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdevice: *mut ::core::ffi::c_void, _brequestdeviceformat: super::super::super::Foundation::BOOL, _ppwfxformat: *mut *mut super::WAVEFORMATEX) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/XAudio2/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/XAudio2/impl.rs
@@ -85,7 +85,7 @@ impl IXAPO_Vtbl {
             this.CalcOutputFrames(::core::mem::transmute_copy(&inputframecount))
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetRegistrationProperties: GetRegistrationProperties::<Identity, Impl, OFFSET>,
             IsInputFormatSupported: IsInputFormatSupported::<Identity, Impl, OFFSET>,
             IsOutputFormatSupported: IsOutputFormatSupported::<Identity, Impl, OFFSET>,
@@ -132,7 +132,7 @@ impl IXAPOHrtfParameters_Vtbl {
             this.SetEnvironment(::core::mem::transmute_copy(&environment)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetSourcePosition: SetSourcePosition::<Identity, Impl, OFFSET>,
             SetSourceOrientation: SetSourceOrientation::<Identity, Impl, OFFSET>,
             SetSourceGain: SetSourceGain::<Identity, Impl, OFFSET>,
@@ -161,7 +161,7 @@ impl IXAPOParameters_Vtbl {
             this.GetParameters(::core::mem::transmute_copy(&pparameters), ::core::mem::transmute_copy(&parameterbytesize))
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetParameters: SetParameters::<Identity, Impl, OFFSET>,
             GetParameters: GetParameters::<Identity, Impl, OFFSET>,
         }
@@ -239,7 +239,7 @@ impl IXAudio2_Vtbl {
             this.SetDebugConfiguration(::core::mem::transmute_copy(&pdebugconfiguration), ::core::mem::transmute_copy(&preserved))
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RegisterForCallbacks: RegisterForCallbacks::<Identity, Impl, OFFSET>,
             UnregisterForCallbacks: UnregisterForCallbacks::<Identity, Impl, OFFSET>,
             CreateSourceVoice: CreateSourceVoice::<Identity, Impl, OFFSET>,
@@ -307,7 +307,7 @@ impl IXAudio2Extension_Vtbl {
             this.GetProcessor(::core::mem::transmute_copy(&processor))
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetProcessingQuantum: GetProcessingQuantum::<Identity, Impl, OFFSET>,
             GetProcessor: GetProcessor::<Identity, Impl, OFFSET>,
         }

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/XAudio2/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/XAudio2/mod.rs
@@ -127,7 +127,7 @@ unsafe impl ::windows::core::Interface for IXAPO {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXAPO_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetRegistrationProperties: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppregistrationproperties: *mut *mut XAPO_REGISTRATION_PROPERTIES) -> ::windows::core::HRESULT,
     pub IsInputFormatSupported: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, poutputformat: *const super::WAVEFORMATEX, prequestedinputformat: *const super::WAVEFORMATEX, ppsupportedinputformat: *mut *mut super::WAVEFORMATEX) -> ::windows::core::HRESULT,
     pub IsOutputFormatSupported: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinputformat: *const super::WAVEFORMATEX, prequestedoutputformat: *const super::WAVEFORMATEX, ppsupportedoutputformat: *mut *mut super::WAVEFORMATEX) -> ::windows::core::HRESULT,
@@ -197,7 +197,7 @@ unsafe impl ::windows::core::Interface for IXAPOHrtfParameters {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXAPOHrtfParameters_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetSourcePosition: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, position: *const HrtfPosition) -> ::windows::core::HRESULT,
     pub SetSourceOrientation: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, orientation: *const HrtfOrientation) -> ::windows::core::HRESULT,
     pub SetSourceGain: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, gain: f32) -> ::windows::core::HRESULT,
@@ -252,7 +252,7 @@ unsafe impl ::windows::core::Interface for IXAPOParameters {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXAPOParameters_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetParameters: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pparameters: *const ::core::ffi::c_void, parameterbytesize: u32),
     pub GetParameters: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pparameters: *mut ::core::ffi::c_void, parameterbytesize: u32),
 }
@@ -349,7 +349,7 @@ unsafe impl ::windows::core::Interface for IXAudio2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXAudio2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub RegisterForCallbacks: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcallback: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub UnregisterForCallbacks: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcallback: *mut ::core::ffi::c_void),
     #[cfg(feature = "Win32_Foundation")]
@@ -463,7 +463,7 @@ unsafe impl ::windows::core::Interface for IXAudio2Extension {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXAudio2Extension_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetProcessingQuantum: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, quantumnumerator: *mut u32, quantumdenominator: *mut u32),
     pub GetProcessor: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, processor: *mut u32),
 }

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/impl.rs
@@ -9,7 +9,7 @@ impl IActivateAudioInterfaceAsyncOperation_Vtbl {
             let this = (*this).get_impl();
             this.GetActivateResult(::core::mem::transmute_copy(&activateresult), ::core::mem::transmute_copy(&activatedinterface)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetActivateResult: GetActivateResult::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetActivateResult: GetActivateResult::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IActivateAudioInterfaceAsyncOperation as ::windows::core::Interface>::IID
@@ -26,7 +26,7 @@ impl IActivateAudioInterfaceCompletionHandler_Vtbl {
             let this = (*this).get_impl();
             this.ActivateCompleted(::core::mem::transmute(&activateoperation)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), ActivateCompleted: ActivateCompleted::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), ActivateCompleted: ActivateCompleted::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IActivateAudioInterfaceCompletionHandler as ::windows::core::Interface>::IID
@@ -71,7 +71,7 @@ impl IAudioAmbisonicsControl_Vtbl {
             this.SetRotation(::core::mem::transmute_copy(&x), ::core::mem::transmute_copy(&y), ::core::mem::transmute_copy(&z), ::core::mem::transmute_copy(&w)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetData: SetData::<Identity, Impl, OFFSET>,
             SetHeadTracking: SetHeadTracking::<Identity, Impl, OFFSET>,
             GetHeadTracking: GetHeadTracking::<Identity, Impl, OFFSET>,
@@ -109,7 +109,7 @@ impl IAudioAutoGainControl_Vtbl {
             this.SetEnabled(::core::mem::transmute_copy(&benable), ::core::mem::transmute_copy(&pguideventcontext)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetEnabled: GetEnabled::<Identity, Impl, OFFSET>,
             SetEnabled: SetEnabled::<Identity, Impl, OFFSET>,
         }
@@ -158,7 +158,7 @@ impl IAudioCaptureClient_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetBuffer: GetBuffer::<Identity, Impl, OFFSET>,
             ReleaseBuffer: ReleaseBuffer::<Identity, Impl, OFFSET>,
             GetNextPacketSize: GetNextPacketSize::<Identity, Impl, OFFSET>,
@@ -192,7 +192,7 @@ impl IAudioChannelConfig_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetChannelConfig: SetChannelConfig::<Identity, Impl, OFFSET>,
             GetChannelConfig: GetChannelConfig::<Identity, Impl, OFFSET>,
         }
@@ -306,7 +306,7 @@ impl IAudioClient_Vtbl {
             this.GetService(::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppv)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             GetBufferSize: GetBufferSize::<Identity, Impl, OFFSET>,
             GetStreamLatency: GetStreamLatency::<Identity, Impl, OFFSET>,
@@ -417,7 +417,7 @@ impl IAudioClientDuckingControl_Vtbl {
             this.SetDuckingOptionsForCurrentStream(::core::mem::transmute_copy(&options)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetDuckingOptionsForCurrentStream: SetDuckingOptionsForCurrentStream::<Identity, Impl, OFFSET>,
         }
     }
@@ -461,7 +461,7 @@ impl IAudioClock_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetFrequency: GetFrequency::<Identity, Impl, OFFSET>,
             GetPosition: GetPosition::<Identity, Impl, OFFSET>,
             GetCharacteristics: GetCharacteristics::<Identity, Impl, OFFSET>,
@@ -482,7 +482,7 @@ impl IAudioClock2_Vtbl {
             let this = (*this).get_impl();
             this.GetDevicePosition(::core::mem::transmute_copy(&deviceposition), ::core::mem::transmute_copy(&qpcposition)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetDevicePosition: GetDevicePosition::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetDevicePosition: GetDevicePosition::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IAudioClock2 as ::windows::core::Interface>::IID
@@ -499,7 +499,7 @@ impl IAudioClockAdjustment_Vtbl {
             let this = (*this).get_impl();
             this.SetSampleRate(::core::mem::transmute_copy(&flsamplerate)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SetSampleRate: SetSampleRate::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SetSampleRate: SetSampleRate::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IAudioClockAdjustment as ::windows::core::Interface>::IID
@@ -516,7 +516,7 @@ impl IAudioEffectsChangedNotificationClient_Vtbl {
             let this = (*this).get_impl();
             this.OnAudioEffectsChanged().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnAudioEffectsChanged: OnAudioEffectsChanged::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnAudioEffectsChanged: OnAudioEffectsChanged::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IAudioEffectsChangedNotificationClient as ::windows::core::Interface>::IID
@@ -555,7 +555,7 @@ impl IAudioEffectsManager_Vtbl {
             this.SetAudioEffectState(::core::mem::transmute(&effectid), ::core::mem::transmute_copy(&state)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RegisterAudioEffectsChangedNotificationCallback: RegisterAudioEffectsChangedNotificationCallback::<Identity, Impl, OFFSET>,
             UnregisterAudioEffectsChangedNotificationCallback: UnregisterAudioEffectsChangedNotificationCallback::<Identity, Impl, OFFSET>,
             GetAudioEffects: GetAudioEffects::<Identity, Impl, OFFSET>,
@@ -596,7 +596,7 @@ impl IAudioFormatEnumerator_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCount: GetCount::<Identity, Impl, OFFSET>,
             GetFormat: GetFormat::<Identity, Impl, OFFSET>,
         }
@@ -629,7 +629,7 @@ impl IAudioInputSelector_Vtbl {
             this.SetSelection(::core::mem::transmute_copy(&nidselect), ::core::mem::transmute_copy(&pguideventcontext)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSelection: GetSelection::<Identity, Impl, OFFSET>,
             SetSelection: SetSelection::<Identity, Impl, OFFSET>,
         }
@@ -665,7 +665,7 @@ impl IAudioLoudness_Vtbl {
             this.SetEnabled(::core::mem::transmute_copy(&benable), ::core::mem::transmute_copy(&pguideventcontext)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetEnabled: GetEnabled::<Identity, Impl, OFFSET>,
             SetEnabled: SetEnabled::<Identity, Impl, OFFSET>,
         }
@@ -711,7 +711,7 @@ impl IAudioMute_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetMute: SetMute::<Identity, Impl, OFFSET>,
             GetMute: GetMute::<Identity, Impl, OFFSET>,
         }
@@ -744,7 +744,7 @@ impl IAudioOutputSelector_Vtbl {
             this.SetSelection(::core::mem::transmute_copy(&nidselect), ::core::mem::transmute_copy(&pguideventcontext)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSelection: GetSelection::<Identity, Impl, OFFSET>,
             SetSelection: SetSelection::<Identity, Impl, OFFSET>,
         }
@@ -783,7 +783,7 @@ impl IAudioPeakMeter_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetChannelCount: GetChannelCount::<Identity, Impl, OFFSET>,
             GetLevel: GetLevel::<Identity, Impl, OFFSET>,
         }
@@ -816,7 +816,7 @@ impl IAudioRenderClient_Vtbl {
             this.ReleaseBuffer(::core::mem::transmute_copy(&numframeswritten), ::core::mem::transmute_copy(&dwflags)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetBuffer: GetBuffer::<Identity, Impl, OFFSET>,
             ReleaseBuffer: ReleaseBuffer::<Identity, Impl, OFFSET>,
         }
@@ -909,7 +909,7 @@ impl IAudioSessionControl_Vtbl {
             this.UnregisterAudioSessionNotification(::core::mem::transmute(&newnotifications)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetState: GetState::<Identity, Impl, OFFSET>,
             GetDisplayName: GetDisplayName::<Identity, Impl, OFFSET>,
             SetDisplayName: SetDisplayName::<Identity, Impl, OFFSET>,
@@ -1024,7 +1024,7 @@ impl IAudioSessionEnumerator_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCount: GetCount::<Identity, Impl, OFFSET>,
             GetSession: GetSession::<Identity, Impl, OFFSET>,
         }
@@ -1084,7 +1084,7 @@ impl IAudioSessionEvents_Vtbl {
             this.OnSessionDisconnected(::core::mem::transmute_copy(&disconnectreason)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnDisplayNameChanged: OnDisplayNameChanged::<Identity, Impl, OFFSET>,
             OnIconPathChanged: OnIconPathChanged::<Identity, Impl, OFFSET>,
             OnSimpleVolumeChanged: OnSimpleVolumeChanged::<Identity, Impl, OFFSET>,
@@ -1128,7 +1128,7 @@ impl IAudioSessionManager_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetAudioSessionControl: GetAudioSessionControl::<Identity, Impl, OFFSET>,
             GetSimpleAudioVolume: GetSimpleAudioVolume::<Identity, Impl, OFFSET>,
         }
@@ -1202,7 +1202,7 @@ impl IAudioSessionNotification_Vtbl {
             let this = (*this).get_impl();
             this.OnSessionCreated(::core::mem::transmute(&newsession)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnSessionCreated: OnSessionCreated::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnSessionCreated: OnSessionCreated::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IAudioSessionNotification as ::windows::core::Interface>::IID
@@ -1238,7 +1238,7 @@ impl IAudioStateMonitor_Vtbl {
             this.GetSoundLevel()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RegisterCallback: RegisterCallback::<Identity, Impl, OFFSET>,
             UnregisterCallback: UnregisterCallback::<Identity, Impl, OFFSET>,
             GetSoundLevel: GetSoundLevel::<Identity, Impl, OFFSET>,
@@ -1296,7 +1296,7 @@ impl IAudioStreamVolume_Vtbl {
             this.GetAllVolumes(::core::mem::transmute_copy(&dwcount), ::core::mem::transmute_copy(&pfvolumes)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetChannelCount: GetChannelCount::<Identity, Impl, OFFSET>,
             SetChannelVolume: SetChannelVolume::<Identity, Impl, OFFSET>,
             GetChannelVolume: GetChannelVolume::<Identity, Impl, OFFSET>,
@@ -1322,7 +1322,7 @@ impl IAudioSystemEffectsPropertyChangeNotificationClient_Vtbl {
             let this = (*this).get_impl();
             this.OnPropertyChanged(::core::mem::transmute_copy(&r#type), ::core::mem::transmute(&key)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnPropertyChanged: OnPropertyChanged::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnPropertyChanged: OnPropertyChanged::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IAudioSystemEffectsPropertyChangeNotificationClient as ::windows::core::Interface>::IID
@@ -1397,7 +1397,7 @@ impl IAudioSystemEffectsPropertyStore_Vtbl {
             this.UnregisterPropertyChangeNotification(::core::mem::transmute(&callback)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OpenDefaultPropertyStore: OpenDefaultPropertyStore::<Identity, Impl, OFFSET>,
             OpenUserPropertyStore: OpenUserPropertyStore::<Identity, Impl, OFFSET>,
             OpenVolatilePropertyStore: OpenVolatilePropertyStore::<Identity, Impl, OFFSET>,
@@ -1439,7 +1439,7 @@ impl IAudioVolumeDuckNotification_Vtbl {
             this.OnVolumeUnduckNotification(::core::mem::transmute(&sessionid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnVolumeDuckNotification: OnVolumeDuckNotification::<Identity, Impl, OFFSET>,
             OnVolumeUnduckNotification: OnVolumeUnduckNotification::<Identity, Impl, OFFSET>,
         }
@@ -1506,7 +1506,7 @@ impl IChannelAudioVolume_Vtbl {
             this.GetAllVolumes(::core::mem::transmute_copy(&dwcount), ::core::mem::transmute_copy(&pfvolumes)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetChannelCount: GetChannelCount::<Identity, Impl, OFFSET>,
             SetChannelVolume: SetChannelVolume::<Identity, Impl, OFFSET>,
             GetChannelVolume: GetChannelVolume::<Identity, Impl, OFFSET>,
@@ -1611,7 +1611,7 @@ impl IConnector_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetType: GetType::<Identity, Impl, OFFSET>,
             GetDataFlow: GetDataFlow::<Identity, Impl, OFFSET>,
             ConnectTo: ConnectTo::<Identity, Impl, OFFSET>,
@@ -1637,7 +1637,7 @@ impl IControlChangeNotify_Vtbl {
             let this = (*this).get_impl();
             this.OnNotify(::core::mem::transmute_copy(&dwsenderprocessid), ::core::mem::transmute_copy(&pguideventcontext)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnNotify: OnNotify::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnNotify: OnNotify::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IControlChangeNotify as ::windows::core::Interface>::IID
@@ -1673,7 +1673,7 @@ impl IControlInterface_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetName: GetName::<Identity, Impl, OFFSET>,
             GetIID: GetIID::<Identity, Impl, OFFSET>,
         }
@@ -1718,7 +1718,7 @@ impl IDeviceSpecificProperty_Vtbl {
             this.Get4BRange(::core::mem::transmute_copy(&plmin), ::core::mem::transmute_copy(&plmax), ::core::mem::transmute_copy(&plstepping)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetType: GetType::<Identity, Impl, OFFSET>,
             GetValue: GetValue::<Identity, Impl, OFFSET>,
             SetValue: SetValue::<Identity, Impl, OFFSET>,
@@ -1822,7 +1822,7 @@ impl IDeviceTopology_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetConnectorCount: GetConnectorCount::<Identity, Impl, OFFSET>,
             GetConnector: GetConnector::<Identity, Impl, OFFSET>,
             GetSubunitCount: GetSubunitCount::<Identity, Impl, OFFSET>,
@@ -1887,7 +1887,7 @@ impl IMMDevice_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Activate: Activate::<Identity, Impl, OFFSET>,
             OpenPropertyStore: OpenPropertyStore::<Identity, Impl, OFFSET>,
             GetId: GetId::<Identity, Impl, OFFSET>,
@@ -1912,7 +1912,7 @@ impl IMMDeviceActivator_Vtbl {
             let this = (*this).get_impl();
             this.Activate(::core::mem::transmute_copy(&iid), ::core::mem::transmute(&pdevice), ::core::mem::transmute_copy(&pactivationparams), ::core::mem::transmute_copy(&ppinterface)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Activate: Activate::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Activate: Activate::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMMDeviceActivator as ::windows::core::Interface>::IID
@@ -1948,7 +1948,7 @@ impl IMMDeviceCollection_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCount: GetCount::<Identity, Impl, OFFSET>,
             Item: Item::<Identity, Impl, OFFSET>,
         }
@@ -2011,7 +2011,7 @@ impl IMMDeviceEnumerator_Vtbl {
             this.UnregisterEndpointNotificationCallback(::core::mem::transmute(&pclient)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             EnumAudioEndpoints: EnumAudioEndpoints::<Identity, Impl, OFFSET>,
             GetDefaultAudioEndpoint: GetDefaultAudioEndpoint::<Identity, Impl, OFFSET>,
             GetDevice: GetDevice::<Identity, Impl, OFFSET>,
@@ -2040,7 +2040,7 @@ impl IMMEndpoint_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetDataFlow: GetDataFlow::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetDataFlow: GetDataFlow::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMMEndpoint as ::windows::core::Interface>::IID
@@ -2085,7 +2085,7 @@ impl IMMNotificationClient_Vtbl {
             this.OnPropertyValueChanged(::core::mem::transmute(&pwstrdeviceid), ::core::mem::transmute(&key)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnDeviceStateChanged: OnDeviceStateChanged::<Identity, Impl, OFFSET>,
             OnDeviceAdded: OnDeviceAdded::<Identity, Impl, OFFSET>,
             OnDeviceRemoved: OnDeviceRemoved::<Identity, Impl, OFFSET>,
@@ -2124,7 +2124,7 @@ impl IMessageFilter_Vtbl {
             this.MessagePending(::core::mem::transmute_copy(&htaskcallee), ::core::mem::transmute_copy(&dwtickcount), ::core::mem::transmute_copy(&dwpendingtype))
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             HandleInComingCall: HandleInComingCall::<Identity, Impl, OFFSET>,
             RetryRejectedCall: RetryRejectedCall::<Identity, Impl, OFFSET>,
             MessagePending: MessagePending::<Identity, Impl, OFFSET>,
@@ -2278,7 +2278,7 @@ impl IPart_Vtbl {
             this.UnregisterControlChangeCallback(::core::mem::transmute(&pnotify)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetName: GetName::<Identity, Impl, OFFSET>,
             GetLocalId: GetLocalId::<Identity, Impl, OFFSET>,
             GetGlobalId: GetGlobalId::<Identity, Impl, OFFSET>,
@@ -2328,7 +2328,7 @@ impl IPartsList_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCount: GetCount::<Identity, Impl, OFFSET>,
             GetPart: GetPart::<Identity, Impl, OFFSET>,
         }
@@ -2391,7 +2391,7 @@ impl IPerChannelDbLevel_Vtbl {
             this.SetLevelAllChannels(::core::mem::transmute_copy(&alevelsdb), ::core::mem::transmute_copy(&cchannels), ::core::mem::transmute_copy(&pguideventcontext)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetChannelCount: GetChannelCount::<Identity, Impl, OFFSET>,
             GetLevelRange: GetLevelRange::<Identity, Impl, OFFSET>,
             GetLevel: GetLevel::<Identity, Impl, OFFSET>,
@@ -2449,7 +2449,7 @@ impl ISimpleAudioVolume_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetMasterVolume: SetMasterVolume::<Identity, Impl, OFFSET>,
             GetMasterVolume: GetMasterVolume::<Identity, Impl, OFFSET>,
             SetMute: SetMute::<Identity, Impl, OFFSET>,
@@ -2541,7 +2541,7 @@ impl ISpatialAudioClient_Vtbl {
             this.ActivateSpatialAudioStream(::core::mem::transmute_copy(&activationparams), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&stream)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetStaticObjectPosition: GetStaticObjectPosition::<Identity, Impl, OFFSET>,
             GetNativeStaticObjectTypeMask: GetNativeStaticObjectTypeMask::<Identity, Impl, OFFSET>,
             GetMaxDynamicObjectCount: GetMaxDynamicObjectCount::<Identity, Impl, OFFSET>,
@@ -2658,7 +2658,7 @@ impl ISpatialAudioMetadataClient_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ActivateSpatialAudioMetadataItems: ActivateSpatialAudioMetadataItems::<Identity, Impl, OFFSET>,
             GetSpatialAudioMetadataItemsBufferLength: GetSpatialAudioMetadataItemsBufferLength::<Identity, Impl, OFFSET>,
             ActivateSpatialAudioMetadataWriter: ActivateSpatialAudioMetadataWriter::<Identity, Impl, OFFSET>,
@@ -2700,7 +2700,7 @@ impl ISpatialAudioMetadataCopier_Vtbl {
             this.Close().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Open: Open::<Identity, Impl, OFFSET>,
             CopyMetadataForFrames: CopyMetadataForFrames::<Identity, Impl, OFFSET>,
             Close: Close::<Identity, Impl, OFFSET>,
@@ -2776,7 +2776,7 @@ impl ISpatialAudioMetadataItems_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetFrameCount: GetFrameCount::<Identity, Impl, OFFSET>,
             GetItemCount: GetItemCount::<Identity, Impl, OFFSET>,
             GetMaxItemCount: GetMaxItemCount::<Identity, Impl, OFFSET>,
@@ -2812,7 +2812,7 @@ impl ISpatialAudioMetadataItemsBuffer_Vtbl {
             this.DetachBuffer().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AttachToBuffer: AttachToBuffer::<Identity, Impl, OFFSET>,
             AttachToPopulatedBuffer: AttachToPopulatedBuffer::<Identity, Impl, OFFSET>,
             DetachBuffer: DetachBuffer::<Identity, Impl, OFFSET>,
@@ -2852,7 +2852,7 @@ impl ISpatialAudioMetadataReader_Vtbl {
             this.Close().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Open: Open::<Identity, Impl, OFFSET>,
             ReadNextItem: ReadNextItem::<Identity, Impl, OFFSET>,
             ReadNextItemCommand: ReadNextItemCommand::<Identity, Impl, OFFSET>,
@@ -2893,7 +2893,7 @@ impl ISpatialAudioMetadataWriter_Vtbl {
             this.Close().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Open: Open::<Identity, Impl, OFFSET>,
             WriteNextItem: WriteNextItem::<Identity, Impl, OFFSET>,
             WriteNextItemCommand: WriteNextItemCommand::<Identity, Impl, OFFSET>,
@@ -2979,7 +2979,7 @@ impl ISpatialAudioObjectBase_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetBuffer: GetBuffer::<Identity, Impl, OFFSET>,
             SetEndOfStream: SetEndOfStream::<Identity, Impl, OFFSET>,
             IsActive: IsActive::<Identity, Impl, OFFSET>,
@@ -3180,7 +3180,7 @@ impl ISpatialAudioObjectRenderStreamBase_Vtbl {
             this.EndUpdatingAudioObjects().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetAvailableDynamicObjectCount: GetAvailableDynamicObjectCount::<Identity, Impl, OFFSET>,
             GetService: GetService::<Identity, Impl, OFFSET>,
             Start: Start::<Identity, Impl, OFFSET>,
@@ -3271,7 +3271,7 @@ impl ISpatialAudioObjectRenderStreamNotify_Vtbl {
             this.OnAvailableDynamicObjectCountChange(::core::mem::transmute(&sender), ::core::mem::transmute_copy(&hnscompliancedeadlinetime), ::core::mem::transmute_copy(&availabledynamicobjectcountchange)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnAvailableDynamicObjectCountChange: OnAvailableDynamicObjectCountChange::<Identity, Impl, OFFSET>,
         }
     }
@@ -3283,7 +3283,7 @@ pub trait ISubunit_Impl: Sized {}
 impl ::windows::core::RuntimeName for ISubunit {}
 impl ISubunit_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ISubunit_Impl, const OFFSET: isize>() -> ISubunit_Vtbl {
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>() }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>() }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ISubunit as ::windows::core::Interface>::IID

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/mod.rs
@@ -1869,7 +1869,7 @@ unsafe impl ::windows::core::Interface for IActivateAudioInterfaceAsyncOperation
 #[repr(C)]
 #[doc(hidden)]
 pub struct IActivateAudioInterfaceAsyncOperation_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetActivateResult: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, activateresult: *mut ::windows::core::HRESULT, activatedinterface: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_Audio\"`*"]
@@ -1921,7 +1921,7 @@ unsafe impl ::windows::core::Interface for IActivateAudioInterfaceCompletionHand
 #[repr(C)]
 #[doc(hidden)]
 pub struct IActivateAudioInterfaceCompletionHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ActivateCompleted: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, activateoperation: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_Audio\"`*"]
@@ -1987,7 +1987,7 @@ unsafe impl ::windows::core::Interface for IAudioAmbisonicsControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAudioAmbisonicsControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pambisonicsparams: *const AMBISONICS_PARAMS, cbambisonicsparams: u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub SetHeadTracking: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, benableheadtracking: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -2056,7 +2056,7 @@ unsafe impl ::windows::core::Interface for IAudioAutoGainControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAudioAutoGainControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetEnabled: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbenabled: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -2199,7 +2199,7 @@ unsafe impl ::windows::core::Interface for IAudioCaptureClient {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAudioCaptureClient_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetBuffer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppdata: *mut *mut u8, pnumframestoread: *mut u32, pdwflags: *mut u32, pu64deviceposition: *mut u64, pu64qpcposition: *mut u64) -> ::windows::core::HRESULT,
     pub ReleaseBuffer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, numframesread: u32) -> ::windows::core::HRESULT,
     pub GetNextPacketSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pnumframesinnextpacket: *mut u32) -> ::windows::core::HRESULT,
@@ -2254,7 +2254,7 @@ unsafe impl ::windows::core::Interface for IAudioChannelConfig {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAudioChannelConfig_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetChannelConfig: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwconfig: u32, pguideventcontext: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub GetChannelConfig: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwconfig: *mut u32) -> ::windows::core::HRESULT,
 }
@@ -2350,7 +2350,7 @@ unsafe impl ::windows::core::Interface for IAudioClient {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAudioClient_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sharemode: AUDCLNT_SHAREMODE, streamflags: u32, hnsbufferduration: i64, hnsperiodicity: i64, pformat: *const WAVEFORMATEX, audiosessionguid: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub GetBufferSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pnumbufferframes: *mut u32) -> ::windows::core::HRESULT,
     pub GetStreamLatency: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, phnslatency: *mut i64) -> ::windows::core::HRESULT,
@@ -2708,7 +2708,7 @@ unsafe impl ::windows::core::Interface for IAudioClientDuckingControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAudioClientDuckingControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetDuckingOptionsForCurrentStream: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, options: AUDIO_DUCKING_OPTIONS) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_Audio\"`*"]
@@ -2765,7 +2765,7 @@ unsafe impl ::windows::core::Interface for IAudioClock {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAudioClock_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetFrequency: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pu64frequency: *mut u64) -> ::windows::core::HRESULT,
     pub GetPosition: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pu64position: *mut u64, pu64qpcposition: *mut u64) -> ::windows::core::HRESULT,
     pub GetCharacteristics: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwcharacteristics: *mut u32) -> ::windows::core::HRESULT,
@@ -2816,7 +2816,7 @@ unsafe impl ::windows::core::Interface for IAudioClock2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAudioClock2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDevicePosition: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, deviceposition: *mut u64, qpcposition: *mut u64) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_Audio\"`*"]
@@ -2865,7 +2865,7 @@ unsafe impl ::windows::core::Interface for IAudioClockAdjustment {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAudioClockAdjustment_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetSampleRate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, flsamplerate: f32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_Audio\"`*"]
@@ -2914,7 +2914,7 @@ unsafe impl ::windows::core::Interface for IAudioEffectsChangedNotificationClien
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAudioEffectsChangedNotificationClient_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnAudioEffectsChanged: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_Audio\"`*"]
@@ -2980,7 +2980,7 @@ unsafe impl ::windows::core::Interface for IAudioEffectsManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAudioEffectsManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub RegisterAudioEffectsChangedNotificationCallback: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, client: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub UnregisterAudioEffectsChangedNotificationCallback: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, client: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -3040,7 +3040,7 @@ unsafe impl ::windows::core::Interface for IAudioFormatEnumerator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAudioFormatEnumerator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, count: *mut u32) -> ::windows::core::HRESULT,
     pub GetFormat: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: u32, format: *mut *mut WAVEFORMATEX) -> ::windows::core::HRESULT,
 }
@@ -3094,7 +3094,7 @@ unsafe impl ::windows::core::Interface for IAudioInputSelector {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAudioInputSelector_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetSelection: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pnidselected: *mut u32) -> ::windows::core::HRESULT,
     pub SetSelection: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, nidselect: u32, pguideventcontext: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
 }
@@ -3155,7 +3155,7 @@ unsafe impl ::windows::core::Interface for IAudioLoudness {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAudioLoudness_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetEnabled: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbenabled: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -3302,7 +3302,7 @@ unsafe impl ::windows::core::Interface for IAudioMute {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAudioMute_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub SetMute: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bmuted: super::super::Foundation::BOOL, pguideventcontext: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -3362,7 +3362,7 @@ unsafe impl ::windows::core::Interface for IAudioOutputSelector {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAudioOutputSelector_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetSelection: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pnidselected: *mut u32) -> ::windows::core::HRESULT,
     pub SetSelection: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, nidselect: u32, pguideventcontext: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
 }
@@ -3417,7 +3417,7 @@ unsafe impl ::windows::core::Interface for IAudioPeakMeter {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAudioPeakMeter_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetChannelCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcchannels: *mut u32) -> ::windows::core::HRESULT,
     pub GetLevel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, nchannel: u32, pflevel: *mut f32) -> ::windows::core::HRESULT,
 }
@@ -3471,7 +3471,7 @@ unsafe impl ::windows::core::Interface for IAudioRenderClient {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAudioRenderClient_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetBuffer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, numframesrequested: u32, ppdata: *mut *mut u8) -> ::windows::core::HRESULT,
     pub ReleaseBuffer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, numframeswritten: u32, dwflags: u32) -> ::windows::core::HRESULT,
 }
@@ -3561,7 +3561,7 @@ unsafe impl ::windows::core::Interface for IAudioSessionControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAudioSessionControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetState: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pretval: *mut AudioSessionState) -> ::windows::core::HRESULT,
     pub GetDisplayName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pretval: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub SetDisplayName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: ::windows::core::PCWSTR, eventcontext: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
@@ -3757,7 +3757,7 @@ unsafe impl ::windows::core::Interface for IAudioSessionEnumerator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAudioSessionEnumerator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sessioncount: *mut i32) -> ::windows::core::HRESULT,
     pub GetSession: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sessioncount: i32, session: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -3836,7 +3836,7 @@ unsafe impl ::windows::core::Interface for IAudioSessionEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAudioSessionEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnDisplayNameChanged: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, newdisplayname: ::windows::core::PCWSTR, eventcontext: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub OnIconPathChanged: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, newiconpath: ::windows::core::PCWSTR, eventcontext: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -3899,7 +3899,7 @@ unsafe impl ::windows::core::Interface for IAudioSessionManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAudioSessionManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetAudioSessionControl: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, audiosessionguid: *const ::windows::core::GUID, streamflags: u32, sessioncontrol: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetSimpleAudioVolume: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, audiosessionguid: *const ::windows::core::GUID, streamflags: u32, audiovolume: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -4054,7 +4054,7 @@ unsafe impl ::windows::core::Interface for IAudioSessionNotification {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAudioSessionNotification_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnSessionCreated: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, newsession: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_Audio\"`*"]
@@ -4110,7 +4110,7 @@ unsafe impl ::windows::core::Interface for IAudioStateMonitor {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAudioStateMonitor_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub RegisterCallback: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, callback: *mut ::core::ffi::c_void, context: *const ::core::ffi::c_void, registration: *mut i64) -> ::windows::core::HRESULT,
     pub UnregisterCallback: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, registration: i64),
     pub GetSoundLevel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> AudioStateMonitorSoundLevel,
@@ -4175,7 +4175,7 @@ unsafe impl ::windows::core::Interface for IAudioStreamVolume {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAudioStreamVolume_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetChannelCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwcount: *mut u32) -> ::windows::core::HRESULT,
     pub SetChannelVolume: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwindex: u32, flevel: f32) -> ::windows::core::HRESULT,
     pub GetChannelVolume: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwindex: u32, pflevel: *mut f32) -> ::windows::core::HRESULT,
@@ -4230,7 +4230,7 @@ unsafe impl ::windows::core::Interface for IAudioSystemEffectsPropertyChangeNoti
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAudioSystemEffectsPropertyChangeNotificationClient_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
     pub OnPropertyChanged: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, r#type: AUDIO_SYSTEMEFFECTS_PROPERTYSTORE_TYPE, key: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_UI_Shell_PropertiesSystem"))]
@@ -4315,7 +4315,7 @@ unsafe impl ::windows::core::Interface for IAudioSystemEffectsPropertyStore {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAudioSystemEffectsPropertyStore_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
     pub OpenDefaultPropertyStore: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, stgmaccess: u32, propstore: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_UI_Shell_PropertiesSystem"))]
@@ -4468,7 +4468,7 @@ unsafe impl ::windows::core::Interface for IAudioVolumeDuckNotification {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAudioVolumeDuckNotification_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnVolumeDuckNotification: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sessionid: ::windows::core::PCWSTR, countcommunicationsessions: u32) -> ::windows::core::HRESULT,
     pub OnVolumeUnduckNotification: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sessionid: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
 }
@@ -4612,7 +4612,7 @@ unsafe impl ::windows::core::Interface for IChannelAudioVolume {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IChannelAudioVolume_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetChannelCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwcount: *mut u32) -> ::windows::core::HRESULT,
     pub SetChannelVolume: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwindex: u32, flevel: f32, eventcontext: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub GetChannelVolume: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwindex: u32, pflevel: *mut f32) -> ::windows::core::HRESULT,
@@ -4697,7 +4697,7 @@ unsafe impl ::windows::core::Interface for IConnector {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IConnector_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptype: *mut ConnectorType) -> ::windows::core::HRESULT,
     pub GetDataFlow: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pflow: *mut DataFlow) -> ::windows::core::HRESULT,
     pub ConnectTo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pconnectto: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -4756,7 +4756,7 @@ unsafe impl ::windows::core::Interface for IControlChangeNotify {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IControlChangeNotify_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnNotify: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwsenderprocessid: u32, pguideventcontext: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_Audio\"`*"]
@@ -4810,7 +4810,7 @@ unsafe impl ::windows::core::Interface for IControlInterface {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IControlInterface_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppwstrname: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetIID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, piid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
 }
@@ -4870,7 +4870,7 @@ unsafe impl ::windows::core::Interface for IDeviceSpecificProperty {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDeviceSpecificProperty_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pvtype: *mut u16) -> ::windows::core::HRESULT,
     pub GetValue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pvvalue: *mut ::core::ffi::c_void, pcbvalue: *mut u32) -> ::windows::core::HRESULT,
     pub SetValue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pvvalue: *const ::core::ffi::c_void, cbvalue: u32, pguideventcontext: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
@@ -4954,7 +4954,7 @@ unsafe impl ::windows::core::Interface for IDeviceTopology {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDeviceTopology_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetConnectorCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcount: *mut u32) -> ::windows::core::HRESULT,
     pub GetConnector: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, nindex: u32, ppconnector: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetSubunitCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcount: *mut u32) -> ::windows::core::HRESULT,
@@ -5032,7 +5032,7 @@ unsafe impl ::windows::core::Interface for IMMDevice {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMMDevice_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
     pub Activate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, iid: *const ::windows::core::GUID, dwclsctx: super::super::System::Com::CLSCTX, pactivationparams: *const super::super::System::Com::StructuredStorage::PROPVARIANT, ppinterface: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage")))]
@@ -5095,7 +5095,7 @@ unsafe impl ::windows::core::Interface for IMMDeviceActivator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMMDeviceActivator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
     pub Activate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, iid: *const ::windows::core::GUID, pdevice: *mut ::core::ffi::c_void, pactivationparams: *const super::super::System::Com::StructuredStorage::PROPVARIANT, ppinterface: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage")))]
@@ -5152,7 +5152,7 @@ unsafe impl ::windows::core::Interface for IMMDeviceCollection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMMDeviceCollection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcdevices: *mut u32) -> ::windows::core::HRESULT,
     pub Item: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ndevice: u32, ppdevice: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -5226,7 +5226,7 @@ unsafe impl ::windows::core::Interface for IMMDeviceEnumerator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMMDeviceEnumerator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub EnumAudioEndpoints: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dataflow: EDataFlow, dwstatemask: u32, ppdevices: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetDefaultAudioEndpoint: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dataflow: EDataFlow, role: ERole, ppendpoint: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetDevice: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwstrid: ::windows::core::PCWSTR, ppdevice: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -5280,7 +5280,7 @@ unsafe impl ::windows::core::Interface for IMMEndpoint {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMMEndpoint_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDataFlow: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdataflow: *mut EDataFlow) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_Audio\"`*"]
@@ -5358,7 +5358,7 @@ unsafe impl ::windows::core::Interface for IMMNotificationClient {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMMNotificationClient_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnDeviceStateChanged: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwstrdeviceid: ::windows::core::PCWSTR, dwnewstate: u32) -> ::windows::core::HRESULT,
     pub OnDeviceAdded: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwstrdeviceid: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub OnDeviceRemoved: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwstrdeviceid: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
@@ -5431,7 +5431,7 @@ unsafe impl ::windows::core::Interface for IMessageFilter {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMessageFilter_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub HandleInComingCall: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwcalltype: u32, htaskcaller: super::HTASK, dwtickcount: u32, lpinterfaceinfo: *const super::super::System::Com::INTERFACEINFO) -> u32,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -5537,7 +5537,7 @@ unsafe impl ::windows::core::Interface for IPart {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPart_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppwstrname: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetLocalId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pnid: *mut u32) -> ::windows::core::HRESULT,
     pub GetGlobalId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppwstrglobalid: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
@@ -5603,7 +5603,7 @@ unsafe impl ::windows::core::Interface for IPartsList {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPartsList_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcount: *mut u32) -> ::windows::core::HRESULT,
     pub GetPart: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, nindex: u32, pppart: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -5670,7 +5670,7 @@ unsafe impl ::windows::core::Interface for IPerChannelDbLevel {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPerChannelDbLevel_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetChannelCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcchannels: *mut u32) -> ::windows::core::HRESULT,
     pub GetLevelRange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, nchannel: u32, pfminleveldb: *mut f32, pfmaxleveldb: *mut f32, pfstepping: *mut f32) -> ::windows::core::HRESULT,
     pub GetLevel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, nchannel: u32, pfleveldb: *mut f32) -> ::windows::core::HRESULT,
@@ -5742,7 +5742,7 @@ unsafe impl ::windows::core::Interface for ISimpleAudioVolume {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISimpleAudioVolume_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetMasterVolume: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, flevel: f32, eventcontext: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub GetMasterVolume: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pflevel: *mut f32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -5833,7 +5833,7 @@ unsafe impl ::windows::core::Interface for ISpatialAudioClient {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISpatialAudioClient_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetStaticObjectPosition: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, r#type: AudioObjectType, x: *mut f32, y: *mut f32, z: *mut f32) -> ::windows::core::HRESULT,
     pub GetNativeStaticObjectTypeMask: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, mask: *mut AudioObjectType) -> ::windows::core::HRESULT,
     pub GetMaxDynamicObjectCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: *mut u32) -> ::windows::core::HRESULT,
@@ -6030,7 +6030,7 @@ unsafe impl ::windows::core::Interface for ISpatialAudioMetadataClient {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISpatialAudioMetadataClient_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ActivateSpatialAudioMetadataItems: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, maxitemcount: u16, framecount: u16, metadataitemsbuffer: *mut *mut ::core::ffi::c_void, metadataitems: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetSpatialAudioMetadataItemsBufferLength: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, maxitemcount: u16, bufferlength: *mut u32) -> ::windows::core::HRESULT,
     pub ActivateSpatialAudioMetadataWriter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, overflowmode: SpatialAudioMetadataWriterOverflowMode, metadatawriter: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -6096,7 +6096,7 @@ unsafe impl ::windows::core::Interface for ISpatialAudioMetadataCopier {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISpatialAudioMetadataCopier_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Open: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, metadataitems: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CopyMetadataForFrames: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, copyframecount: u16, copymode: SpatialAudioMetadataCopyMode, dstmetadataitems: *mut ::core::ffi::c_void, itemscopied: *mut u16) -> ::windows::core::HRESULT,
     pub Close: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -6164,7 +6164,7 @@ unsafe impl ::windows::core::Interface for ISpatialAudioMetadataItems {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISpatialAudioMetadataItems_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetFrameCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, framecount: *mut u16) -> ::windows::core::HRESULT,
     pub GetItemCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, itemcount: *mut u16) -> ::windows::core::HRESULT,
     pub GetMaxItemCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, maxitemcount: *mut u16) -> ::windows::core::HRESULT,
@@ -6223,7 +6223,7 @@ unsafe impl ::windows::core::Interface for ISpatialAudioMetadataItemsBuffer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISpatialAudioMetadataItemsBuffer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AttachToBuffer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, buffer: *mut u8, bufferlength: u32) -> ::windows::core::HRESULT,
     pub AttachToPopulatedBuffer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, buffer: *mut u8, bufferlength: u32) -> ::windows::core::HRESULT,
     pub DetachBuffer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -6286,7 +6286,7 @@ unsafe impl ::windows::core::Interface for ISpatialAudioMetadataReader {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISpatialAudioMetadataReader_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Open: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, metadataitems: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub ReadNextItem: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, commandcount: *mut u8, frameoffset: *mut u16) -> ::windows::core::HRESULT,
     pub ReadNextItemCommand: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, commandid: *mut u8, valuebuffer: *mut ::core::ffi::c_void, maxvaluebufferlength: u32, valuebufferlength: *mut u32) -> ::windows::core::HRESULT,
@@ -6350,7 +6350,7 @@ unsafe impl ::windows::core::Interface for ISpatialAudioMetadataWriter {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISpatialAudioMetadataWriter_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Open: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, metadataitems: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub WriteNextItem: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, frameoffset: u16) -> ::windows::core::HRESULT,
     pub WriteNextItemCommand: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, commandid: u8, valuebuffer: *const ::core::ffi::c_void, valuebufferlength: u32) -> ::windows::core::HRESULT,
@@ -6499,7 +6499,7 @@ unsafe impl ::windows::core::Interface for ISpatialAudioObjectBase {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISpatialAudioObjectBase_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetBuffer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, buffer: *mut *mut u8, bufferlength: *mut u32) -> ::windows::core::HRESULT,
     pub SetEndOfStream: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, framecount: u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -6929,7 +6929,7 @@ unsafe impl ::windows::core::Interface for ISpatialAudioObjectRenderStreamBase {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISpatialAudioObjectRenderStreamBase_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetAvailableDynamicObjectCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: *mut u32) -> ::windows::core::HRESULT,
     pub GetService: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, service: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Start: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -7174,7 +7174,7 @@ unsafe impl ::windows::core::Interface for ISpatialAudioObjectRenderStreamNotify
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISpatialAudioObjectRenderStreamNotify_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnAvailableDynamicObjectCountChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sender: *mut ::core::ffi::c_void, hnscompliancedeadlinetime: i64, availabledynamicobjectcountchange: u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_Audio\"`*"]
@@ -7219,7 +7219,7 @@ unsafe impl ::windows::core::Interface for ISubunit {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISubunit_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
 }
 #[doc = "*Required features: `\"Win32_Media_Audio\"`*"]
 pub const ACMDM_DRIVER_ABOUT: u32 = 24587u32;

--- a/crates/libs/windows/src/Windows/Win32/Media/DeviceManager/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/DeviceManager/impl.rs
@@ -16,7 +16,7 @@ impl IComponentAuthenticate_Vtbl {
             this.SACGetProtocols(::core::mem::transmute_copy(&ppdwprotocols), ::core::mem::transmute_copy(&pdwprotocolcount)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SACAuth: SACAuth::<Identity, Impl, OFFSET>,
             SACGetProtocols: SACGetProtocols::<Identity, Impl, OFFSET>,
         }
@@ -130,7 +130,7 @@ impl IMDSPDevice_Vtbl {
             this.SendOpaqueCommand(::core::mem::transmute_copy(&pcommand)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetName: GetName::<Identity, Impl, OFFSET>,
             GetManufacturer: GetManufacturer::<Identity, Impl, OFFSET>,
             GetVersion: GetVersion::<Identity, Impl, OFFSET>,
@@ -336,7 +336,7 @@ impl IMDSPDeviceControl_Vtbl {
             this.Seek(::core::mem::transmute_copy(&fumode), ::core::mem::transmute_copy(&noffset)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDCStatus: GetDCStatus::<Identity, Impl, OFFSET>,
             GetCapabilities: GetCapabilities::<Identity, Impl, OFFSET>,
             Play: Play::<Identity, Impl, OFFSET>,
@@ -368,7 +368,7 @@ impl IMDSPDirectTransfer_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), TransferToDevice: TransferToDevice::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), TransferToDevice: TransferToDevice::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMDSPDirectTransfer as ::windows::core::Interface>::IID
@@ -416,7 +416,7 @@ impl IMDSPEnumDevice_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -469,7 +469,7 @@ impl IMDSPEnumStorage_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -534,7 +534,7 @@ impl IMDSPObject_Vtbl {
             this.Close().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Open: Open::<Identity, Impl, OFFSET>,
             Read: Read::<Identity, Impl, OFFSET>,
             Write: Write::<Identity, Impl, OFFSET>,
@@ -654,7 +654,7 @@ impl IMDSPObjectInfo_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetPlayLength: GetPlayLength::<Identity, Impl, OFFSET>,
             SetPlayLength: SetPlayLength::<Identity, Impl, OFFSET>,
             GetPlayOffset: GetPlayOffset::<Identity, Impl, OFFSET>,
@@ -679,7 +679,7 @@ impl IMDSPRevoked_Vtbl {
             let this = (*this).get_impl();
             this.GetRevocationURL(::core::mem::transmute_copy(&ppwszrevocationurl), ::core::mem::transmute_copy(&pdwbufferlen)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetRevocationURL: GetRevocationURL::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetRevocationURL: GetRevocationURL::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMDSPRevoked as ::windows::core::Interface>::IID
@@ -778,7 +778,7 @@ impl IMDSPStorage_Vtbl {
             this.SendOpaqueCommand(::core::mem::transmute_copy(&pcommand)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetAttributes: SetAttributes::<Identity, Impl, OFFSET>,
             GetStorageGlobals: GetStorageGlobals::<Identity, Impl, OFFSET>,
             GetAttributes: GetAttributes::<Identity, Impl, OFFSET>,
@@ -1041,7 +1041,7 @@ impl IMDSPStorageGlobals_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCapabilities: GetCapabilities::<Identity, Impl, OFFSET>,
             GetSerialNumber: GetSerialNumber::<Identity, Impl, OFFSET>,
             GetTotalSize: GetTotalSize::<Identity, Impl, OFFSET>,
@@ -1087,7 +1087,7 @@ impl IMDServiceProvider_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDeviceCount: GetDeviceCount::<Identity, Impl, OFFSET>,
             EnumDevices: EnumDevices::<Identity, Impl, OFFSET>,
         }
@@ -1147,7 +1147,7 @@ impl ISCPSecureAuthenticate_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetSecureQuery: GetSecureQuery::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetSecureQuery: GetSecureQuery::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ISCPSecureAuthenticate as ::windows::core::Interface>::IID
@@ -1200,7 +1200,7 @@ impl ISCPSecureExchange_Vtbl {
             this.TransferComplete().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             TransferContainerData: TransferContainerData::<Identity, Impl, OFFSET>,
             ObjectData: ObjectData::<Identity, Impl, OFFSET>,
             TransferComplete: TransferComplete::<Identity, Impl, OFFSET>,
@@ -1297,7 +1297,7 @@ impl ISCPSecureQuery_Vtbl {
             this.GetRights(::core::mem::transmute_copy(&pdata), ::core::mem::transmute_copy(&dwsize), ::core::mem::transmute_copy(&pbspsessionkey), ::core::mem::transmute_copy(&dwsessionkeylen), ::core::mem::transmute(&pstgglobals), ::core::mem::transmute_copy(&pprights), ::core::mem::transmute_copy(&pnrightscount), ::core::mem::transmute_copy(&abmac)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDataDemands: GetDataDemands::<Identity, Impl, OFFSET>,
             ExamineData: ExamineData::<Identity, Impl, OFFSET>,
             MakeDecision: MakeDecision::<Identity, Impl, OFFSET>,
@@ -1422,7 +1422,7 @@ impl ISCPSession_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             BeginSession: BeginSession::<Identity, Impl, OFFSET>,
             EndSession: EndSession::<Identity, Impl, OFFSET>,
             GetSecureQuery: GetSecureQuery::<Identity, Impl, OFFSET>,
@@ -1537,7 +1537,7 @@ impl IWMDMDevice_Vtbl {
             this.SendOpaqueCommand(::core::mem::transmute_copy(&pcommand)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetName: GetName::<Identity, Impl, OFFSET>,
             GetManufacturer: GetManufacturer::<Identity, Impl, OFFSET>,
             GetVersion: GetVersion::<Identity, Impl, OFFSET>,
@@ -1743,7 +1743,7 @@ impl IWMDMDeviceControl_Vtbl {
             this.Seek(::core::mem::transmute_copy(&fumode), ::core::mem::transmute_copy(&noffset)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetStatus: GetStatus::<Identity, Impl, OFFSET>,
             GetCapabilities: GetCapabilities::<Identity, Impl, OFFSET>,
             Play: Play::<Identity, Impl, OFFSET>,
@@ -1776,7 +1776,7 @@ impl IWMDMDeviceSession_Vtbl {
             this.EndSession(::core::mem::transmute_copy(&r#type), ::core::mem::transmute_copy(&pctx), ::core::mem::transmute_copy(&dwsizectx)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             BeginSession: BeginSession::<Identity, Impl, OFFSET>,
             EndSession: EndSession::<Identity, Impl, OFFSET>,
         }
@@ -1827,7 +1827,7 @@ impl IWMDMEnumDevice_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -1880,7 +1880,7 @@ impl IWMDMEnumStorage_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -1960,7 +1960,7 @@ impl IWMDMLogger_Vtbl {
             this.SetSizeParams(::core::mem::transmute_copy(&dwmaxsize), ::core::mem::transmute_copy(&dwshrinktosize)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             IsEnabled: IsEnabled::<Identity, Impl, OFFSET>,
             Enable: Enable::<Identity, Impl, OFFSET>,
             GetLogFileName: GetLogFileName::<Identity, Impl, OFFSET>,
@@ -2012,7 +2012,7 @@ impl IWMDMMetaData_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddItem: AddItem::<Identity, Impl, OFFSET>,
             QueryByName: QueryByName::<Identity, Impl, OFFSET>,
             QueryByIndex: QueryByIndex::<Identity, Impl, OFFSET>,
@@ -2034,7 +2034,7 @@ impl IWMDMNotification_Vtbl {
             let this = (*this).get_impl();
             this.WMDMMessage(::core::mem::transmute_copy(&dwmessagetype), ::core::mem::transmute(&pwszcanonicalname)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), WMDMMessage: WMDMMessage::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), WMDMMessage: WMDMMessage::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWMDMNotification as ::windows::core::Interface>::IID
@@ -2118,7 +2118,7 @@ impl IWMDMObjectInfo_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetPlayLength: GetPlayLength::<Identity, Impl, OFFSET>,
             SetPlayLength: SetPlayLength::<Identity, Impl, OFFSET>,
             GetPlayOffset: GetPlayOffset::<Identity, Impl, OFFSET>,
@@ -2201,7 +2201,7 @@ impl IWMDMOperation_Vtbl {
             this.End(::core::mem::transmute_copy(&phcompletioncode), ::core::mem::transmute(&pnewobject)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             BeginRead: BeginRead::<Identity, Impl, OFFSET>,
             BeginWrite: BeginWrite::<Identity, Impl, OFFSET>,
             GetObjectName: GetObjectName::<Identity, Impl, OFFSET>,
@@ -2295,7 +2295,7 @@ impl IWMDMProgress_Vtbl {
             this.End().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Begin: Begin::<Identity, Impl, OFFSET>,
             Progress: Progress::<Identity, Impl, OFFSET>,
             End: End::<Identity, Impl, OFFSET>,
@@ -2367,7 +2367,7 @@ impl IWMDMRevoked_Vtbl {
             let this = (*this).get_impl();
             this.GetRevocationURL(::core::mem::transmute_copy(&ppwszrevocationurl), ::core::mem::transmute_copy(&pdwbufferlen), ::core::mem::transmute_copy(&pdwrevokedbitflag)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetRevocationURL: GetRevocationURL::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetRevocationURL: GetRevocationURL::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWMDMRevoked as ::windows::core::Interface>::IID
@@ -2454,7 +2454,7 @@ impl IWMDMStorage_Vtbl {
             this.SendOpaqueCommand(::core::mem::transmute_copy(&pcommand)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetAttributes: SetAttributes::<Identity, Impl, OFFSET>,
             GetStorageGlobals: GetStorageGlobals::<Identity, Impl, OFFSET>,
             GetAttributes: GetAttributes::<Identity, Impl, OFFSET>,
@@ -2687,7 +2687,7 @@ impl IWMDMStorageControl_Vtbl {
             this.Move(::core::mem::transmute_copy(&fumode), ::core::mem::transmute(&ptargetobject), ::core::mem::transmute(&pprogress)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Insert: Insert::<Identity, Impl, OFFSET>,
             Delete: Delete::<Identity, Impl, OFFSET>,
             Rename: Rename::<Identity, Impl, OFFSET>,
@@ -2793,7 +2793,7 @@ impl IWMDMStorageGlobals_Vtbl {
             this.Initialize(::core::mem::transmute_copy(&fumode), ::core::mem::transmute(&pprogress)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCapabilities: GetCapabilities::<Identity, Impl, OFFSET>,
             GetSerialNumber: GetSerialNumber::<Identity, Impl, OFFSET>,
             GetTotalSize: GetTotalSize::<Identity, Impl, OFFSET>,
@@ -2849,7 +2849,7 @@ impl IWMDeviceManager_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetRevision: GetRevision::<Identity, Impl, OFFSET>,
             GetDeviceCount: GetDeviceCount::<Identity, Impl, OFFSET>,
             EnumDevices: EnumDevices::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/Media/DeviceManager/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/DeviceManager/mod.rs
@@ -47,7 +47,7 @@ unsafe impl ::windows::core::Interface for IComponentAuthenticate {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IComponentAuthenticate_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SACAuth: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwprotocolid: u32, dwpass: u32, pbdatain: *const u8, dwdatainlen: u32, ppbdataout: *mut *mut u8, pdwdataoutlen: *mut u32) -> ::windows::core::HRESULT,
     pub SACGetProtocols: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppdwprotocols: *mut *mut u32, pdwprotocolcount: *mut u32) -> ::windows::core::HRESULT,
 }
@@ -134,7 +134,7 @@ unsafe impl ::windows::core::Interface for IMDSPDevice {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMDSPDevice_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszname: ::windows::core::PWSTR, nmaxchars: u32) -> ::windows::core::HRESULT,
     pub GetManufacturer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszname: ::windows::core::PWSTR, nmaxchars: u32) -> ::windows::core::HRESULT,
     pub GetVersion: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwversion: *mut u32) -> ::windows::core::HRESULT,
@@ -533,7 +533,7 @@ unsafe impl ::windows::core::Interface for IMDSPDeviceControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMDSPDeviceControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDCStatus: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwstatus: *mut u32) -> ::windows::core::HRESULT,
     pub GetCapabilities: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwcapabilitiesmask: *mut u32) -> ::windows::core::HRESULT,
     pub Play: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -600,7 +600,7 @@ unsafe impl ::windows::core::Interface for IMDSPDirectTransfer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMDSPDirectTransfer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub TransferToDevice: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszsourcefilepath: ::windows::core::PCWSTR, psourceoperation: *mut ::core::ffi::c_void, fuflags: u32, pwszdestinationname: ::windows::core::PCWSTR, psourcemetadata: *mut ::core::ffi::c_void, ptransferprogress: *mut ::core::ffi::c_void, ppnewobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_DeviceManager\"`*"]
@@ -660,7 +660,7 @@ unsafe impl ::windows::core::Interface for IMDSPEnumDevice {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMDSPEnumDevice_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, ppdevice: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -723,7 +723,7 @@ unsafe impl ::windows::core::Interface for IMDSPEnumStorage {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMDSPEnumStorage_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, ppstorage: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -807,7 +807,7 @@ unsafe impl ::windows::core::Interface for IMDSPObject {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMDSPObject_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Open: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fumode: u32) -> ::windows::core::HRESULT,
     pub Read: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdata: *mut u8, pdwsize: *mut u32, abmac: *mut u8) -> ::windows::core::HRESULT,
     pub Write: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdata: *const u8, pdwsize: *mut u32, abmac: *mut u8) -> ::windows::core::HRESULT,
@@ -989,7 +989,7 @@ unsafe impl ::windows::core::Interface for IMDSPObjectInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMDSPObjectInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetPlayLength: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwlength: *mut u32) -> ::windows::core::HRESULT,
     pub SetPlayLength: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwlength: u32) -> ::windows::core::HRESULT,
     pub GetPlayOffset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwoffset: *mut u32) -> ::windows::core::HRESULT,
@@ -1044,7 +1044,7 @@ unsafe impl ::windows::core::Interface for IMDSPRevoked {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMDSPRevoked_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetRevocationURL: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppwszrevocationurl: *mut ::windows::core::PWSTR, pdwbufferlen: *mut u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_DeviceManager\"`*"]
@@ -1133,7 +1133,7 @@ unsafe impl ::windows::core::Interface for IMDSPStorage {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMDSPStorage_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Media_Audio")]
     pub SetAttributes: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwattributes: u32, pformat: *const super::Audio::WAVEFORMATEX) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Media_Audio"))]
@@ -1739,7 +1739,7 @@ unsafe impl ::windows::core::Interface for IMDSPStorageGlobals {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMDSPStorageGlobals_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCapabilities: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwcapabilities: *mut u32) -> ::windows::core::HRESULT,
     pub GetSerialNumber: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pserialnum: *mut WMDMID, abmac: *mut u8) -> ::windows::core::HRESULT,
     pub GetTotalSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwtotalsizelow: *mut u32, pdwtotalsizehigh: *mut u32) -> ::windows::core::HRESULT,
@@ -1801,7 +1801,7 @@ unsafe impl ::windows::core::Interface for IMDServiceProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMDServiceProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDeviceCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwcount: *mut u32) -> ::windows::core::HRESULT,
     pub EnumDevices: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppenumdevice: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -2020,7 +2020,7 @@ unsafe impl ::windows::core::Interface for ISCPSecureAuthenticate {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISCPSecureAuthenticate_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetSecureQuery: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppsecurequery: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_DeviceManager\"`*"]
@@ -2144,7 +2144,7 @@ unsafe impl ::windows::core::Interface for ISCPSecureExchange {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISCPSecureExchange_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub TransferContainerData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdata: *const u8, dwsize: u32, pfureadyflags: *mut u32, abmac: *mut u8) -> ::windows::core::HRESULT,
     pub ObjectData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdata: *mut u8, pdwsize: *mut u32, abmac: *mut u8) -> ::windows::core::HRESULT,
     pub TransferComplete: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -2402,7 +2402,7 @@ unsafe impl ::windows::core::Interface for ISCPSecureQuery {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISCPSecureQuery_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDataDemands: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfuflags: *mut u32, pdwminrightsdata: *mut u32, pdwminexaminedata: *mut u32, pdwmindecidedata: *mut u32, abmac: *mut u8) -> ::windows::core::HRESULT,
     pub ExamineData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fuflags: u32, pwszextension: ::windows::core::PCWSTR, pdata: *const u8, dwsize: u32, abmac: *mut u8) -> ::windows::core::HRESULT,
     pub MakeDecision: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fuflags: u32, pdata: *const u8, dwsize: u32, dwappsec: u32, pbspsessionkey: *const u8, dwsessionkeylen: u32, pstorageglobals: *mut ::core::ffi::c_void, ppexchange: *mut *mut ::core::ffi::c_void, abmac: *mut u8) -> ::windows::core::HRESULT,
@@ -2736,7 +2736,7 @@ unsafe impl ::windows::core::Interface for ISCPSession {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISCPSession_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub BeginSession: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pidevice: *mut ::core::ffi::c_void, pctx: *const u8, dwsizectx: u32) -> ::windows::core::HRESULT,
     pub EndSession: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pctx: *const u8, dwsizectx: u32) -> ::windows::core::HRESULT,
     pub GetSecureQuery: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppsecurequery: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -2824,7 +2824,7 @@ unsafe impl ::windows::core::Interface for IWMDMDevice {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMDMDevice_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszname: ::windows::core::PWSTR, nmaxchars: u32) -> ::windows::core::HRESULT,
     pub GetManufacturer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszname: ::windows::core::PWSTR, nmaxchars: u32) -> ::windows::core::HRESULT,
     pub GetVersion: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwversion: *mut u32) -> ::windows::core::HRESULT,
@@ -3223,7 +3223,7 @@ unsafe impl ::windows::core::Interface for IWMDMDeviceControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMDMDeviceControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetStatus: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwstatus: *mut u32) -> ::windows::core::HRESULT,
     pub GetCapabilities: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwcapabilitiesmask: *mut u32) -> ::windows::core::HRESULT,
     pub Play: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -3285,7 +3285,7 @@ unsafe impl ::windows::core::Interface for IWMDMDeviceSession {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMDMDeviceSession_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub BeginSession: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, r#type: WMDM_SESSION_TYPE, pctx: *const u8, dwsizectx: u32) -> ::windows::core::HRESULT,
     pub EndSession: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, r#type: WMDM_SESSION_TYPE, pctx: *const u8, dwsizectx: u32) -> ::windows::core::HRESULT,
 }
@@ -3346,7 +3346,7 @@ unsafe impl ::windows::core::Interface for IWMDMEnumDevice {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMDMEnumDevice_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, ppdevice: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -3409,7 +3409,7 @@ unsafe impl ::windows::core::Interface for IWMDMEnumStorage {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMDMEnumStorage_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, ppstorage: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -3504,7 +3504,7 @@ unsafe impl ::windows::core::Interface for IWMDMLogger {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMDMLogger_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub IsEnabled: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfenabled: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -3583,7 +3583,7 @@ unsafe impl ::windows::core::Interface for IWMDMMetaData {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMDMMetaData_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddItem: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, r#type: WMDM_TAG_DATATYPE, pwsztagname: ::windows::core::PCWSTR, pvalue: *const u8, ilength: u32) -> ::windows::core::HRESULT,
     pub QueryByName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwsztagname: ::windows::core::PCWSTR, ptype: *mut WMDM_TAG_DATATYPE, pvalue: *mut *mut u8, pcblength: *mut u32) -> ::windows::core::HRESULT,
     pub QueryByIndex: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, iindex: u32, ppwszname: *mut *mut u16, ptype: *mut WMDM_TAG_DATATYPE, ppvalue: *mut *mut u8, pcblength: *mut u32) -> ::windows::core::HRESULT,
@@ -3638,7 +3638,7 @@ unsafe impl ::windows::core::Interface for IWMDMNotification {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMDMNotification_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub WMDMMessage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwmessagetype: u32, pwszcanonicalname: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_DeviceManager\"`*"]
@@ -3710,7 +3710,7 @@ unsafe impl ::windows::core::Interface for IWMDMObjectInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMDMObjectInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetPlayLength: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwlength: *mut u32) -> ::windows::core::HRESULT,
     pub SetPlayLength: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwlength: u32) -> ::windows::core::HRESULT,
     pub GetPlayOffset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwoffset: *mut u32) -> ::windows::core::HRESULT,
@@ -3799,7 +3799,7 @@ unsafe impl ::windows::core::Interface for IWMDMOperation {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMDMOperation_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub BeginRead: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub BeginWrite: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetObjectName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszname: ::windows::core::PWSTR, nmaxchars: u32) -> ::windows::core::HRESULT,
@@ -4085,7 +4085,7 @@ unsafe impl ::windows::core::Interface for IWMDMProgress {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMDMProgress_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Begin: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwestimatedticks: u32) -> ::windows::core::HRESULT,
     pub Progress: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwtranspiredticks: u32) -> ::windows::core::HRESULT,
     pub End: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -4308,7 +4308,7 @@ unsafe impl ::windows::core::Interface for IWMDMRevoked {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMDMRevoked_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetRevocationURL: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppwszrevocationurl: *mut ::windows::core::PWSTR, pdwbufferlen: *mut u32, pdwrevokedbitflag: *mut u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_DeviceManager\"`*"]
@@ -4388,7 +4388,7 @@ unsafe impl ::windows::core::Interface for IWMDMStorage {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMDMStorage_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Media_Audio")]
     pub SetAttributes: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwattributes: u32, pformat: *const super::Audio::WAVEFORMATEX) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Media_Audio"))]
@@ -4943,7 +4943,7 @@ unsafe impl ::windows::core::Interface for IWMDMStorageControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMDMStorageControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Insert: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fumode: u32, pwszfile: ::windows::core::PCWSTR, poperation: *mut ::core::ffi::c_void, pprogress: *mut ::core::ffi::c_void, ppnewobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Delete: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fumode: u32, pprogress: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Rename: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fumode: u32, pwsznewname: ::windows::core::PCWSTR, pprogress: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -5261,7 +5261,7 @@ unsafe impl ::windows::core::Interface for IWMDMStorageGlobals {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMDMStorageGlobals_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCapabilities: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwcapabilities: *mut u32) -> ::windows::core::HRESULT,
     pub GetSerialNumber: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pserialnum: *mut WMDMID, abmac: *mut u8) -> ::windows::core::HRESULT,
     pub GetTotalSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwtotalsizelow: *mut u32, pdwtotalsizehigh: *mut u32) -> ::windows::core::HRESULT,
@@ -5325,7 +5325,7 @@ unsafe impl ::windows::core::Interface for IWMDeviceManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMDeviceManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetRevision: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwrevision: *mut u32) -> ::windows::core::HRESULT,
     pub GetDeviceCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwcount: *mut u32) -> ::windows::core::HRESULT,
     pub EnumDevices: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppenumdevice: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/Media/DirectShow/Xml/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/DirectShow/Xml/impl.rs
@@ -25,7 +25,7 @@ impl IXMLGraphBuilder_Vtbl {
             this.BuildFromXMLFile(::core::mem::transmute(&pgraph), ::core::mem::transmute(&wszfilename), ::core::mem::transmute(&wszbaseurl)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             BuildFromXML: BuildFromXML::<Identity, Impl, OFFSET>,
             SaveToXML: SaveToXML::<Identity, Impl, OFFSET>,
             BuildFromXMLFile: BuildFromXMLFile::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/Media/DirectShow/Xml/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/DirectShow/Xml/mod.rs
@@ -64,7 +64,7 @@ unsafe impl ::windows::core::Interface for IXMLGraphBuilder {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXMLGraphBuilder_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Data_Xml_MsXml", feature = "Win32_System_Com"))]
     pub BuildFromXML: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pgraph: *mut ::core::ffi::c_void, pxml: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Data_Xml_MsXml", feature = "Win32_System_Com")))]

--- a/crates/libs/windows/src/Windows/Win32/Media/DirectShow/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/DirectShow/impl.rs
@@ -94,7 +94,7 @@ impl IAMAnalogVideoDecoder_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AvailableTVFormats: AvailableTVFormats::<Identity, Impl, OFFSET>,
             SetTVFormat: SetTVFormat::<Identity, Impl, OFFSET>,
             TVFormat: TVFormat::<Identity, Impl, OFFSET>,
@@ -182,7 +182,7 @@ impl IAMAnalogVideoEncoder_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AvailableTVFormats: AvailableTVFormats::<Identity, Impl, OFFSET>,
             SetTVFormat: SetTVFormat::<Identity, Impl, OFFSET>,
             TVFormat: TVFormat::<Identity, Impl, OFFSET>,
@@ -223,7 +223,7 @@ impl IAMAsyncReaderTimestampScaling_Vtbl {
             this.SetTimestampMode(::core::mem::transmute_copy(&fraw)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTimestampMode: GetTimestampMode::<Identity, Impl, OFFSET>,
             SetTimestampMode: SetTimestampMode::<Identity, Impl, OFFSET>,
         }
@@ -391,7 +391,7 @@ impl IAMAudioInputMixer_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetEnable: SetEnable::<Identity, Impl, OFFSET>,
             Enable: Enable::<Identity, Impl, OFFSET>,
             SetMono: SetMono::<Identity, Impl, OFFSET>,
@@ -425,7 +425,7 @@ impl IAMAudioRendererStats_Vtbl {
             let this = (*this).get_impl();
             this.GetStatParam(::core::mem::transmute_copy(&dwparam), ::core::mem::transmute_copy(&pdwparam1), ::core::mem::transmute_copy(&pdwparam2)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetStatParam: GetStatParam::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetStatParam: GetStatParam::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IAMAudioRendererStats as ::windows::core::Interface>::IID
@@ -455,7 +455,7 @@ impl IAMBufferNegotiation_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SuggestAllocatorProperties: SuggestAllocatorProperties::<Identity, Impl, OFFSET>,
             GetAllocatorProperties: GetAllocatorProperties::<Identity, Impl, OFFSET>,
         }
@@ -488,7 +488,7 @@ impl IAMCameraControl_Vtbl {
             this.Get(::core::mem::transmute_copy(&property), ::core::mem::transmute_copy(&lvalue), ::core::mem::transmute_copy(&flags)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetRange: GetRange::<Identity, Impl, OFFSET>,
             Set: Set::<Identity, Impl, OFFSET>,
             Get: Get::<Identity, Impl, OFFSET>,
@@ -534,7 +534,7 @@ impl IAMCertifiedOutputProtection_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             KeyExchange: KeyExchange::<Identity, Impl, OFFSET>,
             SessionSequenceStart: SessionSequenceStart::<Identity, Impl, OFFSET>,
             ProtectionCommand: ProtectionCommand::<Identity, Impl, OFFSET>,
@@ -614,7 +614,7 @@ impl IAMClockAdjust_Vtbl {
             let this = (*this).get_impl();
             this.SetClockDelta(::core::mem::transmute_copy(&rtdelta)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SetClockDelta: SetClockDelta::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SetClockDelta: SetClockDelta::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IAMClockAdjust as ::windows::core::Interface>::IID
@@ -644,7 +644,7 @@ impl IAMClockSlave_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetErrorTolerance: SetErrorTolerance::<Identity, Impl, OFFSET>,
             GetErrorTolerance: GetErrorTolerance::<Identity, Impl, OFFSET>,
         }
@@ -719,7 +719,7 @@ impl IAMCopyCaptureFileProgress_Vtbl {
             let this = (*this).get_impl();
             this.Progress(::core::mem::transmute_copy(&iprogress)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Progress: Progress::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Progress: Progress::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IAMCopyCaptureFileProgress as ::windows::core::Interface>::IID
@@ -770,7 +770,7 @@ impl IAMCrossbar_Vtbl {
             this.get_CrossbarPinInfo(::core::mem::transmute_copy(&isinputpin), ::core::mem::transmute_copy(&pinindex), ::core::mem::transmute_copy(&pinindexrelated), ::core::mem::transmute_copy(&physicaltype)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             get_PinCounts: get_PinCounts::<Identity, Impl, OFFSET>,
             CanRoute: CanRoute::<Identity, Impl, OFFSET>,
             Route: Route::<Identity, Impl, OFFSET>,
@@ -799,7 +799,7 @@ impl IAMDecoderCaps_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetDecoderCaps: GetDecoderCaps::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetDecoderCaps: GetDecoderCaps::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IAMDecoderCaps as ::windows::core::Interface>::IID
@@ -841,7 +841,7 @@ impl IAMDevMemoryAllocator_Vtbl {
             this.GetDevMemoryObject(::core::mem::transmute_copy(&ppunkinnner), ::core::mem::transmute(&punkouter)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetInfo: GetInfo::<Identity, Impl, OFFSET>,
             CheckMemory: CheckMemory::<Identity, Impl, OFFSET>,
             Alloc: Alloc::<Identity, Impl, OFFSET>,
@@ -883,7 +883,7 @@ impl IAMDevMemoryControl_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             QueryWriteSync: QueryWriteSync::<Identity, Impl, OFFSET>,
             WriteSync: WriteSync::<Identity, Impl, OFFSET>,
             GetDevId: GetDevId::<Identity, Impl, OFFSET>,
@@ -917,7 +917,7 @@ impl IAMDeviceRemoval_Vtbl {
             this.Disassociate().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             DeviceInfo: DeviceInfo::<Identity, Impl, OFFSET>,
             Reassociate: Reassociate::<Identity, Impl, OFFSET>,
             Disassociate: Disassociate::<Identity, Impl, OFFSET>,
@@ -1002,7 +1002,7 @@ impl IAMDirectSound_Vtbl {
             this.GetFocusWindow(::core::mem::transmute_copy(&param0), ::core::mem::transmute_copy(&param1)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDirectSoundInterface: GetDirectSoundInterface::<Identity, Impl, OFFSET>,
             GetPrimaryBufferInterface: GetPrimaryBufferInterface::<Identity, Impl, OFFSET>,
             GetSecondaryBufferInterface: GetSecondaryBufferInterface::<Identity, Impl, OFFSET>,
@@ -1065,7 +1065,7 @@ impl IAMDroppedFrames_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetNumDropped: GetNumDropped::<Identity, Impl, OFFSET>,
             GetNumNotDropped: GetNumNotDropped::<Identity, Impl, OFFSET>,
             GetDroppedInfo: GetDroppedInfo::<Identity, Impl, OFFSET>,
@@ -1160,7 +1160,7 @@ impl IAMExtDevice_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCapability: GetCapability::<Identity, Impl, OFFSET>,
             ExternalDeviceID: ExternalDeviceID::<Identity, Impl, OFFSET>,
             ExternalDeviceVersion: ExternalDeviceVersion::<Identity, Impl, OFFSET>,
@@ -1415,7 +1415,7 @@ impl IAMExtTransport_Vtbl {
             this.SetEditStart(::core::mem::transmute_copy(&value)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCapability: GetCapability::<Identity, Impl, OFFSET>,
             SetMediaState: SetMediaState::<Identity, Impl, OFFSET>,
             MediaState: MediaState::<Identity, Impl, OFFSET>,
@@ -1563,7 +1563,7 @@ impl IAMFilterGraphCallback_Vtbl {
             let this = (*this).get_impl();
             this.UnableToRender(::core::mem::transmute(&ppin)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), UnableToRender: UnableToRender::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), UnableToRender: UnableToRender::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IAMFilterGraphCallback as ::windows::core::Interface>::IID
@@ -1580,7 +1580,7 @@ impl IAMFilterMiscFlags_Vtbl {
             let this = (*this).get_impl();
             this.GetMiscFlags()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetMiscFlags: GetMiscFlags::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetMiscFlags: GetMiscFlags::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IAMFilterMiscFlags as ::windows::core::Interface>::IID
@@ -1607,7 +1607,7 @@ impl IAMGraphBuilderCallback_Vtbl {
             this.CreatedFilter(::core::mem::transmute(&pfil)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SelectedFilter: SelectedFilter::<Identity, Impl, OFFSET>,
             CreatedFilter: CreatedFilter::<Identity, Impl, OFFSET>,
         }
@@ -1643,7 +1643,7 @@ impl IAMGraphStreams_Vtbl {
             this.SetMaxGraphLatency(::core::mem::transmute_copy(&rtmaxgraphlatency)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             FindUpstreamInterface: FindUpstreamInterface::<Identity, Impl, OFFSET>,
             SyncUsingStreamOffset: SyncUsingStreamOffset::<Identity, Impl, OFFSET>,
             SetMaxGraphLatency: SetMaxGraphLatency::<Identity, Impl, OFFSET>,
@@ -1670,7 +1670,7 @@ impl IAMLatency_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetLatency: GetLatency::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetLatency: GetLatency::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IAMLatency as ::windows::core::Interface>::IID
@@ -1763,7 +1763,7 @@ impl IAMLine21Decoder_Vtbl {
             this.SetDrawBackgroundMode(::core::mem::transmute_copy(&mode)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDecoderLevel: GetDecoderLevel::<Identity, Impl, OFFSET>,
             GetCurrentService: GetCurrentService::<Identity, Impl, OFFSET>,
             SetCurrentService: SetCurrentService::<Identity, Impl, OFFSET>,
@@ -2633,7 +2633,7 @@ impl IAMOpenProgress_Vtbl {
             this.AbortOperation().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             QueryProgress: QueryProgress::<Identity, Impl, OFFSET>,
             AbortOperation: AbortOperation::<Identity, Impl, OFFSET>,
         }
@@ -2678,7 +2678,7 @@ impl IAMOverlayFX_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             QueryOverlayFXCaps: QueryOverlayFXCaps::<Identity, Impl, OFFSET>,
             SetOverlayFX: SetOverlayFX::<Identity, Impl, OFFSET>,
             GetOverlayFX: GetOverlayFX::<Identity, Impl, OFFSET>,
@@ -2718,7 +2718,7 @@ impl IAMParse_Vtbl {
             this.Flush().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetParseTime: GetParseTime::<Identity, Impl, OFFSET>,
             SetParseTime: SetParseTime::<Identity, Impl, OFFSET>,
             Flush: Flush::<Identity, Impl, OFFSET>,
@@ -2739,7 +2739,7 @@ impl IAMPhysicalPinInfo_Vtbl {
             let this = (*this).get_impl();
             this.GetPhysicalType(::core::mem::transmute_copy(&ptype), ::core::mem::transmute_copy(&ppsztype)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetPhysicalType: GetPhysicalType::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetPhysicalType: GetPhysicalType::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IAMPhysicalPinInfo as ::windows::core::Interface>::IID
@@ -2799,7 +2799,7 @@ impl IAMPlayList_Vtbl {
             this.GetRepeatInfo(::core::mem::transmute_copy(&pdwrepeatcount), ::core::mem::transmute_copy(&pdwrepeatstart), ::core::mem::transmute_copy(&pdwrepeatend)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetFlags: GetFlags::<Identity, Impl, OFFSET>,
             GetItemCount: GetItemCount::<Identity, Impl, OFFSET>,
             GetItem: GetItem::<Identity, Impl, OFFSET>,
@@ -2949,7 +2949,7 @@ impl IAMPlayListItem_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetFlags: GetFlags::<Identity, Impl, OFFSET>,
             GetSourceCount: GetSourceCount::<Identity, Impl, OFFSET>,
             GetSourceURL: GetSourceURL::<Identity, Impl, OFFSET>,
@@ -3030,7 +3030,7 @@ impl IAMPluginControl_Vtbl {
             this.IsLegacyDisabled(::core::mem::transmute(&dllname)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetPreferredClsid: GetPreferredClsid::<Identity, Impl, OFFSET>,
             GetPreferredClsidByIndex: GetPreferredClsidByIndex::<Identity, Impl, OFFSET>,
             SetPreferredClsid: SetPreferredClsid::<Identity, Impl, OFFSET>,
@@ -3128,7 +3128,7 @@ impl IAMRebuild_Vtbl {
             let this = (*this).get_impl();
             this.RebuildNow().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), RebuildNow: RebuildNow::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), RebuildNow: RebuildNow::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IAMRebuild as ::windows::core::Interface>::IID
@@ -3145,7 +3145,7 @@ impl IAMResourceControl_Vtbl {
             let this = (*this).get_impl();
             this.Reserve(::core::mem::transmute_copy(&dwflags), ::core::mem::transmute_copy(&pvreserved)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Reserve: Reserve::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Reserve: Reserve::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IAMResourceControl as ::windows::core::Interface>::IID
@@ -3260,7 +3260,7 @@ impl IAMStreamConfig_Vtbl {
             this.GetStreamCaps(::core::mem::transmute_copy(&iindex), ::core::mem::transmute_copy(&ppmt), ::core::mem::transmute_copy(&pscc)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetFormat: SetFormat::<Identity, Impl, OFFSET>,
             GetFormat: GetFormat::<Identity, Impl, OFFSET>,
             GetNumberOfCapabilities: GetNumberOfCapabilities::<Identity, Impl, OFFSET>,
@@ -3304,7 +3304,7 @@ impl IAMStreamControl_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             StartAt: StartAt::<Identity, Impl, OFFSET>,
             StopAt: StopAt::<Identity, Impl, OFFSET>,
             GetInfo: GetInfo::<Identity, Impl, OFFSET>,
@@ -3347,7 +3347,7 @@ impl IAMStreamSelect_Vtbl {
             this.Enable(::core::mem::transmute_copy(&lindex), ::core::mem::transmute_copy(&dwflags)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Count: Count::<Identity, Impl, OFFSET>,
             Info: Info::<Identity, Impl, OFFSET>,
             Enable: Enable::<Identity, Impl, OFFSET>,
@@ -3417,7 +3417,7 @@ impl IAMTVAudio_Vtbl {
             this.UnRegisterNotificationCallBack(::core::mem::transmute(&pnotify)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetHardwareSupportedTVAudioModes: GetHardwareSupportedTVAudioModes::<Identity, Impl, OFFSET>,
             GetAvailableTVAudioModes: GetAvailableTVAudioModes::<Identity, Impl, OFFSET>,
             TVAudioMode: TVAudioMode::<Identity, Impl, OFFSET>,
@@ -3441,7 +3441,7 @@ impl IAMTVAudioNotification_Vtbl {
             let this = (*this).get_impl();
             this.OnEvent(::core::mem::transmute_copy(&event)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnEvent: OnEvent::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnEvent: OnEvent::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IAMTVAudioNotification as ::windows::core::Interface>::IID
@@ -3630,7 +3630,7 @@ impl IAMTimecodeDisplay_Vtbl {
             this.SetTCDisplay(::core::mem::transmute_copy(&param), ::core::mem::transmute_copy(&value)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTCDisplayEnable: GetTCDisplayEnable::<Identity, Impl, OFFSET>,
             SetTCDisplayEnable: SetTCDisplayEnable::<Identity, Impl, OFFSET>,
             GetTCDisplay: GetTCDisplay::<Identity, Impl, OFFSET>,
@@ -3701,7 +3701,7 @@ impl IAMTimecodeGenerator_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTCGMode: GetTCGMode::<Identity, Impl, OFFSET>,
             SetTCGMode: SetTCGMode::<Identity, Impl, OFFSET>,
             SetVITCLine: SetVITCLine::<Identity, Impl, OFFSET>,
@@ -3768,7 +3768,7 @@ impl IAMTimecodeReader_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTCRMode: GetTCRMode::<Identity, Impl, OFFSET>,
             SetTCRMode: SetTCRMode::<Identity, Impl, OFFSET>,
             SetVITCLine: SetVITCLine::<Identity, Impl, OFFSET>,
@@ -3909,7 +3909,7 @@ impl IAMTuner_Vtbl {
             this.UnRegisterNotificationCallBack(::core::mem::transmute(&pnotify)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             put_Channel: put_Channel::<Identity, Impl, OFFSET>,
             get_Channel: get_Channel::<Identity, Impl, OFFSET>,
             ChannelMinMax: ChannelMinMax::<Identity, Impl, OFFSET>,
@@ -3942,7 +3942,7 @@ impl IAMTunerNotification_Vtbl {
             let this = (*this).get_impl();
             this.OnEvent(::core::mem::transmute_copy(&event)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnEvent: OnEvent::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnEvent: OnEvent::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IAMTunerNotification as ::windows::core::Interface>::IID
@@ -3975,7 +3975,7 @@ impl IAMVfwCaptureDialogs_Vtbl {
             this.SendDriverMessage(::core::mem::transmute_copy(&idialog), ::core::mem::transmute_copy(&umsg), ::core::mem::transmute_copy(&dw1), ::core::mem::transmute_copy(&dw2)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             HasDialog: HasDialog::<Identity, Impl, OFFSET>,
             ShowDialog: ShowDialog::<Identity, Impl, OFFSET>,
             SendDriverMessage: SendDriverMessage::<Identity, Impl, OFFSET>,
@@ -4018,7 +4018,7 @@ impl IAMVfwCompressDialogs_Vtbl {
             this.SendDriverMessage(::core::mem::transmute_copy(&umsg), ::core::mem::transmute_copy(&dw1), ::core::mem::transmute_copy(&dw2)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ShowDialog: ShowDialog::<Identity, Impl, OFFSET>,
             GetState: GetState::<Identity, Impl, OFFSET>,
             SetState: SetState::<Identity, Impl, OFFSET>,
@@ -4110,7 +4110,7 @@ impl IAMVideoAccelerator_Vtbl {
             this.DisplayFrame(::core::mem::transmute_copy(&dwfliptoindex), ::core::mem::transmute(&pmediasample)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetVideoAcceleratorGUIDs: GetVideoAcceleratorGUIDs::<Identity, Impl, OFFSET>,
             GetUncompFormatsSupported: GetUncompFormatsSupported::<Identity, Impl, OFFSET>,
             GetInternalMemInfo: GetInternalMemInfo::<Identity, Impl, OFFSET>,
@@ -4156,7 +4156,7 @@ impl IAMVideoAcceleratorNotify_Vtbl {
             this.GetCreateVideoAcceleratorData(::core::mem::transmute_copy(&pguid), ::core::mem::transmute_copy(&pdwsizemiscdata), ::core::mem::transmute_copy(&ppmiscdata)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetUncompSurfacesInfo: GetUncompSurfacesInfo::<Identity, Impl, OFFSET>,
             SetUncompSurfacesInfo: SetUncompSurfacesInfo::<Identity, Impl, OFFSET>,
             GetCreateVideoAcceleratorData: GetCreateVideoAcceleratorData::<Identity, Impl, OFFSET>,
@@ -4262,7 +4262,7 @@ impl IAMVideoCompression_Vtbl {
             this.OverrideFrameSize(::core::mem::transmute_copy(&framenumber), ::core::mem::transmute_copy(&size)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetKeyFrameRate: SetKeyFrameRate::<Identity, Impl, OFFSET>,
             KeyFrameRate: KeyFrameRate::<Identity, Impl, OFFSET>,
             SetPFramesPerKeyFrame: SetPFramesPerKeyFrame::<Identity, Impl, OFFSET>,
@@ -4349,7 +4349,7 @@ impl IAMVideoControl_Vtbl {
             this.GetFrameRateList(::core::mem::transmute(&ppin), ::core::mem::transmute_copy(&iindex), ::core::mem::transmute(&dimensions), ::core::mem::transmute_copy(&listsize), ::core::mem::transmute_copy(&framerates)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCaps: GetCaps::<Identity, Impl, OFFSET>,
             SetMode: SetMode::<Identity, Impl, OFFSET>,
             GetMode: GetMode::<Identity, Impl, OFFSET>,
@@ -4386,7 +4386,7 @@ impl IAMVideoDecimationProperties_Vtbl {
             this.SetDecimationUsage(::core::mem::transmute_copy(&usage)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             QueryDecimationUsage: QueryDecimationUsage::<Identity, Impl, OFFSET>,
             SetDecimationUsage: SetDecimationUsage::<Identity, Impl, OFFSET>,
         }
@@ -4419,7 +4419,7 @@ impl IAMVideoProcAmp_Vtbl {
             this.Get(::core::mem::transmute_copy(&property), ::core::mem::transmute_copy(&lvalue), ::core::mem::transmute_copy(&flags)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetRange: GetRange::<Identity, Impl, OFFSET>,
             Set: Set::<Identity, Impl, OFFSET>,
             Get: Get::<Identity, Impl, OFFSET>,
@@ -4440,7 +4440,7 @@ impl IAMWMBufferPass_Vtbl {
             let this = (*this).get_impl();
             this.SetNotify(::core::mem::transmute(&pcallback)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SetNotify: SetNotify::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SetNotify: SetNotify::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IAMWMBufferPass as ::windows::core::Interface>::IID
@@ -4460,7 +4460,7 @@ impl IAMWMBufferPassCallback_Vtbl {
             let this = (*this).get_impl();
             this.Notify(::core::mem::transmute(&pnssbuffer3), ::core::mem::transmute(&ppin), ::core::mem::transmute_copy(&prtstart), ::core::mem::transmute_copy(&prtend)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Notify: Notify::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Notify: Notify::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IAMWMBufferPassCallback as ::windows::core::Interface>::IID
@@ -4583,7 +4583,7 @@ impl IAMWstDecoder_Vtbl {
             this.SetCurrentPage(::core::mem::transmute(&wstpage)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDecoderLevel: GetDecoderLevel::<Identity, Impl, OFFSET>,
             GetCurrentService: GetCurrentService::<Identity, Impl, OFFSET>,
             GetServiceState: GetServiceState::<Identity, Impl, OFFSET>,
@@ -4626,7 +4626,7 @@ impl IAMovieSetup_Vtbl {
             this.Unregister().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Register: Register::<Identity, Impl, OFFSET>,
             Unregister: Unregister::<Identity, Impl, OFFSET>,
         }
@@ -5039,7 +5039,7 @@ impl IATSC_EIT_Vtbl {
             this.GetRecordDescriptorByTag(::core::mem::transmute_copy(&dwrecordindex), ::core::mem::transmute_copy(&btag), ::core::mem::transmute_copy(&pdwcookie), ::core::mem::transmute_copy(&ppdescriptor)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             GetVersionNumber: GetVersionNumber::<Identity, Impl, OFFSET>,
             GetSourceId: GetSourceId::<Identity, Impl, OFFSET>,
@@ -5113,7 +5113,7 @@ impl IATSC_ETT_Vtbl {
             this.GetExtendedMessageText(::core::mem::transmute_copy(&pdwlength), ::core::mem::transmute_copy(&pptext)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             GetVersionNumber: GetVersionNumber::<Identity, Impl, OFFSET>,
             GetProtocolVersion: GetProtocolVersion::<Identity, Impl, OFFSET>,
@@ -5263,7 +5263,7 @@ impl IATSC_MGT_Vtbl {
             this.GetTableDescriptorByTag(::core::mem::transmute_copy(&btag), ::core::mem::transmute_copy(&pdwcookie), ::core::mem::transmute_copy(&ppdescriptor)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             GetVersionNumber: GetVersionNumber::<Identity, Impl, OFFSET>,
             GetProtocolVersion: GetProtocolVersion::<Identity, Impl, OFFSET>,
@@ -5373,7 +5373,7 @@ impl IATSC_STT_Vtbl {
             this.GetTableDescriptorByTag(::core::mem::transmute_copy(&btag), ::core::mem::transmute_copy(&pdwcookie), ::core::mem::transmute_copy(&ppdescriptor)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             GetProtocolVersion: GetProtocolVersion::<Identity, Impl, OFFSET>,
             GetSystemTime: GetSystemTime::<Identity, Impl, OFFSET>,
@@ -5685,7 +5685,7 @@ impl IATSC_VCT_Vtbl {
             this.GetTableDescriptorByTag(::core::mem::transmute_copy(&btag), ::core::mem::transmute_copy(&pdwcookie), ::core::mem::transmute_copy(&ppdescriptor)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             GetVersionNumber: GetVersionNumber::<Identity, Impl, OFFSET>,
             GetTransportStreamId: GetTransportStreamId::<Identity, Impl, OFFSET>,
@@ -6058,7 +6058,7 @@ impl IAsyncReader_Vtbl {
             this.EndFlush().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RequestAllocator: RequestAllocator::<Identity, Impl, OFFSET>,
             Request: Request::<Identity, Impl, OFFSET>,
             WaitForNext: WaitForNext::<Identity, Impl, OFFSET>,
@@ -6169,7 +6169,7 @@ impl IAtscContentAdvisoryDescriptor_Vtbl {
             this.GetRecordRatingDescriptionText(::core::mem::transmute_copy(&bindex), ::core::mem::transmute_copy(&pblength), ::core::mem::transmute_copy(&pptext)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTag: GetTag::<Identity, Impl, OFFSET>,
             GetLength: GetLength::<Identity, Impl, OFFSET>,
             GetRatingRegionCount: GetRatingRegionCount::<Identity, Impl, OFFSET>,
@@ -6319,7 +6319,7 @@ impl IAtscPsipParser_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             GetPAT: GetPAT::<Identity, Impl, OFFSET>,
             GetCAT: GetCAT::<Identity, Impl, OFFSET>,
@@ -6367,7 +6367,7 @@ impl IAttributeGet_Vtbl {
             this.GetAttrib(::core::mem::transmute(&guidattribute), ::core::mem::transmute_copy(&pbattribute), ::core::mem::transmute_copy(&pdwattributelength)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCount: GetCount::<Identity, Impl, OFFSET>,
             GetAttribIndexed: GetAttribIndexed::<Identity, Impl, OFFSET>,
             GetAttrib: GetAttrib::<Identity, Impl, OFFSET>,
@@ -6388,7 +6388,7 @@ impl IAttributeSet_Vtbl {
             let this = (*this).get_impl();
             this.SetAttrib(::core::mem::transmute(&guidattribute), ::core::mem::transmute_copy(&pbattribute), ::core::mem::transmute_copy(&dwattributelength)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SetAttrib: SetAttrib::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SetAttrib: SetAttrib::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IAttributeSet as ::windows::core::Interface>::IID
@@ -6635,7 +6635,7 @@ impl IBDAComparable_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CompareExact: CompareExact::<Identity, Impl, OFFSET>,
             CompareEquivalent: CompareEquivalent::<Identity, Impl, OFFSET>,
             HashExact: HashExact::<Identity, Impl, OFFSET>,
@@ -6668,7 +6668,7 @@ impl IBDACreateTuneRequestEx_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CreateTuneRequestEx: CreateTuneRequestEx::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CreateTuneRequestEx: CreateTuneRequestEx::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IBDACreateTuneRequestEx as ::windows::core::Interface>::IID
@@ -6698,7 +6698,7 @@ impl IBDA_AUX_Vtbl {
             this.EnumCapability(::core::mem::transmute_copy(&dwindex), ::core::mem::transmute_copy(&dwinputid), ::core::mem::transmute_copy(&pconnectortype), ::core::mem::transmute_copy(&conntypenum), ::core::mem::transmute_copy(&numvideostds), ::core::mem::transmute_copy(&analogstds)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             QueryCapabilities: QueryCapabilities::<Identity, Impl, OFFSET>,
             EnumCapability: EnumCapability::<Identity, Impl, OFFSET>,
         }
@@ -6718,7 +6718,7 @@ impl IBDA_AutoDemodulate_Vtbl {
             let this = (*this).get_impl();
             this.put_AutoDemodulate().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), put_AutoDemodulate: put_AutoDemodulate::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), put_AutoDemodulate: put_AutoDemodulate::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IBDA_AutoDemodulate as ::windows::core::Interface>::IID
@@ -6836,7 +6836,7 @@ impl IBDA_ConditionalAccess_Vtbl {
             this.InformUIClosed(::core::mem::transmute_copy(&bydialognumber), ::core::mem::transmute_copy(&closereason)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             get_SmartCardStatus: get_SmartCardStatus::<Identity, Impl, OFFSET>,
             get_SmartCardInfo: get_SmartCardInfo::<Identity, Impl, OFFSET>,
             get_SmartCardApplications: get_SmartCardApplications::<Identity, Impl, OFFSET>,
@@ -6907,7 +6907,7 @@ impl IBDA_ConditionalAccessEx_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CheckEntitlementToken: CheckEntitlementToken::<Identity, Impl, OFFSET>,
             SetCaptureToken: SetCaptureToken::<Identity, Impl, OFFSET>,
             OpenBroadcastMmi: OpenBroadcastMmi::<Identity, Impl, OFFSET>,
@@ -6943,7 +6943,7 @@ impl IBDA_DRIDRMService_Vtbl {
             this.GetPairingStatus(::core::mem::transmute_copy(&penumpairingstatus)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetDRM: SetDRM::<Identity, Impl, OFFSET>,
             GetDRMStatus: GetDRMStatus::<Identity, Impl, OFFSET>,
             GetPairingStatus: GetPairingStatus::<Identity, Impl, OFFSET>,
@@ -7001,7 +7001,7 @@ impl IBDA_DRIWMDRMSession_Vtbl {
             this.GetLastCardeaError(::core::mem::transmute_copy(&pdwerror)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AcknowledgeLicense: AcknowledgeLicense::<Identity, Impl, OFFSET>,
             ProcessLicenseChallenge: ProcessLicenseChallenge::<Identity, Impl, OFFSET>,
             ProcessRegistrationChallenge: ProcessRegistrationChallenge::<Identity, Impl, OFFSET>,
@@ -7036,7 +7036,7 @@ impl IBDA_DRM_Vtbl {
             this.PerformDRMPairing(::core::mem::transmute_copy(&fsync)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDRMPairingStatus: GetDRMPairingStatus::<Identity, Impl, OFFSET>,
             PerformDRMPairing: PerformDRMPairing::<Identity, Impl, OFFSET>,
         }
@@ -7063,7 +7063,7 @@ impl IBDA_DRMService_Vtbl {
             this.GetDRMStatus(::core::mem::transmute_copy(&pbstrdrmuuidlist), ::core::mem::transmute_copy(&drmuuid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetDRM: SetDRM::<Identity, Impl, OFFSET>,
             GetDRMStatus: GetDRMStatus::<Identity, Impl, OFFSET>,
         }
@@ -7102,7 +7102,7 @@ impl IBDA_DeviceControl_Vtbl {
             this.GetChangeState(::core::mem::transmute_copy(&pstate)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             StartChanges: StartChanges::<Identity, Impl, OFFSET>,
             CheckChanges: CheckChanges::<Identity, Impl, OFFSET>,
             CommitChanges: CommitChanges::<Identity, Impl, OFFSET>,
@@ -7216,7 +7216,7 @@ impl IBDA_DigitalDemodulator_Vtbl {
             this.SpectralInversion(::core::mem::transmute_copy(&pspectralinversion)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetModulationType: SetModulationType::<Identity, Impl, OFFSET>,
             ModulationType: ModulationType::<Identity, Impl, OFFSET>,
             SetInnerFECMethod: SetInnerFECMethod::<Identity, Impl, OFFSET>,
@@ -7392,7 +7392,7 @@ impl IBDA_DiseqCommand_Vtbl {
             this.get_DiseqResponse(::core::mem::transmute_copy(&ulrequestid), ::core::mem::transmute_copy(&pulcbresponselen), ::core::mem::transmute_copy(&pbresponse)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetEnableDiseqCommands: SetEnableDiseqCommands::<Identity, Impl, OFFSET>,
             SetDiseqLNBSource: SetDiseqLNBSource::<Identity, Impl, OFFSET>,
             SetDiseqUseToneBurst: SetDiseqUseToneBurst::<Identity, Impl, OFFSET>,
@@ -7416,7 +7416,7 @@ impl IBDA_EasMessage_Vtbl {
             let this = (*this).get_impl();
             this.get_EasMessage(::core::mem::transmute_copy(&uleventid), ::core::mem::transmute_copy(&ppeasobject)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), get_EasMessage: get_EasMessage::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), get_EasMessage: get_EasMessage::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IBDA_EasMessage as ::windows::core::Interface>::IID
@@ -7482,7 +7482,7 @@ impl IBDA_Encoder_Vtbl {
             .into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             QueryCapabilities: QueryCapabilities::<Identity, Impl, OFFSET>,
             EnumAudioCapability: EnumAudioCapability::<Identity, Impl, OFFSET>,
             EnumVideoCapability: EnumVideoCapability::<Identity, Impl, OFFSET>,
@@ -7536,7 +7536,7 @@ impl IBDA_EthernetFilter_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetMulticastListSize: GetMulticastListSize::<Identity, Impl, OFFSET>,
             PutMulticastList: PutMulticastList::<Identity, Impl, OFFSET>,
             GetMulticastList: GetMulticastList::<Identity, Impl, OFFSET>,
@@ -7559,7 +7559,7 @@ impl IBDA_EventingService_Vtbl {
             let this = (*this).get_impl();
             this.CompleteEvent(::core::mem::transmute_copy(&uleventid), ::core::mem::transmute_copy(&uleventresult)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CompleteEvent: CompleteEvent::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CompleteEvent: CompleteEvent::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IBDA_EventingService as ::windows::core::Interface>::IID
@@ -7628,7 +7628,7 @@ impl IBDA_FDC_Vtbl {
             this.GetTableSection(::core::mem::transmute_copy(&pid), ::core::mem::transmute_copy(&maxbuffersize), ::core::mem::transmute_copy(&actualsize), ::core::mem::transmute_copy(&secbuffer)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetStatus: GetStatus::<Identity, Impl, OFFSET>,
             RequestTables: RequestTables::<Identity, Impl, OFFSET>,
             AddPid: AddPid::<Identity, Impl, OFFSET>,
@@ -7720,7 +7720,7 @@ impl IBDA_FrequencyFilter_Vtbl {
             this.FrequencyMultiplier(::core::mem::transmute_copy(&pulmultiplier)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetAutotune: SetAutotune::<Identity, Impl, OFFSET>,
             Autotune: Autotune::<Identity, Impl, OFFSET>,
             SetFrequency: SetFrequency::<Identity, Impl, OFFSET>,
@@ -7799,7 +7799,7 @@ impl IBDA_GuideDataDeliveryService_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetGuideDataType: GetGuideDataType::<Identity, Impl, OFFSET>,
             GetGuideData: GetGuideData::<Identity, Impl, OFFSET>,
             RequestGuideDataUpdate: RequestGuideDataUpdate::<Identity, Impl, OFFSET>,
@@ -7830,7 +7830,7 @@ impl IBDA_IPSinkControl_Vtbl {
             this.GetAdapterIPAddress(::core::mem::transmute_copy(&pulcbsize), ::core::mem::transmute_copy(&pbbuffer)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetMulticastList: GetMulticastList::<Identity, Impl, OFFSET>,
             GetAdapterIPAddress: GetAdapterIPAddress::<Identity, Impl, OFFSET>,
         }
@@ -7875,7 +7875,7 @@ impl IBDA_IPSinkInfo_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             get_MulticastList: get_MulticastList::<Identity, Impl, OFFSET>,
             AdapterIPAddress: AdapterIPAddress::<Identity, Impl, OFFSET>,
             AdapterDescription: AdapterDescription::<Identity, Impl, OFFSET>,
@@ -7927,7 +7927,7 @@ impl IBDA_IPV4Filter_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetMulticastListSize: GetMulticastListSize::<Identity, Impl, OFFSET>,
             PutMulticastList: PutMulticastList::<Identity, Impl, OFFSET>,
             GetMulticastList: GetMulticastList::<Identity, Impl, OFFSET>,
@@ -7981,7 +7981,7 @@ impl IBDA_IPV6Filter_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetMulticastListSize: GetMulticastListSize::<Identity, Impl, OFFSET>,
             PutMulticastList: PutMulticastList::<Identity, Impl, OFFSET>,
             GetMulticastList: GetMulticastList::<Identity, Impl, OFFSET>,
@@ -8004,7 +8004,7 @@ impl IBDA_ISDBConditionalAccess_Vtbl {
             let this = (*this).get_impl();
             this.SetIsdbCasRequest(::core::mem::transmute_copy(&ulrequestid), ::core::mem::transmute_copy(&ulcbrequestbufferlen), ::core::mem::transmute_copy(&pbrequestbuffer)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SetIsdbCasRequest: SetIsdbCasRequest::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SetIsdbCasRequest: SetIsdbCasRequest::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IBDA_ISDBConditionalAccess as ::windows::core::Interface>::IID
@@ -8052,7 +8052,7 @@ impl IBDA_LNBInfo_Vtbl {
             this.HighLowSwitchFrequency(::core::mem::transmute_copy(&pulswitchfrequency)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetLocalOscilatorFrequencyLowBand: SetLocalOscilatorFrequencyLowBand::<Identity, Impl, OFFSET>,
             LocalOscilatorFrequencyLowBand: LocalOscilatorFrequencyLowBand::<Identity, Impl, OFFSET>,
             SetLocalOscilatorFrequencyHighBand: SetLocalOscilatorFrequencyHighBand::<Identity, Impl, OFFSET>,
@@ -8083,7 +8083,7 @@ impl IBDA_MUX_Vtbl {
             this.GetPidList(::core::mem::transmute_copy(&pulpidlistcount), ::core::mem::transmute_copy(&pbpidlistbuffer)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetPidList: SetPidList::<Identity, Impl, OFFSET>,
             GetPidList: GetPidList::<Identity, Impl, OFFSET>,
         }
@@ -8128,7 +8128,7 @@ impl IBDA_NameValueService_Vtbl {
             this.SetValue(::core::mem::transmute_copy(&uldialogrequest), ::core::mem::transmute(&bstrlanguage), ::core::mem::transmute(&bstrname), ::core::mem::transmute(&bstrvalue), ::core::mem::transmute_copy(&ulreserved)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetValueNameByIndex: GetValueNameByIndex::<Identity, Impl, OFFSET>,
             GetValue: GetValue::<Identity, Impl, OFFSET>,
             SetValue: SetValue::<Identity, Impl, OFFSET>,
@@ -8186,7 +8186,7 @@ impl IBDA_NetworkProvider_Vtbl {
             this.UnRegisterDeviceFilter(::core::mem::transmute_copy(&pvregistrationcontext)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             PutSignalSource: PutSignalSource::<Identity, Impl, OFFSET>,
             GetSignalSource: GetSignalSource::<Identity, Impl, OFFSET>,
             GetNetworkType: GetNetworkType::<Identity, Impl, OFFSET>,
@@ -8217,7 +8217,7 @@ impl IBDA_NullTransform_Vtbl {
             let this = (*this).get_impl();
             this.Stop().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Start: Start::<Identity, Impl, OFFSET>, Stop: Stop::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Start: Start::<Identity, Impl, OFFSET>, Stop: Stop::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IBDA_NullTransform as ::windows::core::Interface>::IID
@@ -8247,7 +8247,7 @@ impl IBDA_PinControl_Vtbl {
             this.RegistrationContext(::core::mem::transmute_copy(&pulregistrationctx)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetPinID: GetPinID::<Identity, Impl, OFFSET>,
             GetPinType: GetPinType::<Identity, Impl, OFFSET>,
             RegistrationContext: RegistrationContext::<Identity, Impl, OFFSET>,
@@ -8299,7 +8299,7 @@ impl IBDA_SignalProperties_Vtbl {
             this.GetTuningSpace(::core::mem::transmute_copy(&pguidtuingspace)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             PutNetworkType: PutNetworkType::<Identity, Impl, OFFSET>,
             GetNetworkType: GetNetworkType::<Identity, Impl, OFFSET>,
             PutSignalSource: PutSignalSource::<Identity, Impl, OFFSET>,
@@ -8381,7 +8381,7 @@ impl IBDA_SignalStatistics_Vtbl {
             this.SampleTime(::core::mem::transmute_copy(&plmssampletime)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetSignalStrength: SetSignalStrength::<Identity, Impl, OFFSET>,
             SignalStrength: SignalStrength::<Identity, Impl, OFFSET>,
             SetSignalQuality: SetSignalQuality::<Identity, Impl, OFFSET>,
@@ -8416,7 +8416,7 @@ impl IBDA_TIF_REGISTRATION_Vtbl {
             this.UnregisterTIF(::core::mem::transmute_copy(&pvregistrationcontext)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RegisterTIFEx: RegisterTIFEx::<Identity, Impl, OFFSET>,
             UnregisterTIF: UnregisterTIF::<Identity, Impl, OFFSET>,
         }
@@ -8500,7 +8500,7 @@ impl IBDA_Topology_Vtbl {
             this.GetControlNode(::core::mem::transmute_copy(&ulinputpinid), ::core::mem::transmute_copy(&uloutputpinid), ::core::mem::transmute_copy(&ulnodetype), ::core::mem::transmute_copy(&ppcontrolnode)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetNodeTypes: GetNodeTypes::<Identity, Impl, OFFSET>,
             GetNodeDescriptors: GetNodeDescriptors::<Identity, Impl, OFFSET>,
             GetNodeInterfaces: GetNodeInterfaces::<Identity, Impl, OFFSET>,
@@ -8535,7 +8535,7 @@ impl IBDA_TransportStreamInfo_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), PatTableTickCount: PatTableTickCount::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), PatTableTickCount: PatTableTickCount::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IBDA_TransportStreamInfo as ::windows::core::Interface>::IID
@@ -8559,7 +8559,7 @@ impl IBDA_TransportStreamSelector_Vtbl {
             this.GetTSInformation(::core::mem::transmute_copy(&pultsinformationbufferlen), ::core::mem::transmute_copy(&pbtsinformationbuffer)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetTSID: SetTSID::<Identity, Impl, OFFSET>,
             GetTSInformation: GetTSInformation::<Identity, Impl, OFFSET>,
         }
@@ -8598,7 +8598,7 @@ impl IBDA_UserActivityService_Vtbl {
             this.UserActivityDetected().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetCurrentTunerUseReason: SetCurrentTunerUseReason::<Identity, Impl, OFFSET>,
             GetUserActivityInterval: GetUserActivityInterval::<Identity, Impl, OFFSET>,
             UserActivityDetected: UserActivityDetected::<Identity, Impl, OFFSET>,
@@ -8625,7 +8625,7 @@ impl IBDA_VoidTransform_Vtbl {
             let this = (*this).get_impl();
             this.Stop().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Start: Start::<Identity, Impl, OFFSET>, Stop: Stop::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Start: Start::<Identity, Impl, OFFSET>, Stop: Stop::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IBDA_VoidTransform as ::windows::core::Interface>::IID
@@ -8685,7 +8685,7 @@ impl IBDA_WMDRMSession_Vtbl {
             this.GetKeyInfo(::core::mem::transmute_copy(&pulkeyinfolen), ::core::mem::transmute_copy(&pbkeyinfo)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetStatus: GetStatus::<Identity, Impl, OFFSET>,
             SetRevInfo: SetRevInfo::<Identity, Impl, OFFSET>,
             SetCrl: SetCrl::<Identity, Impl, OFFSET>,
@@ -8748,7 +8748,7 @@ impl IBDA_WMDRMTuner_Vtbl {
             this.GetStartCodeProfile(::core::mem::transmute_copy(&pulstartcodeprofilelen), ::core::mem::transmute_copy(&pbstartcodeprofile)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             PurchaseEntitlement: PurchaseEntitlement::<Identity, Impl, OFFSET>,
             CancelCaptureToken: CancelCaptureToken::<Identity, Impl, OFFSET>,
             SetPidProtection: SetPidProtection::<Identity, Impl, OFFSET>,
@@ -8945,7 +8945,7 @@ impl IBaseVideoMixer_Vtbl {
             this.SetClockPeriod(::core::mem::transmute_copy(&bvalue)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetLeadPin: SetLeadPin::<Identity, Impl, OFFSET>,
             GetLeadPin: GetLeadPin::<Identity, Impl, OFFSET>,
             GetInputPinCount: GetInputPinCount::<Identity, Impl, OFFSET>,
@@ -9364,7 +9364,7 @@ impl IBroadcastEvent_Vtbl {
             let this = (*this).get_impl();
             this.Fire(::core::mem::transmute(&eventid)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Fire: Fire::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Fire: Fire::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IBroadcastEvent as ::windows::core::Interface>::IID
@@ -9405,7 +9405,7 @@ impl IBufferingTime_Vtbl {
             this.SetBufferingTime(::core::mem::transmute_copy(&dwmilliseconds)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetBufferingTime: GetBufferingTime::<Identity, Impl, OFFSET>,
             SetBufferingTime: SetBufferingTime::<Identity, Impl, OFFSET>,
         }
@@ -9501,7 +9501,7 @@ impl ICAT_Vtbl {
             this.ConvertNextToCurrent().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             GetVersionNumber: GetVersionNumber::<Identity, Impl, OFFSET>,
             GetCountOfTableDescriptors: GetCountOfTableDescriptors::<Identity, Impl, OFFSET>,
@@ -9541,7 +9541,7 @@ impl ICCSubStreamFiltering_Vtbl {
             this.SetSubstreamTypes(::core::mem::transmute_copy(&types)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SubstreamTypes: SubstreamTypes::<Identity, Impl, OFFSET>,
             SetSubstreamTypes: SetSubstreamTypes::<Identity, Impl, OFFSET>,
         }
@@ -9862,7 +9862,7 @@ impl ICameraControl_Vtbl {
             this.put_PrivacyMode(::core::mem::transmute_copy(&value), ::core::mem::transmute_copy(&flags)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             get_Exposure: get_Exposure::<Identity, Impl, OFFSET>,
             put_Exposure: put_Exposure::<Identity, Impl, OFFSET>,
             getRange_Exposure: getRange_Exposure::<Identity, Impl, OFFSET>,
@@ -9992,7 +9992,7 @@ impl ICaptionServiceDescriptor_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetNumberOfServices: GetNumberOfServices::<Identity, Impl, OFFSET>,
             GetLanguageCode: GetLanguageCode::<Identity, Impl, OFFSET>,
             GetCaptionServiceNumber: GetCaptionServiceNumber::<Identity, Impl, OFFSET>,
@@ -10068,7 +10068,7 @@ impl ICaptureGraphBuilder_Vtbl {
             this.CopyCaptureFile(::core::mem::transmute(&lpwstrold), ::core::mem::transmute(&lpwstrnew), ::core::mem::transmute_copy(&fallowescabort), ::core::mem::transmute(&pcallback)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetFiltergraph: SetFiltergraph::<Identity, Impl, OFFSET>,
             GetFiltergraph: GetFiltergraph::<Identity, Impl, OFFSET>,
             SetOutputFileName: SetOutputFileName::<Identity, Impl, OFFSET>,
@@ -10158,7 +10158,7 @@ impl ICaptureGraphBuilder2_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetFiltergraph: SetFiltergraph::<Identity, Impl, OFFSET>,
             GetFiltergraph: GetFiltergraph::<Identity, Impl, OFFSET>,
             SetOutputFileName: SetOutputFileName::<Identity, Impl, OFFSET>,
@@ -10942,7 +10942,7 @@ impl IConfigAsfWriter_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ConfigureFilterUsingProfileId: ConfigureFilterUsingProfileId::<Identity, Impl, OFFSET>,
             GetCurrentProfileId: GetCurrentProfileId::<Identity, Impl, OFFSET>,
             ConfigureFilterUsingProfileGuid: ConfigureFilterUsingProfileGuid::<Identity, Impl, OFFSET>,
@@ -11052,7 +11052,7 @@ impl IConfigAviMux_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetMasterStream: SetMasterStream::<Identity, Impl, OFFSET>,
             GetMasterStream: GetMasterStream::<Identity, Impl, OFFSET>,
             SetOutputCompatibilityIndex: SetOutputCompatibilityIndex::<Identity, Impl, OFFSET>,
@@ -11099,7 +11099,7 @@ impl IConfigInterleaving_Vtbl {
             this.get_Interleaving(::core::mem::transmute_copy(&prtinterleave), ::core::mem::transmute_copy(&prtpreroll)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetMode: SetMode::<Identity, Impl, OFFSET>,
             Mode: Mode::<Identity, Impl, OFFSET>,
             put_Interleaving: put_Interleaving::<Identity, Impl, OFFSET>,
@@ -11124,7 +11124,7 @@ impl ICreateDevEnum_Vtbl {
             let this = (*this).get_impl();
             this.CreateClassEnumerator(::core::mem::transmute_copy(&clsiddeviceclass), ::core::mem::transmute_copy(&ppenummoniker), ::core::mem::transmute_copy(&dwflags)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CreateClassEnumerator: CreateClassEnumerator::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CreateClassEnumerator: CreateClassEnumerator::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ICreateDevEnum as ::windows::core::Interface>::IID
@@ -11144,7 +11144,7 @@ impl ICreatePropBagOnRegKey_Vtbl {
             let this = (*this).get_impl();
             this.Create(::core::mem::transmute_copy(&hkey), ::core::mem::transmute(&subkey), ::core::mem::transmute_copy(&uloptions), ::core::mem::transmute_copy(&samdesired), ::core::mem::transmute_copy(&iid), ::core::mem::transmute_copy(&ppbag)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Create: Create::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Create: Create::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ICreatePropBagOnRegKey as ::windows::core::Interface>::IID
@@ -11201,7 +11201,7 @@ impl IDDrawExclModeVideo_Vtbl {
             this.SetCallbackInterface(::core::mem::transmute(&pcallback), ::core::mem::transmute_copy(&dwflags)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetDDrawObject: SetDDrawObject::<Identity, Impl, OFFSET>,
             GetDDrawObject: GetDDrawObject::<Identity, Impl, OFFSET>,
             SetDDrawSurface: SetDDrawSurface::<Identity, Impl, OFFSET>,
@@ -11242,7 +11242,7 @@ impl IDDrawExclModeVideoCallback_Vtbl {
             this.OnUpdateSize(::core::mem::transmute_copy(&dwwidth), ::core::mem::transmute_copy(&dwheight), ::core::mem::transmute_copy(&dwarwidth), ::core::mem::transmute_copy(&dwarheight)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnUpdateOverlay: OnUpdateOverlay::<Identity, Impl, OFFSET>,
             OnUpdateColorKey: OnUpdateColorKey::<Identity, Impl, OFFSET>,
             OnUpdateSize: OnUpdateSize::<Identity, Impl, OFFSET>,
@@ -11263,7 +11263,7 @@ impl IDMOWrapperFilter_Vtbl {
             let this = (*this).get_impl();
             this.Init(::core::mem::transmute_copy(&clsiddmo), ::core::mem::transmute_copy(&catdmo)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Init: Init::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Init: Init::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDMOWrapperFilter as ::windows::core::Interface>::IID
@@ -11287,7 +11287,7 @@ impl IDShowPlugin_Vtbl {
             this.UserAgent(::core::mem::transmute_copy(&puseragent)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             URL: URL::<Identity, Impl, OFFSET>,
             UserAgent: UserAgent::<Identity, Impl, OFFSET>,
         }
@@ -11377,7 +11377,7 @@ impl IDTFilter_Vtbl {
             this.SetBlockUnRatedDelay(::core::mem::transmute_copy(&msecsdelaybeforeblock)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             EvalRatObjOK: EvalRatObjOK::<Identity, Impl, OFFSET>,
             GetCurrRating: GetCurrRating::<Identity, Impl, OFFSET>,
             get_BlockedRatingAttributes: get_BlockedRatingAttributes::<Identity, Impl, OFFSET>,
@@ -11507,7 +11507,7 @@ impl IDTFilterConfig_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetSecureChannelObject: GetSecureChannelObject::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetSecureChannelObject: GetSecureChannelObject::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDTFilterConfig as ::windows::core::Interface>::IID
@@ -11537,7 +11537,7 @@ impl IDTFilterLicenseRenewal_Vtbl {
             let this = (*this).get_impl();
             this.GetLicenseRenewalData(::core::mem::transmute_copy(&ppwszfilename), ::core::mem::transmute_copy(&ppwszexpiredkid), ::core::mem::transmute_copy(&ppwsztunerid)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetLicenseRenewalData: GetLicenseRenewalData::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetLicenseRenewalData: GetLicenseRenewalData::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDTFilterLicenseRenewal as ::windows::core::Interface>::IID
@@ -12443,7 +12443,7 @@ impl IDVB_BAT_Vtbl {
             this.ConvertNextToCurrent().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             GetVersionNumber: GetVersionNumber::<Identity, Impl, OFFSET>,
             GetBouquetId: GetBouquetId::<Identity, Impl, OFFSET>,
@@ -12493,7 +12493,7 @@ impl IDVB_DIT_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             GetTransitionFlag: GetTransitionFlag::<Identity, Impl, OFFSET>,
         }
@@ -12733,7 +12733,7 @@ impl IDVB_EIT_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             GetVersionNumber: GetVersionNumber::<Identity, Impl, OFFSET>,
             GetServiceId: GetServiceId::<Identity, Impl, OFFSET>,
@@ -12974,7 +12974,7 @@ impl IDVB_NIT_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             GetVersionNumber: GetVersionNumber::<Identity, Impl, OFFSET>,
             GetNetworkId: GetNetworkId::<Identity, Impl, OFFSET>,
@@ -13082,7 +13082,7 @@ impl IDVB_RST_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             GetCountOfRecords: GetCountOfRecords::<Identity, Impl, OFFSET>,
             GetRecordTransportStreamId: GetRecordTransportStreamId::<Identity, Impl, OFFSET>,
@@ -13291,7 +13291,7 @@ impl IDVB_SDT_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             GetVersionNumber: GetVersionNumber::<Identity, Impl, OFFSET>,
             GetTransportStreamId: GetTransportStreamId::<Identity, Impl, OFFSET>,
@@ -13469,7 +13469,7 @@ impl IDVB_SIT_Vtbl {
             this.ConvertNextToCurrent().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             GetVersionNumber: GetVersionNumber::<Identity, Impl, OFFSET>,
             GetCountOfTableDescriptors: GetCountOfTableDescriptors::<Identity, Impl, OFFSET>,
@@ -13527,7 +13527,7 @@ impl IDVB_ST_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             GetDataLength: GetDataLength::<Identity, Impl, OFFSET>,
             GetData: GetData::<Identity, Impl, OFFSET>,
@@ -13561,7 +13561,7 @@ impl IDVB_TDT_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             GetUTCTime: GetUTCTime::<Identity, Impl, OFFSET>,
         }
@@ -13624,7 +13624,7 @@ impl IDVB_TOT_Vtbl {
             this.GetTableDescriptorByTag(::core::mem::transmute_copy(&btag), ::core::mem::transmute_copy(&pdwcookie), ::core::mem::transmute_copy(&ppdescriptor)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             GetUTCTime: GetUTCTime::<Identity, Impl, OFFSET>,
             GetCountOfTableDescriptors: GetCountOfTableDescriptors::<Identity, Impl, OFFSET>,
@@ -13654,7 +13654,7 @@ impl IDVEnc_Vtbl {
             this.put_IFormatResolution(::core::mem::transmute_copy(&videoformat), ::core::mem::transmute_copy(&dvformat), ::core::mem::transmute_copy(&resolution), ::core::mem::transmute_copy(&fdvinfo), ::core::mem::transmute_copy(&sdvinfo)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             get_IFormatResolution: get_IFormatResolution::<Identity, Impl, OFFSET>,
             put_IFormatResolution: put_IFormatResolution::<Identity, Impl, OFFSET>,
         }
@@ -13677,7 +13677,7 @@ impl IDVRGB219_Vtbl {
             let this = (*this).get_impl();
             this.SetRGB219(::core::mem::transmute_copy(&bstate)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SetRGB219: SetRGB219::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SetRGB219: SetRGB219::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDVRGB219 as ::windows::core::Interface>::IID
@@ -13695,7 +13695,7 @@ impl IDVSplitter_Vtbl {
             this.DiscardAlternateVideoFrames(::core::mem::transmute_copy(&ndiscard)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             DiscardAlternateVideoFrames: DiscardAlternateVideoFrames::<Identity, Impl, OFFSET>,
         }
     }
@@ -13721,7 +13721,7 @@ impl IDecimateVideoImage_Vtbl {
             this.ResetDecimationImageSize().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetDecimationImageSize: SetDecimationImageSize::<Identity, Impl, OFFSET>,
             ResetDecimationImageSize: ResetDecimationImageSize::<Identity, Impl, OFFSET>,
         }
@@ -13772,7 +13772,7 @@ impl IDeferredCommand_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Cancel: Cancel::<Identity, Impl, OFFSET>,
             Confidence: Confidence::<Identity, Impl, OFFSET>,
             Postpone: Postpone::<Identity, Impl, OFFSET>,
@@ -13982,7 +13982,7 @@ impl IDirectDrawMediaSample_Vtbl {
             this.LockMediaSamplePointer().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSurfaceAndReleaseLock: GetSurfaceAndReleaseLock::<Identity, Impl, OFFSET>,
             LockMediaSamplePointer: LockMediaSamplePointer::<Identity, Impl, OFFSET>,
         }
@@ -14011,7 +14011,7 @@ impl IDirectDrawMediaSampleAllocator_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetDirectDraw: GetDirectDraw::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetDirectDraw: GetDirectDraw::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDirectDrawMediaSampleAllocator as ::windows::core::Interface>::IID
@@ -14276,7 +14276,7 @@ impl IDirectDrawVideo_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSwitches: GetSwitches::<Identity, Impl, OFFSET>,
             SetSwitches: SetSwitches::<Identity, Impl, OFFSET>,
             GetCaps: GetCaps::<Identity, Impl, OFFSET>,
@@ -14335,7 +14335,7 @@ impl IDistributorNotify_Vtbl {
             this.NotifyGraphChange().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Stop: Stop::<Identity, Impl, OFFSET>,
             Pause: Pause::<Identity, Impl, OFFSET>,
             Run: Run::<Identity, Impl, OFFSET>,
@@ -14374,7 +14374,7 @@ impl IDrawVideoImage_Vtbl {
             this.DrawVideoImageDraw(::core::mem::transmute_copy(&hdc), ::core::mem::transmute_copy(&lprcsrc), ::core::mem::transmute_copy(&lprcdst)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             DrawVideoImageBegin: DrawVideoImageBegin::<Identity, Impl, OFFSET>,
             DrawVideoImageEnd: DrawVideoImageEnd::<Identity, Impl, OFFSET>,
             DrawVideoImageDraw: DrawVideoImageDraw::<Identity, Impl, OFFSET>,
@@ -14474,7 +14474,7 @@ impl IDvbCableDeliverySystemDescriptor_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTag: GetTag::<Identity, Impl, OFFSET>,
             GetLength: GetLength::<Identity, Impl, OFFSET>,
             GetFrequency: GetFrequency::<Identity, Impl, OFFSET>,
@@ -14572,7 +14572,7 @@ impl IDvbComponentDescriptor_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTag: GetTag::<Identity, Impl, OFFSET>,
             GetLength: GetLength::<Identity, Impl, OFFSET>,
             GetStreamContent: GetStreamContent::<Identity, Impl, OFFSET>,
@@ -14640,7 +14640,7 @@ impl IDvbContentDescriptor_Vtbl {
             this.GetRecordUserNibbles(::core::mem::transmute_copy(&brecordindex), ::core::mem::transmute_copy(&pbval1), ::core::mem::transmute_copy(&pbval2)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTag: GetTag::<Identity, Impl, OFFSET>,
             GetLength: GetLength::<Identity, Impl, OFFSET>,
             GetCountOfRecords: GetCountOfRecords::<Identity, Impl, OFFSET>,
@@ -14700,7 +14700,7 @@ impl IDvbContentIdentifierDescriptor_Vtbl {
             this.GetRecordCrid(::core::mem::transmute_copy(&brecordindex), ::core::mem::transmute_copy(&pbtype), ::core::mem::transmute_copy(&pblocation), ::core::mem::transmute_copy(&pblength), ::core::mem::transmute_copy(&ppbbytes)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTag: GetTag::<Identity, Impl, OFFSET>,
             GetLength: GetLength::<Identity, Impl, OFFSET>,
             GetCountOfRecords: GetCountOfRecords::<Identity, Impl, OFFSET>,
@@ -14813,7 +14813,7 @@ impl IDvbDataBroadcastDescriptor_Vtbl {
             this.GetText(::core::mem::transmute_copy(&pblen), ::core::mem::transmute_copy(&pbval)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTag: GetTag::<Identity, Impl, OFFSET>,
             GetLength: GetLength::<Identity, Impl, OFFSET>,
             GetDataBroadcastID: GetDataBroadcastID::<Identity, Impl, OFFSET>,
@@ -14877,7 +14877,7 @@ impl IDvbDataBroadcastIDDescriptor_Vtbl {
             this.GetIDSelectorBytes(::core::mem::transmute_copy(&pblen), ::core::mem::transmute_copy(&pbval)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTag: GetTag::<Identity, Impl, OFFSET>,
             GetLength: GetLength::<Identity, Impl, OFFSET>,
             GetDataBroadcastID: GetDataBroadcastID::<Identity, Impl, OFFSET>,
@@ -14924,7 +14924,7 @@ impl IDvbDefaultAuthorityDescriptor_Vtbl {
             this.GetDefaultAuthority(::core::mem::transmute_copy(&pblength), ::core::mem::transmute_copy(&ppbbytes)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTag: GetTag::<Identity, Impl, OFFSET>,
             GetLength: GetLength::<Identity, Impl, OFFSET>,
             GetDefaultAuthority: GetDefaultAuthority::<Identity, Impl, OFFSET>,
@@ -15048,7 +15048,7 @@ impl IDvbExtendedEventDescriptor_Vtbl {
             this.GetRecordItemRawBytes(::core::mem::transmute_copy(&brecordindex), ::core::mem::transmute_copy(&ppbrawitem), ::core::mem::transmute_copy(&pbitemlength)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTag: GetTag::<Identity, Impl, OFFSET>,
             GetLength: GetLength::<Identity, Impl, OFFSET>,
             GetDescriptorNumber: GetDescriptorNumber::<Identity, Impl, OFFSET>,
@@ -15132,7 +15132,7 @@ impl IDvbFrequencyListDescriptor_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTag: GetTag::<Identity, Impl, OFFSET>,
             GetLength: GetLength::<Identity, Impl, OFFSET>,
             GetCodingType: GetCodingType::<Identity, Impl, OFFSET>,
@@ -15250,7 +15250,7 @@ impl IDvbLinkageDescriptor_Vtbl {
             this.GetPrivateData(::core::mem::transmute_copy(&pblen), ::core::mem::transmute_copy(&pbdata)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTag: GetTag::<Identity, Impl, OFFSET>,
             GetLength: GetLength::<Identity, Impl, OFFSET>,
             GetTSId: GetTSId::<Identity, Impl, OFFSET>,
@@ -15442,7 +15442,7 @@ impl IDvbLogicalChannelDescriptor_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTag: GetTag::<Identity, Impl, OFFSET>,
             GetLength: GetLength::<Identity, Impl, OFFSET>,
             GetCountOfRecords: GetCountOfRecords::<Identity, Impl, OFFSET>,
@@ -15558,7 +15558,7 @@ impl IDvbMultilingualServiceNameDescriptor_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTag: GetTag::<Identity, Impl, OFFSET>,
             GetLength: GetLength::<Identity, Impl, OFFSET>,
             GetCountOfRecords: GetCountOfRecords::<Identity, Impl, OFFSET>,
@@ -15625,7 +15625,7 @@ impl IDvbNetworkNameDescriptor_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTag: GetTag::<Identity, Impl, OFFSET>,
             GetLength: GetLength::<Identity, Impl, OFFSET>,
             GetNetworkName: GetNetworkName::<Identity, Impl, OFFSET>,
@@ -15684,7 +15684,7 @@ impl IDvbParentalRatingDescriptor_Vtbl {
             this.GetRecordRating(::core::mem::transmute_copy(&brecordindex), ::core::mem::transmute_copy(&pszcountrycode), ::core::mem::transmute_copy(&pbval)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTag: GetTag::<Identity, Impl, OFFSET>,
             GetLength: GetLength::<Identity, Impl, OFFSET>,
             GetCountOfRecords: GetCountOfRecords::<Identity, Impl, OFFSET>,
@@ -15737,7 +15737,7 @@ impl IDvbPrivateDataSpecifierDescriptor_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTag: GetTag::<Identity, Impl, OFFSET>,
             GetLength: GetLength::<Identity, Impl, OFFSET>,
             GetPrivateDataSpecifier: GetPrivateDataSpecifier::<Identity, Impl, OFFSET>,
@@ -15861,7 +15861,7 @@ impl IDvbSatelliteDeliverySystemDescriptor_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTag: GetTag::<Identity, Impl, OFFSET>,
             GetLength: GetLength::<Identity, Impl, OFFSET>,
             GetFrequency: GetFrequency::<Identity, Impl, OFFSET>,
@@ -15958,7 +15958,7 @@ impl IDvbServiceAttributeDescriptor_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTag: GetTag::<Identity, Impl, OFFSET>,
             GetLength: GetLength::<Identity, Impl, OFFSET>,
             GetCountOfRecords: GetCountOfRecords::<Identity, Impl, OFFSET>,
@@ -16073,7 +16073,7 @@ impl IDvbServiceDescriptor_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTag: GetTag::<Identity, Impl, OFFSET>,
             GetLength: GetLength::<Identity, Impl, OFFSET>,
             GetServiceType: GetServiceType::<Identity, Impl, OFFSET>,
@@ -16193,7 +16193,7 @@ impl IDvbServiceListDescriptor_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTag: GetTag::<Identity, Impl, OFFSET>,
             GetLength: GetLength::<Identity, Impl, OFFSET>,
             GetCountOfRecords: GetCountOfRecords::<Identity, Impl, OFFSET>,
@@ -16265,7 +16265,7 @@ impl IDvbShortEventDescriptor_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTag: GetTag::<Identity, Impl, OFFSET>,
             GetLength: GetLength::<Identity, Impl, OFFSET>,
             GetLanguageCode: GetLanguageCode::<Identity, Impl, OFFSET>,
@@ -16457,7 +16457,7 @@ impl IDvbSiParser_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             GetPAT: GetPAT::<Identity, Impl, OFFSET>,
             GetCAT: GetCAT::<Identity, Impl, OFFSET>,
@@ -16592,7 +16592,7 @@ impl IDvbSubtitlingDescriptor_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTag: GetTag::<Identity, Impl, OFFSET>,
             GetLength: GetLength::<Identity, Impl, OFFSET>,
             GetCountOfRecords: GetCountOfRecords::<Identity, Impl, OFFSET>,
@@ -16696,7 +16696,7 @@ impl IDvbTeletextDescriptor_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTag: GetTag::<Identity, Impl, OFFSET>,
             GetLength: GetLength::<Identity, Impl, OFFSET>,
             GetCountOfRecords: GetCountOfRecords::<Identity, Impl, OFFSET>,
@@ -16872,7 +16872,7 @@ impl IDvbTerrestrial2DeliverySystemDescriptor_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTag: GetTag::<Identity, Impl, OFFSET>,
             GetLength: GetLength::<Identity, Impl, OFFSET>,
             GetTagExtension: GetTagExtension::<Identity, Impl, OFFSET>,
@@ -17030,7 +17030,7 @@ impl IDvbTerrestrialDeliverySystemDescriptor_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTag: GetTag::<Identity, Impl, OFFSET>,
             GetLength: GetLength::<Identity, Impl, OFFSET>,
             GetCentreFrequency: GetCentreFrequency::<Identity, Impl, OFFSET>,
@@ -17066,7 +17066,7 @@ impl IDvdCmd_Vtbl {
             this.WaitForEnd().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             WaitForStart: WaitForStart::<Identity, Impl, OFFSET>,
             WaitForEnd: WaitForEnd::<Identity, Impl, OFFSET>,
         }
@@ -17294,7 +17294,7 @@ impl IDvdControl_Vtbl {
             this.ChapterPlayAutoStop(::core::mem::transmute_copy(&ultitle), ::core::mem::transmute_copy(&ulchapter), ::core::mem::transmute_copy(&ulchapterstoplay)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             TitlePlay: TitlePlay::<Identity, Impl, OFFSET>,
             ChapterPlay: ChapterPlay::<Identity, Impl, OFFSET>,
             TimePlay: TimePlay::<Identity, Impl, OFFSET>,
@@ -17693,7 +17693,7 @@ impl IDvdControl2_Vtbl {
             this.SelectDefaultSubpictureLanguage(::core::mem::transmute_copy(&language), ::core::mem::transmute_copy(&subpictureextension)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             PlayTitle: PlayTitle::<Identity, Impl, OFFSET>,
             PlayChapterInTitle: PlayChapterInTitle::<Identity, Impl, OFFSET>,
             PlayAtTimeInTitle: PlayAtTimeInTitle::<Identity, Impl, OFFSET>,
@@ -17779,7 +17779,7 @@ impl IDvdGraphBuilder_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetFiltergraph: GetFiltergraph::<Identity, Impl, OFFSET>,
             GetDvdInterface: GetDvdInterface::<Identity, Impl, OFFSET>,
             RenderDvdVideoVolume: RenderDvdVideoVolume::<Identity, Impl, OFFSET>,
@@ -18020,7 +18020,7 @@ impl IDvdInfo_Vtbl {
             this.GetRoot(::core::mem::transmute_copy(&proot), ::core::mem::transmute_copy(&ulbufsize), ::core::mem::transmute_copy(&pulactualsize)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCurrentDomain: GetCurrentDomain::<Identity, Impl, OFFSET>,
             GetCurrentLocation: GetCurrentLocation::<Identity, Impl, OFFSET>,
             GetTotalTitleTime: GetTotalTitleTime::<Identity, Impl, OFFSET>,
@@ -18437,7 +18437,7 @@ impl IDvdInfo2_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCurrentDomain: GetCurrentDomain::<Identity, Impl, OFFSET>,
             GetCurrentLocation: GetCurrentLocation::<Identity, Impl, OFFSET>,
             GetTotalTitleTime: GetTotalTitleTime::<Identity, Impl, OFFSET>,
@@ -18513,7 +18513,7 @@ impl IDvdState_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDiscID: GetDiscID::<Identity, Impl, OFFSET>,
             GetParentalLevel: GetParentalLevel::<Identity, Impl, OFFSET>,
         }
@@ -18611,7 +18611,7 @@ impl IESEvent_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetEventId: GetEventId::<Identity, Impl, OFFSET>,
             GetEventType: GetEventType::<Identity, Impl, OFFSET>,
             SetCompletionStatus: SetCompletionStatus::<Identity, Impl, OFFSET>,
@@ -18640,7 +18640,7 @@ impl IESEventFactory_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CreateESEvent: CreateESEvent::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CreateESEvent: CreateESEvent::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IESEventFactory as ::windows::core::Interface>::IID
@@ -18657,7 +18657,7 @@ impl IESEventService_Vtbl {
             let this = (*this).get_impl();
             this.FireESEvent(::core::mem::transmute(&pesevent)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), FireESEvent: FireESEvent::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), FireESEvent: FireESEvent::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IESEventService as ::windows::core::Interface>::IID
@@ -18705,7 +18705,7 @@ impl IESEventServiceConfiguration_Vtbl {
             this.RemoveGraph(::core::mem::transmute(&pgraph)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetParent: SetParent::<Identity, Impl, OFFSET>,
             RemoveParent: RemoveParent::<Identity, Impl, OFFSET>,
             SetOwner: SetOwner::<Identity, Impl, OFFSET>,
@@ -18729,7 +18729,7 @@ impl IESEvents_Vtbl {
             let this = (*this).get_impl();
             this.OnESEventReceived(::core::mem::transmute(&guideventtype), ::core::mem::transmute(&pesevent)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnESEventReceived: OnESEventReceived::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnESEventReceived: OnESEventReceived::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IESEvents as ::windows::core::Interface>::IID
@@ -19257,7 +19257,7 @@ impl IETFilter_Vtbl {
             this.SetRecordingOn(::core::mem::transmute_copy(&frecstate)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             EvalRatObjOK: EvalRatObjOK::<Identity, Impl, OFFSET>,
             GetCurrRating: GetCurrRating::<Identity, Impl, OFFSET>,
             GetCurrLicenseExpDate: GetCurrLicenseExpDate::<Identity, Impl, OFFSET>,
@@ -19293,7 +19293,7 @@ impl IETFilterConfig_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             InitLicense: InitLicense::<Identity, Impl, OFFSET>,
             GetSecureChannelObject: GetSecureChannelObject::<Identity, Impl, OFFSET>,
         }
@@ -19378,7 +19378,7 @@ impl IEncoderAPI_Vtbl {
             this.SetValue(::core::mem::transmute_copy(&api), ::core::mem::transmute_copy(&value)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             IsSupported: IsSupported::<Identity, Impl, OFFSET>,
             IsAvailable: IsAvailable::<Identity, Impl, OFFSET>,
             GetParameterRange: GetParameterRange::<Identity, Impl, OFFSET>,
@@ -19431,7 +19431,7 @@ impl IEnumComponentTypes_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -19481,7 +19481,7 @@ impl IEnumComponents_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -19531,7 +19531,7 @@ impl IEnumFilters_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -19578,7 +19578,7 @@ impl IEnumGuideDataProperties_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -19628,7 +19628,7 @@ impl IEnumMSVidGraphSegment_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -19678,7 +19678,7 @@ impl IEnumMediaTypes_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -19725,7 +19725,7 @@ impl IEnumPIDMap_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -19772,7 +19772,7 @@ impl IEnumPins_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -19819,7 +19819,7 @@ impl IEnumRegFilters_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -19866,7 +19866,7 @@ impl IEnumStreamBufferRecordingAttrib_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -19913,7 +19913,7 @@ impl IEnumStreamIdMap_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -19963,7 +19963,7 @@ impl IEnumTuneRequests_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -20013,7 +20013,7 @@ impl IEnumTuningSpaces_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -20115,7 +20115,7 @@ impl IFileSinkFilter_Vtbl {
             this.GetCurFile(::core::mem::transmute_copy(&ppszfilename), ::core::mem::transmute_copy(&pmt)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetFileName: SetFileName::<Identity, Impl, OFFSET>,
             GetCurFile: GetCurFile::<Identity, Impl, OFFSET>,
         }
@@ -20181,7 +20181,7 @@ impl IFileSourceFilter_Vtbl {
             this.GetCurFile(::core::mem::transmute_copy(&ppszfilename), ::core::mem::transmute_copy(&pmt)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Load: Load::<Identity, Impl, OFFSET>,
             GetCurFile: GetCurFile::<Identity, Impl, OFFSET>,
         }
@@ -20223,7 +20223,7 @@ impl IFilterChain_Vtbl {
             this.RemoveChain(::core::mem::transmute(&pstartfilter), ::core::mem::transmute(&pendfilter)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             StartChain: StartChain::<Identity, Impl, OFFSET>,
             PauseChain: PauseChain::<Identity, Impl, OFFSET>,
             StopChain: StopChain::<Identity, Impl, OFFSET>,
@@ -20303,7 +20303,7 @@ impl IFilterGraph_Vtbl {
             this.SetDefaultSyncSource().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddFilter: AddFilter::<Identity, Impl, OFFSET>,
             RemoveFilter: RemoveFilter::<Identity, Impl, OFFSET>,
             EnumFilters: EnumFilters::<Identity, Impl, OFFSET>,
@@ -20558,7 +20558,7 @@ impl IFilterMapper_Vtbl {
             this.EnumMatchingFilters(::core::mem::transmute_copy(&ppenum), ::core::mem::transmute_copy(&dwmerit), ::core::mem::transmute_copy(&binputneeded), ::core::mem::transmute(&clsinmaj), ::core::mem::transmute(&clsinsub), ::core::mem::transmute_copy(&brender), ::core::mem::transmute_copy(&boututneeded), ::core::mem::transmute(&clsoutmaj), ::core::mem::transmute(&clsoutsub)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RegisterFilter: RegisterFilter::<Identity, Impl, OFFSET>,
             RegisterFilterInstance: RegisterFilterInstance::<Identity, Impl, OFFSET>,
             RegisterPin: RegisterPin::<Identity, Impl, OFFSET>,
@@ -20623,7 +20623,7 @@ impl IFilterMapper2_Vtbl {
             .into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateCategory: CreateCategory::<Identity, Impl, OFFSET>,
             UnregisterFilter: UnregisterFilter::<Identity, Impl, OFFSET>,
             RegisterFilter: RegisterFilter::<Identity, Impl, OFFSET>,
@@ -20708,7 +20708,7 @@ impl IFrequencyMap_Vtbl {
             this.get_CountryCodeList(::core::mem::transmute_copy(&pulcount), ::core::mem::transmute_copy(&ppullist)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             get_FrequencyMapping: get_FrequencyMapping::<Identity, Impl, OFFSET>,
             put_FrequencyMapping: put_FrequencyMapping::<Identity, Impl, OFFSET>,
             CountryCode: CountryCode::<Identity, Impl, OFFSET>,
@@ -20868,7 +20868,7 @@ impl IFullScreenVideo_Vtbl {
             this.SetDefault().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CountModes: CountModes::<Identity, Impl, OFFSET>,
             GetModeInfo: GetModeInfo::<Identity, Impl, OFFSET>,
             GetCurrentMode: GetCurrentMode::<Identity, Impl, OFFSET>,
@@ -20990,7 +20990,7 @@ impl IGenericDescriptor_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             GetTag: GetTag::<Identity, Impl, OFFSET>,
             GetLength: GetLength::<Identity, Impl, OFFSET>,
@@ -21054,7 +21054,7 @@ impl IGetCapabilitiesKey_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetCapabilitiesKey: GetCapabilitiesKey::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetCapabilitiesKey: GetCapabilitiesKey::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IGetCapabilitiesKey as ::windows::core::Interface>::IID
@@ -21077,7 +21077,7 @@ impl IGpnvsCommonBase_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetValueUpdateName: GetValueUpdateName::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetValueUpdateName: GetValueUpdateName::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IGpnvsCommonBase as ::windows::core::Interface>::IID
@@ -21229,7 +21229,7 @@ impl IGraphConfig_Vtbl {
             this.RemoveFilterEx(::core::mem::transmute(&pfilter), ::core::mem::transmute_copy(&flags)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Reconnect: Reconnect::<Identity, Impl, OFFSET>,
             Reconfigure: Reconfigure::<Identity, Impl, OFFSET>,
             AddFilterToCache: AddFilterToCache::<Identity, Impl, OFFSET>,
@@ -21257,7 +21257,7 @@ impl IGraphConfigCallback_Vtbl {
             let this = (*this).get_impl();
             this.Reconfigure(::core::mem::transmute_copy(&pvcontext), ::core::mem::transmute_copy(&dwflags)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Reconfigure: Reconfigure::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Reconfigure: Reconfigure::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IGraphConfigCallback as ::windows::core::Interface>::IID
@@ -21280,7 +21280,7 @@ impl IGraphVersion_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), QueryVersion: QueryVersion::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), QueryVersion: QueryVersion::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IGraphVersion as ::windows::core::Interface>::IID
@@ -21367,7 +21367,7 @@ impl IGuideData_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetServices: GetServices::<Identity, Impl, OFFSET>,
             GetServiceProperties: GetServiceProperties::<Identity, Impl, OFFSET>,
             GetGuideProgramIDs: GetGuideProgramIDs::<Identity, Impl, OFFSET>,
@@ -21431,7 +21431,7 @@ impl IGuideDataEvent_Vtbl {
             this.ScheduleDeleted(::core::mem::transmute(&varscheduleentrydescriptionid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GuideDataAcquired: GuideDataAcquired::<Identity, Impl, OFFSET>,
             ProgramChanged: ProgramChanged::<Identity, Impl, OFFSET>,
             ServiceChanged: ServiceChanged::<Identity, Impl, OFFSET>,
@@ -21463,7 +21463,7 @@ impl IGuideDataLoader_Vtbl {
             this.Terminate().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Init: Init::<Identity, Impl, OFFSET>,
             Terminate: Terminate::<Identity, Impl, OFFSET>,
         }
@@ -21517,7 +21517,7 @@ impl IGuideDataProperty_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Name: Name::<Identity, Impl, OFFSET>,
             Language: Language::<Identity, Impl, OFFSET>,
             Value: Value::<Identity, Impl, OFFSET>,
@@ -21551,7 +21551,7 @@ impl IIPDVDec_Vtbl {
             this.SetIPDisplay(::core::mem::transmute_copy(&displaypix)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             IPDisplay: IPDisplay::<Identity, Impl, OFFSET>,
             SetIPDisplay: SetIPDisplay::<Identity, Impl, OFFSET>,
         }
@@ -21717,7 +21717,7 @@ impl IISDB_BIT_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             GetVersionNumber: GetVersionNumber::<Identity, Impl, OFFSET>,
             GetOriginalNetworkId: GetOriginalNetworkId::<Identity, Impl, OFFSET>,
@@ -21875,7 +21875,7 @@ impl IISDB_CDT_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             GetVersionNumber: GetVersionNumber::<Identity, Impl, OFFSET>,
             GetDownloadDataId: GetDownloadDataId::<Identity, Impl, OFFSET>,
@@ -21960,7 +21960,7 @@ impl IISDB_EMM_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             GetVersionNumber: GetVersionNumber::<Identity, Impl, OFFSET>,
             GetTableIdExtension: GetTableIdExtension::<Identity, Impl, OFFSET>,
@@ -22100,7 +22100,7 @@ impl IISDB_LDT_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             GetVersionNumber: GetVersionNumber::<Identity, Impl, OFFSET>,
             GetOriginalServiceId: GetOriginalServiceId::<Identity, Impl, OFFSET>,
@@ -22292,7 +22292,7 @@ impl IISDB_NBIT_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             GetVersionNumber: GetVersionNumber::<Identity, Impl, OFFSET>,
             GetOriginalNetworkId: GetOriginalNetworkId::<Identity, Impl, OFFSET>,
@@ -22574,7 +22574,7 @@ impl IISDB_SDTT_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             GetVersionNumber: GetVersionNumber::<Identity, Impl, OFFSET>,
             GetTableIdExt: GetTableIdExt::<Identity, Impl, OFFSET>,
@@ -22766,7 +22766,7 @@ impl IIsdbAudioComponentDescriptor_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTag: GetTag::<Identity, Impl, OFFSET>,
             GetLength: GetLength::<Identity, Impl, OFFSET>,
             GetStreamContent: GetStreamContent::<Identity, Impl, OFFSET>,
@@ -22901,7 +22901,7 @@ impl IIsdbCAContractInformationDescriptor_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTag: GetTag::<Identity, Impl, OFFSET>,
             GetLength: GetLength::<Identity, Impl, OFFSET>,
             GetCASystemId: GetCASystemId::<Identity, Impl, OFFSET>,
@@ -22989,7 +22989,7 @@ impl IIsdbCADescriptor_Vtbl {
             this.GetPrivateDataBytes(::core::mem::transmute_copy(&pbbufferlength), ::core::mem::transmute_copy(&pbbuffer)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTag: GetTag::<Identity, Impl, OFFSET>,
             GetLength: GetLength::<Identity, Impl, OFFSET>,
             GetCASystemId: GetCASystemId::<Identity, Impl, OFFSET>,
@@ -23074,7 +23074,7 @@ impl IIsdbCAServiceDescriptor_Vtbl {
             this.GetServiceIds(::core::mem::transmute_copy(&pbnumserviceids), ::core::mem::transmute_copy(&pwserviceids)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTag: GetTag::<Identity, Impl, OFFSET>,
             GetLength: GetLength::<Identity, Impl, OFFSET>,
             GetCASystemId: GetCASystemId::<Identity, Impl, OFFSET>,
@@ -23225,7 +23225,7 @@ impl IIsdbComponentGroupDescriptor_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTag: GetTag::<Identity, Impl, OFFSET>,
             GetLength: GetLength::<Identity, Impl, OFFSET>,
             GetComponentGroupType: GetComponentGroupType::<Identity, Impl, OFFSET>,
@@ -23363,7 +23363,7 @@ impl IIsdbDataContentDescriptor_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTag: GetTag::<Identity, Impl, OFFSET>,
             GetLength: GetLength::<Identity, Impl, OFFSET>,
             GetDataComponentId: GetDataComponentId::<Identity, Impl, OFFSET>,
@@ -23434,7 +23434,7 @@ impl IIsdbDigitalCopyControlDescriptor_Vtbl {
             this.GetRecordCopyControl(::core::mem::transmute_copy(&brecordindex), ::core::mem::transmute_copy(&pbcomponenttag), ::core::mem::transmute_copy(&pbdigitalrecordingcontroldata), ::core::mem::transmute_copy(&pbcopycontroltype), ::core::mem::transmute_copy(&pbapscontroldata), ::core::mem::transmute_copy(&pbmaximumbitrate)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTag: GetTag::<Identity, Impl, OFFSET>,
             GetLength: GetLength::<Identity, Impl, OFFSET>,
             GetCopyControl: GetCopyControl::<Identity, Impl, OFFSET>,
@@ -23647,7 +23647,7 @@ impl IIsdbDownloadContentDescriptor_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTag: GetTag::<Identity, Impl, OFFSET>,
             GetLength: GetLength::<Identity, Impl, OFFSET>,
             GetFlags: GetFlags::<Identity, Impl, OFFSET>,
@@ -23755,7 +23755,7 @@ impl IIsdbEmergencyInformationDescriptor_Vtbl {
             this.GetAreaCode(::core::mem::transmute_copy(&brecordindex), ::core::mem::transmute_copy(&ppwval), ::core::mem::transmute_copy(&pbnumareacodes)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTag: GetTag::<Identity, Impl, OFFSET>,
             GetLength: GetLength::<Identity, Impl, OFFSET>,
             GetCountOfRecords: GetCountOfRecords::<Identity, Impl, OFFSET>,
@@ -23847,7 +23847,7 @@ impl IIsdbEventGroupDescriptor_Vtbl {
             this.GetRefRecordEvent(::core::mem::transmute_copy(&brecordindex), ::core::mem::transmute_copy(&pworiginalnetworkid), ::core::mem::transmute_copy(&pwtransportstreamid), ::core::mem::transmute_copy(&pwserviceid), ::core::mem::transmute_copy(&pweventid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTag: GetTag::<Identity, Impl, OFFSET>,
             GetLength: GetLength::<Identity, Impl, OFFSET>,
             GetGroupType: GetGroupType::<Identity, Impl, OFFSET>,
@@ -23939,7 +23939,7 @@ impl IIsdbHierarchicalTransmissionDescriptor_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTag: GetTag::<Identity, Impl, OFFSET>,
             GetLength: GetLength::<Identity, Impl, OFFSET>,
             GetFutureUse1: GetFutureUse1::<Identity, Impl, OFFSET>,
@@ -24042,7 +24042,7 @@ impl IIsdbLogoTransmissionDescriptor_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTag: GetTag::<Identity, Impl, OFFSET>,
             GetLength: GetLength::<Identity, Impl, OFFSET>,
             GetLogoTransmissionType: GetLogoTransmissionType::<Identity, Impl, OFFSET>,
@@ -24152,7 +24152,7 @@ impl IIsdbSIParameterDescriptor_Vtbl {
             this.GetTableDescriptionBytes(::core::mem::transmute_copy(&brecordindex), ::core::mem::transmute_copy(&pbbufferlength), ::core::mem::transmute_copy(&pbbuffer)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTag: GetTag::<Identity, Impl, OFFSET>,
             GetLength: GetLength::<Identity, Impl, OFFSET>,
             GetParameterVersion: GetParameterVersion::<Identity, Impl, OFFSET>,
@@ -24278,7 +24278,7 @@ impl IIsdbSeriesDescriptor_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTag: GetTag::<Identity, Impl, OFFSET>,
             GetLength: GetLength::<Identity, Impl, OFFSET>,
             GetSeriesId: GetSeriesId::<Identity, Impl, OFFSET>,
@@ -24500,7 +24500,7 @@ impl IIsdbTSInformationDescriptor_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTag: GetTag::<Identity, Impl, OFFSET>,
             GetLength: GetLength::<Identity, Impl, OFFSET>,
             GetRemoteControlKeyId: GetRemoteControlKeyId::<Identity, Impl, OFFSET>,
@@ -24605,7 +24605,7 @@ impl IIsdbTerrestrialDeliverySystemDescriptor_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTag: GetTag::<Identity, Impl, OFFSET>,
             GetLength: GetLength::<Identity, Impl, OFFSET>,
             GetAreaCode: GetAreaCode::<Identity, Impl, OFFSET>,
@@ -24637,7 +24637,7 @@ impl IKsNodeControl_Vtbl {
             this.SetKsControl(::core::mem::transmute_copy(&pkscontrol)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetNodeId: SetNodeId::<Identity, Impl, OFFSET>,
             SetKsControl: SetKsControl::<Identity, Impl, OFFSET>,
         }
@@ -24739,7 +24739,7 @@ impl IKsTopologyInfo_Vtbl {
             this.CreateNodeInstance(::core::mem::transmute_copy(&dwnodeid), ::core::mem::transmute_copy(&iid), ::core::mem::transmute_copy(&ppvobject)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             NumCategories: NumCategories::<Identity, Impl, OFFSET>,
             get_Category: get_Category::<Identity, Impl, OFFSET>,
             NumConnections: NumConnections::<Identity, Impl, OFFSET>,
@@ -25101,7 +25101,7 @@ impl IMPEG2PIDMap_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             MapPID: MapPID::<Identity, Impl, OFFSET>,
             UnmapPID: UnmapPID::<Identity, Impl, OFFSET>,
             EnumPIDMap: EnumPIDMap::<Identity, Impl, OFFSET>,
@@ -25141,7 +25141,7 @@ impl IMPEG2StreamIdMap_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             MapStreamId: MapStreamId::<Identity, Impl, OFFSET>,
             UnmapStreamId: UnmapStreamId::<Identity, Impl, OFFSET>,
             EnumStreamIdMap: EnumStreamIdMap::<Identity, Impl, OFFSET>,
@@ -25240,7 +25240,7 @@ pub trait IMPEG2TuneRequestSupport_Impl: Sized {}
 impl ::windows::core::RuntimeName for IMPEG2TuneRequestSupport {}
 impl IMPEG2TuneRequestSupport_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IMPEG2TuneRequestSupport_Impl, const OFFSET: isize>() -> IMPEG2TuneRequestSupport_Vtbl {
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>() }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>() }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMPEG2TuneRequestSupport as ::windows::core::Interface>::IID
@@ -25294,7 +25294,7 @@ impl IMPEG2_TIF_CONTROL_Vtbl {
             this.GetPIDs(::core::mem::transmute_copy(&pulcpids), ::core::mem::transmute_copy(&pulpids)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RegisterTIF: RegisterTIF::<Identity, Impl, OFFSET>,
             UnregisterTIF: UnregisterTIF::<Identity, Impl, OFFSET>,
             AddPIDs: AddPIDs::<Identity, Impl, OFFSET>,
@@ -26490,7 +26490,7 @@ impl IMSVidDevice2_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), DevicePath: DevicePath::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), DevicePath: DevicePath::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMSVidDevice2 as ::windows::core::Interface>::IID
@@ -27155,7 +27155,7 @@ impl IMSVidGraphSegmentContainer_Vtbl {
             this.GetFocus().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Graph: Graph::<Identity, Impl, OFFSET>,
             Input: Input::<Identity, Impl, OFFSET>,
             Outputs: Outputs::<Identity, Impl, OFFSET>,
@@ -27227,7 +27227,7 @@ impl IMSVidGraphSegmentUserInput_Vtbl {
             this.MouseUp(::core::mem::transmute_copy(&buttonstate), ::core::mem::transmute_copy(&shiftstate), ::core::mem::transmute_copy(&x), ::core::mem::transmute_copy(&y)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Click: Click::<Identity, Impl, OFFSET>,
             DblClick: DblClick::<Identity, Impl, OFFSET>,
             KeyDown: KeyDown::<Identity, Impl, OFFSET>,
@@ -30968,7 +30968,7 @@ impl IMceBurnerControl_Vtbl {
             let this = (*this).get_impl();
             this.GetBurnerNoDecryption().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetBurnerNoDecryption: GetBurnerNoDecryption::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetBurnerNoDecryption: GetBurnerNoDecryption::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMceBurnerControl as ::windows::core::Interface>::IID
@@ -31201,7 +31201,7 @@ impl IMediaEventSink_Vtbl {
             let this = (*this).get_impl();
             this.Notify(::core::mem::transmute_copy(&eventcode), ::core::mem::transmute_copy(&eventparam1), ::core::mem::transmute_copy(&eventparam2)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Notify: Notify::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Notify: Notify::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMediaEventSink as ::windows::core::Interface>::IID
@@ -31349,7 +31349,7 @@ impl IMediaParamInfo_Vtbl {
             this.GetCurrentTimeFormat(::core::mem::transmute_copy(&pguidtimeformat), ::core::mem::transmute_copy(&ptimedata)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetParamCount: GetParamCount::<Identity, Impl, OFFSET>,
             GetParamInfo: GetParamInfo::<Identity, Impl, OFFSET>,
             GetParamText: GetParamText::<Identity, Impl, OFFSET>,
@@ -31404,7 +31404,7 @@ impl IMediaParams_Vtbl {
             this.SetTimeFormat(::core::mem::transmute(&guidtimeformat), ::core::mem::transmute_copy(&mptimedata)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetParam: GetParam::<Identity, Impl, OFFSET>,
             SetParam: SetParam::<Identity, Impl, OFFSET>,
             AddEnvelope: AddEnvelope::<Identity, Impl, OFFSET>,
@@ -31691,7 +31691,7 @@ impl IMediaSample_Vtbl {
             this.SetMediaTime(::core::mem::transmute_copy(&ptimestart), ::core::mem::transmute_copy(&ptimeend)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetPointer: GetPointer::<Identity, Impl, OFFSET>,
             GetSize: GetSize::<Identity, Impl, OFFSET>,
             GetTime: GetTime::<Identity, Impl, OFFSET>,
@@ -31761,7 +31761,7 @@ impl IMediaSample2Config_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetSurface: GetSurface::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetSurface: GetSurface::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMediaSample2Config as ::windows::core::Interface>::IID
@@ -31923,7 +31923,7 @@ impl IMediaSeeking_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCapabilities: GetCapabilities::<Identity, Impl, OFFSET>,
             CheckCapabilities: CheckCapabilities::<Identity, Impl, OFFSET>,
             IsFormatSupported: IsFormatSupported::<Identity, Impl, OFFSET>,
@@ -32007,7 +32007,7 @@ impl IMediaStream_Vtbl {
             this.SendEndOfStream(::core::mem::transmute_copy(&dwflags)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetMultiMediaStream: GetMultiMediaStream::<Identity, Impl, OFFSET>,
             GetInformation: GetInformation::<Identity, Impl, OFFSET>,
             SetSameFormat: SetSameFormat::<Identity, Impl, OFFSET>,
@@ -32219,7 +32219,7 @@ impl IMemAllocator_Vtbl {
             this.ReleaseBuffer(::core::mem::transmute(&pbuffer)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetProperties: SetProperties::<Identity, Impl, OFFSET>,
             GetProperties: GetProperties::<Identity, Impl, OFFSET>,
             Commit: Commit::<Identity, Impl, OFFSET>,
@@ -32276,7 +32276,7 @@ impl IMemAllocatorNotifyCallbackTemp_Vtbl {
             let this = (*this).get_impl();
             this.NotifyRelease().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), NotifyRelease: NotifyRelease::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), NotifyRelease: NotifyRelease::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMemAllocatorNotifyCallbackTemp as ::windows::core::Interface>::IID
@@ -32345,7 +32345,7 @@ impl IMemInputPin_Vtbl {
             this.ReceiveCanBlock().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetAllocator: GetAllocator::<Identity, Impl, OFFSET>,
             NotifyAllocator: NotifyAllocator::<Identity, Impl, OFFSET>,
             GetAllocatorRequirements: GetAllocatorRequirements::<Identity, Impl, OFFSET>,
@@ -32382,7 +32382,7 @@ impl IMemoryData_Vtbl {
             this.SetActual(::core::mem::transmute_copy(&cbdatavalid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetBuffer: SetBuffer::<Identity, Impl, OFFSET>,
             GetInfo: GetInfo::<Identity, Impl, OFFSET>,
             SetActual: SetActual::<Identity, Impl, OFFSET>,
@@ -32455,7 +32455,7 @@ impl IMixerOCX_Vtbl {
             this.UnAdvise().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnDisplayChange: OnDisplayChange::<Identity, Impl, OFFSET>,
             GetAspectRatio: GetAspectRatio::<Identity, Impl, OFFSET>,
             GetVideoSize: GetVideoSize::<Identity, Impl, OFFSET>,
@@ -32497,7 +32497,7 @@ impl IMixerOCXNotify_Vtbl {
             this.OnDataChange(::core::mem::transmute_copy(&uldataflags)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnInvalidateRect: OnInvalidateRect::<Identity, Impl, OFFSET>,
             OnStatusChange: OnStatusChange::<Identity, Impl, OFFSET>,
             OnDataChange: OnDataChange::<Identity, Impl, OFFSET>,
@@ -32588,7 +32588,7 @@ impl IMixerPinConfig_Vtbl {
             this.GetStreamTransparent(::core::mem::transmute_copy(&pbstreamtransparent)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetRelativePosition: SetRelativePosition::<Identity, Impl, OFFSET>,
             GetRelativePosition: GetRelativePosition::<Identity, Impl, OFFSET>,
             SetZOrder: SetZOrder::<Identity, Impl, OFFSET>,
@@ -32682,7 +32682,7 @@ impl IMpeg2Data_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSection: GetSection::<Identity, Impl, OFFSET>,
             GetTable: GetTable::<Identity, Impl, OFFSET>,
             GetStreamOfSections: GetStreamOfSections::<Identity, Impl, OFFSET>,
@@ -32719,7 +32719,7 @@ impl IMpeg2Demultiplexer_Vtbl {
             this.DeleteOutputPin(::core::mem::transmute(&pszpinname)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateOutputPin: CreateOutputPin::<Identity, Impl, OFFSET>,
             SetOutputPinMediaType: SetOutputPinMediaType::<Identity, Impl, OFFSET>,
             DeleteOutputPin: DeleteOutputPin::<Identity, Impl, OFFSET>,
@@ -32750,7 +32750,7 @@ impl IMpeg2Stream_Vtbl {
             this.SupplyDataBuffer(::core::mem::transmute_copy(&pstreambuffer)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             SupplyDataBuffer: SupplyDataBuffer::<Identity, Impl, OFFSET>,
         }
@@ -32801,7 +32801,7 @@ impl IMpeg2TableFilter_Vtbl {
             this.RemoveExtension(::core::mem::transmute_copy(&p), ::core::mem::transmute_copy(&t), ::core::mem::transmute_copy(&e)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddPID: AddPID::<Identity, Impl, OFFSET>,
             AddTable: AddTable::<Identity, Impl, OFFSET>,
             AddExtension: AddExtension::<Identity, Impl, OFFSET>,
@@ -32937,7 +32937,7 @@ impl IMpegAudioDecoder_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             FrequencyDivider: FrequencyDivider::<Identity, Impl, OFFSET>,
             SetFrequencyDivider: SetFrequencyDivider::<Identity, Impl, OFFSET>,
             DecoderAccuracy: DecoderAccuracy::<Identity, Impl, OFFSET>,
@@ -33056,7 +33056,7 @@ impl IMultiMediaStream_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetInformation: GetInformation::<Identity, Impl, OFFSET>,
             GetMediaStream: GetMediaStream::<Identity, Impl, OFFSET>,
             EnumMediaStreams: EnumMediaStreams::<Identity, Impl, OFFSET>,
@@ -33159,7 +33159,7 @@ impl IOverlay_Vtbl {
             this.Unadvise().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetPalette: GetPalette::<Identity, Impl, OFFSET>,
             SetPalette: SetPalette::<Identity, Impl, OFFSET>,
             GetDefaultColorKey: GetDefaultColorKey::<Identity, Impl, OFFSET>,
@@ -33209,7 +33209,7 @@ impl IOverlayNotify_Vtbl {
             this.OnPositionChange(::core::mem::transmute_copy(&psourcerect), ::core::mem::transmute_copy(&pdestinationrect)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnPaletteChange: OnPaletteChange::<Identity, Impl, OFFSET>,
             OnClipChange: OnClipChange::<Identity, Impl, OFFSET>,
             OnColorKeyChange: OnColorKeyChange::<Identity, Impl, OFFSET>,
@@ -33357,7 +33357,7 @@ impl IPAT_Vtbl {
             this.ConvertNextToCurrent().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             GetTransportStreamId: GetTransportStreamId::<Identity, Impl, OFFSET>,
             GetVersionNumber: GetVersionNumber::<Identity, Impl, OFFSET>,
@@ -33411,7 +33411,7 @@ impl IPBDAAttributesDescriptor_Vtbl {
             this.GetAttributePayload(::core::mem::transmute_copy(&ppbattributebuffer), ::core::mem::transmute_copy(&pdwattributelength)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTag: GetTag::<Identity, Impl, OFFSET>,
             GetLength: GetLength::<Identity, Impl, OFFSET>,
             GetAttributePayload: GetAttributePayload::<Identity, Impl, OFFSET>,
@@ -33457,7 +33457,7 @@ impl IPBDAEntitlementDescriptor_Vtbl {
             this.GetToken(::core::mem::transmute_copy(&ppbtokenbuffer), ::core::mem::transmute_copy(&pdwtokenlength)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTag: GetTag::<Identity, Impl, OFFSET>,
             GetLength: GetLength::<Identity, Impl, OFFSET>,
             GetToken: GetToken::<Identity, Impl, OFFSET>,
@@ -33503,7 +33503,7 @@ impl IPBDASiParser_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             GetEIT: GetEIT::<Identity, Impl, OFFSET>,
             GetServices: GetServices::<Identity, Impl, OFFSET>,
@@ -33639,7 +33639,7 @@ impl IPBDA_EIT_Vtbl {
             this.GetRecordDescriptorByTag(::core::mem::transmute_copy(&dwrecordindex), ::core::mem::transmute_copy(&btag), ::core::mem::transmute_copy(&pdwcookie), ::core::mem::transmute_copy(&ppdescriptor)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             GetTableId: GetTableId::<Identity, Impl, OFFSET>,
             GetVersionNumber: GetVersionNumber::<Identity, Impl, OFFSET>,
@@ -33693,7 +33693,7 @@ impl IPBDA_Services_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             GetCountOfRecords: GetCountOfRecords::<Identity, Impl, OFFSET>,
             GetRecordByIndex: GetRecordByIndex::<Identity, Impl, OFFSET>,
@@ -33892,7 +33892,7 @@ impl IPMT_Vtbl {
             this.ConvertNextToCurrent().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             GetProgramNumber: GetProgramNumber::<Identity, Impl, OFFSET>,
             GetVersionNumber: GetVersionNumber::<Identity, Impl, OFFSET>,
@@ -33935,7 +33935,7 @@ impl IPSITables_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetTable: GetTable::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetTable: GetTable::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IPSITables as ::windows::core::Interface>::IID
@@ -33962,7 +33962,7 @@ impl IPTFilterLicenseRenewal_Vtbl {
             this.CancelLicenseRenewal().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RenewLicenses: RenewLicenses::<Identity, Impl, OFFSET>,
             CancelLicenseRenewal: CancelLicenseRenewal::<Identity, Impl, OFFSET>,
         }
@@ -34071,7 +34071,7 @@ impl IPersistTuneXmlUtility_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Deserialize: Deserialize::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Deserialize: Deserialize::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IPersistTuneXmlUtility as ::windows::core::Interface>::IID
@@ -34238,7 +34238,7 @@ impl IPin_Vtbl {
             this.NewSegment(::core::mem::transmute_copy(&tstart), ::core::mem::transmute_copy(&tstop), ::core::mem::transmute_copy(&drate)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Connect: Connect::<Identity, Impl, OFFSET>,
             ReceiveConnection: ReceiveConnection::<Identity, Impl, OFFSET>,
             Disconnect: Disconnect::<Identity, Impl, OFFSET>,
@@ -34293,7 +34293,7 @@ impl IPinConnection_Vtbl {
             this.DynamicDisconnect().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             DynamicQueryAccept: DynamicQueryAccept::<Identity, Impl, OFFSET>,
             NotifyEndOfStream: NotifyEndOfStream::<Identity, Impl, OFFSET>,
             IsEndPin: IsEndPin::<Identity, Impl, OFFSET>,
@@ -34318,7 +34318,7 @@ impl IPinFlowControl_Vtbl {
             let this = (*this).get_impl();
             this.Block(::core::mem::transmute_copy(&dwblockflags), ::core::mem::transmute_copy(&hevent)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Block: Block::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Block: Block::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IPinFlowControl as ::windows::core::Interface>::IID
@@ -34557,7 +34557,7 @@ impl IQualProp_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             FramesDroppedInRenderer: FramesDroppedInRenderer::<Identity, Impl, OFFSET>,
             FramesDrawn: FramesDrawn::<Identity, Impl, OFFSET>,
             AvgFrameRate: AvgFrameRate::<Identity, Impl, OFFSET>,
@@ -34591,7 +34591,7 @@ impl IQualityControl_Vtbl {
             this.SetSink(::core::mem::transmute(&piqc)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Notify: Notify::<Identity, Impl, OFFSET>,
             SetSink: SetSink::<Identity, Impl, OFFSET>,
         }
@@ -34621,7 +34621,7 @@ impl IQueueCommand_Vtbl {
             this.InvokeAtPresentationTime(::core::mem::transmute_copy(&pcmd), ::core::mem::transmute_copy(&time), ::core::mem::transmute_copy(&iid), ::core::mem::transmute_copy(&dispidmethod), ::core::mem::transmute_copy(&wflags), ::core::mem::transmute_copy(&cargs), ::core::mem::transmute_copy(&pdispparams), ::core::mem::transmute_copy(&pvarresult), ::core::mem::transmute_copy(&puargerr)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             InvokeAtStreamTime: InvokeAtStreamTime::<Identity, Impl, OFFSET>,
             InvokeAtPresentationTime: InvokeAtPresentationTime::<Identity, Impl, OFFSET>,
         }
@@ -34683,7 +34683,7 @@ impl IRegisterServiceProvider_Vtbl {
             let this = (*this).get_impl();
             this.RegisterService(::core::mem::transmute_copy(&guidservice), ::core::mem::transmute(&punkobject)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), RegisterService: RegisterService::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), RegisterService: RegisterService::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IRegisterServiceProvider as ::windows::core::Interface>::IID
@@ -34707,7 +34707,7 @@ impl IRegisterTuner_Vtbl {
             this.Unregister().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Register: Register::<Identity, Impl, OFFSET>,
             Unregister: Unregister::<Identity, Impl, OFFSET>,
         }
@@ -34734,7 +34734,7 @@ impl IResourceConsumer_Vtbl {
             this.ReleaseResource(::core::mem::transmute_copy(&idresource)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AcquireResource: AcquireResource::<Identity, Impl, OFFSET>,
             ReleaseResource: ReleaseResource::<Identity, Impl, OFFSET>,
         }
@@ -34812,7 +34812,7 @@ impl IResourceManager_Vtbl {
             this.ReleaseFocus(::core::mem::transmute(&pfocusobject)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Register: Register::<Identity, Impl, OFFSET>,
             RegisterGroup: RegisterGroup::<Identity, Impl, OFFSET>,
             RequestResource: RequestResource::<Identity, Impl, OFFSET>,
@@ -34869,7 +34869,7 @@ impl ISBE2Crossbar_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             EnableDefaultMode: EnableDefaultMode::<Identity, Impl, OFFSET>,
             GetInitialProfile: GetInitialProfile::<Identity, Impl, OFFSET>,
             SetOutputProfile: SetOutputProfile::<Identity, Impl, OFFSET>,
@@ -34916,7 +34916,7 @@ impl ISBE2EnumStream_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -34938,7 +34938,7 @@ impl ISBE2FileScan_Vtbl {
             let this = (*this).get_impl();
             this.RepairFile(::core::mem::transmute(&filename)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), RepairFile: RepairFile::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), RepairFile: RepairFile::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ISBE2FileScan as ::windows::core::Interface>::IID
@@ -34958,7 +34958,7 @@ impl ISBE2GlobalEvent_Vtbl {
             let this = (*this).get_impl();
             this.GetEvent(::core::mem::transmute_copy(&idevt), ::core::mem::transmute_copy(&param1), ::core::mem::transmute_copy(&param2), ::core::mem::transmute_copy(&param3), ::core::mem::transmute_copy(&param4), ::core::mem::transmute_copy(&pspanning), ::core::mem::transmute_copy(&pcb), ::core::mem::transmute_copy(&pb)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetEvent: GetEvent::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetEvent: GetEvent::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ISBE2GlobalEvent as ::windows::core::Interface>::IID
@@ -35029,7 +35029,7 @@ impl ISBE2MediaTypeProfile_Vtbl {
             this.DeleteStream(::core::mem::transmute_copy(&index)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetStreamCount: GetStreamCount::<Identity, Impl, OFFSET>,
             GetStream: GetStream::<Identity, Impl, OFFSET>,
             AddStream: AddStream::<Identity, Impl, OFFSET>,
@@ -35051,7 +35051,7 @@ impl ISBE2SpanningEvent_Vtbl {
             let this = (*this).get_impl();
             this.GetEvent(::core::mem::transmute_copy(&idevt), ::core::mem::transmute_copy(&streamid), ::core::mem::transmute_copy(&pcb), ::core::mem::transmute_copy(&pb)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetEvent: GetEvent::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetEvent: GetEvent::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ISBE2SpanningEvent as ::windows::core::Interface>::IID
@@ -35087,7 +35087,7 @@ impl ISBE2StreamMap_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             MapStream: MapStream::<Identity, Impl, OFFSET>,
             UnmapStream: UnmapStream::<Identity, Impl, OFFSET>,
             EnumMappedStreams: EnumMappedStreams::<Identity, Impl, OFFSET>,
@@ -35427,7 +35427,7 @@ impl ISCTE_EAS_Vtbl {
             this.GetTableDescriptorByTag(::core::mem::transmute_copy(&btag), ::core::mem::transmute_copy(&pdwcookie), ::core::mem::transmute_copy(&ppdescriptor)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             GetVersionNumber: GetVersionNumber::<Identity, Impl, OFFSET>,
             GetSequencyNumber: GetSequencyNumber::<Identity, Impl, OFFSET>,
@@ -35496,7 +35496,7 @@ impl ISIInbandEPG_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             StartSIEPGScan: StartSIEPGScan::<Identity, Impl, OFFSET>,
             StopSIEPGScan: StopSIEPGScan::<Identity, Impl, OFFSET>,
             IsSIEPGScanRunning: IsSIEPGScanRunning::<Identity, Impl, OFFSET>,
@@ -35517,7 +35517,7 @@ impl ISIInbandEPGEvent_Vtbl {
             let this = (*this).get_impl();
             this.SIObjectEvent(::core::mem::transmute(&pidvb_eit), ::core::mem::transmute_copy(&dwtable_id), ::core::mem::transmute_copy(&dwservice_id)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SIObjectEvent: SIObjectEvent::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SIObjectEvent: SIObjectEvent::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ISIInbandEPGEvent as ::windows::core::Interface>::IID
@@ -35709,7 +35709,7 @@ impl ISectionList_Vtbl {
             this.GetTableIdentifier(::core::mem::transmute_copy(&ptableid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             InitializeWithRawSections: InitializeWithRawSections::<Identity, Impl, OFFSET>,
             CancelPendingRequest: CancelPendingRequest::<Identity, Impl, OFFSET>,
@@ -35737,7 +35737,7 @@ impl ISeekingPassThru_Vtbl {
             let this = (*this).get_impl();
             this.Init(::core::mem::transmute_copy(&bsupportrendering), ::core::mem::transmute(&ppin)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Init: Init::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Init: Init::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ISeekingPassThru as ::windows::core::Interface>::IID
@@ -35779,7 +35779,7 @@ impl ISelector_Vtbl {
             this.SetSourceNodeId(::core::mem::transmute_copy(&dwpinid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             NumSources: NumSources::<Identity, Impl, OFFSET>,
             SourceNodeId: SourceNodeId::<Identity, Impl, OFFSET>,
             SetSourceNodeId: SetSourceNodeId::<Identity, Impl, OFFSET>,
@@ -35849,7 +35849,7 @@ impl IServiceLocationDescriptor_Vtbl {
             this.GetElementLanguageCode(::core::mem::transmute_copy(&bindex), ::core::mem::transmute_copy(&langcode)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetPCR_PID: GetPCR_PID::<Identity, Impl, OFFSET>,
             GetNumberOfElements: GetNumberOfElements::<Identity, Impl, OFFSET>,
             GetElementStreamType: GetElementStreamType::<Identity, Impl, OFFSET>,
@@ -35881,7 +35881,7 @@ impl ISpecifyParticularPages_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetPages: GetPages::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetPages: GetPages::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ISpecifyParticularPages as ::windows::core::Interface>::IID
@@ -35941,7 +35941,7 @@ impl IStreamBufferConfigure_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetDirectory: SetDirectory::<Identity, Impl, OFFSET>,
             GetDirectory: GetDirectory::<Identity, Impl, OFFSET>,
             SetBackingFileCount: SetBackingFileCount::<Identity, Impl, OFFSET>,
@@ -36081,7 +36081,7 @@ impl IStreamBufferDataCounters_Vtbl {
             this.ResetData().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetData: GetData::<Identity, Impl, OFFSET>,
             ResetData: ResetData::<Identity, Impl, OFFSET>,
         }
@@ -36111,7 +36111,7 @@ impl IStreamBufferInitialize_Vtbl {
             this.SetSIDs(::core::mem::transmute_copy(&csids), ::core::mem::transmute_copy(&ppsid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetHKEY: SetHKEY::<Identity, Impl, OFFSET>,
             SetSIDs: SetSIDs::<Identity, Impl, OFFSET>,
         }
@@ -36195,7 +36195,7 @@ impl IStreamBufferRecComp_Vtbl {
             this.Cancel().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             Append: Append::<Identity, Impl, OFFSET>,
             AppendEx: AppendEx::<Identity, Impl, OFFSET>,
@@ -36235,7 +36235,7 @@ impl IStreamBufferRecordControl_Vtbl {
             this.GetRecordingStatus(::core::mem::transmute_copy(&phresult), ::core::mem::transmute_copy(&pbstarted), ::core::mem::transmute_copy(&pbstopped)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Start: Start::<Identity, Impl, OFFSET>,
             Stop: Stop::<Identity, Impl, OFFSET>,
             GetRecordingStatus: GetRecordingStatus::<Identity, Impl, OFFSET>,
@@ -36293,7 +36293,7 @@ impl IStreamBufferRecordingAttribute_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetAttribute: SetAttribute::<Identity, Impl, OFFSET>,
             GetAttributeCount: GetAttributeCount::<Identity, Impl, OFFSET>,
             GetAttributeByName: GetAttributeByName::<Identity, Impl, OFFSET>,
@@ -36335,7 +36335,7 @@ impl IStreamBufferSink_Vtbl {
             this.IsProfileLocked().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             LockProfile: LockProfile::<Identity, Impl, OFFSET>,
             CreateRecorder: CreateRecorder::<Identity, Impl, OFFSET>,
             IsProfileLocked: IsProfileLocked::<Identity, Impl, OFFSET>,
@@ -36390,7 +36390,7 @@ impl IStreamBufferSource_Vtbl {
             let this = (*this).get_impl();
             this.SetStreamSink(::core::mem::transmute(&pistreambuffersink)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SetStreamSink: SetStreamSink::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SetStreamSink: SetStreamSink::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IStreamBufferSource as ::windows::core::Interface>::IID
@@ -36414,7 +36414,7 @@ impl IStreamBuilder_Vtbl {
             this.Backout(::core::mem::transmute(&ppinout), ::core::mem::transmute(&pgraph)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Render: Render::<Identity, Impl, OFFSET>,
             Backout: Backout::<Identity, Impl, OFFSET>,
         }
@@ -36462,7 +36462,7 @@ impl IStreamSample_Vtbl {
             this.CompletionStatus(::core::mem::transmute_copy(&dwflags), ::core::mem::transmute_copy(&dwmilliseconds)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetMediaStream: GetMediaStream::<Identity, Impl, OFFSET>,
             GetSampleTimes: GetSampleTimes::<Identity, Impl, OFFSET>,
             SetSampleTimes: SetSampleTimes::<Identity, Impl, OFFSET>,
@@ -36561,7 +36561,7 @@ impl ITSDT_Vtbl {
             this.ConvertNextToCurrent().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             GetVersionNumber: GetVersionNumber::<Identity, Impl, OFFSET>,
             GetCountOfTableDescriptors: GetCountOfTableDescriptors::<Identity, Impl, OFFSET>,
@@ -36727,7 +36727,7 @@ impl ITuneRequestInfo_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetLocatorData: GetLocatorData::<Identity, Impl, OFFSET>,
             GetComponentData: GetComponentData::<Identity, Impl, OFFSET>,
             CreateComponentList: CreateComponentList::<Identity, Impl, OFFSET>,
@@ -36866,7 +36866,7 @@ impl ITuner_Vtbl {
             this.TriggerSignalEvents(::core::mem::transmute_copy(&interval)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             TuningSpace: TuningSpace::<Identity, Impl, OFFSET>,
             SetTuningSpace: SetTuningSpace::<Identity, Impl, OFFSET>,
             EnumTuningSpaces: EnumTuningSpaces::<Identity, Impl, OFFSET>,
@@ -36907,7 +36907,7 @@ impl ITunerCap_Vtbl {
             this.get_AuxInputCount(::core::mem::transmute_copy(&pulcompositecount), ::core::mem::transmute_copy(&pulsvideocount)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             get_SupportedNetworkTypes: get_SupportedNetworkTypes::<Identity, Impl, OFFSET>,
             get_SupportedVideoFormats: get_SupportedVideoFormats::<Identity, Impl, OFFSET>,
             get_AuxInputCount: get_AuxInputCount::<Identity, Impl, OFFSET>,
@@ -36934,7 +36934,7 @@ impl ITunerCapEx_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Has608_708Caption: Has608_708Caption::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Has608_708Caption: Has608_708Caption::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ITunerCapEx as ::windows::core::Interface>::IID
@@ -37414,7 +37414,7 @@ impl IVMRAspectRatioControl_Vtbl {
             this.SetAspectRatioMode(::core::mem::transmute_copy(&dwarmode)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetAspectRatioMode: GetAspectRatioMode::<Identity, Impl, OFFSET>,
             SetAspectRatioMode: SetAspectRatioMode::<Identity, Impl, OFFSET>,
         }
@@ -37447,7 +37447,7 @@ impl IVMRAspectRatioControl9_Vtbl {
             this.SetAspectRatioMode(::core::mem::transmute_copy(&dwarmode)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetAspectRatioMode: GetAspectRatioMode::<Identity, Impl, OFFSET>,
             SetAspectRatioMode: SetAspectRatioMode::<Identity, Impl, OFFSET>,
         }
@@ -37507,7 +37507,7 @@ impl IVMRDeinterlaceControl_Vtbl {
             this.GetActualDeinterlaceMode(::core::mem::transmute_copy(&dwstreamid), ::core::mem::transmute_copy(&lpdeinterlacemode)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetNumberOfDeinterlaceModes: GetNumberOfDeinterlaceModes::<Identity, Impl, OFFSET>,
             GetDeinterlaceModeCaps: GetDeinterlaceModeCaps::<Identity, Impl, OFFSET>,
             GetDeinterlaceMode: GetDeinterlaceMode::<Identity, Impl, OFFSET>,
@@ -37593,7 +37593,7 @@ impl IVMRDeinterlaceControl9_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetNumberOfDeinterlaceModes: GetNumberOfDeinterlaceModes::<Identity, Impl, OFFSET>,
             GetDeinterlaceModeCaps: GetDeinterlaceModeCaps::<Identity, Impl, OFFSET>,
             GetDeinterlaceMode: GetDeinterlaceMode::<Identity, Impl, OFFSET>,
@@ -37655,7 +37655,7 @@ impl IVMRFilterConfig_Vtbl {
             this.GetRenderingMode(::core::mem::transmute_copy(&pmode)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetImageCompositor: SetImageCompositor::<Identity, Impl, OFFSET>,
             SetNumberOfStreams: SetNumberOfStreams::<Identity, Impl, OFFSET>,
             GetNumberOfStreams: GetNumberOfStreams::<Identity, Impl, OFFSET>,
@@ -37735,7 +37735,7 @@ impl IVMRFilterConfig9_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetImageCompositor: SetImageCompositor::<Identity, Impl, OFFSET>,
             SetNumberOfStreams: SetNumberOfStreams::<Identity, Impl, OFFSET>,
             GetNumberOfStreams: GetNumberOfStreams::<Identity, Impl, OFFSET>,
@@ -37782,7 +37782,7 @@ impl IVMRImageCompositor_Vtbl {
             this.CompositeImage(::core::mem::transmute(&pd3ddevice), ::core::mem::transmute(&pddsrendertarget), ::core::mem::transmute_copy(&pmtrendertarget), ::core::mem::transmute_copy(&rtstart), ::core::mem::transmute_copy(&rtend), ::core::mem::transmute_copy(&dwclrbkgnd), ::core::mem::transmute_copy(&pvideostreaminfo), ::core::mem::transmute_copy(&cstreams)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             InitCompositionTarget: InitCompositionTarget::<Identity, Impl, OFFSET>,
             TermCompositionTarget: TermCompositionTarget::<Identity, Impl, OFFSET>,
             SetStreamMediaType: SetStreamMediaType::<Identity, Impl, OFFSET>,
@@ -37826,7 +37826,7 @@ impl IVMRImageCompositor9_Vtbl {
             this.CompositeImage(::core::mem::transmute(&pd3ddevice), ::core::mem::transmute(&pddsrendertarget), ::core::mem::transmute_copy(&pmtrendertarget), ::core::mem::transmute_copy(&rtstart), ::core::mem::transmute_copy(&rtend), ::core::mem::transmute_copy(&dwclrbkgnd), ::core::mem::transmute_copy(&pvideostreaminfo), ::core::mem::transmute_copy(&cstreams)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             InitCompositionDevice: InitCompositionDevice::<Identity, Impl, OFFSET>,
             TermCompositionDevice: TermCompositionDevice::<Identity, Impl, OFFSET>,
             SetStreamMediaType: SetStreamMediaType::<Identity, Impl, OFFSET>,
@@ -37864,7 +37864,7 @@ impl IVMRImagePresenter_Vtbl {
             this.PresentImage(::core::mem::transmute_copy(&dwuserid), ::core::mem::transmute_copy(&lppresinfo)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             StartPresenting: StartPresenting::<Identity, Impl, OFFSET>,
             StopPresenting: StopPresenting::<Identity, Impl, OFFSET>,
             PresentImage: PresentImage::<Identity, Impl, OFFSET>,
@@ -37901,7 +37901,7 @@ impl IVMRImagePresenter9_Vtbl {
             this.PresentImage(::core::mem::transmute_copy(&dwuserid), ::core::mem::transmute_copy(&lppresinfo)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             StartPresenting: StartPresenting::<Identity, Impl, OFFSET>,
             StopPresenting: StopPresenting::<Identity, Impl, OFFSET>,
             PresentImage: PresentImage::<Identity, Impl, OFFSET>,
@@ -37929,7 +37929,7 @@ impl IVMRImagePresenterConfig_Vtbl {
             this.GetRenderingPrefs(::core::mem::transmute_copy(&dwrenderflags)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetRenderingPrefs: SetRenderingPrefs::<Identity, Impl, OFFSET>,
             GetRenderingPrefs: GetRenderingPrefs::<Identity, Impl, OFFSET>,
         }
@@ -37962,7 +37962,7 @@ impl IVMRImagePresenterConfig9_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetRenderingPrefs: SetRenderingPrefs::<Identity, Impl, OFFSET>,
             GetRenderingPrefs: GetRenderingPrefs::<Identity, Impl, OFFSET>,
         }
@@ -38028,7 +38028,7 @@ impl IVMRMixerBitmap_Vtbl {
             this.GetAlphaBitmapParameters(::core::mem::transmute_copy(&pbmpparms)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetAlphaBitmap: SetAlphaBitmap::<Identity, Impl, OFFSET>,
             UpdateAlphaBitmapParameters: UpdateAlphaBitmapParameters::<Identity, Impl, OFFSET>,
             GetAlphaBitmapParameters: GetAlphaBitmapParameters::<Identity, Impl, OFFSET>,
@@ -38071,7 +38071,7 @@ impl IVMRMixerBitmap9_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetAlphaBitmap: SetAlphaBitmap::<Identity, Impl, OFFSET>,
             UpdateAlphaBitmapParameters: UpdateAlphaBitmapParameters::<Identity, Impl, OFFSET>,
             GetAlphaBitmapParameters: GetAlphaBitmapParameters::<Identity, Impl, OFFSET>,
@@ -38150,7 +38150,7 @@ impl IVMRMixerControl_Vtbl {
             this.GetMixingPrefs(::core::mem::transmute_copy(&pdwmixerprefs)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetAlpha: SetAlpha::<Identity, Impl, OFFSET>,
             GetAlpha: GetAlpha::<Identity, Impl, OFFSET>,
             SetZOrder: SetZOrder::<Identity, Impl, OFFSET>,
@@ -38278,7 +38278,7 @@ impl IVMRMixerControl9_Vtbl {
             this.GetProcAmpControlRange(::core::mem::transmute_copy(&dwstreamid), ::core::mem::transmute_copy(&lpclrcontrol)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetAlpha: SetAlpha::<Identity, Impl, OFFSET>,
             GetAlpha: GetAlpha::<Identity, Impl, OFFSET>,
             SetZOrder: SetZOrder::<Identity, Impl, OFFSET>,
@@ -38337,7 +38337,7 @@ impl IVMRMonitorConfig_Vtbl {
             this.GetAvailableMonitors(::core::mem::transmute_copy(&pinfo), ::core::mem::transmute_copy(&dwmaxinfoarraysize), ::core::mem::transmute_copy(&pdwnumdevices)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetMonitor: SetMonitor::<Identity, Impl, OFFSET>,
             GetMonitor: GetMonitor::<Identity, Impl, OFFSET>,
             SetDefaultMonitor: SetDefaultMonitor::<Identity, Impl, OFFSET>,
@@ -38400,7 +38400,7 @@ impl IVMRMonitorConfig9_Vtbl {
             this.GetAvailableMonitors(::core::mem::transmute_copy(&pinfo), ::core::mem::transmute_copy(&dwmaxinfoarraysize), ::core::mem::transmute_copy(&pdwnumdevices)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetMonitor: SetMonitor::<Identity, Impl, OFFSET>,
             GetMonitor: GetMonitor::<Identity, Impl, OFFSET>,
             SetDefaultMonitor: SetDefaultMonitor::<Identity, Impl, OFFSET>,
@@ -38451,7 +38451,7 @@ impl IVMRSurface_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             IsSurfaceLocked: IsSurfaceLocked::<Identity, Impl, OFFSET>,
             LockSurface: LockSurface::<Identity, Impl, OFFSET>,
             UnlockSurface: UnlockSurface::<Identity, Impl, OFFSET>,
@@ -38507,7 +38507,7 @@ impl IVMRSurface9_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             IsSurfaceLocked: IsSurfaceLocked::<Identity, Impl, OFFSET>,
             LockSurface: LockSurface::<Identity, Impl, OFFSET>,
             UnlockSurface: UnlockSurface::<Identity, Impl, OFFSET>,
@@ -38551,7 +38551,7 @@ impl IVMRSurfaceAllocator_Vtbl {
             this.AdviseNotify(::core::mem::transmute(&lpivmrsurfallocnotify)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AllocateSurface: AllocateSurface::<Identity, Impl, OFFSET>,
             FreeSurface: FreeSurface::<Identity, Impl, OFFSET>,
             PrepareSurface: PrepareSurface::<Identity, Impl, OFFSET>,
@@ -38601,7 +38601,7 @@ impl IVMRSurfaceAllocator9_Vtbl {
             this.AdviseNotify(::core::mem::transmute(&lpivmrsurfallocnotify)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             InitializeDevice: InitializeDevice::<Identity, Impl, OFFSET>,
             TerminateDevice: TerminateDevice::<Identity, Impl, OFFSET>,
             GetSurface: GetSurface::<Identity, Impl, OFFSET>,
@@ -38677,7 +38677,7 @@ impl IVMRSurfaceAllocatorNotify_Vtbl {
             this.SetBorderColor(::core::mem::transmute_copy(&clrborder)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AdviseSurfaceAllocator: AdviseSurfaceAllocator::<Identity, Impl, OFFSET>,
             SetDDrawDevice: SetDDrawDevice::<Identity, Impl, OFFSET>,
             ChangeDDrawDevice: ChangeDDrawDevice::<Identity, Impl, OFFSET>,
@@ -38729,7 +38729,7 @@ impl IVMRSurfaceAllocatorNotify9_Vtbl {
             this.NotifyEvent(::core::mem::transmute_copy(&eventcode), ::core::mem::transmute_copy(&param1), ::core::mem::transmute_copy(&param2)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AdviseSurfaceAllocator: AdviseSurfaceAllocator::<Identity, Impl, OFFSET>,
             SetD3DDevice: SetD3DDevice::<Identity, Impl, OFFSET>,
             ChangeD3DDevice: ChangeD3DDevice::<Identity, Impl, OFFSET>,
@@ -38774,7 +38774,7 @@ impl IVMRVideoStreamControl_Vtbl {
             this.GetStreamActiveState(::core::mem::transmute_copy(&lpfactive)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetColorKey: SetColorKey::<Identity, Impl, OFFSET>,
             GetColorKey: GetColorKey::<Identity, Impl, OFFSET>,
             SetStreamActiveState: SetStreamActiveState::<Identity, Impl, OFFSET>,
@@ -38812,7 +38812,7 @@ impl IVMRVideoStreamControl9_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetStreamActiveState: SetStreamActiveState::<Identity, Impl, OFFSET>,
             GetStreamActiveState: GetStreamActiveState::<Identity, Impl, OFFSET>,
         }
@@ -38920,7 +38920,7 @@ impl IVMRWindowlessControl_Vtbl {
             this.GetColorKey(::core::mem::transmute_copy(&lpclr)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetNativeVideoSize: GetNativeVideoSize::<Identity, Impl, OFFSET>,
             GetMinIdealVideoSize: GetMinIdealVideoSize::<Identity, Impl, OFFSET>,
             GetMaxIdealVideoSize: GetMaxIdealVideoSize::<Identity, Impl, OFFSET>,
@@ -39047,7 +39047,7 @@ impl IVMRWindowlessControl9_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetNativeVideoSize: GetNativeVideoSize::<Identity, Impl, OFFSET>,
             GetMinIdealVideoSize: GetMinIdealVideoSize::<Identity, Impl, OFFSET>,
             GetMaxIdealVideoSize: GetMaxIdealVideoSize::<Identity, Impl, OFFSET>,
@@ -39160,7 +39160,7 @@ impl IVPBaseConfig_Vtbl {
             this.SetSurfaceParameters(::core::mem::transmute_copy(&dwpitch), ::core::mem::transmute_copy(&dwxorigin), ::core::mem::transmute_copy(&dwyorigin)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetConnectInfo: GetConnectInfo::<Identity, Impl, OFFSET>,
             SetConnectInfo: SetConnectInfo::<Identity, Impl, OFFSET>,
             GetVPDataInfo: GetVPDataInfo::<Identity, Impl, OFFSET>,
@@ -39191,7 +39191,7 @@ impl IVPBaseNotify_Vtbl {
             let this = (*this).get_impl();
             this.RenegotiateVPParameters().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), RenegotiateVPParameters: RenegotiateVPParameters::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), RenegotiateVPParameters: RenegotiateVPParameters::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IVPBaseNotify as ::windows::core::Interface>::IID
@@ -39245,7 +39245,7 @@ impl IVPManager_Vtbl {
             this.GetVideoPortIndex(::core::mem::transmute_copy(&pdwvideoportindex)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetVideoPortIndex: SetVideoPortIndex::<Identity, Impl, OFFSET>,
             GetVideoPortIndex: GetVideoPortIndex::<Identity, Impl, OFFSET>,
         }
@@ -39371,7 +39371,7 @@ impl IVideoFrameStep_Vtbl {
             this.CancelStep().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Step: Step::<Identity, Impl, OFFSET>,
             CanStep: CanStep::<Identity, Impl, OFFSET>,
             CancelStep: CancelStep::<Identity, Impl, OFFSET>,
@@ -39621,7 +39621,7 @@ impl IVideoProcAmp_Vtbl {
             this.getRange_WhiteBalanceComponent(::core::mem::transmute_copy(&pmin), ::core::mem::transmute_copy(&pmax), ::core::mem::transmute_copy(&psteppingdelta), ::core::mem::transmute_copy(&pdefault), ::core::mem::transmute_copy(&pcapsflag)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             get_BacklightCompensation: get_BacklightCompensation::<Identity, Impl, OFFSET>,
             put_BacklightCompensation: put_BacklightCompensation::<Identity, Impl, OFFSET>,
             getRange_BacklightCompensation: getRange_BacklightCompensation::<Identity, Impl, OFFSET>,
@@ -40079,7 +40079,7 @@ impl IWMCodecAMVideoAccelerator_Vtbl {
             this.SetPlayerNotify(::core::mem::transmute(&phook)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetAcceleratorInterface: SetAcceleratorInterface::<Identity, Impl, OFFSET>,
             NegotiateConnection: NegotiateConnection::<Identity, Impl, OFFSET>,
             SetPlayerNotify: SetPlayerNotify::<Identity, Impl, OFFSET>,
@@ -40110,7 +40110,7 @@ impl IWMCodecVideoAccelerator_Vtbl {
             this.SetPlayerNotify(::core::mem::transmute(&phook)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             NegotiateConnection: NegotiateConnection::<Identity, Impl, OFFSET>,
             SetPlayerNotify: SetPlayerNotify::<Identity, Impl, OFFSET>,
         }
@@ -40185,7 +40185,7 @@ impl IXDSCodec_Vtbl {
             this.GetLastErrorCode().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             XDSToRatObjOK: XDSToRatObjOK::<Identity, Impl, OFFSET>,
             SetCCSubstreamService: SetCCSubstreamService::<Identity, Impl, OFFSET>,
             CCSubstreamService: CCSubstreamService::<Identity, Impl, OFFSET>,
@@ -40223,7 +40223,7 @@ impl IXDSCodecConfig_Vtbl {
             this.SetPauseBufferTime(::core::mem::transmute_copy(&dwpausebuffertime)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSecureChannelObject: GetSecureChannelObject::<Identity, Impl, OFFSET>,
             SetPauseBufferTime: SetPauseBufferTime::<Identity, Impl, OFFSET>,
         }

--- a/crates/libs/windows/src/Windows/Win32/Media/DxMediaObjects/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/DxMediaObjects/impl.rs
@@ -28,7 +28,7 @@ impl IDMOQualityControl_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetNow: SetNow::<Identity, Impl, OFFSET>,
             SetStatus: SetStatus::<Identity, Impl, OFFSET>,
             GetStatus: GetStatus::<Identity, Impl, OFFSET>,
@@ -86,7 +86,7 @@ impl IDMOVideoOutputOptimizations_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             QueryOperationModePreferences: QueryOperationModePreferences::<Identity, Impl, OFFSET>,
             SetOperationMode: SetOperationMode::<Identity, Impl, OFFSET>,
             GetCurrentOperationMode: GetCurrentOperationMode::<Identity, Impl, OFFSET>,
@@ -133,7 +133,7 @@ impl IEnumDMO_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -174,7 +174,7 @@ impl IMediaBuffer_Vtbl {
             this.GetBufferAndLength(::core::mem::transmute_copy(&ppbuffer), ::core::mem::transmute_copy(&pcblength)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetLength: SetLength::<Identity, Impl, OFFSET>,
             GetMaxLength: GetMaxLength::<Identity, Impl, OFFSET>,
             GetBufferAndLength: GetBufferAndLength::<Identity, Impl, OFFSET>,
@@ -367,7 +367,7 @@ impl IMediaObject_Vtbl {
             this.Lock(::core::mem::transmute_copy(&block)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetStreamCount: GetStreamCount::<Identity, Impl, OFFSET>,
             GetInputStreamInfo: GetInputStreamInfo::<Identity, Impl, OFFSET>,
             GetOutputStreamInfo: GetOutputStreamInfo::<Identity, Impl, OFFSET>,
@@ -431,7 +431,7 @@ impl IMediaObjectInPlace_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Process: Process::<Identity, Impl, OFFSET>,
             Clone: Clone::<Identity, Impl, OFFSET>,
             GetLatency: GetLatency::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/Media/DxMediaObjects/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/DxMediaObjects/mod.rs
@@ -160,7 +160,7 @@ unsafe impl ::windows::core::Interface for IDMOQualityControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDMOQualityControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetNow: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, rtnow: i64) -> ::windows::core::HRESULT,
     pub SetStatus: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwflags: u32) -> ::windows::core::HRESULT,
     pub GetStatus: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwflags: *mut u32) -> ::windows::core::HRESULT,
@@ -223,7 +223,7 @@ unsafe impl ::windows::core::Interface for IDMOVideoOutputOptimizations {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDMOVideoOutputOptimizations_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub QueryOperationModePreferences: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, uloutputstreamindex: u32, pdwrequestedcapabilities: *mut u32) -> ::windows::core::HRESULT,
     pub SetOperationMode: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, uloutputstreamindex: u32, dwenabledfeatures: u32) -> ::windows::core::HRESULT,
     pub GetCurrentOperationMode: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, uloutputstreamindex: u32, pdwenabledfeatures: *mut u32) -> ::windows::core::HRESULT,
@@ -285,7 +285,7 @@ unsafe impl ::windows::core::Interface for IEnumDMO {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumDMO_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, citemstofetch: u32, pclsid: *mut ::windows::core::GUID, names: *mut ::windows::core::PWSTR, pcitemsfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, citemstoskip: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -344,7 +344,7 @@ unsafe impl ::windows::core::Interface for IMediaBuffer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMediaBuffer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetLength: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cblength: u32) -> ::windows::core::HRESULT,
     pub GetMaxLength: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcbmaxlength: *mut u32) -> ::windows::core::HRESULT,
     pub GetBufferAndLength: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppbuffer: *mut *mut u8, pcblength: *mut u32) -> ::windows::core::HRESULT,
@@ -478,7 +478,7 @@ unsafe impl ::windows::core::Interface for IMediaObject {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMediaObject_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetStreamCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcinputstreams: *mut u32, pcoutputstreams: *mut u32) -> ::windows::core::HRESULT,
     pub GetInputStreamInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwinputstreamindex: u32, pdwflags: *mut u32) -> ::windows::core::HRESULT,
     pub GetOutputStreamInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwoutputstreamindex: u32, pdwflags: *mut u32) -> ::windows::core::HRESULT,
@@ -573,7 +573,7 @@ unsafe impl ::windows::core::Interface for IMediaObjectInPlace {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMediaObjectInPlace_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Process: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ulsize: u32, pdata: *mut u8, reftimestart: i64, dwflags: u32) -> ::windows::core::HRESULT,
     pub Clone: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppmediaobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetLatency: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, platencytime: *mut i64) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/Media/KernelStreaming/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/KernelStreaming/impl.rs
@@ -16,7 +16,7 @@ impl IKsAggregateControl_Vtbl {
             this.KsRemoveAggregate(::core::mem::transmute_copy(&aggregateclass)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             KsAddAggregate: KsAddAggregate::<Identity, Impl, OFFSET>,
             KsRemoveAggregate: KsRemoveAggregate::<Identity, Impl, OFFSET>,
         }
@@ -49,7 +49,7 @@ impl IKsControl_Vtbl {
             this.KsEvent(::core::mem::transmute_copy(&event), ::core::mem::transmute_copy(&eventlength), ::core::mem::transmute_copy(&eventdata), ::core::mem::transmute_copy(&datalength), ::core::mem::transmute_copy(&bytesreturned)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             KsProperty: KsProperty::<Identity, Impl, OFFSET>,
             KsMethod: KsMethod::<Identity, Impl, OFFSET>,
             KsEvent: KsEvent::<Identity, Impl, OFFSET>,
@@ -86,7 +86,7 @@ impl IKsFormatSupport_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             IsFormatSupported: IsFormatSupported::<Identity, Impl, OFFSET>,
             GetDevicePreferredFormat: GetDevicePreferredFormat::<Identity, Impl, OFFSET>,
         }
@@ -112,7 +112,7 @@ impl IKsJackContainerId_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetJackContainerId: GetJackContainerId::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetJackContainerId: GetJackContainerId::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IKsJackContainerId as ::windows::core::Interface>::IID
@@ -151,7 +151,7 @@ impl IKsJackDescription_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetJackCount: GetJackCount::<Identity, Impl, OFFSET>,
             GetJackDescription: GetJackDescription::<Identity, Impl, OFFSET>,
         }
@@ -190,7 +190,7 @@ impl IKsJackDescription2_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetJackCount: GetJackCount::<Identity, Impl, OFFSET>,
             GetJackDescription2: GetJackDescription2::<Identity, Impl, OFFSET>,
         }
@@ -219,7 +219,7 @@ impl IKsJackSinkInformation_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetJackSinkInformation: GetJackSinkInformation::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetJackSinkInformation: GetJackSinkInformation::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IKsJackSinkInformation as ::windows::core::Interface>::IID
@@ -255,7 +255,7 @@ impl IKsPropertySet_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Set: Set::<Identity, Impl, OFFSET>,
             Get: Get::<Identity, Impl, OFFSET>,
             QuerySupported: QuerySupported::<Identity, Impl, OFFSET>,
@@ -276,7 +276,7 @@ impl IKsTopology_Vtbl {
             let this = (*this).get_impl();
             this.CreateNodeInstance(::core::mem::transmute_copy(&nodeid), ::core::mem::transmute_copy(&flags), ::core::mem::transmute_copy(&desiredaccess), ::core::mem::transmute(&unkouter), ::core::mem::transmute_copy(&interfaceid), ::core::mem::transmute_copy(&interface)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CreateNodeInstance: CreateNodeInstance::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CreateNodeInstance: CreateNodeInstance::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IKsTopology as ::windows::core::Interface>::IID

--- a/crates/libs/windows/src/Windows/Win32/Media/KernelStreaming/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/KernelStreaming/mod.rs
@@ -155,7 +155,7 @@ unsafe impl ::windows::core::Interface for IKsAggregateControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IKsAggregateControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub KsAddAggregate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, aggregateclass: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub KsRemoveAggregate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, aggregateclass: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
 }
@@ -211,7 +211,7 @@ unsafe impl ::windows::core::Interface for IKsControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IKsControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub KsProperty: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, property: *const KSIDENTIFIER, propertylength: u32, propertydata: *mut ::core::ffi::c_void, datalength: u32, bytesreturned: *mut u32) -> ::windows::core::HRESULT,
     pub KsMethod: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, method: *const KSIDENTIFIER, methodlength: u32, methoddata: *mut ::core::ffi::c_void, datalength: u32, bytesreturned: *mut u32) -> ::windows::core::HRESULT,
     pub KsEvent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, event: *const KSIDENTIFIER, eventlength: u32, eventdata: *mut ::core::ffi::c_void, datalength: u32, bytesreturned: *mut u32) -> ::windows::core::HRESULT,
@@ -268,7 +268,7 @@ unsafe impl ::windows::core::Interface for IKsFormatSupport {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IKsFormatSupport_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub IsFormatSupported: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pksformat: *mut KSDATAFORMAT, cbformat: u32, pbsupported: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -322,7 +322,7 @@ unsafe impl ::windows::core::Interface for IKsJackContainerId {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IKsJackContainerId_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetJackContainerId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pjackcontainerid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_KernelStreaming\"`*"]
@@ -378,7 +378,7 @@ unsafe impl ::windows::core::Interface for IKsJackDescription {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IKsJackDescription_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetJackCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcjacks: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub GetJackDescription: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, njack: u32, pdescription: *mut KSJACK_DESCRIPTION) -> ::windows::core::HRESULT,
@@ -436,7 +436,7 @@ unsafe impl ::windows::core::Interface for IKsJackDescription2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IKsJackDescription2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetJackCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcjacks: *mut u32) -> ::windows::core::HRESULT,
     pub GetJackDescription2: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, njack: u32, pdescription2: *mut KSJACK_DESCRIPTION2) -> ::windows::core::HRESULT,
 }
@@ -489,7 +489,7 @@ unsafe impl ::windows::core::Interface for IKsJackSinkInformation {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IKsJackSinkInformation_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetJackSinkInformation: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pjacksinkinformation: *mut KSJACK_SINK_INFORMATION) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -548,7 +548,7 @@ unsafe impl ::windows::core::Interface for IKsPropertySet {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IKsPropertySet_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Set: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, propset: *const ::windows::core::GUID, id: u32, instancedata: *const ::core::ffi::c_void, instancelength: u32, propertydata: *const ::core::ffi::c_void, datalength: u32) -> ::windows::core::HRESULT,
     pub Get: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, propset: *const ::windows::core::GUID, id: u32, instancedata: *const ::core::ffi::c_void, instancelength: u32, propertydata: *mut ::core::ffi::c_void, datalength: u32, bytesreturned: *mut u32) -> ::windows::core::HRESULT,
     pub QuerySupported: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, propset: *const ::windows::core::GUID, id: u32, typesupport: *mut u32) -> ::windows::core::HRESULT,
@@ -602,7 +602,7 @@ unsafe impl ::windows::core::Interface for IKsTopology {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IKsTopology_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateNodeInstance: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, nodeid: u32, flags: u32, desiredaccess: u32, unkouter: *mut ::core::ffi::c_void, interfaceid: *const ::windows::core::GUID, interface: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_KernelStreaming\"`*"]

--- a/crates/libs/windows/src/Windows/Win32/Media/MediaFoundation/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/MediaFoundation/impl.rs
@@ -16,7 +16,7 @@ impl IAdvancedMediaCapture_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetAdvancedMediaCaptureSettings: GetAdvancedMediaCaptureSettings::<Identity, Impl, OFFSET>,
         }
     }
@@ -35,7 +35,7 @@ impl IAdvancedMediaCaptureInitializationSettings_Vtbl {
             let this = (*this).get_impl();
             this.SetDirectxDeviceManager(::core::mem::transmute(&value)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SetDirectxDeviceManager: SetDirectxDeviceManager::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SetDirectxDeviceManager: SetDirectxDeviceManager::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IAdvancedMediaCaptureInitializationSettings as ::windows::core::Interface>::IID
@@ -58,7 +58,7 @@ impl IAdvancedMediaCaptureSettings_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetDirectxDeviceManager: GetDirectxDeviceManager::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetDirectxDeviceManager: GetDirectxDeviceManager::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IAdvancedMediaCaptureSettings as ::windows::core::Interface>::IID
@@ -75,7 +75,7 @@ impl IAudioSourceProvider_Vtbl {
             let this = (*this).get_impl();
             this.ProvideInput(::core::mem::transmute_copy(&dwsamplecount), ::core::mem::transmute_copy(&pdwchannelcount), ::core::mem::transmute_copy(&pinterleavedaudiodata)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), ProvideInput: ProvideInput::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), ProvideInput: ProvideInput::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IAudioSourceProvider as ::windows::core::Interface>::IID
@@ -105,7 +105,7 @@ impl IClusterDetector_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             Detect: Detect::<Identity, Impl, OFFSET>,
         }
@@ -225,7 +225,7 @@ impl ICodecAPI_Vtbl {
             this.SetAllSettingsWithNotify(::core::mem::transmute(&__midl__icodecapi0002), ::core::mem::transmute_copy(&changedparam), ::core::mem::transmute_copy(&changedparamcount)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             IsSupported: IsSupported::<Identity, Impl, OFFSET>,
             IsModifiable: IsModifiable::<Identity, Impl, OFFSET>,
             GetParameterRange: GetParameterRange::<Identity, Impl, OFFSET>,
@@ -537,7 +537,7 @@ impl ID3D12VideoDevice_Vtbl {
             this.CreateVideoProcessor(::core::mem::transmute_copy(&nodemask), ::core::mem::transmute_copy(&poutputstreamdesc), ::core::mem::transmute_copy(&numinputstreamdescs), ::core::mem::transmute_copy(&pinputstreamdescs), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppvideoprocessor)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CheckFeatureSupport: CheckFeatureSupport::<Identity, Impl, OFFSET>,
             CreateVideoDecoder: CreateVideoDecoder::<Identity, Impl, OFFSET>,
             CreateVideoDecoderHeap: CreateVideoDecoderHeap::<Identity, Impl, OFFSET>,
@@ -1380,7 +1380,7 @@ impl IDXVAHD_Device_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateVideoSurface: CreateVideoSurface::<Identity, Impl, OFFSET>,
             GetVideoProcessorDeviceCaps: GetVideoProcessorDeviceCaps::<Identity, Impl, OFFSET>,
             GetVideoProcessorOutputFormats: GetVideoProcessorOutputFormats::<Identity, Impl, OFFSET>,
@@ -1434,7 +1434,7 @@ impl IDXVAHD_VideoProcessor_Vtbl {
             this.VideoProcessBltHD(::core::mem::transmute(&poutputsurface), ::core::mem::transmute_copy(&outputframe), ::core::mem::transmute_copy(&streamcount), ::core::mem::transmute_copy(&pstreams)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetVideoProcessBltState: SetVideoProcessBltState::<Identity, Impl, OFFSET>,
             GetVideoProcessBltState: GetVideoProcessBltState::<Identity, Impl, OFFSET>,
             SetVideoProcessStreamState: SetVideoProcessStreamState::<Identity, Impl, OFFSET>,
@@ -1460,7 +1460,7 @@ impl IDirect3D9ExOverlayExtension_Vtbl {
             let this = (*this).get_impl();
             this.CheckDeviceOverlayType(::core::mem::transmute_copy(&adapter), ::core::mem::transmute_copy(&devtype), ::core::mem::transmute_copy(&overlaywidth), ::core::mem::transmute_copy(&overlayheight), ::core::mem::transmute_copy(&overlayformat), ::core::mem::transmute_copy(&pdisplaymode), ::core::mem::transmute_copy(&displayrotation), ::core::mem::transmute_copy(&poverlaycaps)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CheckDeviceOverlayType: CheckDeviceOverlayType::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CheckDeviceOverlayType: CheckDeviceOverlayType::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDirect3D9ExOverlayExtension as ::windows::core::Interface>::IID
@@ -1505,7 +1505,7 @@ impl IDirect3DAuthenticatedChannel9_Vtbl {
             this.Configure(::core::mem::transmute_copy(&inputsize), ::core::mem::transmute_copy(&pinput), ::core::mem::transmute_copy(&poutput)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCertificateSize: GetCertificateSize::<Identity, Impl, OFFSET>,
             GetCertificate: GetCertificate::<Identity, Impl, OFFSET>,
             NegotiateKeyExchange: NegotiateKeyExchange::<Identity, Impl, OFFSET>,
@@ -1580,7 +1580,7 @@ impl IDirect3DCryptoSession9_Vtbl {
             this.GetEncryptionBltKey(::core::mem::transmute_copy(&preadbackkey), ::core::mem::transmute_copy(&keysize)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCertificateSize: GetCertificateSize::<Identity, Impl, OFFSET>,
             GetCertificate: GetCertificate::<Identity, Impl, OFFSET>,
             NegotiateKeyExchange: NegotiateKeyExchange::<Identity, Impl, OFFSET>,
@@ -1623,7 +1623,7 @@ impl IDirect3DDevice9Video_Vtbl {
             this.CreateCryptoSession(::core::mem::transmute_copy(&pcryptotype), ::core::mem::transmute_copy(&pdecodeprofile), ::core::mem::transmute_copy(&ppcryptosession), ::core::mem::transmute_copy(&pcryptohandle)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetContentProtectionCaps: GetContentProtectionCaps::<Identity, Impl, OFFSET>,
             CreateAuthenticatedChannel: CreateAuthenticatedChannel::<Identity, Impl, OFFSET>,
             CreateCryptoSession: CreateCryptoSession::<Identity, Impl, OFFSET>,
@@ -1690,7 +1690,7 @@ impl IDirect3DDeviceManager9_Vtbl {
             this.GetVideoService(::core::mem::transmute_copy(&hdevice), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppservice)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ResetDevice: ResetDevice::<Identity, Impl, OFFSET>,
             OpenDeviceHandle: OpenDeviceHandle::<Identity, Impl, OFFSET>,
             CloseDeviceHandle: CloseDeviceHandle::<Identity, Impl, OFFSET>,
@@ -1718,7 +1718,7 @@ impl IDirectXVideoAccelerationService_Vtbl {
             let this = (*this).get_impl();
             this.CreateSurface(::core::mem::transmute_copy(&width), ::core::mem::transmute_copy(&height), ::core::mem::transmute_copy(&backbuffers), ::core::mem::transmute_copy(&format), ::core::mem::transmute_copy(&pool), ::core::mem::transmute_copy(&usage), ::core::mem::transmute_copy(&dxvatype), ::core::mem::transmute_copy(&ppsurface), ::core::mem::transmute_copy(&psharedhandle)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CreateSurface: CreateSurface::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CreateSurface: CreateSurface::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDirectXVideoAccelerationService as ::windows::core::Interface>::IID
@@ -1781,7 +1781,7 @@ impl IDirectXVideoDecoder_Vtbl {
             this.Execute(::core::mem::transmute_copy(&pexecuteparams)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetVideoDecoderService: GetVideoDecoderService::<Identity, Impl, OFFSET>,
             GetCreationParameters: GetCreationParameters::<Identity, Impl, OFFSET>,
             GetBuffer: GetBuffer::<Identity, Impl, OFFSET>,
@@ -1869,7 +1869,7 @@ impl IDirectXVideoMemoryConfiguration_Vtbl {
             this.SetSurfaceType(::core::mem::transmute_copy(&dwtype)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetAvailableSurfaceTypeByIndex: GetAvailableSurfaceTypeByIndex::<Identity, Impl, OFFSET>,
             SetSurfaceType: SetSurfaceType::<Identity, Impl, OFFSET>,
         }
@@ -1947,7 +1947,7 @@ impl IDirectXVideoProcessor_Vtbl {
             this.VideoProcessBlt(::core::mem::transmute(&prendertarget), ::core::mem::transmute_copy(&pbltparams), ::core::mem::transmute_copy(&psamples), ::core::mem::transmute_copy(&numsamples), ::core::mem::transmute_copy(&phandlecomplete)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetVideoProcessorService: GetVideoProcessorService::<Identity, Impl, OFFSET>,
             GetCreationParameters: GetCreationParameters::<Identity, Impl, OFFSET>,
             GetVideoProcessorCaps: GetVideoProcessorCaps::<Identity, Impl, OFFSET>,
@@ -2080,7 +2080,7 @@ impl IEVRFilterConfig_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetNumberOfStreams: SetNumberOfStreams::<Identity, Impl, OFFSET>,
             GetNumberOfStreams: GetNumberOfStreams::<Identity, Impl, OFFSET>,
         }
@@ -2167,7 +2167,7 @@ impl IEVRTrustedVideoPlugin_Vtbl {
             this.DisableImageExport(::core::mem::transmute_copy(&bdisable)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             IsInTrustedVideoMode: IsInTrustedVideoMode::<Identity, Impl, OFFSET>,
             CanConstrict: CanConstrict::<Identity, Impl, OFFSET>,
             SetConstriction: SetConstriction::<Identity, Impl, OFFSET>,
@@ -2205,7 +2205,7 @@ impl IEVRVideoStreamControl_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetStreamActiveState: SetStreamActiveState::<Identity, Impl, OFFSET>,
             GetStreamActiveState: GetStreamActiveState::<Identity, Impl, OFFSET>,
         }
@@ -2238,7 +2238,7 @@ impl IFileClient_Vtbl {
             this.Read(::core::mem::transmute(&pfio)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetObjectDiskSize: GetObjectDiskSize::<Identity, Impl, OFFSET>,
             Write: Write::<Identity, Impl, OFFSET>,
             Read: Read::<Identity, Impl, OFFSET>,
@@ -2317,7 +2317,7 @@ impl IFileIo_Vtbl {
             this.Close().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             GetLength: GetLength::<Identity, Impl, OFFSET>,
             SetLength: SetLength::<Identity, Impl, OFFSET>,
@@ -2397,7 +2397,7 @@ impl IMF2DBuffer_Vtbl {
             this.ContiguousCopyFrom(::core::mem::transmute_copy(&pbsrcbuffer), ::core::mem::transmute_copy(&cbsrcbuffer)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Lock2D: Lock2D::<Identity, Impl, OFFSET>,
             Unlock2D: Unlock2D::<Identity, Impl, OFFSET>,
             GetScanline0AndPitch: GetScanline0AndPitch::<Identity, Impl, OFFSET>,
@@ -2522,7 +2522,7 @@ impl IMFASFContentInfo_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetHeaderSize: GetHeaderSize::<Identity, Impl, OFFSET>,
             ParseHeader: ParseHeader::<Identity, Impl, OFFSET>,
             GenerateHeader: GenerateHeader::<Identity, Impl, OFFSET>,
@@ -2647,7 +2647,7 @@ impl IMFASFIndexer_Vtbl {
             this.GetCompletedIndex(::core::mem::transmute(&piindexbuffer), ::core::mem::transmute_copy(&cboffsetwithinindex)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetFlags: SetFlags::<Identity, Impl, OFFSET>,
             GetFlags: GetFlags::<Identity, Impl, OFFSET>,
             Initialize: Initialize::<Identity, Impl, OFFSET>,
@@ -2739,7 +2739,7 @@ impl IMFASFMultiplexer_Vtbl {
             this.SetSyncTolerance(::core::mem::transmute_copy(&mssynctolerance)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             SetFlags: SetFlags::<Identity, Impl, OFFSET>,
             GetFlags: GetFlags::<Identity, Impl, OFFSET>,
@@ -2839,7 +2839,7 @@ impl IMFASFMutualExclusion_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetType: GetType::<Identity, Impl, OFFSET>,
             SetType: SetType::<Identity, Impl, OFFSET>,
             GetRecordCount: GetRecordCount::<Identity, Impl, OFFSET>,
@@ -3109,7 +3109,7 @@ impl IMFASFSplitter_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             SetFlags: SetFlags::<Identity, Impl, OFFSET>,
             GetFlags: GetFlags::<Identity, Impl, OFFSET>,
@@ -3283,7 +3283,7 @@ impl IMFASFStreamPrioritization_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetStreamCount: GetStreamCount::<Identity, Impl, OFFSET>,
             GetStream: GetStream::<Identity, Impl, OFFSET>,
             AddStream: AddStream::<Identity, Impl, OFFSET>,
@@ -3445,7 +3445,7 @@ impl IMFASFStreamSelector_Vtbl {
             this.SetStreamSelectorFlags(::core::mem::transmute_copy(&dwstreamselectorflags)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetStreamCount: GetStreamCount::<Identity, Impl, OFFSET>,
             GetOutputCount: GetOutputCount::<Identity, Impl, OFFSET>,
             GetOutputStreamCount: GetOutputStreamCount::<Identity, Impl, OFFSET>,
@@ -3521,7 +3521,7 @@ impl IMFAsyncCallback_Vtbl {
             this.Invoke(::core::mem::transmute(&pasyncresult)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetParameters: GetParameters::<Identity, Impl, OFFSET>,
             Invoke: Invoke::<Identity, Impl, OFFSET>,
         }
@@ -3605,7 +3605,7 @@ impl IMFAsyncResult_Vtbl {
             this.GetStateNoAddRef()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetState: GetState::<Identity, Impl, OFFSET>,
             GetStatus: GetStatus::<Identity, Impl, OFFSET>,
             SetStatus: SetStatus::<Identity, Impl, OFFSET>,
@@ -3866,7 +3866,7 @@ impl IMFAttributes_Vtbl {
             this.CopyAllItems(::core::mem::transmute(&pdest)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetItem: GetItem::<Identity, Impl, OFFSET>,
             GetItemType: GetItemType::<Identity, Impl, OFFSET>,
             CompareItem: CompareItem::<Identity, Impl, OFFSET>,
@@ -3983,7 +3983,7 @@ impl IMFAudioPolicy_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetGroupingParam: SetGroupingParam::<Identity, Impl, OFFSET>,
             GetGroupingParam: GetGroupingParam::<Identity, Impl, OFFSET>,
             SetDisplayName: SetDisplayName::<Identity, Impl, OFFSET>,
@@ -4044,7 +4044,7 @@ impl IMFAudioStreamVolume_Vtbl {
             this.GetAllVolumes(::core::mem::transmute_copy(&dwcount), ::core::mem::transmute_copy(&pfvolumes)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetChannelCount: GetChannelCount::<Identity, Impl, OFFSET>,
             SetChannelVolume: SetChannelVolume::<Identity, Impl, OFFSET>,
             GetChannelVolume: GetChannelVolume::<Identity, Impl, OFFSET>,
@@ -4074,7 +4074,7 @@ impl IMFBufferListNotify_Vtbl {
             this.OnRemoveSourceBuffer()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnAddSourceBuffer: OnAddSourceBuffer::<Identity, Impl, OFFSET>,
             OnRemoveSourceBuffer: OnRemoveSourceBuffer::<Identity, Impl, OFFSET>,
         }
@@ -4230,7 +4230,7 @@ impl IMFByteStream_Vtbl {
             this.Close().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCapabilities: GetCapabilities::<Identity, Impl, OFFSET>,
             GetLength: GetLength::<Identity, Impl, OFFSET>,
             SetLength: SetLength::<Identity, Impl, OFFSET>,
@@ -4279,7 +4279,7 @@ impl IMFByteStreamBuffering_Vtbl {
             this.StopBuffering().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetBufferingParams: SetBufferingParams::<Identity, Impl, OFFSET>,
             EnableBuffering: EnableBuffering::<Identity, Impl, OFFSET>,
             StopBuffering: StopBuffering::<Identity, Impl, OFFSET>,
@@ -4300,7 +4300,7 @@ impl IMFByteStreamCacheControl_Vtbl {
             let this = (*this).get_impl();
             this.StopBackgroundTransfer().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), StopBackgroundTransfer: StopBackgroundTransfer::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), StopBackgroundTransfer: StopBackgroundTransfer::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMFByteStreamCacheControl as ::windows::core::Interface>::IID
@@ -4388,7 +4388,7 @@ impl IMFByteStreamHandler_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             BeginCreateObject: BeginCreateObject::<Identity, Impl, OFFSET>,
             EndCreateObject: EndCreateObject::<Identity, Impl, OFFSET>,
             CancelObjectCreation: CancelObjectCreation::<Identity, Impl, OFFSET>,
@@ -4410,7 +4410,7 @@ impl IMFByteStreamProxyClassFactory_Vtbl {
             let this = (*this).get_impl();
             this.CreateByteStreamProxy(::core::mem::transmute(&pbytestream), ::core::mem::transmute(&pattributes), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppvobject)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CreateByteStreamProxy: CreateByteStreamProxy::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CreateByteStreamProxy: CreateByteStreamProxy::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMFByteStreamProxyClassFactory as ::windows::core::Interface>::IID
@@ -4449,7 +4449,7 @@ impl IMFByteStreamTimeSeek_Vtbl {
             this.GetTimeSeekResult(::core::mem::transmute_copy(&pqwstarttime), ::core::mem::transmute_copy(&pqwstoptime), ::core::mem::transmute_copy(&pqwduration)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             IsTimeSeekSupported: IsTimeSeekSupported::<Identity, Impl, OFFSET>,
             TimeSeek: TimeSeek::<Identity, Impl, OFFSET>,
             GetTimeSeekResult: GetTimeSeekResult::<Identity, Impl, OFFSET>,
@@ -4483,7 +4483,7 @@ impl IMFCameraOcclusionStateMonitor_Vtbl {
             this.GetSupportedStates()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Start: Start::<Identity, Impl, OFFSET>,
             Stop: Stop::<Identity, Impl, OFFSET>,
             GetSupportedStates: GetSupportedStates::<Identity, Impl, OFFSET>,
@@ -4510,7 +4510,7 @@ impl IMFCameraOcclusionStateReport_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetOcclusionState: GetOcclusionState::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetOcclusionState: GetOcclusionState::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMFCameraOcclusionStateReport as ::windows::core::Interface>::IID
@@ -4527,7 +4527,7 @@ impl IMFCameraOcclusionStateReportCallback_Vtbl {
             let this = (*this).get_impl();
             this.OnOcclusionStateReport(::core::mem::transmute(&occlusionstatereport)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnOcclusionStateReport: OnOcclusionStateReport::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnOcclusionStateReport: OnOcclusionStateReport::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMFCameraOcclusionStateReportCallback as ::windows::core::Interface>::IID
@@ -4551,7 +4551,7 @@ impl IMFCameraSyncObject_Vtbl {
             this.Shutdown()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             WaitOnSignal: WaitOnSignal::<Identity, Impl, OFFSET>,
             Shutdown: Shutdown::<Identity, Impl, OFFSET>,
         }
@@ -4629,7 +4629,7 @@ impl IMFCaptureEngine_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             StartPreview: StartPreview::<Identity, Impl, OFFSET>,
             StopPreview: StopPreview::<Identity, Impl, OFFSET>,
@@ -4655,7 +4655,7 @@ impl IMFCaptureEngineClassFactory_Vtbl {
             let this = (*this).get_impl();
             this.CreateInstance(::core::mem::transmute_copy(&clsid), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppvobject)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CreateInstance: CreateInstance::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CreateInstance: CreateInstance::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMFCaptureEngineClassFactory as ::windows::core::Interface>::IID
@@ -4672,7 +4672,7 @@ impl IMFCaptureEngineOnEventCallback_Vtbl {
             let this = (*this).get_impl();
             this.OnEvent(::core::mem::transmute(&pevent)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnEvent: OnEvent::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnEvent: OnEvent::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMFCaptureEngineOnEventCallback as ::windows::core::Interface>::IID
@@ -4689,7 +4689,7 @@ impl IMFCaptureEngineOnSampleCallback_Vtbl {
             let this = (*this).get_impl();
             this.OnSample(::core::mem::transmute(&psample)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnSample: OnSample::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnSample: OnSample::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMFCaptureEngineOnSampleCallback as ::windows::core::Interface>::IID
@@ -4745,7 +4745,7 @@ impl IMFCapturePhotoConfirmation_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetPhotoConfirmationCallback: SetPhotoConfirmationCallback::<Identity, Impl, OFFSET>,
             SetPixelFormat: SetPixelFormat::<Identity, Impl, OFFSET>,
             GetPixelFormat: GetPixelFormat::<Identity, Impl, OFFSET>,
@@ -4995,7 +4995,7 @@ impl IMFCaptureSink_Vtbl {
             this.RemoveAllStreams().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetOutputMediaType: GetOutputMediaType::<Identity, Impl, OFFSET>,
             GetService: GetService::<Identity, Impl, OFFSET>,
             AddStream: AddStream::<Identity, Impl, OFFSET>,
@@ -5171,7 +5171,7 @@ impl IMFCaptureSource_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCaptureDeviceSource: GetCaptureDeviceSource::<Identity, Impl, OFFSET>,
             GetCaptureDeviceActivate: GetCaptureDeviceActivate::<Identity, Impl, OFFSET>,
             GetService: GetService::<Identity, Impl, OFFSET>,
@@ -5209,7 +5209,7 @@ impl IMFCdmSuspendNotify_Vtbl {
             let this = (*this).get_impl();
             this.End().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Begin: Begin::<Identity, Impl, OFFSET>, End: End::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Begin: Begin::<Identity, Impl, OFFSET>, End: End::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMFCdmSuspendNotify as ::windows::core::Interface>::IID
@@ -5275,7 +5275,7 @@ impl IMFClock_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetClockCharacteristics: GetClockCharacteristics::<Identity, Impl, OFFSET>,
             GetCorrelatedTime: GetCorrelatedTime::<Identity, Impl, OFFSET>,
             GetContinuityKey: GetContinuityKey::<Identity, Impl, OFFSET>,
@@ -5311,7 +5311,7 @@ impl IMFClockConsumer_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetPresentationClock: SetPresentationClock::<Identity, Impl, OFFSET>,
             GetPresentationClock: GetPresentationClock::<Identity, Impl, OFFSET>,
         }
@@ -5356,7 +5356,7 @@ impl IMFClockStateSink_Vtbl {
             this.OnClockSetRate(::core::mem::transmute_copy(&hnssystemtime), ::core::mem::transmute_copy(&flrate)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnClockStart: OnClockStart::<Identity, Impl, OFFSET>,
             OnClockStop: OnClockStop::<Identity, Impl, OFFSET>,
             OnClockPause: OnClockPause::<Identity, Impl, OFFSET>,
@@ -5428,7 +5428,7 @@ impl IMFCollection_Vtbl {
             this.RemoveAllElements().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetElementCount: GetElementCount::<Identity, Impl, OFFSET>,
             GetElement: GetElement::<Identity, Impl, OFFSET>,
             AddElement: AddElement::<Identity, Impl, OFFSET>,
@@ -5507,7 +5507,7 @@ impl IMFContentDecryptionModule_Vtbl {
             this.GetProtectionSystemIds(::core::mem::transmute_copy(&systemids), ::core::mem::transmute_copy(&count)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetContentEnabler: SetContentEnabler::<Identity, Impl, OFFSET>,
             GetSuspendNotify: GetSuspendNotify::<Identity, Impl, OFFSET>,
             SetPMPHostApp: SetPMPHostApp::<Identity, Impl, OFFSET>,
@@ -5566,7 +5566,7 @@ impl IMFContentDecryptionModuleAccess_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateContentDecryptionModule: CreateContentDecryptionModule::<Identity, Impl, OFFSET>,
             GetConfiguration: GetConfiguration::<Identity, Impl, OFFSET>,
             GetKeySystem: GetKeySystem::<Identity, Impl, OFFSET>,
@@ -5603,7 +5603,7 @@ impl IMFContentDecryptionModuleFactory_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             IsTypeSupported: IsTypeSupported::<Identity, Impl, OFFSET>,
             CreateContentDecryptionModuleAccess: CreateContentDecryptionModuleAccess::<Identity, Impl, OFFSET>,
         }
@@ -5687,7 +5687,7 @@ impl IMFContentDecryptionModuleSession_Vtbl {
             this.Remove().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSessionId: GetSessionId::<Identity, Impl, OFFSET>,
             GetExpiration: GetExpiration::<Identity, Impl, OFFSET>,
             GetKeyStatuses: GetKeyStatuses::<Identity, Impl, OFFSET>,
@@ -5720,7 +5720,7 @@ impl IMFContentDecryptionModuleSessionCallbacks_Vtbl {
             this.KeyStatusChanged().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             KeyMessage: KeyMessage::<Identity, Impl, OFFSET>,
             KeyStatusChanged: KeyStatusChanged::<Identity, Impl, OFFSET>,
         }
@@ -5746,7 +5746,7 @@ impl IMFContentDecryptorContext_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), InitializeHardwareKey: InitializeHardwareKey::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), InitializeHardwareKey: InitializeHardwareKey::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMFContentDecryptorContext as ::windows::core::Interface>::IID
@@ -5815,7 +5815,7 @@ impl IMFContentEnabler_Vtbl {
             this.Cancel().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetEnableType: GetEnableType::<Identity, Impl, OFFSET>,
             GetEnableURL: GetEnableURL::<Identity, Impl, OFFSET>,
             GetEnableData: GetEnableData::<Identity, Impl, OFFSET>,
@@ -5847,7 +5847,7 @@ impl IMFContentProtectionDevice_Vtbl {
             this.GetPrivateDataByteCount(::core::mem::transmute_copy(&privateinputbytecount), ::core::mem::transmute_copy(&privateoutputbytecount)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             InvokeFunction: InvokeFunction::<Identity, Impl, OFFSET>,
             GetPrivateDataByteCount: GetPrivateDataByteCount::<Identity, Impl, OFFSET>,
         }
@@ -5874,7 +5874,7 @@ impl IMFContentProtectionManager_Vtbl {
             this.EndEnableContent(::core::mem::transmute(&presult)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             BeginEnableContent: BeginEnableContent::<Identity, Impl, OFFSET>,
             EndEnableContent: EndEnableContent::<Identity, Impl, OFFSET>,
         }
@@ -5904,7 +5904,7 @@ impl IMFD3D12SynchronizationObject_Vtbl {
             this.Reset().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SignalEventOnFinalResourceRelease: SignalEventOnFinalResourceRelease::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
         }
@@ -5946,7 +5946,7 @@ impl IMFD3D12SynchronizationObjectCommands_Vtbl {
             this.EnqueueResourceRelease(::core::mem::transmute(&pconsumercommandqueue)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             EnqueueResourceReady: EnqueueResourceReady::<Identity, Impl, OFFSET>,
             EnqueueResourceReadyWait: EnqueueResourceReadyWait::<Identity, Impl, OFFSET>,
             SignalEventOnResourceReady: SignalEventOnResourceReady::<Identity, Impl, OFFSET>,
@@ -5971,7 +5971,7 @@ impl IMFDLNASinkInit_Vtbl {
             let this = (*this).get_impl();
             this.Initialize(::core::mem::transmute(&pbytestream), ::core::mem::transmute_copy(&fpal)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Initialize: Initialize::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Initialize: Initialize::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMFDLNASinkInit as ::windows::core::Interface>::IID
@@ -5995,7 +5995,7 @@ impl IMFDRMNetHelper_Vtbl {
             this.GetChainedLicenseResponse(::core::mem::transmute_copy(&pplicenseresponse), ::core::mem::transmute_copy(&pcblicenseresponse)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ProcessLicenseRequest: ProcessLicenseRequest::<Identity, Impl, OFFSET>,
             GetChainedLicenseResponse: GetChainedLicenseResponse::<Identity, Impl, OFFSET>,
         }
@@ -6040,7 +6040,7 @@ impl IMFDXGIBuffer_Vtbl {
             this.SetUnknown(::core::mem::transmute_copy(&guid), ::core::mem::transmute(&punkdata)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetResource: GetResource::<Identity, Impl, OFFSET>,
             GetSubresourceIndex: GetSubresourceIndex::<Identity, Impl, OFFSET>,
             GetUnknown: GetUnknown::<Identity, Impl, OFFSET>,
@@ -6108,7 +6108,7 @@ impl IMFDXGIDeviceManager_Vtbl {
             this.UnlockDevice(::core::mem::transmute_copy(&hdevice), ::core::mem::transmute_copy(&fsavestate)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CloseDeviceHandle: CloseDeviceHandle::<Identity, Impl, OFFSET>,
             GetVideoService: GetVideoService::<Identity, Impl, OFFSET>,
             LockDevice: LockDevice::<Identity, Impl, OFFSET>,
@@ -6139,7 +6139,7 @@ impl IMFDXGIDeviceManagerSource_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetManager: GetManager::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetManager: GetManager::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMFDXGIDeviceManagerSource as ::windows::core::Interface>::IID
@@ -6169,7 +6169,7 @@ impl IMFDesiredSample_Vtbl {
             this.Clear()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDesiredSampleTimeAndDuration: GetDesiredSampleTimeAndDuration::<Identity, Impl, OFFSET>,
             SetDesiredSampleTimeAndDuration: SetDesiredSampleTimeAndDuration::<Identity, Impl, OFFSET>,
             Clear: Clear::<Identity, Impl, OFFSET>,
@@ -6353,7 +6353,7 @@ impl IMFDeviceTransform_Vtbl {
             this.FlushOutputStream(::core::mem::transmute_copy(&dwstreamindex), ::core::mem::transmute_copy(&dwflags)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             InitializeTransform: InitializeTransform::<Identity, Impl, OFFSET>,
             GetInputAvailableType: GetInputAvailableType::<Identity, Impl, OFFSET>,
             GetInputCurrentType: GetInputCurrentType::<Identity, Impl, OFFSET>,
@@ -6391,7 +6391,7 @@ impl IMFDeviceTransformCallback_Vtbl {
             let this = (*this).get_impl();
             this.OnBufferSent(::core::mem::transmute(&pcallbackattributes), ::core::mem::transmute_copy(&pinid)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnBufferSent: OnBufferSent::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnBufferSent: OnBufferSent::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMFDeviceTransformCallback as ::windows::core::Interface>::IID
@@ -6439,7 +6439,7 @@ impl IMFExtendedCameraControl_Vtbl {
             this.CommitSettings().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCapabilities: GetCapabilities::<Identity, Impl, OFFSET>,
             SetFlags: SetFlags::<Identity, Impl, OFFSET>,
             GetFlags: GetFlags::<Identity, Impl, OFFSET>,
@@ -6469,7 +6469,7 @@ impl IMFExtendedCameraController_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetExtendedCameraControl: GetExtendedCameraControl::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetExtendedCameraControl: GetExtendedCameraControl::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMFExtendedCameraController as ::windows::core::Interface>::IID
@@ -6511,7 +6511,7 @@ impl IMFExtendedCameraIntrinsicModel_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetModel: GetModel::<Identity, Impl, OFFSET>,
             SetModel: SetModel::<Identity, Impl, OFFSET>,
             GetDistortionModelType: GetDistortionModelType::<Identity, Impl, OFFSET>,
@@ -6581,7 +6581,7 @@ impl IMFExtendedCameraIntrinsics_Vtbl {
             this.AddIntrinsicModel(::core::mem::transmute(&pintrinsicmodel)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             InitializeFromBuffer: InitializeFromBuffer::<Identity, Impl, OFFSET>,
             GetBufferSize: GetBufferSize::<Identity, Impl, OFFSET>,
             SerializeToBuffer: SerializeToBuffer::<Identity, Impl, OFFSET>,
@@ -6618,7 +6618,7 @@ impl IMFExtendedCameraIntrinsicsDistortionModel6KT_Vtbl {
             this.SetDistortionModel(::core::mem::transmute_copy(&pdistortionmodel)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDistortionModel: GetDistortionModel::<Identity, Impl, OFFSET>,
             SetDistortionModel: SetDistortionModel::<Identity, Impl, OFFSET>,
         }
@@ -6651,7 +6651,7 @@ impl IMFExtendedCameraIntrinsicsDistortionModelArcTan_Vtbl {
             this.SetDistortionModel(::core::mem::transmute_copy(&pdistortionmodel)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDistortionModel: GetDistortionModel::<Identity, Impl, OFFSET>,
             SetDistortionModel: SetDistortionModel::<Identity, Impl, OFFSET>,
         }
@@ -6677,7 +6677,7 @@ impl IMFExtendedDRMTypeSupport_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), IsTypeSupportedEx: IsTypeSupportedEx::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), IsTypeSupportedEx: IsTypeSupportedEx::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMFExtendedDRMTypeSupport as ::windows::core::Interface>::IID
@@ -6694,7 +6694,7 @@ impl IMFFieldOfUseMFTUnlock_Vtbl {
             let this = (*this).get_impl();
             this.Unlock(::core::mem::transmute(&punkmft)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Unlock: Unlock::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Unlock: Unlock::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMFFieldOfUseMFTUnlock as ::windows::core::Interface>::IID
@@ -6738,7 +6738,7 @@ impl IMFGetService_Vtbl {
             let this = (*this).get_impl();
             this.GetService(::core::mem::transmute_copy(&guidservice), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppvobject)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetService: GetService::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetService: GetService::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMFGetService as ::windows::core::Interface>::IID
@@ -6764,7 +6764,7 @@ impl IMFHDCPStatus_Vtbl {
             let this = (*this).get_impl();
             this.Set(::core::mem::transmute_copy(&status)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Query: Query::<Identity, Impl, OFFSET>, Set: Set::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Query: Query::<Identity, Impl, OFFSET>, Set: Set::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMFHDCPStatus as ::windows::core::Interface>::IID
@@ -6917,7 +6917,7 @@ impl IMFHttpDownloadRequest_Vtbl {
             this.Close().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddHeader: AddHeader::<Identity, Impl, OFFSET>,
             BeginSendRequest: BeginSendRequest::<Identity, Impl, OFFSET>,
             EndSendRequest: EndSendRequest::<Identity, Impl, OFFSET>,
@@ -6973,7 +6973,7 @@ impl IMFHttpDownloadSession_Vtbl {
             this.Close().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetServer: SetServer::<Identity, Impl, OFFSET>,
             CreateRequest: CreateRequest::<Identity, Impl, OFFSET>,
             Close: Close::<Identity, Impl, OFFSET>,
@@ -7000,7 +7000,10 @@ impl IMFHttpDownloadSessionProvider_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CreateHttpDownloadSession: CreateHttpDownloadSession::<Identity, Impl, OFFSET> }
+        Self {
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
+            CreateHttpDownloadSession: CreateHttpDownloadSession::<Identity, Impl, OFFSET>,
+        }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMFHttpDownloadSessionProvider as ::windows::core::Interface>::IID
@@ -7036,7 +7039,7 @@ impl IMFImageSharingEngine_Vtbl {
             this.Shutdown().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetSource: SetSource::<Identity, Impl, OFFSET>,
             GetDevice: GetDevice::<Identity, Impl, OFFSET>,
             Shutdown: Shutdown::<Identity, Impl, OFFSET>,
@@ -7063,7 +7066,7 @@ impl IMFImageSharingEngineClassFactory_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CreateInstanceFromUDN: CreateInstanceFromUDN::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CreateInstanceFromUDN: CreateInstanceFromUDN::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMFImageSharingEngineClassFactory as ::windows::core::Interface>::IID
@@ -7123,7 +7126,7 @@ impl IMFInputTrustAuthority_Vtbl {
             this.Reset().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDecrypter: GetDecrypter::<Identity, Impl, OFFSET>,
             RequestAccess: RequestAccess::<Identity, Impl, OFFSET>,
             GetPolicy: GetPolicy::<Identity, Impl, OFFSET>,
@@ -7147,7 +7150,7 @@ impl IMFLocalMFTRegistration_Vtbl {
             let this = (*this).get_impl();
             this.RegisterMFTs(::core::mem::transmute_copy(&pmfts), ::core::mem::transmute_copy(&cmfts)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), RegisterMFTs: RegisterMFTs::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), RegisterMFTs: RegisterMFTs::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMFLocalMFTRegistration as ::windows::core::Interface>::IID
@@ -7201,7 +7204,7 @@ impl IMFMediaBuffer_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Lock: Lock::<Identity, Impl, OFFSET>,
             Unlock: Unlock::<Identity, Impl, OFFSET>,
             GetCurrentLength: GetCurrentLength::<Identity, Impl, OFFSET>,
@@ -7516,7 +7519,7 @@ impl IMFMediaEngine_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetError: GetError::<Identity, Impl, OFFSET>,
             SetErrorCode: SetErrorCode::<Identity, Impl, OFFSET>,
             SetSourceElements: SetSourceElements::<Identity, Impl, OFFSET>,
@@ -7589,7 +7592,7 @@ impl IMFMediaEngineAudioEndpointId_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetAudioEndpointId: SetAudioEndpointId::<Identity, Impl, OFFSET>,
             GetAudioEndpointId: GetAudioEndpointId::<Identity, Impl, OFFSET>,
         }
@@ -7640,7 +7643,7 @@ impl IMFMediaEngineClassFactory_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateInstance: CreateInstance::<Identity, Impl, OFFSET>,
             CreateTimeRange: CreateTimeRange::<Identity, Impl, OFFSET>,
             CreateError: CreateError::<Identity, Impl, OFFSET>,
@@ -7667,7 +7670,7 @@ impl IMFMediaEngineClassFactory2_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CreateMediaKeys2: CreateMediaKeys2::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CreateMediaKeys2: CreateMediaKeys2::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMFMediaEngineClassFactory2 as ::windows::core::Interface>::IID
@@ -7694,7 +7697,7 @@ impl IMFMediaEngineClassFactory3_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateMediaKeySystemAccess: CreateMediaKeySystemAccess::<Identity, Impl, OFFSET>,
         }
     }
@@ -7714,7 +7717,7 @@ impl IMFMediaEngineClassFactory4_Vtbl {
             this.CreateContentDecryptionModuleFactory(::core::mem::transmute(&keysystem), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppvobject)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateContentDecryptionModuleFactory: CreateContentDecryptionModuleFactory::<Identity, Impl, OFFSET>,
         }
     }
@@ -7801,7 +7804,7 @@ impl IMFMediaEngineEME_Vtbl {
             this.SetMediaKeys(::core::mem::transmute(&keys)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Keys: Keys::<Identity, Impl, OFFSET>,
             SetMediaKeys: SetMediaKeys::<Identity, Impl, OFFSET>,
         }
@@ -7828,7 +7831,7 @@ impl IMFMediaEngineEMENotify_Vtbl {
             this.WaitingForKey()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Encrypted: Encrypted::<Identity, Impl, OFFSET>,
             WaitingForKey: WaitingForKey::<Identity, Impl, OFFSET>,
         }
@@ -8241,7 +8244,7 @@ impl IMFMediaEngineExtension_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CanPlayType: CanPlayType::<Identity, Impl, OFFSET>,
             BeginCreateObject: BeginCreateObject::<Identity, Impl, OFFSET>,
             CancelObjectCreation: CancelObjectCreation::<Identity, Impl, OFFSET>,
@@ -8263,7 +8266,7 @@ impl IMFMediaEngineNeedKeyNotify_Vtbl {
             let this = (*this).get_impl();
             this.NeedKey(::core::mem::transmute_copy(&initdata), ::core::mem::transmute_copy(&cb))
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), NeedKey: NeedKey::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), NeedKey: NeedKey::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMFMediaEngineNeedKeyNotify as ::windows::core::Interface>::IID
@@ -8280,7 +8283,7 @@ impl IMFMediaEngineNotify_Vtbl {
             let this = (*this).get_impl();
             this.EventNotify(::core::mem::transmute_copy(&event), ::core::mem::transmute_copy(&param1), ::core::mem::transmute_copy(&param2)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), EventNotify: EventNotify::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), EventNotify: EventNotify::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMFMediaEngineNotify as ::windows::core::Interface>::IID
@@ -8300,7 +8303,7 @@ impl IMFMediaEngineOPMInfo_Vtbl {
             let this = (*this).get_impl();
             this.GetOPMInfo(::core::mem::transmute_copy(&pstatus), ::core::mem::transmute_copy(&pconstricted)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetOPMInfo: GetOPMInfo::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetOPMInfo: GetOPMInfo::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMFMediaEngineOPMInfo as ::windows::core::Interface>::IID
@@ -8363,7 +8366,7 @@ impl IMFMediaEngineProtectedContent_Vtbl {
             this.SetApplicationCertificate(::core::mem::transmute_copy(&pbblob), ::core::mem::transmute_copy(&cbblob)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ShareResources: ShareResources::<Identity, Impl, OFFSET>,
             GetRequiredProtections: GetRequiredProtections::<Identity, Impl, OFFSET>,
             SetOPMWindow: SetOPMWindow::<Identity, Impl, OFFSET>,
@@ -8436,7 +8439,7 @@ impl IMFMediaEngineSrcElements_Vtbl {
             this.RemoveAllElements().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetLength: GetLength::<Identity, Impl, OFFSET>,
             GetURL: GetURL::<Identity, Impl, OFFSET>,
             GetType: GetType::<Identity, Impl, OFFSET>,
@@ -8515,7 +8518,7 @@ impl IMFMediaEngineSupportsSourceTransfer_Vtbl {
             this.AttachMediaSource(::core::mem::transmute(&pbytestream), ::core::mem::transmute(&pmediasource), ::core::mem::transmute(&pmse)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ShouldTransferSource: ShouldTransferSource::<Identity, Impl, OFFSET>,
             DetachMediaSource: DetachMediaSource::<Identity, Impl, OFFSET>,
             AttachMediaSource: AttachMediaSource::<Identity, Impl, OFFSET>,
@@ -8537,7 +8540,7 @@ impl IMFMediaEngineTransferSource_Vtbl {
             this.TransferSourceToMediaEngine(::core::mem::transmute(&destination)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             TransferSourceToMediaEngine: TransferSourceToMediaEngine::<Identity, Impl, OFFSET>,
         }
     }
@@ -8578,7 +8581,7 @@ impl IMFMediaEngineWebSupport_Vtbl {
             this.DisconnectWebAudio().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ShouldDelayTheLoadEvent: ShouldDelayTheLoadEvent::<Identity, Impl, OFFSET>,
             ConnectWebAudio: ConnectWebAudio::<Identity, Impl, OFFSET>,
             DisconnectWebAudio: DisconnectWebAudio::<Identity, Impl, OFFSET>,
@@ -8618,7 +8621,7 @@ impl IMFMediaError_Vtbl {
             this.SetExtendedErrorCode(::core::mem::transmute_copy(&error)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetErrorCode: GetErrorCode::<Identity, Impl, OFFSET>,
             GetExtendedErrorCode: GetExtendedErrorCode::<Identity, Impl, OFFSET>,
             SetErrorCode: SetErrorCode::<Identity, Impl, OFFSET>,
@@ -8742,7 +8745,7 @@ impl IMFMediaEventGenerator_Vtbl {
             this.QueueEvent(::core::mem::transmute_copy(&met), ::core::mem::transmute_copy(&guidextendedtype), ::core::mem::transmute_copy(&hrstatus), ::core::mem::transmute_copy(&pvvalue)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetEvent: GetEvent::<Identity, Impl, OFFSET>,
             BeginGetEvent: BeginGetEvent::<Identity, Impl, OFFSET>,
             EndGetEvent: EndGetEvent::<Identity, Impl, OFFSET>,
@@ -8816,7 +8819,7 @@ impl IMFMediaEventQueue_Vtbl {
             this.Shutdown().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetEvent: GetEvent::<Identity, Impl, OFFSET>,
             BeginGetEvent: BeginGetEvent::<Identity, Impl, OFFSET>,
             EndGetEvent: EndGetEvent::<Identity, Impl, OFFSET>,
@@ -8878,7 +8881,7 @@ impl IMFMediaKeySession_Vtbl {
             this.Close().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetError: GetError::<Identity, Impl, OFFSET>,
             KeySystem: KeySystem::<Identity, Impl, OFFSET>,
             SessionId: SessionId::<Identity, Impl, OFFSET>,
@@ -8984,7 +8987,7 @@ impl IMFMediaKeySessionNotify_Vtbl {
             this.KeyError(::core::mem::transmute_copy(&code), ::core::mem::transmute_copy(&systemcode))
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             KeyMessage: KeyMessage::<Identity, Impl, OFFSET>,
             KeyAdded: KeyAdded::<Identity, Impl, OFFSET>,
             KeyError: KeyError::<Identity, Impl, OFFSET>,
@@ -9066,7 +9069,7 @@ impl IMFMediaKeySystemAccess_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateMediaKeys: CreateMediaKeys::<Identity, Impl, OFFSET>,
             SupportedConfiguration: SupportedConfiguration::<Identity, Impl, OFFSET>,
             KeySystem: KeySystem::<Identity, Impl, OFFSET>,
@@ -9124,7 +9127,7 @@ impl IMFMediaKeys_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateSession: CreateSession::<Identity, Impl, OFFSET>,
             KeySystem: KeySystem::<Identity, Impl, OFFSET>,
             Shutdown: Shutdown::<Identity, Impl, OFFSET>,
@@ -9328,7 +9331,7 @@ impl IMFMediaSharingEngineClassFactory_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CreateInstance: CreateInstance::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CreateInstance: CreateInstance::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMFMediaSharingEngineClassFactory as ::windows::core::Interface>::IID
@@ -9430,7 +9433,7 @@ impl IMFMediaSink_Vtbl {
             this.Shutdown().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCharacteristics: GetCharacteristics::<Identity, Impl, OFFSET>,
             AddStreamSink: AddStreamSink::<Identity, Impl, OFFSET>,
             RemoveStreamSink: RemoveStreamSink::<Identity, Impl, OFFSET>,
@@ -9457,7 +9460,7 @@ impl IMFMediaSinkPreroll_Vtbl {
             let this = (*this).get_impl();
             this.NotifyPreroll(::core::mem::transmute_copy(&hnsupcomingstarttime)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), NotifyPreroll: NotifyPreroll::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), NotifyPreroll: NotifyPreroll::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMFMediaSinkPreroll as ::windows::core::Interface>::IID
@@ -9677,7 +9680,7 @@ impl IMFMediaSourceExtension_Vtbl {
             this.GetSourceBuffer(::core::mem::transmute_copy(&dwstreamindex))
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSourceBuffers: GetSourceBuffers::<Identity, Impl, OFFSET>,
             GetActiveSourceBuffers: GetActiveSourceBuffers::<Identity, Impl, OFFSET>,
             GetReadyState: GetReadyState::<Identity, Impl, OFFSET>,
@@ -9712,7 +9715,7 @@ impl IMFMediaSourceExtensionLiveSeekableRange_Vtbl {
             this.ClearLiveSeekableRange().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetLiveSeekableRange: SetLiveSeekableRange::<Identity, Impl, OFFSET>,
             ClearLiveSeekableRange: ClearLiveSeekableRange::<Identity, Impl, OFFSET>,
         }
@@ -9745,7 +9748,7 @@ impl IMFMediaSourceExtensionNotify_Vtbl {
             this.OnSourceClose()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnSourceOpen: OnSourceOpen::<Identity, Impl, OFFSET>,
             OnSourceEnded: OnSourceEnded::<Identity, Impl, OFFSET>,
             OnSourceClose: OnSourceClose::<Identity, Impl, OFFSET>,
@@ -9766,7 +9769,7 @@ impl IMFMediaSourcePresentationProvider_Vtbl {
             let this = (*this).get_impl();
             this.ForceEndOfPresentation(::core::mem::transmute(&ppresentationdescriptor)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), ForceEndOfPresentation: ForceEndOfPresentation::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), ForceEndOfPresentation: ForceEndOfPresentation::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMFMediaSourcePresentationProvider as ::windows::core::Interface>::IID
@@ -9789,7 +9792,7 @@ impl IMFMediaSourceTopologyProvider_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetMediaSourceTopology: GetMediaSourceTopology::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetMediaSourceTopology: GetMediaSourceTopology::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMFMediaSourceTopologyProvider as ::windows::core::Interface>::IID
@@ -9891,7 +9894,7 @@ impl IMFMediaStreamSourceSampleRequest_Vtbl {
             let this = (*this).get_impl();
             this.SetSample(::core::mem::transmute(&value)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SetSample: SetSample::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SetSample: SetSample::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMFMediaStreamSourceSampleRequest as ::windows::core::Interface>::IID
@@ -9954,7 +9957,7 @@ impl IMFMediaTimeRange_Vtbl {
             this.Clear().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetLength: GetLength::<Identity, Impl, OFFSET>,
             GetStart: GetStart::<Identity, Impl, OFFSET>,
             GetEnd: GetEnd::<Identity, Impl, OFFSET>,
@@ -10108,7 +10111,7 @@ impl IMFMediaTypeHandler_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             IsMediaTypeSupported: IsMediaTypeSupported::<Identity, Impl, OFFSET>,
             GetMediaTypeCount: GetMediaTypeCount::<Identity, Impl, OFFSET>,
             GetMediaTypeByIndex: GetMediaTypeByIndex::<Identity, Impl, OFFSET>,
@@ -10196,7 +10199,7 @@ impl IMFMetadata_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetLanguage: SetLanguage::<Identity, Impl, OFFSET>,
             GetLanguage: GetLanguage::<Identity, Impl, OFFSET>,
             GetAllLanguages: GetAllLanguages::<Identity, Impl, OFFSET>,
@@ -10227,7 +10230,7 @@ impl IMFMetadataProvider_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetMFMetadata: GetMFMetadata::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetMFMetadata: GetMFMetadata::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMFMetadataProvider as ::windows::core::Interface>::IID
@@ -10263,7 +10266,7 @@ impl IMFMuxStreamAttributesManager_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetStreamCount: GetStreamCount::<Identity, Impl, OFFSET>,
             GetAttributes: GetAttributes::<Identity, Impl, OFFSET>,
         }
@@ -10338,7 +10341,7 @@ impl IMFMuxStreamMediaTypeManager_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetStreamCount: GetStreamCount::<Identity, Impl, OFFSET>,
             GetMediaType: GetMediaType::<Identity, Impl, OFFSET>,
             GetStreamConfigurationCount: GetStreamConfigurationCount::<Identity, Impl, OFFSET>,
@@ -10387,7 +10390,7 @@ impl IMFMuxStreamSampleManager_Vtbl {
             this.GetStreamConfiguration()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetStreamCount: GetStreamCount::<Identity, Impl, OFFSET>,
             GetSample: GetSample::<Identity, Impl, OFFSET>,
             GetStreamConfiguration: GetStreamConfiguration::<Identity, Impl, OFFSET>,
@@ -10442,7 +10445,7 @@ impl IMFNetCredential_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetUser: SetUser::<Identity, Impl, OFFSET>,
             SetPassword: SetPassword::<Identity, Impl, OFFSET>,
             GetUser: GetUser::<Identity, Impl, OFFSET>,
@@ -10481,7 +10484,7 @@ impl IMFNetCredentialCache_Vtbl {
             this.SetUserOptions(::core::mem::transmute(&pcred), ::core::mem::transmute_copy(&dwoptionsflags)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCredential: GetCredential::<Identity, Impl, OFFSET>,
             SetGood: SetGood::<Identity, Impl, OFFSET>,
             SetUserOptions: SetUserOptions::<Identity, Impl, OFFSET>,
@@ -10524,7 +10527,7 @@ impl IMFNetCredentialManager_Vtbl {
             this.SetGood(::core::mem::transmute(&pcred), ::core::mem::transmute_copy(&fgood)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             BeginGetCredentials: BeginGetCredentials::<Identity, Impl, OFFSET>,
             EndGetCredentials: EndGetCredentials::<Identity, Impl, OFFSET>,
             SetGood: SetGood::<Identity, Impl, OFFSET>,
@@ -10579,7 +10582,7 @@ impl IMFNetCrossOriginSupport_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCrossOriginPolicy: GetCrossOriginPolicy::<Identity, Impl, OFFSET>,
             GetSourceOrigin: GetSourceOrigin::<Identity, Impl, OFFSET>,
             IsSameOrigin: IsSameOrigin::<Identity, Impl, OFFSET>,
@@ -10634,7 +10637,7 @@ impl IMFNetProxyLocator_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             FindFirstProxy: FindFirstProxy::<Identity, Impl, OFFSET>,
             FindNextProxy: FindNextProxy::<Identity, Impl, OFFSET>,
             RegisterProxyResult: RegisterProxyResult::<Identity, Impl, OFFSET>,
@@ -10663,7 +10666,7 @@ impl IMFNetProxyLocatorFactory_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CreateProxyLocator: CreateProxyLocator::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CreateProxyLocator: CreateProxyLocator::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMFNetProxyLocatorFactory as ::windows::core::Interface>::IID
@@ -10693,7 +10696,7 @@ impl IMFNetResourceFilter_Vtbl {
             this.OnSendingRequest(::core::mem::transmute(&pszurl)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnRedirect: OnRedirect::<Identity, Impl, OFFSET>,
             OnSendingRequest: OnSendingRequest::<Identity, Impl, OFFSET>,
         }
@@ -10738,7 +10741,7 @@ impl IMFNetSchemeHandlerConfig_Vtbl {
             this.ResetProtocolRolloverSettings().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetNumberOfSupportedProtocols: GetNumberOfSupportedProtocols::<Identity, Impl, OFFSET>,
             GetSupportedProtocolType: GetSupportedProtocolType::<Identity, Impl, OFFSET>,
             ResetProtocolRolloverSettings: ResetProtocolRolloverSettings::<Identity, Impl, OFFSET>,
@@ -10766,7 +10769,7 @@ impl IMFObjectReferenceStream_Vtbl {
             this.LoadReference(::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppv)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SaveReference: SaveReference::<Identity, Impl, OFFSET>,
             LoadReference: LoadReference::<Identity, Impl, OFFSET>,
         }
@@ -10909,7 +10912,7 @@ impl IMFOutputTrustAuthority_Vtbl {
             this.SetPolicy(::core::mem::transmute_copy(&pppolicy), ::core::mem::transmute_copy(&npolicy), ::core::mem::transmute_copy(&ppbticket), ::core::mem::transmute_copy(&pcbticket)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetAction: GetAction::<Identity, Impl, OFFSET>,
             SetPolicy: SetPolicy::<Identity, Impl, OFFSET>,
         }
@@ -10929,7 +10932,7 @@ impl IMFPMPClient_Vtbl {
             let this = (*this).get_impl();
             this.SetPMPHost(::core::mem::transmute(&ppmphost)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SetPMPHost: SetPMPHost::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SetPMPHost: SetPMPHost::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMFPMPClient as ::windows::core::Interface>::IID
@@ -10946,7 +10949,7 @@ impl IMFPMPClientApp_Vtbl {
             let this = (*this).get_impl();
             this.SetPMPHost(::core::mem::transmute(&ppmphost)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SetPMPHost: SetPMPHost::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SetPMPHost: SetPMPHost::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMFPMPClientApp as ::windows::core::Interface>::IID
@@ -10979,7 +10982,7 @@ impl IMFPMPHost_Vtbl {
             this.CreateObjectByCLSID(::core::mem::transmute_copy(&clsid), ::core::mem::transmute(&pstream), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppv)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             LockProcess: LockProcess::<Identity, Impl, OFFSET>,
             UnlockProcess: UnlockProcess::<Identity, Impl, OFFSET>,
             CreateObjectByCLSID: CreateObjectByCLSID::<Identity, Impl, OFFSET>,
@@ -11016,7 +11019,7 @@ impl IMFPMPHostApp_Vtbl {
             this.ActivateClassById(::core::mem::transmute(&id), ::core::mem::transmute(&pstream), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppv)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             LockProcess: LockProcess::<Identity, Impl, OFFSET>,
             UnlockProcess: UnlockProcess::<Identity, Impl, OFFSET>,
             ActivateClassById: ActivateClassById::<Identity, Impl, OFFSET>,
@@ -11050,7 +11053,7 @@ impl IMFPMPServer_Vtbl {
             this.CreateObjectByCLSID(::core::mem::transmute_copy(&clsid), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppobject)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             LockProcess: LockProcess::<Identity, Impl, OFFSET>,
             UnlockProcess: UnlockProcess::<Identity, Impl, OFFSET>,
             CreateObjectByCLSID: CreateObjectByCLSID::<Identity, Impl, OFFSET>,
@@ -11255,7 +11258,7 @@ impl IMFPMediaItem_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetMediaPlayer: GetMediaPlayer::<Identity, Impl, OFFSET>,
             GetURL: GetURL::<Identity, Impl, OFFSET>,
             GetObject: GetObject::<Identity, Impl, OFFSET>,
@@ -11590,7 +11593,7 @@ impl IMFPMediaPlayer_Vtbl {
             this.Shutdown().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Play: Play::<Identity, Impl, OFFSET>,
             Pause: Pause::<Identity, Impl, OFFSET>,
             Stop: Stop::<Identity, Impl, OFFSET>,
@@ -11647,7 +11650,7 @@ impl IMFPMediaPlayerCallback_Vtbl {
             let this = (*this).get_impl();
             this.OnMediaPlayerEvent(::core::mem::transmute_copy(&peventheader))
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnMediaPlayerEvent: OnMediaPlayerEvent::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnMediaPlayerEvent: OnMediaPlayerEvent::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMFPMediaPlayerCallback as ::windows::core::Interface>::IID
@@ -11710,7 +11713,7 @@ impl IMFPluginControl_Vtbl {
             this.SetDisabled(::core::mem::transmute_copy(&plugintype), ::core::mem::transmute_copy(&clsid), ::core::mem::transmute_copy(&disabled)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetPreferredClsid: GetPreferredClsid::<Identity, Impl, OFFSET>,
             GetPreferredClsidByIndex: GetPreferredClsidByIndex::<Identity, Impl, OFFSET>,
             SetPreferredClsid: SetPreferredClsid::<Identity, Impl, OFFSET>,
@@ -11928,7 +11931,7 @@ impl IMFProtectedEnvironmentAccess_Vtbl {
             this.ReadGRL(::core::mem::transmute_copy(&outputlength), ::core::mem::transmute_copy(&output)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Call: Call::<Identity, Impl, OFFSET>,
             ReadGRL: ReadGRL::<Identity, Impl, OFFSET>,
         }
@@ -11985,7 +11988,7 @@ impl IMFQualityAdvise_Vtbl {
             this.DropTime(::core::mem::transmute_copy(&hnsamounttodrop)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetDropMode: SetDropMode::<Identity, Impl, OFFSET>,
             SetQualityLevel: SetQualityLevel::<Identity, Impl, OFFSET>,
             GetDropMode: GetDropMode::<Identity, Impl, OFFSET>,
@@ -12050,7 +12053,7 @@ impl IMFQualityAdviseLimits_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetMaximumDropMode: GetMaximumDropMode::<Identity, Impl, OFFSET>,
             GetMinimumQualityLevel: GetMinimumQualityLevel::<Identity, Impl, OFFSET>,
         }
@@ -12101,7 +12104,7 @@ impl IMFQualityManager_Vtbl {
             this.Shutdown().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             NotifyTopology: NotifyTopology::<Identity, Impl, OFFSET>,
             NotifyPresentationClock: NotifyPresentationClock::<Identity, Impl, OFFSET>,
             NotifyProcessInput: NotifyProcessInput::<Identity, Impl, OFFSET>,
@@ -12135,7 +12138,7 @@ impl IMFRateControl_Vtbl {
             this.GetRate(::core::mem::transmute_copy(&pfthin), ::core::mem::transmute_copy(&pflrate)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetRate: SetRate::<Identity, Impl, OFFSET>,
             GetRate: GetRate::<Identity, Impl, OFFSET>,
         }
@@ -12183,7 +12186,7 @@ impl IMFRateSupport_Vtbl {
             this.IsRateSupported(::core::mem::transmute_copy(&fthin), ::core::mem::transmute_copy(&flrate), ::core::mem::transmute_copy(&pflnearestsupportedrate)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSlowestRate: GetSlowestRate::<Identity, Impl, OFFSET>,
             GetFastestRate: GetFastestRate::<Identity, Impl, OFFSET>,
             IsRateSupported: IsRateSupported::<Identity, Impl, OFFSET>,
@@ -12211,7 +12214,7 @@ impl IMFReadWriteClassFactory_Vtbl {
             this.CreateInstanceFromObject(::core::mem::transmute_copy(&clsid), ::core::mem::transmute(&punkobject), ::core::mem::transmute(&pattributes), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppvobject)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateInstanceFromURL: CreateInstanceFromURL::<Identity, Impl, OFFSET>,
             CreateInstanceFromObject: CreateInstanceFromObject::<Identity, Impl, OFFSET>,
         }
@@ -12244,7 +12247,7 @@ impl IMFRealTimeClient_Vtbl {
             this.SetWorkQueue(::core::mem::transmute_copy(&dwworkqueueid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RegisterThreads: RegisterThreads::<Identity, Impl, OFFSET>,
             UnregisterThreads: UnregisterThreads::<Identity, Impl, OFFSET>,
             SetWorkQueue: SetWorkQueue::<Identity, Impl, OFFSET>,
@@ -12278,7 +12281,7 @@ impl IMFRealTimeClientEx_Vtbl {
             this.SetWorkQueueEx(::core::mem::transmute_copy(&dwmultithreadedworkqueueid), ::core::mem::transmute_copy(&lworkitembasepriority)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RegisterThreadsEx: RegisterThreadsEx::<Identity, Impl, OFFSET>,
             UnregisterThreads: UnregisterThreads::<Identity, Impl, OFFSET>,
             SetWorkQueueEx: SetWorkQueueEx::<Identity, Impl, OFFSET>,
@@ -12305,7 +12308,7 @@ impl IMFRelativePanelReport_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetRelativePanel: GetRelativePanel::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetRelativePanel: GetRelativePanel::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMFRelativePanelReport as ::windows::core::Interface>::IID
@@ -12368,7 +12371,7 @@ impl IMFRemoteAsyncCallback_Vtbl {
             let this = (*this).get_impl();
             this.Invoke(::core::mem::transmute_copy(&hr), ::core::mem::transmute(&premoteresult)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Invoke: Invoke::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Invoke: Invoke::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMFRemoteAsyncCallback as ::windows::core::Interface>::IID
@@ -12385,7 +12388,7 @@ impl IMFRemoteDesktopPlugin_Vtbl {
             let this = (*this).get_impl();
             this.UpdateTopology(::core::mem::transmute(&ptopology)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), UpdateTopology: UpdateTopology::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), UpdateTopology: UpdateTopology::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMFRemoteDesktopPlugin as ::windows::core::Interface>::IID
@@ -12409,7 +12412,7 @@ impl IMFRemoteProxy_Vtbl {
             this.GetRemoteHost(::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppv)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetRemoteObject: GetRemoteObject::<Identity, Impl, OFFSET>,
             GetRemoteHost: GetRemoteHost::<Identity, Impl, OFFSET>,
         }
@@ -12469,7 +12472,7 @@ impl IMFSAMIStyle_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetStyleCount: GetStyleCount::<Identity, Impl, OFFSET>,
             GetStyles: GetStyles::<Identity, Impl, OFFSET>,
             SetSelectedStyle: SetSelectedStyle::<Identity, Impl, OFFSET>,
@@ -12525,7 +12528,7 @@ impl IMFSSLCertificateManager_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetClientCertificate: GetClientCertificate::<Identity, Impl, OFFSET>,
             BeginGetClientCertificate: BeginGetClientCertificate::<Identity, Impl, OFFSET>,
             EndGetClientCertificate: EndGetClientCertificate::<Identity, Impl, OFFSET>,
@@ -12711,7 +12714,7 @@ impl IMFSampleAllocatorControl_Vtbl {
             this.GetAllocatorUsage(::core::mem::transmute_copy(&dwoutputstreamid), ::core::mem::transmute_copy(&pdwinputstreamid), ::core::mem::transmute_copy(&peusage)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetDefaultAllocator: SetDefaultAllocator::<Identity, Impl, OFFSET>,
             GetAllocatorUsage: GetAllocatorUsage::<Identity, Impl, OFFSET>,
         }
@@ -12795,7 +12798,7 @@ impl IMFSampleOutputStream_Vtbl {
             this.Close().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             BeginWriteSample: BeginWriteSample::<Identity, Impl, OFFSET>,
             EndWriteSample: EndWriteSample::<Identity, Impl, OFFSET>,
             Close: Close::<Identity, Impl, OFFSET>,
@@ -12853,7 +12856,7 @@ impl IMFSampleProtection_Vtbl {
             this.InitInputProtection(::core::mem::transmute_copy(&dwversion), ::core::mem::transmute_copy(&dwinputid), ::core::mem::transmute_copy(&pbseed), ::core::mem::transmute_copy(&cbseed)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetInputProtectionVersion: GetInputProtectionVersion::<Identity, Impl, OFFSET>,
             GetOutputProtectionVersion: GetOutputProtectionVersion::<Identity, Impl, OFFSET>,
             GetProtectionCertificate: GetProtectionCertificate::<Identity, Impl, OFFSET>,
@@ -12901,7 +12904,7 @@ impl IMFSaveJob_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             BeginSave: BeginSave::<Identity, Impl, OFFSET>,
             EndSave: EndSave::<Identity, Impl, OFFSET>,
             CancelSave: CancelSave::<Identity, Impl, OFFSET>,
@@ -12939,7 +12942,7 @@ impl IMFSchemeHandler_Vtbl {
             this.CancelObjectCreation(::core::mem::transmute(&piunknowncancelcookie)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             BeginCreateObject: BeginCreateObject::<Identity, Impl, OFFSET>,
             EndCreateObject: EndCreateObject::<Identity, Impl, OFFSET>,
             CancelObjectCreation: CancelObjectCreation::<Identity, Impl, OFFSET>,
@@ -12966,7 +12969,7 @@ impl IMFSecureBuffer_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetIdentifier: GetIdentifier::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetIdentifier: GetIdentifier::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMFSecureBuffer as ::windows::core::Interface>::IID
@@ -12990,7 +12993,7 @@ impl IMFSecureChannel_Vtbl {
             this.SetupSession(::core::mem::transmute_copy(&pbencryptedsessionkey), ::core::mem::transmute_copy(&cbsessionkey)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCertificate: GetCertificate::<Identity, Impl, OFFSET>,
             SetupSession: SetupSession::<Identity, Impl, OFFSET>,
         }
@@ -13013,7 +13016,7 @@ impl IMFSeekInfo_Vtbl {
             let this = (*this).get_impl();
             this.GetNearestKeyFrames(::core::mem::transmute_copy(&pguidtimeformat), ::core::mem::transmute_copy(&pvarstartposition), ::core::mem::transmute_copy(&pvarpreviouskeyframe), ::core::mem::transmute_copy(&pvarnextkeyframe)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetNearestKeyFrames: GetNearestKeyFrames::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetNearestKeyFrames: GetNearestKeyFrames::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMFSeekInfo as ::windows::core::Interface>::IID
@@ -13061,7 +13064,7 @@ impl IMFSensorActivitiesReport_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCount: GetCount::<Identity, Impl, OFFSET>,
             GetActivityReport: GetActivityReport::<Identity, Impl, OFFSET>,
             GetActivityReportByDeviceName: GetActivityReportByDeviceName::<Identity, Impl, OFFSET>,
@@ -13082,7 +13085,7 @@ impl IMFSensorActivitiesReportCallback_Vtbl {
             let this = (*this).get_impl();
             this.OnActivitiesReport(::core::mem::transmute(&sensoractivitiesreport)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnActivitiesReport: OnActivitiesReport::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnActivitiesReport: OnActivitiesReport::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMFSensorActivitiesReportCallback as ::windows::core::Interface>::IID
@@ -13105,7 +13108,7 @@ impl IMFSensorActivityMonitor_Vtbl {
             let this = (*this).get_impl();
             this.Stop().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Start: Start::<Identity, Impl, OFFSET>, Stop: Stop::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Start: Start::<Identity, Impl, OFFSET>, Stop: Stop::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMFSensorActivityMonitor as ::windows::core::Interface>::IID
@@ -13153,7 +13156,7 @@ impl IMFSensorActivityReport_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetFriendlyName: GetFriendlyName::<Identity, Impl, OFFSET>,
             GetSymbolicLink: GetSymbolicLink::<Identity, Impl, OFFSET>,
             GetProcessCount: GetProcessCount::<Identity, Impl, OFFSET>,
@@ -13266,7 +13269,7 @@ impl IMFSensorDevice_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDeviceId: GetDeviceId::<Identity, Impl, OFFSET>,
             GetDeviceType: GetDeviceType::<Identity, Impl, OFFSET>,
             GetFlags: GetFlags::<Identity, Impl, OFFSET>,
@@ -13372,7 +13375,7 @@ impl IMFSensorGroup_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSymbolicLink: GetSymbolicLink::<Identity, Impl, OFFSET>,
             GetFlags: GetFlags::<Identity, Impl, OFFSET>,
             GetSensorGroupAttributes: GetSensorGroupAttributes::<Identity, Impl, OFFSET>,
@@ -13444,7 +13447,7 @@ impl IMFSensorProcessActivity_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetProcessId: GetProcessId::<Identity, Impl, OFFSET>,
             GetStreamingState: GetStreamingState::<Identity, Impl, OFFSET>,
             GetStreamingMode: GetStreamingMode::<Identity, Impl, OFFSET>,
@@ -13500,7 +13503,7 @@ impl IMFSensorProfile_Vtbl {
             this.AddBlockedControl(::core::mem::transmute(&wzblockedcontrol)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetProfileId: GetProfileId::<Identity, Impl, OFFSET>,
             AddProfileFilter: AddProfileFilter::<Identity, Impl, OFFSET>,
             IsMediaTypeSupported: IsMediaTypeSupported::<Identity, Impl, OFFSET>,
@@ -13565,7 +13568,7 @@ impl IMFSensorProfileCollection_Vtbl {
             this.RemoveProfile(::core::mem::transmute_copy(&profileid))
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetProfileCount: GetProfileCount::<Identity, Impl, OFFSET>,
             GetProfile: GetProfile::<Identity, Impl, OFFSET>,
             AddProfile: AddProfile::<Identity, Impl, OFFSET>,
@@ -13687,7 +13690,7 @@ impl IMFSensorTransformFactory_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetFactoryAttributes: GetFactoryAttributes::<Identity, Impl, OFFSET>,
             InitializeFactory: InitializeFactory::<Identity, Impl, OFFSET>,
             GetTransformCount: GetTransformCount::<Identity, Impl, OFFSET>,
@@ -13741,7 +13744,7 @@ impl IMFSequencerSource_Vtbl {
             this.UpdateTopologyFlags(::core::mem::transmute_copy(&dwid), ::core::mem::transmute_copy(&dwflags)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AppendTopology: AppendTopology::<Identity, Impl, OFFSET>,
             DeleteTopology: DeleteTopology::<Identity, Impl, OFFSET>,
             GetPresentationContext: GetPresentationContext::<Identity, Impl, OFFSET>,
@@ -13770,7 +13773,7 @@ impl IMFSharingEngineClassFactory_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CreateInstance: CreateInstance::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CreateInstance: CreateInstance::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMFSharingEngineClassFactory as ::windows::core::Interface>::IID
@@ -13800,7 +13803,7 @@ impl IMFShutdown_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Shutdown: Shutdown::<Identity, Impl, OFFSET>,
             GetShutdownStatus: GetShutdownStatus::<Identity, Impl, OFFSET>,
         }
@@ -13820,7 +13823,7 @@ impl IMFSignedLibrary_Vtbl {
             let this = (*this).get_impl();
             this.GetProcedureAddress(::core::mem::transmute(&name), ::core::mem::transmute_copy(&address)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetProcedureAddress: GetProcedureAddress::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetProcedureAddress: GetProcedureAddress::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMFSignedLibrary as ::windows::core::Interface>::IID
@@ -13871,7 +13874,7 @@ impl IMFSimpleAudioVolume_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetMasterVolume: SetMasterVolume::<Identity, Impl, OFFSET>,
             GetMasterVolume: GetMasterVolume::<Identity, Impl, OFFSET>,
             SetMute: SetMute::<Identity, Impl, OFFSET>,
@@ -13966,7 +13969,7 @@ impl IMFSinkWriter_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddStream: AddStream::<Identity, Impl, OFFSET>,
             SetInputMediaType: SetInputMediaType::<Identity, Impl, OFFSET>,
             BeginWriting: BeginWriting::<Identity, Impl, OFFSET>,
@@ -14002,7 +14005,7 @@ impl IMFSinkWriterCallback_Vtbl {
             this.OnMarker(::core::mem::transmute_copy(&dwstreamindex), ::core::mem::transmute_copy(&pvcontext)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnFinalize: OnFinalize::<Identity, Impl, OFFSET>,
             OnMarker: OnMarker::<Identity, Impl, OFFSET>,
         }
@@ -14056,7 +14059,7 @@ impl IMFSinkWriterEncoderConfig_Vtbl {
             this.PlaceEncodingParameters(::core::mem::transmute_copy(&dwstreamindex), ::core::mem::transmute(&pencodingparameters)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetTargetMediaType: SetTargetMediaType::<Identity, Impl, OFFSET>,
             PlaceEncodingParameters: PlaceEncodingParameters::<Identity, Impl, OFFSET>,
         }
@@ -14169,7 +14172,7 @@ impl IMFSourceBuffer_Vtbl {
             this.Remove(::core::mem::transmute_copy(&start), ::core::mem::transmute_copy(&end)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetUpdating: GetUpdating::<Identity, Impl, OFFSET>,
             GetBuffered: GetBuffered::<Identity, Impl, OFFSET>,
             GetTimeStampOffset: GetTimeStampOffset::<Identity, Impl, OFFSET>,
@@ -14206,7 +14209,7 @@ impl IMFSourceBufferAppendMode_Vtbl {
             this.SetAppendMode(::core::mem::transmute_copy(&mode)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetAppendMode: GetAppendMode::<Identity, Impl, OFFSET>,
             SetAppendMode: SetAppendMode::<Identity, Impl, OFFSET>,
         }
@@ -14233,7 +14236,7 @@ impl IMFSourceBufferList_Vtbl {
             this.GetSourceBuffer(::core::mem::transmute_copy(&index))
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetLength: GetLength::<Identity, Impl, OFFSET>,
             GetSourceBuffer: GetSourceBuffer::<Identity, Impl, OFFSET>,
         }
@@ -14278,7 +14281,7 @@ impl IMFSourceBufferNotify_Vtbl {
             this.OnUpdateEnd()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnUpdateStart: OnUpdateStart::<Identity, Impl, OFFSET>,
             OnAbort: OnAbort::<Identity, Impl, OFFSET>,
             OnError: OnError::<Identity, Impl, OFFSET>,
@@ -14301,7 +14304,7 @@ impl IMFSourceOpenMonitor_Vtbl {
             let this = (*this).get_impl();
             this.OnSourceEvent(::core::mem::transmute(&pevent)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnSourceEvent: OnSourceEvent::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnSourceEvent: OnSourceEvent::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMFSourceOpenMonitor as ::windows::core::Interface>::IID
@@ -14400,7 +14403,7 @@ impl IMFSourceReader_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetStreamSelection: GetStreamSelection::<Identity, Impl, OFFSET>,
             SetStreamSelection: SetStreamSelection::<Identity, Impl, OFFSET>,
             GetNativeMediaType: GetNativeMediaType::<Identity, Impl, OFFSET>,
@@ -14441,7 +14444,7 @@ impl IMFSourceReaderCallback_Vtbl {
             this.OnEvent(::core::mem::transmute_copy(&dwstreamindex), ::core::mem::transmute(&pevent)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnReadSample: OnReadSample::<Identity, Impl, OFFSET>,
             OnFlush: OnFlush::<Identity, Impl, OFFSET>,
             OnEvent: OnEvent::<Identity, Impl, OFFSET>,
@@ -14579,7 +14582,7 @@ impl IMFSourceResolver_Vtbl {
             this.CancelObjectCreation(::core::mem::transmute(&piunknowncancelcookie)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateObjectFromURL: CreateObjectFromURL::<Identity, Impl, OFFSET>,
             CreateObjectFromByteStream: CreateObjectFromByteStream::<Identity, Impl, OFFSET>,
             BeginCreateObjectFromURL: BeginCreateObjectFromURL::<Identity, Impl, OFFSET>,
@@ -14843,7 +14846,7 @@ impl IMFStreamingSinkConfig_Vtbl {
             let this = (*this).get_impl();
             this.StartStreaming(::core::mem::transmute_copy(&fseekoffsetisbyteoffset), ::core::mem::transmute_copy(&qwseekoffset)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), StartStreaming: StartStreaming::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), StartStreaming: StartStreaming::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMFStreamingSinkConfig as ::windows::core::Interface>::IID
@@ -14867,7 +14870,7 @@ impl IMFSystemId_Vtbl {
             this.Setup(::core::mem::transmute_copy(&stage), ::core::mem::transmute_copy(&cbin), ::core::mem::transmute_copy(&pbin), ::core::mem::transmute_copy(&pcbout), ::core::mem::transmute_copy(&ppbout)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetData: GetData::<Identity, Impl, OFFSET>,
             Setup: Setup::<Identity, Impl, OFFSET>,
         }
@@ -14921,7 +14924,7 @@ impl IMFTimecodeTranslate_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             BeginConvertTimecodeToHNS: BeginConvertTimecodeToHNS::<Identity, Impl, OFFSET>,
             EndConvertTimecodeToHNS: EndConvertTimecodeToHNS::<Identity, Impl, OFFSET>,
             BeginConvertHNSToTimecode: BeginConvertHNSToTimecode::<Identity, Impl, OFFSET>,
@@ -15073,7 +15076,7 @@ impl IMFTimedText_Vtbl {
             this.IsInBandEnabled()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RegisterNotifications: RegisterNotifications::<Identity, Impl, OFFSET>,
             SelectTrack: SelectTrack::<Identity, Impl, OFFSET>,
             AddDataSource: AddDataSource::<Identity, Impl, OFFSET>,
@@ -15105,7 +15108,7 @@ impl IMFTimedTextBinary_Vtbl {
             let this = (*this).get_impl();
             this.GetData(::core::mem::transmute_copy(&data), ::core::mem::transmute_copy(&length)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetData: GetData::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetData: GetData::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMFTimedTextBinary as ::windows::core::Interface>::IID
@@ -15153,7 +15156,7 @@ impl IMFTimedTextBouten_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetBoutenType: GetBoutenType::<Identity, Impl, OFFSET>,
             GetBoutenColor: GetBoutenColor::<Identity, Impl, OFFSET>,
             GetBoutenPosition: GetBoutenPosition::<Identity, Impl, OFFSET>,
@@ -15265,7 +15268,7 @@ impl IMFTimedTextCue_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetId: GetId::<Identity, Impl, OFFSET>,
             GetOriginalId: GetOriginalId::<Identity, Impl, OFFSET>,
             GetCueKind: GetCueKind::<Identity, Impl, OFFSET>,
@@ -15361,7 +15364,7 @@ impl IMFTimedTextCueList_Vtbl {
             this.RemoveCue(::core::mem::transmute(&cue)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetLength: GetLength::<Identity, Impl, OFFSET>,
             GetCueByIndex: GetCueByIndex::<Identity, Impl, OFFSET>,
             GetCueById: GetCueById::<Identity, Impl, OFFSET>,
@@ -15405,7 +15408,7 @@ impl IMFTimedTextFormattedText_Vtbl {
             this.GetSubformatting(::core::mem::transmute_copy(&index), ::core::mem::transmute_copy(&firstchar), ::core::mem::transmute_copy(&charlength), ::core::mem::transmute_copy(&style)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetText: GetText::<Identity, Impl, OFFSET>,
             GetSubformattingCount: GetSubformattingCount::<Identity, Impl, OFFSET>,
             GetSubformatting: GetSubformatting::<Identity, Impl, OFFSET>,
@@ -15466,7 +15469,7 @@ impl IMFTimedTextNotify_Vtbl {
             this.Reset()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             TrackAdded: TrackAdded::<Identity, Impl, OFFSET>,
             TrackRemoved: TrackRemoved::<Identity, Impl, OFFSET>,
             TrackSelected: TrackSelected::<Identity, Impl, OFFSET>,
@@ -15609,7 +15612,7 @@ impl IMFTimedTextRegion_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetName: GetName::<Identity, Impl, OFFSET>,
             GetPosition: GetPosition::<Identity, Impl, OFFSET>,
             GetExtent: GetExtent::<Identity, Impl, OFFSET>,
@@ -15682,7 +15685,7 @@ impl IMFTimedTextRuby_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetRubyText: GetRubyText::<Identity, Impl, OFFSET>,
             GetRubyPosition: GetRubyPosition::<Identity, Impl, OFFSET>,
             GetRubyAlign: GetRubyAlign::<Identity, Impl, OFFSET>,
@@ -15840,7 +15843,7 @@ impl IMFTimedTextStyle_Vtbl {
             this.GetTextOutline(::core::mem::transmute_copy(&color), ::core::mem::transmute_copy(&thickness), ::core::mem::transmute_copy(&blurradius), ::core::mem::transmute_copy(&unittype)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetName: GetName::<Identity, Impl, OFFSET>,
             IsExternal: IsExternal::<Identity, Impl, OFFSET>,
             GetFontFamily: GetFontFamily::<Identity, Impl, OFFSET>,
@@ -15917,7 +15920,7 @@ impl IMFTimedTextStyle2_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetRuby: GetRuby::<Identity, Impl, OFFSET>,
             GetBouten: GetBouten::<Identity, Impl, OFFSET>,
             IsTextCombined: IsTextCombined::<Identity, Impl, OFFSET>,
@@ -16045,7 +16048,7 @@ impl IMFTimedTextTrack_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetId: GetId::<Identity, Impl, OFFSET>,
             GetLabel: GetLabel::<Identity, Impl, OFFSET>,
             SetLabel: SetLabel::<Identity, Impl, OFFSET>,
@@ -16101,7 +16104,7 @@ impl IMFTimedTextTrackList_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetLength: GetLength::<Identity, Impl, OFFSET>,
             GetTrack: GetTrack::<Identity, Impl, OFFSET>,
             GetTrackById: GetTrackById::<Identity, Impl, OFFSET>,
@@ -16135,7 +16138,7 @@ impl IMFTimer_Vtbl {
             this.CancelTimer(::core::mem::transmute(&punkkey)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetTimer: SetTimer::<Identity, Impl, OFFSET>,
             CancelTimer: CancelTimer::<Identity, Impl, OFFSET>,
         }
@@ -16155,7 +16158,7 @@ impl IMFTopoLoader_Vtbl {
             let this = (*this).get_impl();
             this.Load(::core::mem::transmute(&pinputtopo), ::core::mem::transmute_copy(&ppoutputtopo), ::core::mem::transmute(&pcurrenttopo)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Load: Load::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Load: Load::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMFTopoLoader as ::windows::core::Interface>::IID
@@ -16464,7 +16467,7 @@ impl IMFTopologyNodeAttributeEditor_Vtbl {
             let this = (*this).get_impl();
             this.UpdateNodeAttributes(::core::mem::transmute_copy(&topoid), ::core::mem::transmute_copy(&cupdates), ::core::mem::transmute_copy(&pupdates)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), UpdateNodeAttributes: UpdateNodeAttributes::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), UpdateNodeAttributes: UpdateNodeAttributes::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMFTopologyNodeAttributeEditor as ::windows::core::Interface>::IID
@@ -16481,7 +16484,7 @@ impl IMFTopologyServiceLookup_Vtbl {
             let this = (*this).get_impl();
             this.LookupService(::core::mem::transmute_copy(&r#type), ::core::mem::transmute_copy(&dwindex), ::core::mem::transmute_copy(&guidservice), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppvobjects), ::core::mem::transmute_copy(&pnobjects)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), LookupService: LookupService::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), LookupService: LookupService::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMFTopologyServiceLookup as ::windows::core::Interface>::IID
@@ -16505,7 +16508,7 @@ impl IMFTopologyServiceLookupClient_Vtbl {
             this.ReleaseServicePointers().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             InitServicePointers: InitServicePointers::<Identity, Impl, OFFSET>,
             ReleaseServicePointers: ReleaseServicePointers::<Identity, Impl, OFFSET>,
         }
@@ -16525,7 +16528,7 @@ impl IMFTrackedSample_Vtbl {
             let this = (*this).get_impl();
             this.SetAllocator(::core::mem::transmute(&psampleallocator), ::core::mem::transmute(&punkstate)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SetAllocator: SetAllocator::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SetAllocator: SetAllocator::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMFTrackedSample as ::windows::core::Interface>::IID
@@ -16591,7 +16594,7 @@ impl IMFTranscodeProfile_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetAudioAttributes: SetAudioAttributes::<Identity, Impl, OFFSET>,
             GetAudioAttributes: GetAudioAttributes::<Identity, Impl, OFFSET>,
             SetVideoAttributes: SetVideoAttributes::<Identity, Impl, OFFSET>,
@@ -16640,7 +16643,7 @@ impl IMFTranscodeSinkInfoProvider_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetOutputFile: SetOutputFile::<Identity, Impl, OFFSET>,
             SetOutputByteStream: SetOutputByteStream::<Identity, Impl, OFFSET>,
             SetProfile: SetProfile::<Identity, Impl, OFFSET>,
@@ -16861,7 +16864,7 @@ impl IMFTransform_Vtbl {
             this.ProcessOutput(::core::mem::transmute_copy(&dwflags), ::core::mem::transmute_copy(&coutputbuffercount), ::core::mem::transmute_copy(&poutputsamples), ::core::mem::transmute_copy(&pdwstatus)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetStreamLimits: GetStreamLimits::<Identity, Impl, OFFSET>,
             GetStreamCount: GetStreamCount::<Identity, Impl, OFFSET>,
             GetStreamIDs: GetStreamIDs::<Identity, Impl, OFFSET>,
@@ -16908,7 +16911,7 @@ impl IMFTrustedInput_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetInputTrustAuthority: GetInputTrustAuthority::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetInputTrustAuthority: GetInputTrustAuthority::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMFTrustedInput as ::windows::core::Interface>::IID
@@ -16959,7 +16962,7 @@ impl IMFTrustedOutput_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetOutputTrustAuthorityCount: GetOutputTrustAuthorityCount::<Identity, Impl, OFFSET>,
             GetOutputTrustAuthorityByIndex: GetOutputTrustAuthorityByIndex::<Identity, Impl, OFFSET>,
             IsFinal: IsFinal::<Identity, Impl, OFFSET>,
@@ -17006,7 +17009,7 @@ impl IMFVideoDeviceID_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetDeviceID: GetDeviceID::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetDeviceID: GetDeviceID::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMFVideoDeviceID as ::windows::core::Interface>::IID
@@ -17147,7 +17150,7 @@ impl IMFVideoDisplayControl_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetNativeVideoSize: GetNativeVideoSize::<Identity, Impl, OFFSET>,
             GetIdealVideoSize: GetIdealVideoSize::<Identity, Impl, OFFSET>,
             SetVideoPosition: SetVideoPosition::<Identity, Impl, OFFSET>,
@@ -17239,7 +17242,7 @@ impl IMFVideoMixerBitmap_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetAlphaBitmap: SetAlphaBitmap::<Identity, Impl, OFFSET>,
             ClearAlphaBitmap: ClearAlphaBitmap::<Identity, Impl, OFFSET>,
             UpdateAlphaBitmapParameters: UpdateAlphaBitmapParameters::<Identity, Impl, OFFSET>,
@@ -17292,7 +17295,7 @@ impl IMFVideoMixerControl_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetStreamZOrder: SetStreamZOrder::<Identity, Impl, OFFSET>,
             GetStreamZOrder: GetStreamZOrder::<Identity, Impl, OFFSET>,
             SetStreamOutputRect: SetStreamOutputRect::<Identity, Impl, OFFSET>,
@@ -17348,7 +17351,7 @@ impl IMFVideoPositionMapper_Vtbl {
             this.MapOutputCoordinateToInputStream(::core::mem::transmute_copy(&xout), ::core::mem::transmute_copy(&yout), ::core::mem::transmute_copy(&dwoutputstreamindex), ::core::mem::transmute_copy(&dwinputstreamindex), ::core::mem::transmute_copy(&pxin), ::core::mem::transmute_copy(&pyin)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             MapOutputCoordinateToInputStream: MapOutputCoordinateToInputStream::<Identity, Impl, OFFSET>,
         }
     }
@@ -17512,7 +17515,7 @@ impl IMFVideoProcessor_Vtbl {
             this.SetBackgroundColor(::core::mem::transmute_copy(&clrbkg)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetAvailableVideoProcessorModes: GetAvailableVideoProcessorModes::<Identity, Impl, OFFSET>,
             GetVideoProcessorCaps: GetVideoProcessorCaps::<Identity, Impl, OFFSET>,
             GetVideoProcessorMode: GetVideoProcessorMode::<Identity, Impl, OFFSET>,
@@ -17576,7 +17579,7 @@ impl IMFVideoProcessorControl_Vtbl {
             this.SetConstrictionSize(::core::mem::transmute_copy(&pconstrictionsize)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetBorderColor: SetBorderColor::<Identity, Impl, OFFSET>,
             SetSourceRectangle: SetSourceRectangle::<Identity, Impl, OFFSET>,
             SetDestinationRectangle: SetDestinationRectangle::<Identity, Impl, OFFSET>,
@@ -17693,7 +17696,7 @@ impl IMFVideoRenderer_Vtbl {
             let this = (*this).get_impl();
             this.InitializeRenderer(::core::mem::transmute(&pvideomixer), ::core::mem::transmute(&pvideopresenter)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), InitializeRenderer: InitializeRenderer::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), InitializeRenderer: InitializeRenderer::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMFVideoRenderer as ::windows::core::Interface>::IID
@@ -17711,7 +17714,7 @@ impl IMFVideoRendererEffectControl_Vtbl {
             this.OnAppServiceConnectionEstablished(::core::mem::transmute(&pappserviceconnection)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnAppServiceConnectionEstablished: OnAppServiceConnectionEstablished::<Identity, Impl, OFFSET>,
         }
     }
@@ -17755,7 +17758,7 @@ impl IMFVideoSampleAllocator_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetDirectXManager: SetDirectXManager::<Identity, Impl, OFFSET>,
             UninitializeSampleAllocator: UninitializeSampleAllocator::<Identity, Impl, OFFSET>,
             InitializeSampleAllocator: InitializeSampleAllocator::<Identity, Impl, OFFSET>,
@@ -17790,7 +17793,7 @@ impl IMFVideoSampleAllocatorCallback_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetCallback: SetCallback::<Identity, Impl, OFFSET>,
             GetFreeSampleCount: GetFreeSampleCount::<Identity, Impl, OFFSET>,
         }
@@ -17830,7 +17833,7 @@ impl IMFVideoSampleAllocatorNotify_Vtbl {
             let this = (*this).get_impl();
             this.NotifyRelease().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), NotifyRelease: NotifyRelease::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), NotifyRelease: NotifyRelease::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMFVideoSampleAllocatorNotify as ::windows::core::Interface>::IID
@@ -18060,7 +18063,7 @@ impl IMFWorkQueueServices_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             BeginRegisterTopologyWorkQueuesWithMMCSS: BeginRegisterTopologyWorkQueuesWithMMCSS::<Identity, Impl, OFFSET>,
             EndRegisterTopologyWorkQueuesWithMMCSS: EndRegisterTopologyWorkQueuesWithMMCSS::<Identity, Impl, OFFSET>,
             BeginUnregisterTopologyWorkQueuesWithMMCSS: BeginUnregisterTopologyWorkQueuesWithMMCSS::<Identity, Impl, OFFSET>,
@@ -18173,7 +18176,7 @@ impl IOPMVideoOutput_Vtbl {
             this.Configure(::core::mem::transmute_copy(&pparameters), ::core::mem::transmute_copy(&uladditionalparameterssize), ::core::mem::transmute_copy(&pbadditionalparameters)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             StartInitialization: StartInitialization::<Identity, Impl, OFFSET>,
             FinishInitialization: FinishInitialization::<Identity, Impl, OFFSET>,
             GetInformation: GetInformation::<Identity, Impl, OFFSET>,
@@ -18203,7 +18206,7 @@ impl IPlayToControl_Vtbl {
             this.Disconnect().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Connect: Connect::<Identity, Impl, OFFSET>,
             Disconnect: Disconnect::<Identity, Impl, OFFSET>,
         }
@@ -18252,7 +18255,7 @@ impl IPlayToSourceClassFactory_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CreateInstance: CreateInstance::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CreateInstance: CreateInstance::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IPlayToSourceClassFactory as ::windows::core::Interface>::IID
@@ -18336,7 +18339,7 @@ impl IToc_Vtbl {
             this.RemoveEntryListByIndex(::core::mem::transmute_copy(&wentrylistindex)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetDescriptor: SetDescriptor::<Identity, Impl, OFFSET>,
             GetDescriptor: GetDescriptor::<Identity, Impl, OFFSET>,
             SetDescription: SetDescription::<Identity, Impl, OFFSET>,
@@ -18396,7 +18399,7 @@ impl ITocCollection_Vtbl {
             this.RemoveEntryByIndex(::core::mem::transmute_copy(&dwentryindex)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetEntryCount: GetEntryCount::<Identity, Impl, OFFSET>,
             GetEntryByIndex: GetEntryByIndex::<Identity, Impl, OFFSET>,
             AddEntry: AddEntry::<Identity, Impl, OFFSET>,
@@ -18462,7 +18465,7 @@ impl ITocEntry_Vtbl {
             this.GetDescriptionData(::core::mem::transmute_copy(&pdwdescriptiondatasize), ::core::mem::transmute_copy(&pbtdescriptiondata), ::core::mem::transmute_copy(&pguidtype)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetTitle: SetTitle::<Identity, Impl, OFFSET>,
             GetTitle: GetTitle::<Identity, Impl, OFFSET>,
             SetDescriptor: SetDescriptor::<Identity, Impl, OFFSET>,
@@ -18519,7 +18522,7 @@ impl ITocEntryList_Vtbl {
             this.RemoveEntryByIndex(::core::mem::transmute_copy(&dwentryindex)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetEntryCount: GetEntryCount::<Identity, Impl, OFFSET>,
             GetEntryByIndex: GetEntryByIndex::<Identity, Impl, OFFSET>,
             AddEntry: AddEntry::<Identity, Impl, OFFSET>,
@@ -18597,7 +18600,7 @@ impl ITocParser_Vtbl {
             this.Commit().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Init: Init::<Identity, Impl, OFFSET>,
             GetTocCount: GetTocCount::<Identity, Impl, OFFSET>,
             GetTocByIndex: GetTocByIndex::<Identity, Impl, OFFSET>,
@@ -18623,7 +18626,7 @@ impl IValidateBinding_Vtbl {
             let this = (*this).get_impl();
             this.GetIdentifier(::core::mem::transmute(&guidlicensorid), ::core::mem::transmute_copy(&pbephemeron), ::core::mem::transmute_copy(&cbephemeron), ::core::mem::transmute_copy(&ppbblobvalidationid), ::core::mem::transmute_copy(&pcbblobsize)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetIdentifier: GetIdentifier::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetIdentifier: GetIdentifier::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IValidateBinding as ::windows::core::Interface>::IID
@@ -18659,7 +18662,7 @@ impl IWMCodecLeakyBucket_Vtbl {
             this.GetBufferFullnessBits(::core::mem::transmute_copy(&pulbufferfullness)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetBufferSizeBits: SetBufferSizeBits::<Identity, Impl, OFFSET>,
             GetBufferSizeBits: GetBufferSizeBits::<Identity, Impl, OFFSET>,
             SetBufferFullnessBits: SetBufferFullnessBits::<Identity, Impl, OFFSET>,
@@ -18681,7 +18684,7 @@ impl IWMCodecOutputTimestamp_Vtbl {
             let this = (*this).get_impl();
             this.GetNextOutputTime(::core::mem::transmute_copy(&prttime)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetNextOutputTime: GetNextOutputTime::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetNextOutputTime: GetNextOutputTime::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWMCodecOutputTimestamp as ::windows::core::Interface>::IID
@@ -18708,7 +18711,7 @@ impl IWMCodecPrivateData_Vtbl {
             this.GetPrivateData(::core::mem::transmute_copy(&pbdata), ::core::mem::transmute_copy(&pcbdata)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetPartialOutputType: SetPartialOutputType::<Identity, Impl, OFFSET>,
             GetPrivateData: GetPrivateData::<Identity, Impl, OFFSET>,
         }
@@ -18738,7 +18741,7 @@ impl IWMCodecProps_Vtbl {
             this.GetCodecProp(::core::mem::transmute_copy(&dwformat), ::core::mem::transmute(&pszname), ::core::mem::transmute_copy(&ptype), ::core::mem::transmute_copy(&pvalue), ::core::mem::transmute_copy(&pdwsize)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetFormatProp: GetFormatProp::<Identity, Impl, OFFSET>,
             GetCodecProp: GetCodecProp::<Identity, Impl, OFFSET>,
         }
@@ -18768,7 +18771,7 @@ impl IWMCodecStrings_Vtbl {
             this.GetDescription(::core::mem::transmute_copy(&pmt), ::core::mem::transmute_copy(&cchlength), ::core::mem::transmute_copy(&szdescription), ::core::mem::transmute_copy(&pcchlength)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetName: GetName::<Identity, Impl, OFFSET>,
             GetDescription: GetDescription::<Identity, Impl, OFFSET>,
         }
@@ -18795,7 +18798,7 @@ impl IWMColorConvProps_Vtbl {
             this.SetFullCroppingParam(::core::mem::transmute_copy(&lsrccropleft), ::core::mem::transmute_copy(&lsrccroptop), ::core::mem::transmute_copy(&ldstcropleft), ::core::mem::transmute_copy(&ldstcroptop), ::core::mem::transmute_copy(&lcropwidth), ::core::mem::transmute_copy(&lcropheight)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetMode: SetMode::<Identity, Impl, OFFSET>,
             SetFullCroppingParam: SetFullCroppingParam::<Identity, Impl, OFFSET>,
         }
@@ -18815,7 +18818,7 @@ impl IWMColorLegalizerProps_Vtbl {
             let this = (*this).get_impl();
             this.SetColorLegalizerQuality(::core::mem::transmute_copy(&lquality)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SetColorLegalizerQuality: SetColorLegalizerQuality::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SetColorLegalizerQuality: SetColorLegalizerQuality::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWMColorLegalizerProps as ::windows::core::Interface>::IID
@@ -18854,7 +18857,7 @@ impl IWMFrameInterpProps_Vtbl {
             this.SetComplexityLevel(::core::mem::transmute_copy(&icomplexity)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetFrameRateIn: SetFrameRateIn::<Identity, Impl, OFFSET>,
             SetFrameRateOut: SetFrameRateOut::<Identity, Impl, OFFSET>,
             SetFrameInterpEnabled: SetFrameInterpEnabled::<Identity, Impl, OFFSET>,
@@ -18889,7 +18892,7 @@ impl IWMInterlaceProps_Vtbl {
             this.SetLastFrame().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetProcessType: SetProcessType::<Identity, Impl, OFFSET>,
             SetInitInverseTeleCinePattern: SetInitInverseTeleCinePattern::<Identity, Impl, OFFSET>,
             SetLastFrame: SetLastFrame::<Identity, Impl, OFFSET>,
@@ -18917,7 +18920,7 @@ impl IWMResamplerProps_Vtbl {
             this.SetUserChannelMtx(::core::mem::transmute_copy(&userchannelmtx)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetHalfFilterLength: SetHalfFilterLength::<Identity, Impl, OFFSET>,
             SetUserChannelMtx: SetUserChannelMtx::<Identity, Impl, OFFSET>,
         }
@@ -18962,7 +18965,7 @@ impl IWMResizerProps_Vtbl {
             this.GetFullCropRegion(::core::mem::transmute_copy(&lcliporixsrc), ::core::mem::transmute_copy(&lcliporiysrc), ::core::mem::transmute_copy(&lclipwidthsrc), ::core::mem::transmute_copy(&lclipheightsrc), ::core::mem::transmute_copy(&lcliporixdst), ::core::mem::transmute_copy(&lcliporiydst), ::core::mem::transmute_copy(&lclipwidthdst), ::core::mem::transmute_copy(&lclipheightdst)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetResizerQuality: SetResizerQuality::<Identity, Impl, OFFSET>,
             SetInterlaceMode: SetInterlaceMode::<Identity, Impl, OFFSET>,
             SetClipRegion: SetClipRegion::<Identity, Impl, OFFSET>,
@@ -18988,7 +18991,7 @@ impl IWMSampleExtensionSupport_Vtbl {
             let this = (*this).get_impl();
             this.SetUseSampleExtensions(::core::mem::transmute_copy(&fuseextensions)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SetUseSampleExtensions: SetUseSampleExtensions::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SetUseSampleExtensions: SetUseSampleExtensions::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWMSampleExtensionSupport as ::windows::core::Interface>::IID
@@ -19005,7 +19008,7 @@ impl IWMValidate_Vtbl {
             let this = (*this).get_impl();
             this.SetIdentifier(::core::mem::transmute(&guidvalidationid)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SetIdentifier: SetIdentifier::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SetIdentifier: SetIdentifier::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWMValidate as ::windows::core::Interface>::IID
@@ -19029,7 +19032,7 @@ impl IWMVideoDecoderHurryup_Vtbl {
             this.GetHurryup(::core::mem::transmute_copy(&plhurryup)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetHurryup: SetHurryup::<Identity, Impl, OFFSET>,
             GetHurryup: GetHurryup::<Identity, Impl, OFFSET>,
         }
@@ -19065,7 +19068,7 @@ impl IWMVideoDecoderReconBuffer_Vtbl {
             this.SetReconstructedVideoFrame(::core::mem::transmute(&pbuf)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetReconstructedVideoFrameSize: GetReconstructedVideoFrameSize::<Identity, Impl, OFFSET>,
             GetReconstructedVideoFrame: GetReconstructedVideoFrame::<Identity, Impl, OFFSET>,
             SetReconstructedVideoFrame: SetReconstructedVideoFrame::<Identity, Impl, OFFSET>,
@@ -19086,7 +19089,7 @@ impl IWMVideoForceKeyFrame_Vtbl {
             let this = (*this).get_impl();
             this.SetKeyFrame().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SetKeyFrame: SetKeyFrame::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SetKeyFrame: SetKeyFrame::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWMVideoForceKeyFrame as ::windows::core::Interface>::IID

--- a/crates/libs/windows/src/Windows/Win32/Media/MediaFoundation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/MediaFoundation/mod.rs
@@ -2891,7 +2891,7 @@ unsafe impl ::windows::core::Interface for IAdvancedMediaCapture {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAdvancedMediaCapture_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetAdvancedMediaCaptureSettings: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -2943,7 +2943,7 @@ unsafe impl ::windows::core::Interface for IAdvancedMediaCaptureInitializationSe
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAdvancedMediaCaptureInitializationSettings_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetDirectxDeviceManager: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -2993,7 +2993,7 @@ unsafe impl ::windows::core::Interface for IAdvancedMediaCaptureSettings {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAdvancedMediaCaptureSettings_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDirectxDeviceManager: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -3042,7 +3042,7 @@ unsafe impl ::windows::core::Interface for IAudioSourceProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAudioSourceProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ProvideInput: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwsamplecount: u32, pdwchannelcount: *mut u32, pinterleavedaudiodata: *mut f32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -3098,7 +3098,7 @@ unsafe impl ::windows::core::Interface for IClusterDetector {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IClusterDetector_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wbaseentrylevel: u16, wclusterentrylevel: u16) -> ::windows::core::HRESULT,
     pub Detect: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwmaxnumclusters: u32, fminclusterduration: f32, fmaxclusterduration: f32, psrctoc: *mut ::core::ffi::c_void, ppdsttoc: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -3219,7 +3219,7 @@ unsafe impl ::windows::core::Interface for ICodecAPI {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICodecAPI_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub IsSupported: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, api: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub IsModifiable: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, api: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -4863,7 +4863,7 @@ unsafe impl ::windows::core::Interface for ID3D12VideoDevice {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D12VideoDevice_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CheckFeatureSupport: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, featurevideo: D3D12_FEATURE_VIDEO, pfeaturesupportdata: *mut ::core::ffi::c_void, featuresupportdatasize: u32) -> ::windows::core::HRESULT,
     pub CreateVideoDecoder: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdesc: *const D3D12_VIDEO_DECODER_DESC, riid: *const ::windows::core::GUID, ppvideodecoder: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -8457,7 +8457,7 @@ unsafe impl ::windows::core::Interface for IDXVAHD_Device {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDXVAHD_Device_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
     pub CreateVideoSurface: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, width: u32, height: u32, format: super::super::Graphics::Direct3D9::D3DFORMAT, pool: super::super::Graphics::Direct3D9::D3DPOOL, usage: u32, r#type: DXVAHD_SURFACE_TYPE, numsurfaces: u32, ppsurfaces: *mut *mut ::core::ffi::c_void, psharedhandle: *mut super::super::Foundation::HANDLE) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9")))]
@@ -8545,7 +8545,7 @@ unsafe impl ::windows::core::Interface for IDXVAHD_VideoProcessor {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDXVAHD_VideoProcessor_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetVideoProcessBltState: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, state: DXVAHD_BLT_STATE, datasize: u32, pdata: *const ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetVideoProcessBltState: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, state: DXVAHD_BLT_STATE, datasize: u32, pdata: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetVideoProcessStreamState: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, streamnumber: u32, state: DXVAHD_STREAM_STATE, datasize: u32, pdata: *const ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -8603,7 +8603,7 @@ unsafe impl ::windows::core::Interface for IDirect3D9ExOverlayExtension {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirect3D9ExOverlayExtension_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Graphics_Direct3D9")]
     pub CheckDeviceOverlayType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, adapter: u32, devtype: super::super::Graphics::Direct3D9::D3DDEVTYPE, overlaywidth: u32, overlayheight: u32, overlayformat: super::super::Graphics::Direct3D9::D3DFORMAT, pdisplaymode: *mut super::super::Graphics::Direct3D9::D3DDISPLAYMODEEX, displayrotation: super::super::Graphics::Direct3D9::D3DDISPLAYROTATION, poverlaycaps: *mut D3DOVERLAYCAPS) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Graphics_Direct3D9"))]
@@ -8669,7 +8669,7 @@ unsafe impl ::windows::core::Interface for IDirect3DAuthenticatedChannel9 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirect3DAuthenticatedChannel9_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCertificateSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcertificatesize: *mut u32) -> ::windows::core::HRESULT,
     pub GetCertificate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, certifactesize: u32, ppcertificate: *mut u8) -> ::windows::core::HRESULT,
     pub NegotiateKeyExchange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, datasize: u32, pdata: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -8766,7 +8766,7 @@ unsafe impl ::windows::core::Interface for IDirect3DCryptoSession9 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirect3DCryptoSession9_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCertificateSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcertificatesize: *mut u32) -> ::windows::core::HRESULT,
     pub GetCertificate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, certifactesize: u32, ppcertificate: *mut u8) -> ::windows::core::HRESULT,
     pub NegotiateKeyExchange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, datasize: u32, pdata: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -8842,7 +8842,7 @@ unsafe impl ::windows::core::Interface for IDirect3DDevice9Video {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirect3DDevice9Video_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetContentProtectionCaps: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcryptotype: *const ::windows::core::GUID, pdecodeprofile: *const ::windows::core::GUID, pcaps: *mut D3DCONTENTPROTECTIONCAPS) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
     pub CreateAuthenticatedChannel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, channeltype: super::super::Graphics::Direct3D9::D3DAUTHENTICATEDCHANNELTYPE, ppauthenticatedchannel: *mut *mut ::core::ffi::c_void, pchannelhandle: *mut super::super::Foundation::HANDLE) -> ::windows::core::HRESULT,
@@ -8952,7 +8952,7 @@ unsafe impl ::windows::core::Interface for IDirect3DDeviceManager9 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirect3DDeviceManager9_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Graphics_Direct3D9")]
     pub ResetDevice: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdevice: *mut ::core::ffi::c_void, resettoken: u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Graphics_Direct3D9"))]
@@ -9030,7 +9030,7 @@ unsafe impl ::windows::core::Interface for IDirectXVideoAccelerationService {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectXVideoAccelerationService_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
     pub CreateSurface: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, width: u32, height: u32, backbuffers: u32, format: super::super::Graphics::Direct3D9::D3DFORMAT, pool: super::super::Graphics::Direct3D9::D3DPOOL, usage: u32, dxvatype: DXVA2_VideoRenderTargetType, ppsurface: *mut *mut ::core::ffi::c_void, psharedhandle: *mut super::super::Foundation::HANDLE) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9")))]
@@ -9110,7 +9110,7 @@ unsafe impl ::windows::core::Interface for IDirectXVideoDecoder {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectXVideoDecoder_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetVideoDecoderService: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppservice: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Graphics_Direct3D9")]
     pub GetCreationParameters: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdeviceguid: *mut ::windows::core::GUID, pvideodesc: *mut DXVA2_VideoDesc, pconfig: *mut DXVA2_ConfigPictureDecode, pdecoderrendertargets: *mut *mut *mut ::core::ffi::c_void, pnumsurfaces: *mut u32) -> ::windows::core::HRESULT,
@@ -9275,7 +9275,7 @@ unsafe impl ::windows::core::Interface for IDirectXVideoMemoryConfiguration {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectXVideoMemoryConfiguration_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetAvailableSurfaceTypeByIndex: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwtypeindex: u32, pdwtype: *mut DXVA2_SurfaceType) -> ::windows::core::HRESULT,
     pub SetSurfaceType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwtype: DXVA2_SurfaceType) -> ::windows::core::HRESULT,
 }
@@ -9353,7 +9353,7 @@ unsafe impl ::windows::core::Interface for IDirectXVideoProcessor {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectXVideoProcessor_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetVideoProcessorService: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppservice: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Graphics_Direct3D9")]
     pub GetCreationParameters: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdeviceguid: *mut ::windows::core::GUID, pvideodesc: *mut DXVA2_VideoDesc, prendertargetformat: *mut super::super::Graphics::Direct3D9::D3DFORMAT, pmaxnumsubstreams: *mut u32) -> ::windows::core::HRESULT,
@@ -9556,7 +9556,7 @@ unsafe impl ::windows::core::Interface for IEVRFilterConfig {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEVRFilterConfig_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetNumberOfStreams: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwmaxstreams: u32) -> ::windows::core::HRESULT,
     pub GetNumberOfStreams: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwmaxstreams: *mut u32) -> ::windows::core::HRESULT,
 }
@@ -9702,7 +9702,7 @@ unsafe impl ::windows::core::Interface for IEVRTrustedVideoPlugin {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEVRTrustedVideoPlugin_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub IsInTrustedVideoMode: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pyes: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -9774,7 +9774,7 @@ unsafe impl ::windows::core::Interface for IEVRVideoStreamControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEVRVideoStreamControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub SetStreamActiveState: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, factive: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -9842,7 +9842,7 @@ unsafe impl ::windows::core::Interface for IFileClient {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IFileClient_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetObjectDiskSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pqwsize: *mut u64) -> ::windows::core::HRESULT,
     pub Write: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfio: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Read: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfio: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -9925,7 +9925,7 @@ unsafe impl ::windows::core::Interface for IFileIo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IFileIo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, eaccessmode: FILE_ACCESSMODE, eopenmode: FILE_OPENMODE, pwszfilename: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub GetLength: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pqwlength: *mut u64) -> ::windows::core::HRESULT,
     pub SetLength: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, qwlength: u64) -> ::windows::core::HRESULT,
@@ -10008,7 +10008,7 @@ unsafe impl ::windows::core::Interface for IMF2DBuffer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMF2DBuffer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Lock2D: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppbscanline0: *mut *mut u8, plpitch: *mut i32) -> ::windows::core::HRESULT,
     pub Unlock2D: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetScanline0AndPitch: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbscanline0: *mut *mut u8, plpitch: *mut i32) -> ::windows::core::HRESULT,
@@ -10199,7 +10199,7 @@ unsafe impl ::windows::core::Interface for IMFASFContentInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFASFContentInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetHeaderSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pistartofcontent: *mut ::core::ffi::c_void, cbheadersize: *mut u64) -> ::windows::core::HRESULT,
     pub ParseHeader: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, piheaderbuffer: *mut ::core::ffi::c_void, cboffsetwithinheader: u64) -> ::windows::core::HRESULT,
     pub GenerateHeader: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, piheader: *mut ::core::ffi::c_void, pcbheader: *mut u32) -> ::windows::core::HRESULT,
@@ -10321,7 +10321,7 @@ unsafe impl ::windows::core::Interface for IMFASFIndexer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFASFIndexer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetFlags: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwflags: u32) -> ::windows::core::HRESULT,
     pub GetFlags: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwflags: *mut u32) -> ::windows::core::HRESULT,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, picontentinfo: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -10426,7 +10426,7 @@ unsafe impl ::windows::core::Interface for IMFASFMultiplexer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFASFMultiplexer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, picontentinfo: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetFlags: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwflags: u32) -> ::windows::core::HRESULT,
     pub GetFlags: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwflags: *mut u32) -> ::windows::core::HRESULT,
@@ -10511,7 +10511,7 @@ unsafe impl ::windows::core::Interface for IMFASFMutualExclusion {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFASFMutualExclusion_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pguidtype: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub SetType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, guidtype: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub GetRecordCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwrecordcount: *mut u32) -> ::windows::core::HRESULT,
@@ -10871,7 +10871,7 @@ unsafe impl ::windows::core::Interface for IMFASFSplitter {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFASFSplitter_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, picontentinfo: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetFlags: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwflags: u32) -> ::windows::core::HRESULT,
     pub GetFlags: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwflags: *mut u32) -> ::windows::core::HRESULT,
@@ -11175,7 +11175,7 @@ unsafe impl ::windows::core::Interface for IMFASFStreamPrioritization {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFASFStreamPrioritization_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetStreamCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwstreamcount: *mut u32) -> ::windows::core::HRESULT,
     pub GetStream: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwstreamindex: u32, pwstreamnumber: *mut u16, pwstreamflags: *mut u16) -> ::windows::core::HRESULT,
     pub AddStream: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wstreamnumber: u16, wstreamflags: u16) -> ::windows::core::HRESULT,
@@ -11277,7 +11277,7 @@ unsafe impl ::windows::core::Interface for IMFASFStreamSelector {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFASFStreamSelector_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetStreamCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcstreams: *mut u32) -> ::windows::core::HRESULT,
     pub GetOutputCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcoutputs: *mut u32) -> ::windows::core::HRESULT,
     pub GetOutputStreamCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwoutputnum: u32, pcstreams: *mut u32) -> ::windows::core::HRESULT,
@@ -11547,7 +11547,7 @@ unsafe impl ::windows::core::Interface for IMFAsyncCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFAsyncCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetParameters: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwflags: *mut u32, pdwqueue: *mut u32) -> ::windows::core::HRESULT,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pasyncresult: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -11688,7 +11688,7 @@ unsafe impl ::windows::core::Interface for IMFAsyncResult {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFAsyncResult_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetState: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppunkstate: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetStatus: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetStatus: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hrstatus: ::windows::core::HRESULT) -> ::windows::core::HRESULT,
@@ -11864,7 +11864,7 @@ unsafe impl ::windows::core::Interface for IMFAttributes {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFAttributes_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
     pub GetItem: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, guidkey: *const ::windows::core::GUID, pvalue: *mut super::super::System::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage")))]
@@ -12214,7 +12214,7 @@ unsafe impl ::windows::core::Interface for IMFAudioPolicy {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFAudioPolicy_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetGroupingParam: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, rguidclass: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub GetGroupingParam: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pguidclass: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub SetDisplayName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszname: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
@@ -12282,7 +12282,7 @@ unsafe impl ::windows::core::Interface for IMFAudioStreamVolume {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFAudioStreamVolume_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetChannelCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwcount: *mut u32) -> ::windows::core::HRESULT,
     pub SetChannelVolume: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwindex: u32, flevel: f32) -> ::windows::core::HRESULT,
     pub GetChannelVolume: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwindex: u32, pflevel: *mut f32) -> ::windows::core::HRESULT,
@@ -12338,7 +12338,7 @@ unsafe impl ::windows::core::Interface for IMFBufferListNotify {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFBufferListNotify_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnAddSourceBuffer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void),
     pub OnRemoveSourceBuffer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void),
 }
@@ -12454,7 +12454,7 @@ unsafe impl ::windows::core::Interface for IMFByteStream {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFByteStream_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCapabilities: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwcapabilities: *mut u32) -> ::windows::core::HRESULT,
     pub GetLength: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pqwlength: *mut u64) -> ::windows::core::HRESULT,
     pub SetLength: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, qwlength: u64) -> ::windows::core::HRESULT,
@@ -12531,7 +12531,7 @@ unsafe impl ::windows::core::Interface for IMFByteStreamBuffering {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFByteStreamBuffering_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetBufferingParams: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pparams: *const MFBYTESTREAM_BUFFERING_PARAMS) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub EnableBuffering: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fenable: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -12585,7 +12585,7 @@ unsafe impl ::windows::core::Interface for IMFByteStreamCacheControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFByteStreamCacheControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub StopBackgroundTransfer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -12740,7 +12740,7 @@ unsafe impl ::windows::core::Interface for IMFByteStreamHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFByteStreamHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
     pub BeginCreateObject: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbytestream: *mut ::core::ffi::c_void, pwszurl: ::windows::core::PCWSTR, dwflags: u32, pprops: *mut ::core::ffi::c_void, ppiunknowncancelcookie: *mut *mut ::core::ffi::c_void, pcallback: *mut ::core::ffi::c_void, punkstate: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_UI_Shell_PropertiesSystem"))]
@@ -12801,7 +12801,7 @@ unsafe impl ::windows::core::Interface for IMFByteStreamProxyClassFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFByteStreamProxyClassFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateByteStreamProxy: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbytestream: *mut ::core::ffi::c_void, pattributes: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -12859,7 +12859,7 @@ unsafe impl ::windows::core::Interface for IMFByteStreamTimeSeek {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFByteStreamTimeSeek_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub IsTimeSeekSupported: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pftimeseekissupported: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -12919,7 +12919,7 @@ unsafe impl ::windows::core::Interface for IMFCameraOcclusionStateMonitor {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFCameraOcclusionStateMonitor_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Start: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Stop: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetSupportedStates: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32,
@@ -12971,7 +12971,7 @@ unsafe impl ::windows::core::Interface for IMFCameraOcclusionStateReport {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFCameraOcclusionStateReport_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetOcclusionState: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, occlusionstate: *mut u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -13023,7 +13023,7 @@ unsafe impl ::windows::core::Interface for IMFCameraOcclusionStateReportCallback
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFCameraOcclusionStateReportCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnOcclusionStateReport: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, occlusionstatereport: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -13075,7 +13075,7 @@ unsafe impl ::windows::core::Interface for IMFCameraSyncObject {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFCameraSyncObject_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub WaitOnSignal: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, timeoutinms: u32) -> ::windows::core::HRESULT,
     pub Shutdown: unsafe extern "system" fn(this: *mut ::core::ffi::c_void),
 }
@@ -13160,7 +13160,7 @@ unsafe impl ::windows::core::Interface for IMFCaptureEngine {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFCaptureEngine_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, peventcallback: *mut ::core::ffi::c_void, pattributes: *mut ::core::ffi::c_void, paudiosource: *mut ::core::ffi::c_void, pvideosource: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub StartPreview: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub StopPreview: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -13223,7 +13223,7 @@ unsafe impl ::windows::core::Interface for IMFCaptureEngineClassFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFCaptureEngineClassFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateInstance: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, clsid: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -13275,7 +13275,7 @@ unsafe impl ::windows::core::Interface for IMFCaptureEngineOnEventCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFCaptureEngineOnEventCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnEvent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pevent: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -13327,7 +13327,7 @@ unsafe impl ::windows::core::Interface for IMFCaptureEngineOnSampleCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFCaptureEngineOnSampleCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnSample: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psample: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -13459,7 +13459,7 @@ unsafe impl ::windows::core::Interface for IMFCapturePhotoConfirmation {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFCapturePhotoConfirmation_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetPhotoConfirmationCallback: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pnotificationcallback: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetPixelFormat: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, subtype: ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub GetPixelFormat: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, subtype: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
@@ -13906,7 +13906,7 @@ unsafe impl ::windows::core::Interface for IMFCaptureSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFCaptureSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetOutputMediaType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwsinkstreamindex: u32, ppmediatype: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetService: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwsinkstreamindex: u32, rguidservice: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, ppunknown: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub AddStream: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwsourcestreamindex: u32, pmediatype: *mut ::core::ffi::c_void, pattributes: *mut ::core::ffi::c_void, pdwsinkstreamindex: *mut u32) -> ::windows::core::HRESULT,
@@ -14113,7 +14113,7 @@ unsafe impl ::windows::core::Interface for IMFCaptureSource {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFCaptureSource_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCaptureDeviceSource: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, mfcaptureenginedevicetype: MF_CAPTURE_ENGINE_DEVICE_TYPE, ppmediasource: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetCaptureDeviceActivate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, mfcaptureenginedevicetype: MF_CAPTURE_ENGINE_DEVICE_TYPE, ppactivate: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetService: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, rguidservice: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, ppunknown: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -14184,7 +14184,7 @@ unsafe impl ::windows::core::Interface for IMFCdmSuspendNotify {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFCdmSuspendNotify_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Begin: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub End: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -14250,7 +14250,7 @@ unsafe impl ::windows::core::Interface for IMFClock {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFClock_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetClockCharacteristics: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwcharacteristics: *mut u32) -> ::windows::core::HRESULT,
     pub GetCorrelatedTime: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwreserved: u32, pllclocktime: *mut i64, phnssystemtime: *mut i64) -> ::windows::core::HRESULT,
     pub GetContinuityKey: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwcontinuitykey: *mut u32) -> ::windows::core::HRESULT,
@@ -14310,7 +14310,7 @@ unsafe impl ::windows::core::Interface for IMFClockConsumer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFClockConsumer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetPresentationClock: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppresentationclock: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetPresentationClock: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pppresentationclock: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -14372,7 +14372,7 @@ unsafe impl ::windows::core::Interface for IMFClockStateSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFClockStateSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnClockStart: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hnssystemtime: i64, llclockstartoffset: i64) -> ::windows::core::HRESULT,
     pub OnClockStop: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hnssystemtime: i64) -> ::windows::core::HRESULT,
     pub OnClockPause: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hnssystemtime: i64) -> ::windows::core::HRESULT,
@@ -14449,7 +14449,7 @@ unsafe impl ::windows::core::Interface for IMFCollection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFCollection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetElementCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcelements: *mut u32) -> ::windows::core::HRESULT,
     pub GetElement: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwelementindex: u32, ppunkelement: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub AddElement: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punkelement: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -14534,7 +14534,7 @@ unsafe impl ::windows::core::Interface for IMFContentDecryptionModule {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFContentDecryptionModule_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetContentEnabler: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, contentenabler: *mut ::core::ffi::c_void, result: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetSuspendNotify: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, notify: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetPMPHostApp: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pmphostapp: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -14605,7 +14605,7 @@ unsafe impl ::windows::core::Interface for IMFContentDecryptionModuleAccess {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFContentDecryptionModuleAccess_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
     pub CreateContentDecryptionModule: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, contentdecryptionmoduleproperties: *mut ::core::ffi::c_void, contentdecryptionmodule: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_UI_Shell_PropertiesSystem"))]
@@ -14677,7 +14677,7 @@ unsafe impl ::windows::core::Interface for IMFContentDecryptionModuleFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFContentDecryptionModuleFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub IsTypeSupported: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, keysystem: ::windows::core::PCWSTR, contenttype: ::windows::core::PCWSTR) -> super::super::Foundation::BOOL,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -14765,7 +14765,7 @@ unsafe impl ::windows::core::Interface for IMFContentDecryptionModuleSession {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFContentDecryptionModuleSession_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetSessionId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sessionid: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetExpiration: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, expiration: *mut f64) -> ::windows::core::HRESULT,
     pub GetKeyStatuses: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, keystatuses: *mut *mut MFMediaKeyStatus, numkeystatuses: *mut u32) -> ::windows::core::HRESULT,
@@ -14830,7 +14830,7 @@ unsafe impl ::windows::core::Interface for IMFContentDecryptionModuleSessionCall
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFContentDecryptionModuleSessionCallbacks_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub KeyMessage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, messagetype: MF_MEDIAKEYSESSION_MESSAGETYPE, message: *const u8, messagesize: u32, destinationurl: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub KeyStatusChanged: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -14881,7 +14881,7 @@ unsafe impl ::windows::core::Interface for IMFContentDecryptorContext {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFContentDecryptorContext_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub InitializeHardwareKey: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, inputprivatedatabytecount: u32, inputprivatedata: *const ::core::ffi::c_void, outputprivatedata: *mut u64) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -14952,7 +14952,7 @@ unsafe impl ::windows::core::Interface for IMFContentEnabler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFContentEnabler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetEnableType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptype: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub GetEnableURL: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppwszurl: *mut ::windows::core::PWSTR, pcchurl: *mut u32, ptruststatus: *mut MF_URL_TRUST_STATUS) -> ::windows::core::HRESULT,
     pub GetEnableData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppbdata: *mut *mut u8, pcbdata: *mut u32) -> ::windows::core::HRESULT,
@@ -15013,7 +15013,7 @@ unsafe impl ::windows::core::Interface for IMFContentProtectionDevice {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFContentProtectionDevice_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub InvokeFunction: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, functionid: u32, inputbufferbytecount: u32, inputbuffer: *const u8, outputbufferbytecount: *mut u32, outputbuffer: *mut u8) -> ::windows::core::HRESULT,
     pub GetPrivateDataByteCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, privateinputbytecount: *mut u32, privateoutputbytecount: *mut u32) -> ::windows::core::HRESULT,
 }
@@ -15075,7 +15075,7 @@ unsafe impl ::windows::core::Interface for IMFContentProtectionManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFContentProtectionManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub BeginEnableContent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, penableractivate: *mut ::core::ffi::c_void, ptopo: *mut ::core::ffi::c_void, pcallback: *mut ::core::ffi::c_void, punkstate: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub EndEnableContent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, presult: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -15133,7 +15133,7 @@ unsafe impl ::windows::core::Interface for IMFD3D12SynchronizationObject {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFD3D12SynchronizationObject_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub SignalEventOnFinalResourceRelease: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hevent: super::super::Foundation::HANDLE) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -15215,7 +15215,7 @@ unsafe impl ::windows::core::Interface for IMFD3D12SynchronizationObjectCommands
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFD3D12SynchronizationObjectCommands_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Graphics_Direct3D12")]
     pub EnqueueResourceReady: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pproducercommandqueue: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Graphics_Direct3D12"))]
@@ -15285,7 +15285,7 @@ unsafe impl ::windows::core::Interface for IMFDLNASinkInit {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFDLNASinkInit_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbytestream: *mut ::core::ffi::c_void, fpal: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -15340,7 +15340,7 @@ unsafe impl ::windows::core::Interface for IMFDRMNetHelper {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFDRMNetHelper_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ProcessLicenseRequest: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, plicenserequest: *const u8, cblicenserequest: u32, pplicenseresponse: *mut *mut u8, pcblicenseresponse: *mut u32, pbstrkid: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub GetChainedLicenseResponse: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pplicenseresponse: *mut *mut u8, pcblicenseresponse: *mut u32) -> ::windows::core::HRESULT,
 }
@@ -15403,7 +15403,7 @@ unsafe impl ::windows::core::Interface for IMFDXGIBuffer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFDXGIBuffer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetResource: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetSubresourceIndex: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pusubresource: *mut u32) -> ::windows::core::HRESULT,
     pub GetUnknown: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, guid: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -15506,7 +15506,7 @@ unsafe impl ::windows::core::Interface for IMFDXGIDeviceManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFDXGIDeviceManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub CloseDeviceHandle: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hdevice: super::super::Foundation::HANDLE) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -15580,7 +15580,7 @@ unsafe impl ::windows::core::Interface for IMFDXGIDeviceManagerSource {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFDXGIDeviceManagerSource_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetManager: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppmanager: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -15635,7 +15635,7 @@ unsafe impl ::windows::core::Interface for IMFDesiredSample {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFDesiredSample_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDesiredSampleTimeAndDuration: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, phnssampletime: *mut i64, phnssampleduration: *mut i64) -> ::windows::core::HRESULT,
     pub SetDesiredSampleTimeAndDuration: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hnssampletime: i64, hnssampleduration: i64),
     pub Clear: unsafe extern "system" fn(this: *mut ::core::ffi::c_void),
@@ -15766,7 +15766,7 @@ unsafe impl ::windows::core::Interface for IMFDeviceTransform {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFDeviceTransform_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub InitializeTransform: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pattributes: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetInputAvailableType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwinputstreamid: u32, dwtypeindex: u32, pmediatype: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetInputCurrentType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwinputstreamid: u32, pmediatype: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -15837,7 +15837,7 @@ unsafe impl ::windows::core::Interface for IMFDeviceTransformCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFDeviceTransformCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnBufferSent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcallbackattributes: *mut ::core::ffi::c_void, pinid: u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -15901,7 +15901,7 @@ unsafe impl ::windows::core::Interface for IMFExtendedCameraControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFExtendedCameraControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCapabilities: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u64,
     pub SetFlags: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ulflags: u64) -> ::windows::core::HRESULT,
     pub GetFlags: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u64,
@@ -15956,7 +15956,7 @@ unsafe impl ::windows::core::Interface for IMFExtendedCameraController {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFExtendedCameraController_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetExtendedCameraControl: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwstreamindex: u32, ulpropertyid: u32, ppcontrol: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -16013,7 +16013,7 @@ unsafe impl ::windows::core::Interface for IMFExtendedCameraIntrinsicModel {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFExtendedCameraIntrinsicModel_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetModel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pintrinsicmodel: *mut MFExtendedCameraIntrinsic_IntrinsicModel) -> ::windows::core::HRESULT,
     pub SetModel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pintrinsicmodel: *const MFExtendedCameraIntrinsic_IntrinsicModel) -> ::windows::core::HRESULT,
     pub GetDistortionModelType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdistortionmodeltype: *mut MFCameraIntrinsic_DistortionModelType) -> ::windows::core::HRESULT,
@@ -16085,7 +16085,7 @@ unsafe impl ::windows::core::Interface for IMFExtendedCameraIntrinsics {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFExtendedCameraIntrinsics_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub InitializeFromBuffer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbbuffer: *const u8, dwbuffersize: u32) -> ::windows::core::HRESULT,
     pub GetBufferSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwbuffersize: *mut u32) -> ::windows::core::HRESULT,
     pub SerializeToBuffer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbbuffer: *mut u8, pdwbuffersize: *mut u32) -> ::windows::core::HRESULT,
@@ -16143,7 +16143,7 @@ unsafe impl ::windows::core::Interface for IMFExtendedCameraIntrinsicsDistortion
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFExtendedCameraIntrinsicsDistortionModel6KT_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDistortionModel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdistortionmodel: *mut MFCameraIntrinsic_DistortionModel6KT) -> ::windows::core::HRESULT,
     pub SetDistortionModel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdistortionmodel: *const MFCameraIntrinsic_DistortionModel6KT) -> ::windows::core::HRESULT,
 }
@@ -16197,7 +16197,7 @@ unsafe impl ::windows::core::Interface for IMFExtendedCameraIntrinsicsDistortion
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFExtendedCameraIntrinsicsDistortionModelArcTan_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDistortionModel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdistortionmodel: *mut MFCameraIntrinsic_DistortionModelArcTan) -> ::windows::core::HRESULT,
     pub SetDistortionModel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdistortionmodel: *const MFCameraIntrinsic_DistortionModelArcTan) -> ::windows::core::HRESULT,
 }
@@ -16248,7 +16248,7 @@ unsafe impl ::windows::core::Interface for IMFExtendedDRMTypeSupport {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFExtendedDRMTypeSupport_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub IsTypeSupportedEx: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, r#type: ::core::mem::ManuallyDrop<::windows::core::BSTR>, keysystem: ::core::mem::ManuallyDrop<::windows::core::BSTR>, panswer: *mut MF_MEDIA_ENGINE_CANPLAY) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -16300,7 +16300,7 @@ unsafe impl ::windows::core::Interface for IMFFieldOfUseMFTUnlock {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFFieldOfUseMFTUnlock_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Unlock: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punkmft: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -16467,7 +16467,7 @@ unsafe impl ::windows::core::Interface for IMFGetService {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFGetService_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetService: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, guidservice: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -16521,7 +16521,7 @@ unsafe impl ::windows::core::Interface for IMFHDCPStatus {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFHDCPStatus_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Query: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pstatus: *mut MF_HDCP_STATUS, pfstatus: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -16657,7 +16657,7 @@ unsafe impl ::windows::core::Interface for IMFHttpDownloadRequest {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFHttpDownloadRequest_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddHeader: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, szheader: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub BeginSendRequest: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbpayload: *const u8, cbpayload: u32, pcallback: *mut ::core::ffi::c_void, punkstate: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub EndSendRequest: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, presult: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -16746,7 +16746,7 @@ unsafe impl ::windows::core::Interface for IMFHttpDownloadSession {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFHttpDownloadSession_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetServer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, szservername: ::windows::core::PCWSTR, nport: u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub CreateRequest: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, szobjectname: ::windows::core::PCWSTR, fbypassproxycache: super::super::Foundation::BOOL, fsecure: super::super::Foundation::BOOL, szverb: ::windows::core::PCWSTR, szreferrer: ::windows::core::PCWSTR, pprequest: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -16804,7 +16804,7 @@ unsafe impl ::windows::core::Interface for IMFHttpDownloadSessionProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFHttpDownloadSessionProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateHttpDownloadSession: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wszscheme: ::windows::core::PCWSTR, ppdownloadsession: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -16863,7 +16863,7 @@ unsafe impl ::windows::core::Interface for IMFImageSharingEngine {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFImageSharingEngine_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetSource: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pstream: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetDevice: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdevice: *mut DEVICE_INFO) -> ::windows::core::HRESULT,
     pub Shutdown: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -16915,7 +16915,7 @@ unsafe impl ::windows::core::Interface for IMFImageSharingEngineClassFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFImageSharingEngineClassFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateInstanceFromUDN: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, puniquedevicename: ::core::mem::ManuallyDrop<::windows::core::BSTR>, ppengine: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -16981,7 +16981,7 @@ unsafe impl ::windows::core::Interface for IMFInputTrustAuthority {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFInputTrustAuthority_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDecrypter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub RequestAccess: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, action: MFPOLICYMANAGER_ACTION, ppcontentenableractivate: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetPolicy: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, action: MFPOLICYMANAGER_ACTION, pppolicy: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -17035,7 +17035,7 @@ unsafe impl ::windows::core::Interface for IMFLocalMFTRegistration {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFLocalMFTRegistration_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub RegisterMFTs: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pmfts: *const MFT_REGISTRATION_INFO, cmfts: u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -17098,7 +17098,7 @@ unsafe impl ::windows::core::Interface for IMFMediaBuffer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFMediaBuffer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Lock: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppbbuffer: *mut *mut u8, pcbmaxlength: *mut u32, pcbcurrentlength: *mut u32) -> ::windows::core::HRESULT,
     pub Unlock: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetCurrentLength: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcbcurrentlength: *mut u32) -> ::windows::core::HRESULT,
@@ -17320,7 +17320,7 @@ unsafe impl ::windows::core::Interface for IMFMediaEngine {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFMediaEngine_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetError: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pperror: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetErrorCode: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, error: MF_MEDIA_ENGINE_ERR) -> ::windows::core::HRESULT,
     pub SetSourceElements: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psrcelements: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -17453,7 +17453,7 @@ unsafe impl ::windows::core::Interface for IMFMediaEngineAudioEndpointId {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFMediaEngineAudioEndpointId_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetAudioEndpointId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszendpointid: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub GetAudioEndpointId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppszendpointid: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
 }
@@ -17515,7 +17515,7 @@ unsafe impl ::windows::core::Interface for IMFMediaEngineClassFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFMediaEngineClassFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateInstance: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwflags: u32, pattr: *mut ::core::ffi::c_void, ppplayer: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CreateTimeRange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pptimerange: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CreateError: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pperror: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -17567,7 +17567,7 @@ unsafe impl ::windows::core::Interface for IMFMediaEngineClassFactory2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFMediaEngineClassFactory2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateMediaKeys2: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, keysystem: ::core::mem::ManuallyDrop<::windows::core::BSTR>, defaultcdmstorepath: ::core::mem::ManuallyDrop<::windows::core::BSTR>, inprivatecdmstorepath: ::core::mem::ManuallyDrop<::windows::core::BSTR>, ppkeys: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -17619,7 +17619,7 @@ unsafe impl ::windows::core::Interface for IMFMediaEngineClassFactory3 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFMediaEngineClassFactory3_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
     pub CreateMediaKeySystemAccess: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, keysystem: ::core::mem::ManuallyDrop<::windows::core::BSTR>, ppsupportedconfigurationsarray: *const *mut ::core::ffi::c_void, usize: u32, ppkeyaccess: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_UI_Shell_PropertiesSystem"))]
@@ -17674,7 +17674,7 @@ unsafe impl ::windows::core::Interface for IMFMediaEngineClassFactory4 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFMediaEngineClassFactory4_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateContentDecryptionModuleFactory: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, keysystem: ::windows::core::PCWSTR, riid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -17828,7 +17828,7 @@ unsafe impl ::windows::core::Interface for IMFMediaEngineEME {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFMediaEngineEME_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Keys: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, keys: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetMediaKeys: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, keys: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -17881,7 +17881,7 @@ unsafe impl ::windows::core::Interface for IMFMediaEngineEMENotify {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFMediaEngineEMENotify_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Encrypted: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbinitdata: *const u8, cb: u32, bstrinitdatatype: ::core::mem::ManuallyDrop<::windows::core::BSTR>),
     pub WaitingForKey: unsafe extern "system" fn(this: *mut ::core::ffi::c_void),
 }
@@ -18471,7 +18471,7 @@ unsafe impl ::windows::core::Interface for IMFMediaEngineExtension {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFMediaEngineExtension_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub CanPlayType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, audioonly: super::super::Foundation::BOOL, mimetype: ::core::mem::ManuallyDrop<::windows::core::BSTR>, panswer: *mut MF_MEDIA_ENGINE_CANPLAY) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -18526,7 +18526,7 @@ unsafe impl ::windows::core::Interface for IMFMediaEngineNeedKeyNotify {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFMediaEngineNeedKeyNotify_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub NeedKey: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, initdata: *const u8, cb: u32),
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -18575,7 +18575,7 @@ unsafe impl ::windows::core::Interface for IMFMediaEngineNotify {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFMediaEngineNotify_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub EventNotify: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, event: u32, param1: usize, param2: u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -18626,7 +18626,7 @@ unsafe impl ::windows::core::Interface for IMFMediaEngineOPMInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFMediaEngineOPMInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetOPMInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pstatus: *mut MF_MEDIA_ENGINE_OPM_STATUS, pconstricted: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -18711,7 +18711,7 @@ unsafe impl ::windows::core::Interface for IMFMediaEngineProtectedContent {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFMediaEngineProtectedContent_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ShareResources: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punkdevicecontext: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetRequiredProtections: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pframeprotectionflags: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -18789,7 +18789,7 @@ unsafe impl ::windows::core::Interface for IMFMediaEngineSrcElements {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFMediaEngineSrcElements_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetLength: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32,
     pub GetURL: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: u32, purl: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub GetType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: u32, ptype: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
@@ -18947,7 +18947,7 @@ unsafe impl ::windows::core::Interface for IMFMediaEngineSupportsSourceTransfer 
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFMediaEngineSupportsSourceTransfer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub ShouldTransferSource: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfshouldtransfer: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -19004,7 +19004,7 @@ unsafe impl ::windows::core::Interface for IMFMediaEngineTransferSource {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFMediaEngineTransferSource_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub TransferSourceToMediaEngine: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, destination: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -19062,7 +19062,7 @@ unsafe impl ::windows::core::Interface for IMFMediaEngineWebSupport {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFMediaEngineWebSupport_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub ShouldDelayTheLoadEvent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> super::super::Foundation::BOOL,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -19125,7 +19125,7 @@ unsafe impl ::windows::core::Interface for IMFMediaError {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFMediaError_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetErrorCode: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u16,
     pub GetExtendedErrorCode: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetErrorCode: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, error: MF_MEDIA_ENGINE_ERR) -> ::windows::core::HRESULT,
@@ -19408,7 +19408,7 @@ unsafe impl ::windows::core::Interface for IMFMediaEventGenerator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFMediaEventGenerator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetEvent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwflags: MEDIA_EVENT_GENERATOR_GET_EVENT_FLAGS, ppevent: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub BeginGetEvent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcallback: *mut ::core::ffi::c_void, punkstate: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub EndGetEvent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, presult: *mut ::core::ffi::c_void, ppevent: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -19498,7 +19498,7 @@ unsafe impl ::windows::core::Interface for IMFMediaEventQueue {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFMediaEventQueue_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetEvent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwflags: u32, ppevent: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub BeginGetEvent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcallback: *mut ::core::ffi::c_void, punkstate: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub EndGetEvent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, presult: *mut ::core::ffi::c_void, ppevent: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -19570,7 +19570,7 @@ unsafe impl ::windows::core::Interface for IMFMediaKeySession {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFMediaKeySession_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetError: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, code: *mut u16, systemcode: *mut u32) -> ::windows::core::HRESULT,
     pub KeySystem: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, keysystem: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub SessionId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sessionid: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
@@ -19737,7 +19737,7 @@ unsafe impl ::windows::core::Interface for IMFMediaKeySessionNotify {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFMediaKeySessionNotify_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub KeyMessage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, destinationurl: ::core::mem::ManuallyDrop<::windows::core::BSTR>, message: *const u8, cb: u32),
     pub KeyAdded: unsafe extern "system" fn(this: *mut ::core::ffi::c_void),
     pub KeyError: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, code: u16, systemcode: u32),
@@ -19881,7 +19881,7 @@ unsafe impl ::windows::core::Interface for IMFMediaKeySystemAccess {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFMediaKeySystemAccess_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
     pub CreateMediaKeys: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcdmcustomconfig: *mut ::core::ffi::c_void, ppkeys: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_UI_Shell_PropertiesSystem"))]
@@ -19953,7 +19953,7 @@ unsafe impl ::windows::core::Interface for IMFMediaKeys {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFMediaKeys_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateSession: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, mimetype: ::core::mem::ManuallyDrop<::windows::core::BSTR>, initdata: *const u8, cb: u32, customdata: *const u8, cbcustomdata: u32, notify: *mut ::core::ffi::c_void, ppsession: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub KeySystem: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, keysystem: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub Shutdown: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -20475,7 +20475,7 @@ unsafe impl ::windows::core::Interface for IMFMediaSharingEngineClassFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFMediaSharingEngineClassFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateInstance: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwflags: u32, pattr: *mut ::core::ffi::c_void, ppengine: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -20560,7 +20560,7 @@ unsafe impl ::windows::core::Interface for IMFMediaSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFMediaSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCharacteristics: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwcharacteristics: *mut u32) -> ::windows::core::HRESULT,
     pub AddStreamSink: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwstreamsinkidentifier: u32, pmediatype: *mut ::core::ffi::c_void, ppstreamsink: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub RemoveStreamSink: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwstreamsinkidentifier: u32) -> ::windows::core::HRESULT,
@@ -20617,7 +20617,7 @@ unsafe impl ::windows::core::Interface for IMFMediaSinkPreroll {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFMediaSinkPreroll_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub NotifyPreroll: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hnsupcomingstarttime: i64) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -21118,7 +21118,7 @@ unsafe impl ::windows::core::Interface for IMFMediaSourceExtension {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFMediaSourceExtension_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetSourceBuffers: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::core::option::Option<IMFSourceBufferList>,
     pub GetActiveSourceBuffers: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::core::option::Option<IMFSourceBufferList>,
     pub GetReadyState: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> MF_MSE_READY,
@@ -21182,7 +21182,7 @@ unsafe impl ::windows::core::Interface for IMFMediaSourceExtensionLiveSeekableRa
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFMediaSourceExtensionLiveSeekableRange_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetLiveSeekableRange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, start: f64, end: f64) -> ::windows::core::HRESULT,
     pub ClearLiveSeekableRange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -21238,7 +21238,7 @@ unsafe impl ::windows::core::Interface for IMFMediaSourceExtensionNotify {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFMediaSourceExtensionNotify_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnSourceOpen: unsafe extern "system" fn(this: *mut ::core::ffi::c_void),
     pub OnSourceEnded: unsafe extern "system" fn(this: *mut ::core::ffi::c_void),
     pub OnSourceClose: unsafe extern "system" fn(this: *mut ::core::ffi::c_void),
@@ -21292,7 +21292,7 @@ unsafe impl ::windows::core::Interface for IMFMediaSourcePresentationProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFMediaSourcePresentationProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ForceEndOfPresentation: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppresentationdescriptor: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -21345,7 +21345,7 @@ unsafe impl ::windows::core::Interface for IMFMediaSourceTopologyProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFMediaSourceTopologyProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetMediaSourceTopology: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppresentationdescriptor: *mut ::core::ffi::c_void, pptopology: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -21618,7 +21618,7 @@ unsafe impl ::windows::core::Interface for IMFMediaStreamSourceSampleRequest {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFMediaStreamSourceSampleRequest_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetSample: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -21686,7 +21686,7 @@ unsafe impl ::windows::core::Interface for IMFMediaTimeRange {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFMediaTimeRange_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetLength: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32,
     pub GetStart: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: u32, pstart: *mut f64) -> ::windows::core::HRESULT,
     pub GetEnd: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: u32, pend: *mut f64) -> ::windows::core::HRESULT,
@@ -21986,7 +21986,7 @@ unsafe impl ::windows::core::Interface for IMFMediaTypeHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFMediaTypeHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub IsMediaTypeSupported: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pmediatype: *mut ::core::ffi::c_void, ppmediatype: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetMediaTypeCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwtypecount: *mut u32) -> ::windows::core::HRESULT,
     pub GetMediaTypeByIndex: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwindex: u32, pptype: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -22082,7 +22082,7 @@ unsafe impl ::windows::core::Interface for IMFMetadata {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFMetadata_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetLanguage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszrfc1766: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub GetLanguage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppwszrfc1766: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
@@ -22153,7 +22153,7 @@ unsafe impl ::windows::core::Interface for IMFMetadataProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFMetadataProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetMFMetadata: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppresentationdescriptor: *mut ::core::ffi::c_void, dwstreamidentifier: u32, dwflags: u32, ppmfmetadata: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -22207,7 +22207,7 @@ unsafe impl ::windows::core::Interface for IMFMuxStreamAttributesManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFMuxStreamAttributesManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetStreamCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwmuxstreamcount: *mut u32) -> ::windows::core::HRESULT,
     pub GetAttributes: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwmuxstreamindex: u32, ppstreamattributes: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -22276,7 +22276,7 @@ unsafe impl ::windows::core::Interface for IMFMuxStreamMediaTypeManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFMuxStreamMediaTypeManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetStreamCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwmuxstreamcount: *mut u32) -> ::windows::core::HRESULT,
     pub GetMediaType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwmuxstreamindex: u32, ppmediatype: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetStreamConfigurationCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwcount: *mut u32) -> ::windows::core::HRESULT,
@@ -22338,7 +22338,7 @@ unsafe impl ::windows::core::Interface for IMFMuxStreamSampleManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFMuxStreamSampleManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetStreamCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwmuxstreamcount: *mut u32) -> ::windows::core::HRESULT,
     pub GetSample: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwmuxstreamindex: u32, ppsample: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetStreamConfiguration: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u64,
@@ -22424,7 +22424,7 @@ unsafe impl ::windows::core::Interface for IMFNetCredential {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFNetCredential_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub SetUser: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbdata: *const u8, cbdata: u32, fdataisencrypted: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -22511,7 +22511,7 @@ unsafe impl ::windows::core::Interface for IMFNetCredentialCache {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFNetCredentialCache_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCredential: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszurl: ::windows::core::PCWSTR, pszrealm: ::windows::core::PCWSTR, dwauthenticationflags: u32, ppcred: *mut *mut ::core::ffi::c_void, pdwrequirementsflags: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub SetGood: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcred: *mut ::core::ffi::c_void, fgood: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -22587,7 +22587,7 @@ unsafe impl ::windows::core::Interface for IMFNetCredentialManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFNetCredentialManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub BeginGetCredentials: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pparam: *const MFNetCredentialManagerGetParam, pcallback: *mut ::core::ffi::c_void, pstate: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -22658,7 +22658,7 @@ unsafe impl ::windows::core::Interface for IMFNetCrossOriginSupport {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFNetCrossOriginSupport_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCrossOriginPolicy: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppolicy: *mut MF_CROSS_ORIGIN_POLICY) -> ::windows::core::HRESULT,
     pub GetSourceOrigin: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wszsourceorigin: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -22732,7 +22732,7 @@ unsafe impl ::windows::core::Interface for IMFNetProxyLocator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFNetProxyLocator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub FindFirstProxy: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszhost: ::windows::core::PCWSTR, pszurl: ::windows::core::PCWSTR, freserved: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -22792,7 +22792,7 @@ unsafe impl ::windows::core::Interface for IMFNetProxyLocatorFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFNetProxyLocatorFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateProxyLocator: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszprotocol: ::windows::core::PCWSTR, ppproxylocator: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -22851,7 +22851,7 @@ unsafe impl ::windows::core::Interface for IMFNetResourceFilter {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFNetResourceFilter_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnRedirect: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszurl: ::windows::core::PCWSTR, pvbcancel: *mut i16) -> ::windows::core::HRESULT,
     pub OnSendingRequest: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszurl: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
 }
@@ -22909,7 +22909,7 @@ unsafe impl ::windows::core::Interface for IMFNetSchemeHandlerConfig {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFNetSchemeHandlerConfig_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetNumberOfSupportedProtocols: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcprotocols: *mut u32) -> ::windows::core::HRESULT,
     pub GetSupportedProtocolType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, nprotocolindex: u32, pnprotocoltype: *mut MFNETSOURCE_PROTOCOL_TYPE) -> ::windows::core::HRESULT,
     pub ResetProtocolRolloverSettings: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -22966,7 +22966,7 @@ unsafe impl ::windows::core::Interface for IMFObjectReferenceStream {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFObjectReferenceStream_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SaveReference: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, punk: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub LoadReference: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -23422,7 +23422,7 @@ unsafe impl ::windows::core::Interface for IMFOutputTrustAuthority {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFOutputTrustAuthority_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetAction: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, paction: *mut MFPOLICYMANAGER_ACTION) -> ::windows::core::HRESULT,
     pub SetPolicy: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pppolicy: *const *mut ::core::ffi::c_void, npolicy: u32, ppbticket: *mut *mut u8, pcbticket: *mut u32) -> ::windows::core::HRESULT,
 }
@@ -23475,7 +23475,7 @@ unsafe impl ::windows::core::Interface for IMFPMPClient {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFPMPClient_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetPMPHost: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppmphost: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -23527,7 +23527,7 @@ unsafe impl ::windows::core::Interface for IMFPMPClientApp {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFPMPClientApp_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetPMPHost: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppmphost: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -23589,7 +23589,7 @@ unsafe impl ::windows::core::Interface for IMFPMPHost {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFPMPHost_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub LockProcess: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub UnlockProcess: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
@@ -23657,7 +23657,7 @@ unsafe impl ::windows::core::Interface for IMFPMPHostApp {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFPMPHostApp_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub LockProcess: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub UnlockProcess: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
@@ -23721,7 +23721,7 @@ unsafe impl ::windows::core::Interface for IMFPMPServer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFPMPServer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub LockProcess: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub UnlockProcess: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CreateObjectByCLSID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, clsid: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, ppobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -23866,7 +23866,7 @@ unsafe impl ::windows::core::Interface for IMFPMediaItem {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFPMediaItem_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetMediaPlayer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppmediaplayer: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetURL: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppwszurl: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetObject: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppiunknown: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -24140,7 +24140,7 @@ unsafe impl ::windows::core::Interface for IMFPMediaPlayer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFPMediaPlayer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Play: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Pause: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Stop: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -24268,7 +24268,7 @@ unsafe impl ::windows::core::Interface for IMFPMediaPlayerCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFPMediaPlayerCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
     pub OnMediaPlayerEvent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, peventheader: *const MFP_EVENT_HEADER),
     #[cfg(not(feature = "Win32_UI_Shell_PropertiesSystem"))]
@@ -24348,7 +24348,7 @@ unsafe impl ::windows::core::Interface for IMFPluginControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFPluginControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetPreferredClsid: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, plugintype: u32, selector: ::windows::core::PCWSTR, clsid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub GetPreferredClsidByIndex: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, plugintype: u32, index: u32, selector: *mut ::windows::core::PWSTR, clsid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub SetPreferredClsid: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, plugintype: u32, selector: ::windows::core::PCWSTR, clsid: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
@@ -24922,7 +24922,7 @@ unsafe impl ::windows::core::Interface for IMFProtectedEnvironmentAccess {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFProtectedEnvironmentAccess_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Call: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, inputlength: u32, input: *const u8, outputlength: u32, output: *mut u8) -> ::windows::core::HRESULT,
     pub ReadGRL: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, outputlength: *mut u32, output: *mut *mut u8) -> ::windows::core::HRESULT,
 }
@@ -24986,7 +24986,7 @@ unsafe impl ::windows::core::Interface for IMFQualityAdvise {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFQualityAdvise_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetDropMode: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, edropmode: MF_QUALITY_DROP_MODE) -> ::windows::core::HRESULT,
     pub SetQualityLevel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, equalitylevel: MF_QUALITY_LEVEL) -> ::windows::core::HRESULT,
     pub GetDropMode: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pedropmode: *mut MF_QUALITY_DROP_MODE) -> ::windows::core::HRESULT,
@@ -25129,7 +25129,7 @@ unsafe impl ::windows::core::Interface for IMFQualityAdviseLimits {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFQualityAdviseLimits_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetMaximumDropMode: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pedropmode: *mut MF_QUALITY_DROP_MODE) -> ::windows::core::HRESULT,
     pub GetMinimumQualityLevel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pequalitylevel: *mut MF_QUALITY_LEVEL) -> ::windows::core::HRESULT,
 }
@@ -25212,7 +25212,7 @@ unsafe impl ::windows::core::Interface for IMFQualityManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFQualityManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub NotifyTopology: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptopology: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub NotifyPresentationClock: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pclock: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub NotifyProcessInput: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pnode: *mut ::core::ffi::c_void, linputindex: i32, psample: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -25276,7 +25276,7 @@ unsafe impl ::windows::core::Interface for IMFRateControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFRateControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub SetRate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fthin: super::super::Foundation::BOOL, flrate: f32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -25355,7 +25355,7 @@ unsafe impl ::windows::core::Interface for IMFRateSupport {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFRateSupport_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetSlowestRate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, edirection: MFRATE_DIRECTION, fthin: super::super::Foundation::BOOL, pflrate: *mut f32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -25430,7 +25430,7 @@ unsafe impl ::windows::core::Interface for IMFReadWriteClassFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFReadWriteClassFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateInstanceFromURL: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, clsid: *const ::windows::core::GUID, pwszurl: ::windows::core::PCWSTR, pattributes: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CreateInstanceFromObject: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, clsid: *const ::windows::core::GUID, punkobject: *mut ::core::ffi::c_void, pattributes: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -25489,7 +25489,7 @@ unsafe impl ::windows::core::Interface for IMFRealTimeClient {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFRealTimeClient_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub RegisterThreads: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwtaskindex: u32, wszclass: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub UnregisterThreads: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetWorkQueue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwworkqueueid: u32) -> ::windows::core::HRESULT,
@@ -25549,7 +25549,7 @@ unsafe impl ::windows::core::Interface for IMFRealTimeClientEx {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFRealTimeClientEx_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub RegisterThreadsEx: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwtaskindex: *mut u32, wszclassname: ::windows::core::PCWSTR, lbasepriority: i32) -> ::windows::core::HRESULT,
     pub UnregisterThreads: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetWorkQueueEx: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwmultithreadedworkqueueid: u32, lworkitembasepriority: i32) -> ::windows::core::HRESULT,
@@ -25601,7 +25601,7 @@ unsafe impl ::windows::core::Interface for IMFRelativePanelReport {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFRelativePanelReport_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetRelativePanel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, panel: *mut u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -25741,7 +25741,7 @@ unsafe impl ::windows::core::Interface for IMFRemoteAsyncCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFRemoteAsyncCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hr: ::windows::core::HRESULT, premoteresult: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -25793,7 +25793,7 @@ unsafe impl ::windows::core::Interface for IMFRemoteDesktopPlugin {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFRemoteDesktopPlugin_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub UpdateTopology: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptopology: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -25845,7 +25845,7 @@ unsafe impl ::windows::core::Interface for IMFRemoteProxy {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFRemoteProxy_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetRemoteObject: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetRemoteHost: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -25912,7 +25912,7 @@ unsafe impl ::windows::core::Interface for IMFSAMIStyle {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFSAMIStyle_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetStyleCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwcount: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
     pub GetStyles: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppropvarstylearray: *mut super::super::System::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::HRESULT,
@@ -26001,7 +26001,7 @@ unsafe impl ::windows::core::Interface for IMFSSLCertificateManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFSSLCertificateManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetClientCertificate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszurl: ::windows::core::PCWSTR, ppbdata: *mut *mut u8, pcbdata: *mut u32) -> ::windows::core::HRESULT,
     pub BeginGetClientCertificate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszurl: ::windows::core::PCWSTR, pcallback: *mut ::core::ffi::c_void, pstate: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub EndGetClientCertificate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, presult: *mut ::core::ffi::c_void, ppbdata: *mut *mut u8, pcbdata: *mut u32) -> ::windows::core::HRESULT,
@@ -26321,7 +26321,7 @@ unsafe impl ::windows::core::Interface for IMFSampleAllocatorControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFSampleAllocatorControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetDefaultAllocator: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwoutputstreamid: u32, pallocator: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetAllocatorUsage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwoutputstreamid: u32, pdwinputstreamid: *mut u32, peusage: *mut MFSampleAllocatorUsage) -> ::windows::core::HRESULT,
 }
@@ -26584,7 +26584,7 @@ unsafe impl ::windows::core::Interface for IMFSampleOutputStream {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFSampleOutputStream_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub BeginWriteSample: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psample: *mut ::core::ffi::c_void, pcallback: *mut ::core::ffi::c_void, punkstate: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub EndWriteSample: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, presult: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Close: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -26649,7 +26649,7 @@ unsafe impl ::windows::core::Interface for IMFSampleProtection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFSampleProtection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetInputProtectionVersion: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwversion: *mut u32) -> ::windows::core::HRESULT,
     pub GetOutputProtectionVersion: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwversion: *mut u32) -> ::windows::core::HRESULT,
     pub GetProtectionCertificate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwversion: u32, ppcert: *mut *mut u8, pcbcert: *mut u32) -> ::windows::core::HRESULT,
@@ -26720,7 +26720,7 @@ unsafe impl ::windows::core::Interface for IMFSaveJob {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFSaveJob_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub BeginSave: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pstream: *mut ::core::ffi::c_void, pcallback: *mut ::core::ffi::c_void, pstate: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub EndSave: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, presult: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CancelSave: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -26792,7 +26792,7 @@ unsafe impl ::windows::core::Interface for IMFSchemeHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFSchemeHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
     pub BeginCreateObject: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszurl: ::windows::core::PCWSTR, dwflags: u32, pprops: *mut ::core::ffi::c_void, ppiunknowncancelcookie: *mut *mut ::core::ffi::c_void, pcallback: *mut ::core::ffi::c_void, punkstate: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_UI_Shell_PropertiesSystem"))]
@@ -26847,7 +26847,7 @@ unsafe impl ::windows::core::Interface for IMFSecureBuffer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFSecureBuffer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetIdentifier: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pguididentifier: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -26899,7 +26899,7 @@ unsafe impl ::windows::core::Interface for IMFSecureChannel {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFSecureChannel_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCertificate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppcert: *mut *mut u8, pcbcert: *mut u32) -> ::windows::core::HRESULT,
     pub SetupSession: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbencryptedsessionkey: *const u8, cbsessionkey: u32) -> ::windows::core::HRESULT,
 }
@@ -26951,7 +26951,7 @@ unsafe impl ::windows::core::Interface for IMFSeekInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFSeekInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
     pub GetNearestKeyFrames: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pguidtimeformat: *const ::windows::core::GUID, pvarstartposition: *const super::super::System::Com::StructuredStorage::PROPVARIANT, pvarpreviouskeyframe: *mut super::super::System::Com::StructuredStorage::PROPVARIANT, pvarnextkeyframe: *mut super::super::System::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage")))]
@@ -27015,7 +27015,7 @@ unsafe impl ::windows::core::Interface for IMFSensorActivitiesReport {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFSensorActivitiesReport_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pccount: *mut u32) -> ::windows::core::HRESULT,
     pub GetActivityReport: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: u32, sensoractivityreport: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetActivityReportByDeviceName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, symbolicname: ::windows::core::PCWSTR, sensoractivityreport: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -27069,7 +27069,7 @@ unsafe impl ::windows::core::Interface for IMFSensorActivitiesReportCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFSensorActivitiesReportCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnActivitiesReport: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sensoractivitiesreport: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -27121,7 +27121,7 @@ unsafe impl ::windows::core::Interface for IMFSensorActivityMonitor {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFSensorActivityMonitor_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Start: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Stop: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -27182,7 +27182,7 @@ unsafe impl ::windows::core::Interface for IMFSensorActivityReport {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFSensorActivityReport_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetFriendlyName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, friendlyname: ::windows::core::PWSTR, cchfriendlyname: u32, pcchwritten: *mut u32) -> ::windows::core::HRESULT,
     pub GetSymbolicLink: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, symboliclink: ::windows::core::PWSTR, cchsymboliclink: u32, pcchwritten: *mut u32) -> ::windows::core::HRESULT,
     pub GetProcessCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pccount: *mut u32) -> ::windows::core::HRESULT,
@@ -27265,7 +27265,7 @@ unsafe impl ::windows::core::Interface for IMFSensorDevice {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFSensorDevice_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDeviceId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdeviceid: *mut u64) -> ::windows::core::HRESULT,
     pub GetDeviceType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptype: *mut MFSensorDeviceType) -> ::windows::core::HRESULT,
     pub GetFlags: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pflags: *mut u64) -> ::windows::core::HRESULT,
@@ -27349,7 +27349,7 @@ unsafe impl ::windows::core::Interface for IMFSensorGroup {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFSensorGroup_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetSymbolicLink: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, symboliclink: ::windows::core::PWSTR, cchsymboliclink: i32, pcchwritten: *mut i32) -> ::windows::core::HRESULT,
     pub GetFlags: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pflags: *mut u64) -> ::windows::core::HRESULT,
     pub GetSensorGroupAttributes: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppattributes: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -27422,7 +27422,7 @@ unsafe impl ::windows::core::Interface for IMFSensorProcessActivity {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFSensorProcessActivity_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetProcessId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppid: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub GetStreamingState: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfstreaming: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -27502,7 +27502,7 @@ unsafe impl ::windows::core::Interface for IMFSensorProfile {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFSensorProfile_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetProfileId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pid: *mut SENSORPROFILEID) -> ::windows::core::HRESULT,
     pub AddProfileFilter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, streamid: u32, wzfiltersetstring: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -27577,7 +27577,7 @@ unsafe impl ::windows::core::Interface for IMFSensorProfileCollection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFSensorProfileCollection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetProfileCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32,
     pub GetProfile: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: u32, ppprofile: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub AddProfile: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pprofile: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -27854,7 +27854,7 @@ unsafe impl ::windows::core::Interface for IMFSensorTransformFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFSensorTransformFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetFactoryAttributes: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppattributes: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub InitializeFactory: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwmaxtransformcount: u32, psensordevices: *mut ::core::ffi::c_void, pattributes: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetTransformCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwcount: *mut u32) -> ::windows::core::HRESULT,
@@ -27929,7 +27929,7 @@ unsafe impl ::windows::core::Interface for IMFSequencerSource {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFSequencerSource_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AppendTopology: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptopology: *mut ::core::ffi::c_void, dwflags: u32, pdwid: *mut u32) -> ::windows::core::HRESULT,
     pub DeleteTopology: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwid: u32) -> ::windows::core::HRESULT,
     pub GetPresentationContext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppd: *mut ::core::ffi::c_void, pid: *mut u32, pptopology: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -27986,7 +27986,7 @@ unsafe impl ::windows::core::Interface for IMFSharingEngineClassFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFSharingEngineClassFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateInstance: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwflags: u32, pattr: *mut ::core::ffi::c_void, ppengine: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -28039,7 +28039,7 @@ unsafe impl ::windows::core::Interface for IMFShutdown {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFShutdown_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Shutdown: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetShutdownStatus: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pstatus: *mut MFSHUTDOWN_STATUS) -> ::windows::core::HRESULT,
 }
@@ -28092,7 +28092,7 @@ unsafe impl ::windows::core::Interface for IMFSignedLibrary {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFSignedLibrary_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetProcedureAddress: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, name: ::windows::core::PCSTR, address: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -28159,7 +28159,7 @@ unsafe impl ::windows::core::Interface for IMFSimpleAudioVolume {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFSimpleAudioVolume_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetMasterVolume: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, flevel: f32) -> ::windows::core::HRESULT,
     pub GetMasterVolume: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pflevel: *mut f32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -28259,7 +28259,7 @@ unsafe impl ::windows::core::Interface for IMFSinkWriter {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFSinkWriter_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddStream: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptargetmediatype: *mut ::core::ffi::c_void, pdwstreamindex: *mut u32) -> ::windows::core::HRESULT,
     pub SetInputMediaType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwstreamindex: u32, pinputmediatype: *mut ::core::ffi::c_void, pencodingparameters: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub BeginWriting: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -28321,7 +28321,7 @@ unsafe impl ::windows::core::Interface for IMFSinkWriterCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFSinkWriterCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnFinalize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hrstatus: ::windows::core::HRESULT) -> ::windows::core::HRESULT,
     pub OnMarker: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwstreamindex: u32, pvcontext: *const ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -28455,7 +28455,7 @@ unsafe impl ::windows::core::Interface for IMFSinkWriterEncoderConfig {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFSinkWriterEncoderConfig_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetTargetMediaType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwstreamindex: u32, ptargetmediatype: *mut ::core::ffi::c_void, pencodingparameters: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub PlaceEncodingParameters: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwstreamindex: u32, pencodingparameters: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -28653,7 +28653,7 @@ unsafe impl ::windows::core::Interface for IMFSourceBuffer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFSourceBuffer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetUpdating: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> super::super::Foundation::BOOL,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -28719,7 +28719,7 @@ unsafe impl ::windows::core::Interface for IMFSourceBufferAppendMode {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFSourceBufferAppendMode_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetAppendMode: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> MF_MSE_APPEND_MODE,
     pub SetAppendMode: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, mode: MF_MSE_APPEND_MODE) -> ::windows::core::HRESULT,
 }
@@ -28772,7 +28772,7 @@ unsafe impl ::windows::core::Interface for IMFSourceBufferList {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFSourceBufferList_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetLength: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32,
     pub GetSourceBuffer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: u32) -> ::core::option::Option<IMFSourceBuffer>,
 }
@@ -28834,7 +28834,7 @@ unsafe impl ::windows::core::Interface for IMFSourceBufferNotify {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFSourceBufferNotify_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnUpdateStart: unsafe extern "system" fn(this: *mut ::core::ffi::c_void),
     pub OnAbort: unsafe extern "system" fn(this: *mut ::core::ffi::c_void),
     pub OnError: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hr: ::windows::core::HRESULT),
@@ -28890,7 +28890,7 @@ unsafe impl ::windows::core::Interface for IMFSourceOpenMonitor {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFSourceOpenMonitor_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnSourceEvent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pevent: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -28984,7 +28984,7 @@ unsafe impl ::windows::core::Interface for IMFSourceReader {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFSourceReader_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetStreamSelection: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwstreamindex: u32, pfselected: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -29066,7 +29066,7 @@ unsafe impl ::windows::core::Interface for IMFSourceReaderCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFSourceReaderCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnReadSample: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hrstatus: ::windows::core::HRESULT, dwstreamindex: u32, dwstreamflags: u32, lltimestamp: i64, psample: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub OnFlush: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwstreamindex: u32) -> ::windows::core::HRESULT,
     pub OnEvent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwstreamindex: u32, pevent: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -29388,7 +29388,7 @@ unsafe impl ::windows::core::Interface for IMFSourceResolver {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFSourceResolver_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
     pub CreateObjectFromURL: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszurl: ::windows::core::PCWSTR, dwflags: u32, pprops: *mut ::core::ffi::c_void, pobjecttype: *mut MF_OBJECT_TYPE, ppobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_UI_Shell_PropertiesSystem"))]
@@ -30162,7 +30162,7 @@ unsafe impl ::windows::core::Interface for IMFStreamingSinkConfig {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFStreamingSinkConfig_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub StartStreaming: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fseekoffsetisbyteoffset: super::super::Foundation::BOOL, qwseekoffset: u64) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -30217,7 +30217,7 @@ unsafe impl ::windows::core::Interface for IMFSystemId {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFSystemId_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, size: *mut u32, data: *mut *mut u8) -> ::windows::core::HRESULT,
     pub Setup: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, stage: u32, cbin: u32, pbin: *const u8, pcbout: *mut u32, ppbout: *mut *mut u8) -> ::windows::core::HRESULT,
 }
@@ -30296,7 +30296,7 @@ unsafe impl ::windows::core::Interface for IMFTimecodeTranslate {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFTimecodeTranslate_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
     pub BeginConvertTimecodeToHNS: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppropvartimecode: *const super::super::System::Com::StructuredStorage::PROPVARIANT, pcallback: *mut ::core::ffi::c_void, punkstate: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage")))]
@@ -30439,7 +30439,7 @@ unsafe impl ::windows::core::Interface for IMFTimedText {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFTimedText_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub RegisterNotifications: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, notify: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub SelectTrack: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, trackid: u32, selected: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -30516,7 +30516,7 @@ unsafe impl ::windows::core::Interface for IMFTimedTextBinary {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFTimedTextBinary_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, data: *mut *mut u8, length: *mut u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -30574,7 +30574,7 @@ unsafe impl ::windows::core::Interface for IMFTimedTextBouten {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFTimedTextBouten_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetBoutenType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: *mut MF_TIMED_TEXT_BOUTEN_TYPE) -> ::windows::core::HRESULT,
     pub GetBoutenColor: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: *mut MFARGB) -> ::windows::core::HRESULT,
     pub GetBoutenPosition: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: *mut MF_TIMED_TEXT_BOUTEN_POSITION) -> ::windows::core::HRESULT,
@@ -30660,7 +30660,7 @@ unsafe impl ::windows::core::Interface for IMFTimedTextCue {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFTimedTextCue_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32,
     pub GetOriginalId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, originalid: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetCueKind: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> MF_TIMED_TEXT_TRACK_KIND,
@@ -30751,7 +30751,7 @@ unsafe impl ::windows::core::Interface for IMFTimedTextCueList {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFTimedTextCueList_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetLength: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32,
     pub GetCueByIndex: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: u32, cue: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetCueById: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, id: u32, cue: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -30813,7 +30813,7 @@ unsafe impl ::windows::core::Interface for IMFTimedTextFormattedText {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFTimedTextFormattedText_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetText: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, text: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetSubformattingCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32,
     pub GetSubformatting: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: u32, firstchar: *mut u32, charlength: *mut u32, style: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -30890,7 +30890,7 @@ unsafe impl ::windows::core::Interface for IMFTimedTextNotify {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFTimedTextNotify_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub TrackAdded: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, trackid: u32),
     pub TrackRemoved: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, trackid: u32),
     #[cfg(feature = "Win32_Foundation")]
@@ -30993,7 +30993,7 @@ unsafe impl ::windows::core::Interface for IMFTimedTextRegion {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFTimedTextRegion_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, name: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetPosition: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, px: *mut f64, py: *mut f64, unittype: *mut MF_TIMED_TEXT_UNIT_TYPE) -> ::windows::core::HRESULT,
     pub GetExtent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwidth: *mut f64, pheight: *mut f64, unittype: *mut MF_TIMED_TEXT_UNIT_TYPE) -> ::windows::core::HRESULT,
@@ -31072,7 +31072,7 @@ unsafe impl ::windows::core::Interface for IMFTimedTextRuby {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFTimedTextRuby_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetRubyText: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, rubytext: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetRubyPosition: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: *mut MF_TIMED_TEXT_RUBY_POSITION) -> ::windows::core::HRESULT,
     pub GetRubyAlign: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: *mut MF_TIMED_TEXT_RUBY_ALIGN) -> ::windows::core::HRESULT,
@@ -31178,7 +31178,7 @@ unsafe impl ::windows::core::Interface for IMFTimedTextStyle {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFTimedTextStyle_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, name: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub IsExternal: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> super::super::Foundation::BOOL,
@@ -31266,7 +31266,7 @@ unsafe impl ::windows::core::Interface for IMFTimedTextStyle2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFTimedTextStyle2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetRuby: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ruby: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetBouten: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bouten: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -31369,7 +31369,7 @@ unsafe impl ::windows::core::Interface for IMFTimedTextTrack {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFTimedTextTrack_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32,
     pub GetLabel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, label: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub SetLabel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, label: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
@@ -31444,7 +31444,7 @@ unsafe impl ::windows::core::Interface for IMFTimedTextTrackList {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFTimedTextTrackList_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetLength: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32,
     pub GetTrack: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: u32, track: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetTrackById: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, trackid: u32, track: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -31506,7 +31506,7 @@ unsafe impl ::windows::core::Interface for IMFTimer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFTimer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetTimer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwflags: u32, llclocktime: i64, pcallback: *mut ::core::ffi::c_void, punkstate: *mut ::core::ffi::c_void, ppunkkey: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CancelTimer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punkkey: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -31560,7 +31560,7 @@ unsafe impl ::windows::core::Interface for IMFTopoLoader {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFTopoLoader_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Load: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinputtopo: *mut ::core::ffi::c_void, ppoutputtopo: *mut *mut ::core::ffi::c_void, pcurrenttopo: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -32122,7 +32122,7 @@ unsafe impl ::windows::core::Interface for IMFTopologyNodeAttributeEditor {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFTopologyNodeAttributeEditor_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub UpdateNodeAttributes: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, topoid: u64, cupdates: u32, pupdates: *const MFTOPONODE_ATTRIBUTE_UPDATE) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -32171,7 +32171,7 @@ unsafe impl ::windows::core::Interface for IMFTopologyServiceLookup {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFTopologyServiceLookup_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub LookupService: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, r#type: MF_SERVICE_LOOKUP_TYPE, dwindex: u32, guidservice: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, ppvobjects: *mut *mut ::core::ffi::c_void, pnobjects: *mut u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -32226,7 +32226,7 @@ unsafe impl ::windows::core::Interface for IMFTopologyServiceLookupClient {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFTopologyServiceLookupClient_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub InitServicePointers: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, plookup: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub ReleaseServicePointers: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -32280,7 +32280,7 @@ unsafe impl ::windows::core::Interface for IMFTrackedSample {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFTrackedSample_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetAllocator: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psampleallocator: *mut ::core::ffi::c_void, punkstate: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -32356,7 +32356,7 @@ unsafe impl ::windows::core::Interface for IMFTranscodeProfile {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFTranscodeProfile_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetAudioAttributes: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pattrs: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetAudioAttributes: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppattrs: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetVideoAttributes: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pattrs: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -32429,7 +32429,7 @@ unsafe impl ::windows::core::Interface for IMFTranscodeSinkInfoProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFTranscodeSinkInfoProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetOutputFile: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszfilename: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub SetOutputByteStream: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbytestreamactivate: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetProfile: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pprofile: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -32570,7 +32570,7 @@ unsafe impl ::windows::core::Interface for IMFTransform {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFTransform_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetStreamLimits: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwinputminimum: *mut u32, pdwinputmaximum: *mut u32, pdwoutputminimum: *mut u32, pdwoutputmaximum: *mut u32) -> ::windows::core::HRESULT,
     pub GetStreamCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcinputstreams: *mut u32, pcoutputstreams: *mut u32) -> ::windows::core::HRESULT,
     pub GetStreamIDs: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwinputidarraysize: u32, pdwinputids: *mut u32, dwoutputidarraysize: u32, pdwoutputids: *mut u32) -> ::windows::core::HRESULT,
@@ -32642,7 +32642,7 @@ unsafe impl ::windows::core::Interface for IMFTrustedInput {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFTrustedInput_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetInputTrustAuthority: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwstreamid: u32, riid: *const ::windows::core::GUID, ppunkobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -32702,7 +32702,7 @@ unsafe impl ::windows::core::Interface for IMFTrustedOutput {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFTrustedOutput_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetOutputTrustAuthorityCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcoutputtrustauthorities: *mut u32) -> ::windows::core::HRESULT,
     pub GetOutputTrustAuthorityByIndex: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwindex: u32, ppauthority: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -32844,7 +32844,7 @@ unsafe impl ::windows::core::Interface for IMFVideoDeviceID {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFVideoDeviceID_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDeviceID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdeviceid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -32974,7 +32974,7 @@ unsafe impl ::windows::core::Interface for IMFVideoDisplayControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFVideoDisplayControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetNativeVideoSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszvideo: *mut super::super::Foundation::SIZE, pszarvideo: *mut super::super::Foundation::SIZE) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -33324,7 +33324,7 @@ unsafe impl ::windows::core::Interface for IMFVideoMixerBitmap {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFVideoMixerBitmap_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9", feature = "Win32_Graphics_Gdi"))]
     pub SetAlphaBitmap: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbmpparms: *const MFVideoAlphaBitmap) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9", feature = "Win32_Graphics_Gdi")))]
@@ -33396,7 +33396,7 @@ unsafe impl ::windows::core::Interface for IMFVideoMixerControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFVideoMixerControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetStreamZOrder: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwstreamid: u32, dwz: u32) -> ::windows::core::HRESULT,
     pub GetStreamZOrder: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwstreamid: u32, pdwz: *mut u32) -> ::windows::core::HRESULT,
     pub SetStreamOutputRect: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwstreamid: u32, pnrcoutput: *const MFVideoNormalizedRect) -> ::windows::core::HRESULT,
@@ -33531,7 +33531,7 @@ unsafe impl ::windows::core::Interface for IMFVideoPositionMapper {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFVideoPositionMapper_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub MapOutputCoordinateToInputStream: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, xout: f32, yout: f32, dwoutputstreamindex: u32, dwinputstreamindex: u32, pxin: *mut f32, pyin: *mut f32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -33713,7 +33713,7 @@ unsafe impl ::windows::core::Interface for IMFVideoProcessor {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFVideoProcessor_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetAvailableVideoProcessorModes: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lpdwnumprocessingmodes: *mut u32, ppvideoprocessingmodes: *mut *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Graphics_Direct3D9")]
     pub GetVideoProcessorCaps: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lpvideoprocessormode: *const ::windows::core::GUID, lpvideoprocessorcaps: *mut DXVA2_VideoProcessorCaps) -> ::windows::core::HRESULT,
@@ -33803,7 +33803,7 @@ unsafe impl ::windows::core::Interface for IMFVideoProcessorControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFVideoProcessorControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetBorderColor: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbordercolor: *const MFARGB) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub SetSourceRectangle: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psrcrect: *const super::super::Foundation::RECT) -> ::windows::core::HRESULT,
@@ -34117,7 +34117,7 @@ unsafe impl ::windows::core::Interface for IMFVideoRenderer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFVideoRenderer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub InitializeRenderer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pvideomixer: *mut ::core::ffi::c_void, pvideopresenter: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -34169,7 +34169,7 @@ unsafe impl ::windows::core::Interface for IMFVideoRendererEffectControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFVideoRendererEffectControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnAppServiceConnectionEstablished: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pappserviceconnection: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -34234,7 +34234,7 @@ unsafe impl ::windows::core::Interface for IMFVideoSampleAllocator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFVideoSampleAllocator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetDirectXManager: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pmanager: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub UninitializeSampleAllocator: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub InitializeSampleAllocator: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, crequestedframes: u32, pmediatype: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -34293,7 +34293,7 @@ unsafe impl ::windows::core::Interface for IMFVideoSampleAllocatorCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFVideoSampleAllocatorCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetCallback: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pnotify: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetFreeSampleCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, plsamples: *mut i32) -> ::windows::core::HRESULT,
 }
@@ -34430,7 +34430,7 @@ unsafe impl ::windows::core::Interface for IMFVideoSampleAllocatorNotify {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFVideoSampleAllocatorNotify_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub NotifyRelease: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -34878,7 +34878,7 @@ unsafe impl ::windows::core::Interface for IMFWorkQueueServices {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMFWorkQueueServices_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub BeginRegisterTopologyWorkQueuesWithMMCSS: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcallback: *mut ::core::ffi::c_void, pstate: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub EndRegisterTopologyWorkQueuesWithMMCSS: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, presult: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub BeginUnregisterTopologyWorkQueuesWithMMCSS: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcallback: *mut ::core::ffi::c_void, pstate: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -35099,7 +35099,7 @@ unsafe impl ::windows::core::Interface for IOPMVideoOutput {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOPMVideoOutput_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub StartInitialization: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, prnrandomnumber: *mut OPM_RANDOM_NUMBER, ppbcertificate: *mut *mut u8, pulcertificatelength: *mut u32) -> ::windows::core::HRESULT,
     pub FinishInitialization: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pparameters: *const OPM_ENCRYPTED_INITIALIZATION_PARAMETERS) -> ::windows::core::HRESULT,
     pub GetInformation: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pparameters: *const OPM_GET_INFO_PARAMETERS, prequestedinformation: *mut OPM_REQUESTED_INFORMATION) -> ::windows::core::HRESULT,
@@ -35158,7 +35158,7 @@ unsafe impl ::windows::core::Interface for IPlayToControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPlayToControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Connect: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfactory: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Disconnect: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -35286,7 +35286,7 @@ unsafe impl ::windows::core::Interface for IPlayToSourceClassFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPlayToSourceClassFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateInstance: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwflags: u32, pcontrol: *mut ::core::ffi::c_void, ppsource: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -35375,7 +35375,7 @@ unsafe impl ::windows::core::Interface for IToc {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IToc_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetDescriptor: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdescriptor: *mut TOC_DESCRIPTOR) -> ::windows::core::HRESULT,
     pub GetDescriptor: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdescriptor: *mut TOC_DESCRIPTOR) -> ::windows::core::HRESULT,
     pub SetDescription: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszdescription: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
@@ -35453,7 +35453,7 @@ unsafe impl ::windows::core::Interface for ITocCollection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITocCollection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetEntryCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwentrycount: *mut u32) -> ::windows::core::HRESULT,
     pub GetEntryByIndex: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwentryindex: u32, pptoc: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub AddEntry: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptoc: *mut ::core::ffi::c_void, pdwentryindex: *mut u32) -> ::windows::core::HRESULT,
@@ -35530,7 +35530,7 @@ unsafe impl ::windows::core::Interface for ITocEntry {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITocEntry_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetTitle: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwsztitle: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub GetTitle: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwtitlesize: *mut u16, pwsztitle: ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub SetDescriptor: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdescriptor: *mut TOC_ENTRY_DESCRIPTOR) -> ::windows::core::HRESULT,
@@ -35605,7 +35605,7 @@ unsafe impl ::windows::core::Interface for ITocEntryList {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITocEntryList_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetEntryCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwentrycount: *mut u32) -> ::windows::core::HRESULT,
     pub GetEntryByIndex: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwentryindex: u32, ppentry: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub AddEntry: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pentry: *mut ::core::ffi::c_void, pdwentryindex: *mut u32) -> ::windows::core::HRESULT,
@@ -35687,7 +35687,7 @@ unsafe impl ::windows::core::Interface for ITocParser {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITocParser_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Init: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszfilename: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub GetTocCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, enumtocpostype: TOC_POS_TYPE, pdwtoccount: *mut u32) -> ::windows::core::HRESULT,
     pub GetTocByIndex: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, enumtocpostype: TOC_POS_TYPE, dwtocindex: u32, pptoc: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -35743,7 +35743,7 @@ unsafe impl ::windows::core::Interface for IValidateBinding {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IValidateBinding_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetIdentifier: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, guidlicensorid: ::windows::core::GUID, pbephemeron: *const u8, cbephemeron: u32, ppbblobvalidationid: *mut *mut u8, pcbblobsize: *mut u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -35801,7 +35801,7 @@ unsafe impl ::windows::core::Interface for IWMCodecLeakyBucket {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMCodecLeakyBucket_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetBufferSizeBits: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ulbuffersize: u32) -> ::windows::core::HRESULT,
     pub GetBufferSizeBits: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pulbuffersize: *mut u32) -> ::windows::core::HRESULT,
     pub SetBufferFullnessBits: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ulbufferfullness: u32) -> ::windows::core::HRESULT,
@@ -35853,7 +35853,7 @@ unsafe impl ::windows::core::Interface for IWMCodecOutputTimestamp {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMCodecOutputTimestamp_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetNextOutputTime: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, prttime: *mut i64) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -35907,7 +35907,7 @@ unsafe impl ::windows::core::Interface for IWMCodecPrivateData {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMCodecPrivateData_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_DxMediaObjects"))]
     pub SetPartialOutputType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pmt: *mut super::DxMediaObjects::DMO_MEDIA_TYPE) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_Media_DxMediaObjects")))]
@@ -35971,7 +35971,7 @@ unsafe impl ::windows::core::Interface for IWMCodecProps {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMCodecProps_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_DxMediaObjects"))]
     pub GetFormatProp: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pmt: *mut super::DxMediaObjects::DMO_MEDIA_TYPE, pszname: ::windows::core::PCWSTR, ptype: *mut WMT_PROP_DATATYPE, pvalue: *mut u8, pdwsize: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_Media_DxMediaObjects")))]
@@ -36031,7 +36031,7 @@ unsafe impl ::windows::core::Interface for IWMCodecStrings {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMCodecStrings_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_DxMediaObjects"))]
     pub GetName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pmt: *mut super::DxMediaObjects::DMO_MEDIA_TYPE, cchlength: u32, szname: ::windows::core::PWSTR, pcchlength: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_Media_DxMediaObjects")))]
@@ -36090,7 +36090,7 @@ unsafe impl ::windows::core::Interface for IWMColorConvProps {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMColorConvProps_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetMode: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lmode: i32) -> ::windows::core::HRESULT,
     pub SetFullCroppingParam: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lsrccropleft: i32, lsrccroptop: i32, ldstcropleft: i32, ldstcroptop: i32, lcropwidth: i32, lcropheight: i32) -> ::windows::core::HRESULT,
 }
@@ -36140,7 +36140,7 @@ unsafe impl ::windows::core::Interface for IWMColorLegalizerProps {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMColorLegalizerProps_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetColorLegalizerQuality: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lquality: i32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -36203,7 +36203,7 @@ unsafe impl ::windows::core::Interface for IWMFrameInterpProps {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMFrameInterpProps_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetFrameRateIn: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lframerate: i32, lscale: i32) -> ::windows::core::HRESULT,
     pub SetFrameRateOut: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lframerate: i32, lscale: i32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -36264,7 +36264,7 @@ unsafe impl ::windows::core::Interface for IWMInterlaceProps {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMInterlaceProps_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetProcessType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, iprocesstype: i32) -> ::windows::core::HRESULT,
     pub SetInitInverseTeleCinePattern: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, iinitpattern: i32) -> ::windows::core::HRESULT,
     pub SetLastFrame: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -36318,7 +36318,7 @@ unsafe impl ::windows::core::Interface for IWMResamplerProps {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMResamplerProps_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetHalfFilterLength: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lhalffilterlen: i32) -> ::windows::core::HRESULT,
     pub SetUserChannelMtx: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, userchannelmtx: *mut f32) -> ::windows::core::HRESULT,
 }
@@ -36380,7 +36380,7 @@ unsafe impl ::windows::core::Interface for IWMResizerProps {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMResizerProps_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetResizerQuality: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lquality: i32) -> ::windows::core::HRESULT,
     pub SetInterlaceMode: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lmode: i32) -> ::windows::core::HRESULT,
     pub SetClipRegion: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lcliporixsrc: i32, lcliporiysrc: i32, lclipwidthsrc: i32, lclipheightsrc: i32) -> ::windows::core::HRESULT,
@@ -36438,7 +36438,7 @@ unsafe impl ::windows::core::Interface for IWMSampleExtensionSupport {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMSampleExtensionSupport_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub SetUseSampleExtensions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fuseextensions: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -36490,7 +36490,7 @@ unsafe impl ::windows::core::Interface for IWMValidate {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMValidate_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetIdentifier: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, guidvalidationid: ::windows::core::GUID) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
@@ -36542,7 +36542,7 @@ unsafe impl ::windows::core::Interface for IWMVideoDecoderHurryup {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMVideoDecoderHurryup_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetHurryup: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lhurryup: i32) -> ::windows::core::HRESULT,
     pub GetHurryup: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, plhurryup: *mut i32) -> ::windows::core::HRESULT,
 }
@@ -36608,7 +36608,7 @@ unsafe impl ::windows::core::Interface for IWMVideoDecoderReconBuffer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMVideoDecoderReconBuffer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetReconstructedVideoFrameSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwsize: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Media_DxMediaObjects")]
     pub GetReconstructedVideoFrame: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbuf: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -36665,7 +36665,7 @@ unsafe impl ::windows::core::Interface for IWMVideoForceKeyFrame {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMVideoForceKeyFrame_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetKeyFrame: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]

--- a/crates/libs/windows/src/Windows/Win32/Media/MediaPlayer/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/MediaPlayer/impl.rs
@@ -1701,7 +1701,7 @@ impl IWMPAudioRenderConfig_Vtbl {
             this.SetaudioOutputDevice(::core::mem::transmute(&bstroutputdevice)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             audioOutputDevice: audioOutputDevice::<Identity, Impl, OFFSET>,
             SetaudioOutputDevice: SetaudioOutputDevice::<Identity, Impl, OFFSET>,
         }
@@ -1852,7 +1852,7 @@ impl IWMPCdromBurn_Vtbl {
             this.erase().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             isAvailable: isAvailable::<Identity, Impl, OFFSET>,
             getItemInfo: getItemInfo::<Identity, Impl, OFFSET>,
             label: label::<Identity, Impl, OFFSET>,
@@ -1952,7 +1952,7 @@ impl IWMPCdromRip_Vtbl {
             this.stopRip().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ripState: ripState::<Identity, Impl, OFFSET>,
             ripProgress: ripProgress::<Identity, Impl, OFFSET>,
             startRip: startRip::<Identity, Impl, OFFSET>,
@@ -2164,7 +2164,7 @@ impl IWMPContentContainer_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetID: GetID::<Identity, Impl, OFFSET>,
             GetPrice: GetPrice::<Identity, Impl, OFFSET>,
             GetType: GetType::<Identity, Impl, OFFSET>,
@@ -2219,7 +2219,7 @@ impl IWMPContentContainerList_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTransactionType: GetTransactionType::<Identity, Impl, OFFSET>,
             GetContainerCount: GetContainerCount::<Identity, Impl, OFFSET>,
             GetContainer: GetContainer::<Identity, Impl, OFFSET>,
@@ -2400,7 +2400,7 @@ impl IWMPContentPartner_Vtbl {
             this.VerifyPermission(::core::mem::transmute(&bstrpermission), ::core::mem::transmute_copy(&pcontext)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetCallback: SetCallback::<Identity, Impl, OFFSET>,
             Notify: Notify::<Identity, Impl, OFFSET>,
             GetItemInfo: GetItemInfo::<Identity, Impl, OFFSET>,
@@ -2517,7 +2517,7 @@ impl IWMPContentPartnerCallback_Vtbl {
             this.VerifyPermissionComplete(::core::mem::transmute(&bstrpermission), ::core::mem::transmute_copy(&pcontext), ::core::mem::transmute_copy(&hrpermission)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Notify: Notify::<Identity, Impl, OFFSET>,
             BuyComplete: BuyComplete::<Identity, Impl, OFFSET>,
             DownloadTrack: DownloadTrack::<Identity, Impl, OFFSET>,
@@ -2795,7 +2795,7 @@ impl IWMPConvert_Vtbl {
             this.GetErrorURL(::core::mem::transmute_copy(&pbstrurl)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ConvertFile: ConvertFile::<Identity, Impl, OFFSET>,
             GetErrorURL: GetErrorURL::<Identity, Impl, OFFSET>,
         }
@@ -3432,7 +3432,7 @@ impl IWMPEffects_Vtbl {
             this.RenderFullScreen(::core::mem::transmute_copy(&plevels)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Render: Render::<Identity, Impl, OFFSET>,
             MediaInfo: MediaInfo::<Identity, Impl, OFFSET>,
             GetCapabilities: GetCapabilities::<Identity, Impl, OFFSET>,
@@ -3908,7 +3908,7 @@ impl IWMPEvents_Vtbl {
             this.MouseUp(::core::mem::transmute_copy(&nbutton), ::core::mem::transmute_copy(&nshiftstate), ::core::mem::transmute_copy(&fx), ::core::mem::transmute_copy(&fy))
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OpenStateChange: OpenStateChange::<Identity, Impl, OFFSET>,
             PlayStateChange: PlayStateChange::<Identity, Impl, OFFSET>,
             AudioLanguageChange: AudioLanguageChange::<Identity, Impl, OFFSET>,
@@ -4203,7 +4203,7 @@ impl IWMPFolderMonitorServices_Vtbl {
             this.stopScan().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             count: count::<Identity, Impl, OFFSET>,
             item: item::<Identity, Impl, OFFSET>,
             add: add::<Identity, Impl, OFFSET>,
@@ -4245,7 +4245,7 @@ impl IWMPGraphCreation_Vtbl {
             this.GetGraphCreationFlags(::core::mem::transmute_copy(&pdwflags)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GraphCreationPreRender: GraphCreationPreRender::<Identity, Impl, OFFSET>,
             GraphCreationPostRender: GraphCreationPostRender::<Identity, Impl, OFFSET>,
             GetGraphCreationFlags: GetGraphCreationFlags::<Identity, Impl, OFFSET>,
@@ -4294,7 +4294,7 @@ impl IWMPLibrary_Vtbl {
             this.isIdentical(::core::mem::transmute(&piwmplibrary), ::core::mem::transmute_copy(&pvbool)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             name: name::<Identity, Impl, OFFSET>,
             r#type: r#type::<Identity, Impl, OFFSET>,
             mediaCollection: mediaCollection::<Identity, Impl, OFFSET>,
@@ -4349,7 +4349,7 @@ impl IWMPLibraryServices_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             getCountByType: getCountByType::<Identity, Impl, OFFSET>,
             getLibraryByType: getLibraryByType::<Identity, Impl, OFFSET>,
         }
@@ -4382,7 +4382,7 @@ impl IWMPLibrarySharingServices_Vtbl {
             this.showLibrarySharing().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             isLibraryShared: isLibraryShared::<Identity, Impl, OFFSET>,
             isLibrarySharingEnabled: isLibrarySharingEnabled::<Identity, Impl, OFFSET>,
             showLibrarySharing: showLibrarySharing::<Identity, Impl, OFFSET>,
@@ -4824,7 +4824,7 @@ impl IWMPMediaPluginRegistrar_Vtbl {
             this.WMPUnRegisterPlayerPlugin(::core::mem::transmute(&guidplugintype), ::core::mem::transmute(&clsid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             WMPRegisterPlayerPlugin: WMPRegisterPlayerPlugin::<Identity, Impl, OFFSET>,
             WMPUnRegisterPlayerPlugin: WMPUnRegisterPlayerPlugin::<Identity, Impl, OFFSET>,
         }
@@ -5170,7 +5170,7 @@ impl IWMPNodeRealEstate_Vtbl {
             this.GetFullScreen(::core::mem::transmute_copy(&pffullscreen)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDesiredSize: GetDesiredSize::<Identity, Impl, OFFSET>,
             SetRects: SetRects::<Identity, Impl, OFFSET>,
             GetRects: GetRects::<Identity, Impl, OFFSET>,
@@ -5205,7 +5205,7 @@ impl IWMPNodeRealEstateHost_Vtbl {
             this.OnFullScreenTransition(::core::mem::transmute_copy(&ffullscreen)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnDesiredSizeChange: OnDesiredSizeChange::<Identity, Impl, OFFSET>,
             OnFullScreenTransition: OnFullScreenTransition::<Identity, Impl, OFFSET>,
         }
@@ -5232,7 +5232,7 @@ impl IWMPNodeWindowed_Vtbl {
             this.GetOwnerWindow(::core::mem::transmute_copy(&phwnd)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetOwnerWindow: SetOwnerWindow::<Identity, Impl, OFFSET>,
             GetOwnerWindow: GetOwnerWindow::<Identity, Impl, OFFSET>,
         }
@@ -5256,7 +5256,7 @@ impl IWMPNodeWindowedHost_Vtbl {
             this.OnWindowMessageFromRenderer(::core::mem::transmute_copy(&umsg), ::core::mem::transmute_copy(&wparam), ::core::mem::transmute_copy(&lparam), ::core::mem::transmute_copy(&plret), ::core::mem::transmute_copy(&pfhandled)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnWindowMessageFromRenderer: OnWindowMessageFromRenderer::<Identity, Impl, OFFSET>,
         }
     }
@@ -5298,7 +5298,7 @@ impl IWMPNodeWindowlessHost_Vtbl {
             let this = (*this).get_impl();
             this.InvalidateRect(::core::mem::transmute_copy(&prc), ::core::mem::transmute_copy(&ferase)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), InvalidateRect: InvalidateRect::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), InvalidateRect: InvalidateRect::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWMPNodeWindowlessHost as ::windows::core::Interface>::IID
@@ -5771,7 +5771,7 @@ impl IWMPPlayerServices_Vtbl {
             this.setTaskPaneURL(::core::mem::transmute(&bstrtaskpane), ::core::mem::transmute(&bstrurl), ::core::mem::transmute(&bstrfriendlyname)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             activateUIPlugin: activateUIPlugin::<Identity, Impl, OFFSET>,
             setTaskPane: setTaskPane::<Identity, Impl, OFFSET>,
             setTaskPaneURL: setTaskPaneURL::<Identity, Impl, OFFSET>,
@@ -6088,7 +6088,7 @@ impl IWMPPlugin_Vtbl {
             this.UnAdviseWMPServices().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Init: Init::<Identity, Impl, OFFSET>,
             Shutdown: Shutdown::<Identity, Impl, OFFSET>,
             GetID: GetID::<Identity, Impl, OFFSET>,
@@ -6122,7 +6122,7 @@ impl IWMPPluginEnable_Vtbl {
             this.GetEnable(::core::mem::transmute_copy(&pfenable)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetEnable: SetEnable::<Identity, Impl, OFFSET>,
             GetEnable: GetEnable::<Identity, Impl, OFFSET>,
         }
@@ -6182,7 +6182,7 @@ impl IWMPPluginUI_Vtbl {
             this.TranslateAccelerator(::core::mem::transmute_copy(&lpmsg)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetCore: SetCore::<Identity, Impl, OFFSET>,
             Create: Create::<Identity, Impl, OFFSET>,
             Destroy: Destroy::<Identity, Impl, OFFSET>,
@@ -6259,7 +6259,7 @@ impl IWMPRemoteMediaServices_Vtbl {
             this.GetCustomUIMode(::core::mem::transmute_copy(&pbstrfile)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetServiceType: GetServiceType::<Identity, Impl, OFFSET>,
             GetApplicationName: GetApplicationName::<Identity, Impl, OFFSET>,
             GetScriptableObject: GetScriptableObject::<Identity, Impl, OFFSET>,
@@ -6291,7 +6291,7 @@ impl IWMPRenderConfig_Vtbl {
             this.inProcOnly(::core::mem::transmute_copy(&pfinproc)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetinProcOnly: SetinProcOnly::<Identity, Impl, OFFSET>,
             inProcOnly: inProcOnly::<Identity, Impl, OFFSET>,
         }
@@ -6318,7 +6318,7 @@ impl IWMPServices_Vtbl {
             this.GetStreamState(::core::mem::transmute_copy(&pstate)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetStreamTime: GetStreamTime::<Identity, Impl, OFFSET>,
             GetStreamState: GetStreamState::<Identity, Impl, OFFSET>,
         }
@@ -6552,7 +6552,7 @@ impl IWMPSkinManager_Vtbl {
             let this = (*this).get_impl();
             this.SetVisualStyle(::core::mem::transmute(&bstrpath)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SetVisualStyle: SetVisualStyle::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SetVisualStyle: SetVisualStyle::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWMPSkinManager as ::windows::core::Interface>::IID
@@ -6665,7 +6665,7 @@ impl IWMPSubscriptionService_Vtbl {
             this.startBackgroundProcessing(::core::mem::transmute_copy(&hwnd)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             allowPlay: allowPlay::<Identity, Impl, OFFSET>,
             allowCDBurn: allowCDBurn::<Identity, Impl, OFFSET>,
             allowPDATransfer: allowPDATransfer::<Identity, Impl, OFFSET>,
@@ -6731,7 +6731,7 @@ impl IWMPSubscriptionServiceCallback_Vtbl {
             let this = (*this).get_impl();
             this.onComplete(::core::mem::transmute_copy(&hrresult)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), onComplete: onComplete::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), onComplete: onComplete::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWMPSubscriptionServiceCallback as ::windows::core::Interface>::IID
@@ -6839,7 +6839,7 @@ impl IWMPSyncDevice_Vtbl {
             this.isIdentical(::core::mem::transmute(&pdevice), ::core::mem::transmute_copy(&pvbool)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             friendlyName: friendlyName::<Identity, Impl, OFFSET>,
             SetfriendlyName: SetfriendlyName::<Identity, Impl, OFFSET>,
             deviceName: deviceName::<Identity, Impl, OFFSET>,
@@ -6933,7 +6933,7 @@ impl IWMPSyncServices_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             deviceCount: deviceCount::<Identity, Impl, OFFSET>,
             getDevice: getDevice::<Identity, Impl, OFFSET>,
         }
@@ -6953,7 +6953,7 @@ impl IWMPTranscodePolicy_Vtbl {
             let this = (*this).get_impl();
             this.allowTranscode(::core::mem::transmute_copy(&pvballow)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), allowTranscode: allowTranscode::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), allowTranscode: allowTranscode::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWMPTranscodePolicy as ::windows::core::Interface>::IID
@@ -6970,7 +6970,7 @@ impl IWMPUserEventSink_Vtbl {
             let this = (*this).get_impl();
             this.NotifyUserEvent(::core::mem::transmute_copy(&eventcode)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), NotifyUserEvent: NotifyUserEvent::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), NotifyUserEvent: NotifyUserEvent::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWMPUserEventSink as ::windows::core::Interface>::IID
@@ -6990,7 +6990,7 @@ impl IWMPVideoRenderConfig_Vtbl {
             let this = (*this).get_impl();
             this.SetpresenterActivate(::core::mem::transmute(&pactivate)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SetpresenterActivate: SetpresenterActivate::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SetpresenterActivate: SetpresenterActivate::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWMPVideoRenderConfig as ::windows::core::Interface>::IID
@@ -7010,7 +7010,7 @@ impl IWMPWindowMessageSink_Vtbl {
             let this = (*this).get_impl();
             this.OnWindowMessage(::core::mem::transmute_copy(&umsg), ::core::mem::transmute_copy(&wparam), ::core::mem::transmute_copy(&lparam), ::core::mem::transmute_copy(&plret), ::core::mem::transmute_copy(&pfhandled)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnWindowMessage: OnWindowMessage::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnWindowMessage: OnWindowMessage::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWMPWindowMessageSink as ::windows::core::Interface>::IID
@@ -7457,7 +7457,7 @@ impl IXFeed_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Xml: Xml::<Identity, Impl, OFFSET>,
             Name: Name::<Identity, Impl, OFFSET>,
             Rename: Rename::<Identity, Impl, OFFSET>,
@@ -7716,7 +7716,7 @@ impl IXFeedEnclosure_Vtbl {
             this.SetFile(::core::mem::transmute(&pszdownloadurl), ::core::mem::transmute(&pszdownloadfilepath), ::core::mem::transmute(&pszdownloadmimetype), ::core::mem::transmute(&pszenclosurefilename)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Url: Url::<Identity, Impl, OFFSET>,
             Type: Type::<Identity, Impl, OFFSET>,
             Length: Length::<Identity, Impl, OFFSET>,
@@ -7790,7 +7790,7 @@ impl IXFeedEvents_Vtbl {
             this.FeedItemCountChanged(::core::mem::transmute(&pszpath), ::core::mem::transmute_copy(&feicfflags)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Error: Error::<Identity, Impl, OFFSET>,
             FeedDeleted: FeedDeleted::<Identity, Impl, OFFSET>,
             FeedRenamed: FeedRenamed::<Identity, Impl, OFFSET>,
@@ -7964,7 +7964,7 @@ impl IXFeedFolder_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Feeds: Feeds::<Identity, Impl, OFFSET>,
             Subfolders: Subfolders::<Identity, Impl, OFFSET>,
             CreateFeed: CreateFeed::<Identity, Impl, OFFSET>,
@@ -8091,7 +8091,7 @@ impl IXFeedFolderEvents_Vtbl {
             this.FeedItemCountChanged(::core::mem::transmute(&pszpath), ::core::mem::transmute_copy(&feicfflags)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Error: Error::<Identity, Impl, OFFSET>,
             FolderAdded: FolderAdded::<Identity, Impl, OFFSET>,
             FolderDeleted: FolderDeleted::<Identity, Impl, OFFSET>,
@@ -8303,7 +8303,7 @@ impl IXFeedItem_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Xml: Xml::<Identity, Impl, OFFSET>,
             Title: Title::<Identity, Impl, OFFSET>,
             Link: Link::<Identity, Impl, OFFSET>,
@@ -8376,7 +8376,7 @@ impl IXFeedsEnum_Vtbl {
             let this = (*this).get_impl();
             this.Item(::core::mem::transmute_copy(&uiindex), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppv)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Count: Count::<Identity, Impl, OFFSET>, Item: Item::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Count: Count::<Identity, Impl, OFFSET>, Item: Item::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IXFeedsEnum as ::windows::core::Interface>::IID
@@ -8529,7 +8529,7 @@ impl IXFeedsManager_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RootFolder: RootFolder::<Identity, Impl, OFFSET>,
             IsSubscribed: IsSubscribed::<Identity, Impl, OFFSET>,
             ExistsFeed: ExistsFeed::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/Media/MediaPlayer/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/MediaPlayer/mod.rs
@@ -1831,7 +1831,7 @@ unsafe impl ::windows::core::Interface for IWMPAudioRenderConfig {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMPAudioRenderConfig_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub audioOutputDevice: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstroutputdevice: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub SetaudioOutputDevice: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstroutputdevice: ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
 }
@@ -2020,7 +2020,7 @@ unsafe impl ::windows::core::Interface for IWMPCdromBurn {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMPCdromBurn_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub isAvailable: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstritem: ::core::mem::ManuallyDrop<::windows::core::BSTR>, pisavailable: *mut i16) -> ::windows::core::HRESULT,
     pub getItemInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstritem: ::core::mem::ManuallyDrop<::windows::core::BSTR>, pbstrval: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub label: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstrlabel: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
@@ -2195,7 +2195,7 @@ unsafe impl ::windows::core::Interface for IWMPCdromRip {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMPCdromRip_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ripState: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwmprs: *mut WMPRipState) -> ::windows::core::HRESULT,
     pub ripProgress: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, plprogress: *mut i32) -> ::windows::core::HRESULT,
     pub startRip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -2510,7 +2510,7 @@ unsafe impl ::windows::core::Interface for IWMPContentContainer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMPContentContainer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcontentid: *mut u32) -> ::windows::core::HRESULT,
     pub GetPrice: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstrprice: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub GetType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstrtype: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
@@ -2573,7 +2573,7 @@ unsafe impl ::windows::core::Interface for IWMPContentContainerList {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMPContentContainerList_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetTransactionType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwmptt: *mut WMPTransactionType) -> ::windows::core::HRESULT,
     pub GetContainerCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pccontainer: *mut u32) -> ::windows::core::HRESULT,
     pub GetContainer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, idxcontainer: u32, ppcontent: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -2736,7 +2736,7 @@ unsafe impl ::windows::core::Interface for IWMPContentPartner {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMPContentPartner_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetCallback: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcallback: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub Notify: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, r#type: WMPPartnerNotification, pcontext: *const super::super::System::Com::VARIANT) -> ::windows::core::HRESULT,
@@ -2886,7 +2886,7 @@ unsafe impl ::windows::core::Interface for IWMPContentPartnerCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMPContentPartnerCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub Notify: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, r#type: WMPCallbackNotification, pcontext: *const super::super::System::Com::VARIANT) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole")))]
@@ -3487,7 +3487,7 @@ unsafe impl ::windows::core::Interface for IWMPConvert {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMPConvert_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ConvertFile: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrinputfile: ::core::mem::ManuallyDrop<::windows::core::BSTR>, bstrdestinationfolder: ::core::mem::ManuallyDrop<::windows::core::BSTR>, pbstroutputfile: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub GetErrorURL: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstrurl: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
 }
@@ -4788,7 +4788,7 @@ unsafe impl ::windows::core::Interface for IWMPEffects {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMPEffects_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
     pub Render: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, plevels: *mut TimedLevel, hdc: super::super::Graphics::Gdi::HDC, prc: *mut super::super::Foundation::RECT) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi")))]
@@ -5494,7 +5494,7 @@ unsafe impl ::windows::core::Interface for IWMPEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMPEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OpenStateChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, newstate: i32),
     pub PlayStateChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, newstate: i32),
     pub AudioLanguageChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, langid: i32),
@@ -6646,7 +6646,7 @@ unsafe impl ::windows::core::Interface for IWMPFolderMonitorServices {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMPFolderMonitorServices_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub count: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, plcount: *mut i32) -> ::windows::core::HRESULT,
     pub item: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lindex: i32, pbstrfolder: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub add: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrfolder: ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
@@ -6718,7 +6718,7 @@ unsafe impl ::windows::core::Interface for IWMPGraphCreation {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMPGraphCreation_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GraphCreationPreRender: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfiltergraph: *mut ::core::ffi::c_void, preserved: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GraphCreationPostRender: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfiltergraph: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetGraphCreationFlags: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwflags: *mut u32) -> ::windows::core::HRESULT,
@@ -6784,7 +6784,7 @@ unsafe impl ::windows::core::Interface for IWMPLibrary {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMPLibrary_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub name: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstrname: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub r#type: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwmplt: *mut WMPLibraryType) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
@@ -6925,7 +6925,7 @@ unsafe impl ::windows::core::Interface for IWMPLibraryServices {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMPLibraryServices_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub getCountByType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wmplt: WMPLibraryType, plcount: *mut i32) -> ::windows::core::HRESULT,
     pub getLibraryByType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wmplt: WMPLibraryType, lindex: i32, ppiwmplibrary: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -6981,7 +6981,7 @@ unsafe impl ::windows::core::Interface for IWMPLibrarySharingServices {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMPLibrarySharingServices_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub isLibraryShared: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pvbshared: *mut i16) -> ::windows::core::HRESULT,
     pub isLibrarySharingEnabled: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pvbenabled: *mut i16) -> ::windows::core::HRESULT,
     pub showLibrarySharing: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -7968,7 +7968,7 @@ unsafe impl ::windows::core::Interface for IWMPMediaPluginRegistrar {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMPMediaPluginRegistrar_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub WMPRegisterPlayerPlugin: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszfriendlyname: ::windows::core::PCWSTR, pwszdescription: ::windows::core::PCWSTR, pwszuninstallstring: ::windows::core::PCWSTR, dwpriority: u32, guidplugintype: ::windows::core::GUID, clsid: ::windows::core::GUID, cmediatypes: u32, pmediatypes: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub WMPUnRegisterPlayerPlugin: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, guidplugintype: ::windows::core::GUID, clsid: ::windows::core::GUID) -> ::windows::core::HRESULT,
 }
@@ -8414,7 +8414,7 @@ unsafe impl ::windows::core::Interface for IWMPNodeRealEstate {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMPNodeRealEstate_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetDesiredSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psize: *mut super::super::Foundation::SIZE) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -8500,7 +8500,7 @@ unsafe impl ::windows::core::Interface for IWMPNodeRealEstateHost {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMPNodeRealEstateHost_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub OnDesiredSizeChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psize: *mut super::super::Foundation::SIZE) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -8559,7 +8559,7 @@ unsafe impl ::windows::core::Interface for IWMPNodeWindowed {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMPNodeWindowed_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetOwnerWindow: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hwnd: isize) -> ::windows::core::HRESULT,
     pub GetOwnerWindow: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, phwnd: *mut isize) -> ::windows::core::HRESULT,
 }
@@ -8615,7 +8615,7 @@ unsafe impl ::windows::core::Interface for IWMPNodeWindowedHost {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMPNodeWindowedHost_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub OnWindowMessageFromRenderer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, umsg: u32, wparam: super::super::Foundation::WPARAM, lparam: super::super::Foundation::LPARAM, plret: *mut super::super::Foundation::LRESULT, pfhandled: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -8750,7 +8750,7 @@ unsafe impl ::windows::core::Interface for IWMPNodeWindowlessHost {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMPNodeWindowlessHost_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub InvalidateRect: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, prc: *const super::super::Foundation::RECT, ferase: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -9950,7 +9950,7 @@ unsafe impl ::windows::core::Interface for IWMPPlayerServices {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMPPlayerServices_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub activateUIPlugin: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrplugin: ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub setTaskPane: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrtaskpane: ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub setTaskPaneURL: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrtaskpane: ::core::mem::ManuallyDrop<::windows::core::BSTR>, bstrurl: ::core::mem::ManuallyDrop<::windows::core::BSTR>, bstrfriendlyname: ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
@@ -10501,7 +10501,7 @@ unsafe impl ::windows::core::Interface for IWMPPlugin {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMPPlugin_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Init: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwplaybackcontext: usize) -> ::windows::core::HRESULT,
     pub Shutdown: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pguid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
@@ -10565,7 +10565,7 @@ unsafe impl ::windows::core::Interface for IWMPPluginEnable {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMPPluginEnable_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub SetEnable: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fenable: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -10666,7 +10666,7 @@ unsafe impl ::windows::core::Interface for IWMPPluginUI {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMPPluginUI_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub SetCore: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcore: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -10832,7 +10832,7 @@ unsafe impl ::windows::core::Interface for IWMPRemoteMediaServices {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMPRemoteMediaServices_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetServiceType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstrtype: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub GetApplicationName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstrname: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
@@ -10897,7 +10897,7 @@ unsafe impl ::windows::core::Interface for IWMPRenderConfig {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMPRenderConfig_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub SetinProcOnly: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, finproc: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -10956,7 +10956,7 @@ unsafe impl ::windows::core::Interface for IWMPServices {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMPServices_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetStreamTime: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, prt: *mut i64) -> ::windows::core::HRESULT,
     pub GetStreamState: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pstate: *mut WMPServices_StreamState) -> ::windows::core::HRESULT,
 }
@@ -11345,7 +11345,7 @@ unsafe impl ::windows::core::Interface for IWMPSkinManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMPSkinManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetVisualStyle: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrpath: ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_System_Com\"`*"]
@@ -11635,7 +11635,7 @@ unsafe impl ::windows::core::Interface for IWMPSubscriptionService {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMPSubscriptionService_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
     pub allowPlay: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hwnd: super::super::Foundation::HWND, pmedia: *mut ::core::ffi::c_void, pfallowplay: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com")))]
@@ -11816,7 +11816,7 @@ unsafe impl ::windows::core::Interface for IWMPSubscriptionServiceCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMPSubscriptionServiceCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub onComplete: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hrresult: ::windows::core::HRESULT) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`*"]
@@ -11913,7 +11913,7 @@ unsafe impl ::windows::core::Interface for IWMPSyncDevice {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMPSyncDevice_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub friendlyName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstrname: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub SetfriendlyName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrname: ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub deviceName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstrname: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
@@ -12242,7 +12242,7 @@ unsafe impl ::windows::core::Interface for IWMPSyncServices {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMPSyncServices_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub deviceCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, plcount: *mut i32) -> ::windows::core::HRESULT,
     pub getDevice: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lindex: i32, ppdevice: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -12292,7 +12292,7 @@ unsafe impl ::windows::core::Interface for IWMPTranscodePolicy {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMPTranscodePolicy_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub allowTranscode: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pvballow: *mut i16) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`*"]
@@ -12341,7 +12341,7 @@ unsafe impl ::windows::core::Interface for IWMPUserEventSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMPUserEventSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub NotifyUserEvent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, eventcode: i32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`*"]
@@ -12395,7 +12395,7 @@ unsafe impl ::windows::core::Interface for IWMPVideoRenderConfig {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMPVideoRenderConfig_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Media_MediaFoundation")]
     pub SetpresenterActivate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pactivate: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Media_MediaFoundation"))]
@@ -12453,7 +12453,7 @@ unsafe impl ::windows::core::Interface for IWMPWindowMessageSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMPWindowMessageSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub OnWindowMessage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, umsg: u32, wparam: super::super::Foundation::WPARAM, lparam: super::super::Foundation::LPARAM, plret: *mut super::super::Foundation::LRESULT, pfhandled: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -12708,7 +12708,7 @@ unsafe impl ::windows::core::Interface for IXFeed {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXFeed_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub Xml: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, uiitemcount: u32, sortproperty: FEEDS_XML_SORT_PROPERTY, sortorder: FEEDS_XML_SORT_ORDER, filterflags: FEEDS_XML_FILTER_FLAGS, includeflags: FEEDS_XML_INCLUDE_FLAGS, pps: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -13187,7 +13187,7 @@ unsafe impl ::windows::core::Interface for IXFeedEnclosure {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXFeedEnclosure_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Url: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppszurl: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub Type: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppszmimetype: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub Length: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, puilength: *mut u32) -> ::windows::core::HRESULT,
@@ -13292,7 +13292,7 @@ unsafe impl ::windows::core::Interface for IXFeedEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXFeedEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Error: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub FeedDeleted: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszpath: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub FeedRenamed: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszpath: ::windows::core::PCWSTR, pszoldpath: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
@@ -13453,7 +13453,7 @@ unsafe impl ::windows::core::Interface for IXFeedFolder {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXFeedFolder_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Feeds: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppfe: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Subfolders: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppfe: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CreateFeed: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszname: ::windows::core::PCWSTR, pszurl: ::windows::core::PCWSTR, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -13624,7 +13624,7 @@ unsafe impl ::windows::core::Interface for IXFeedFolderEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXFeedFolderEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Error: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub FolderAdded: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszpath: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub FolderDeleted: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszpath: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
@@ -13772,7 +13772,7 @@ unsafe impl ::windows::core::Interface for IXFeedItem {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXFeedItem_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub Xml: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fxif: FEEDS_XML_INCLUDE_FLAGS, pps: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -14015,7 +14015,7 @@ unsafe impl ::windows::core::Interface for IXFeedsEnum {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXFeedsEnum_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Count: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, puicount: *mut u32) -> ::windows::core::HRESULT,
     pub Item: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, uiindex: u32, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -14162,7 +14162,7 @@ unsafe impl ::windows::core::Interface for IXFeedsManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXFeedsManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub RootFolder: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub IsSubscribed: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszurl: ::windows::core::PCWSTR, pbsubscribed: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/Media/Multimedia/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Multimedia/impl.rs
@@ -43,7 +43,7 @@ impl IAVIEditStream_Vtbl {
             this.SetInfo(::core::mem::transmute_copy(&lpinfo), ::core::mem::transmute_copy(&cbinfo)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Cut: Cut::<Identity, Impl, OFFSET>,
             Copy: Copy::<Identity, Impl, OFFSET>,
             Paste: Paste::<Identity, Impl, OFFSET>,
@@ -106,7 +106,7 @@ impl IAVIFile_Vtbl {
             this.DeleteStream(::core::mem::transmute_copy(&fcctype), ::core::mem::transmute_copy(&lparam)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Info: Info::<Identity, Impl, OFFSET>,
             GetStream: GetStream::<Identity, Impl, OFFSET>,
             CreateStream: CreateStream::<Identity, Impl, OFFSET>,
@@ -215,7 +215,7 @@ impl IAVIStream_Vtbl {
             this.SetInfo(::core::mem::transmute_copy(&lpinfo), ::core::mem::transmute_copy(&cbinfo)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Create: Create::<Identity, Impl, OFFSET>,
             Info: Info::<Identity, Impl, OFFSET>,
             FindSample: FindSample::<Identity, Impl, OFFSET>,
@@ -250,7 +250,7 @@ impl IAVIStreaming_Vtbl {
             let this = (*this).get_impl();
             this.End().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Begin: Begin::<Identity, Impl, OFFSET>, End: End::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Begin: Begin::<Identity, Impl, OFFSET>, End: End::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IAVIStreaming as ::windows::core::Interface>::IID
@@ -289,7 +289,7 @@ impl IGetFrame_Vtbl {
             this.SetFormat(::core::mem::transmute_copy(&lpbi), ::core::mem::transmute_copy(&lpbits), ::core::mem::transmute_copy(&x), ::core::mem::transmute_copy(&y), ::core::mem::transmute_copy(&dx), ::core::mem::transmute_copy(&dy)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetFrame: GetFrame::<Identity, Impl, OFFSET>,
             Begin: Begin::<Identity, Impl, OFFSET>,
             End: End::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/Media/Multimedia/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Multimedia/mod.rs
@@ -2044,7 +2044,7 @@ unsafe impl ::windows::core::Interface for IAVIEditStream {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAVIEditStream_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Cut: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, plstart: *mut i32, pllength: *mut i32, ppresult: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Copy: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, plstart: *mut i32, pllength: *mut i32, ppresult: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Paste: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, plpos: *mut i32, pllength: *mut i32, pstream: *mut ::core::ffi::c_void, lstart: i32, lend: i32) -> ::windows::core::HRESULT,
@@ -2120,7 +2120,7 @@ unsafe impl ::windows::core::Interface for IAVIFile {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAVIFile_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Info: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfi: *mut AVIFILEINFOW, lsize: i32) -> ::windows::core::HRESULT,
     pub GetStream: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppstream: *mut *mut ::core::ffi::c_void, fcctype: u32, lparam: i32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -2356,7 +2356,7 @@ unsafe impl ::windows::core::Interface for IAVIStream {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAVIStream_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Create: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lparam1: super::super::Foundation::LPARAM, lparam2: super::super::Foundation::LPARAM) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -2427,7 +2427,7 @@ unsafe impl ::windows::core::Interface for IAVIStreaming {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAVIStreaming_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Begin: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lstart: i32, lend: i32, lrate: i32) -> ::windows::core::HRESULT,
     pub End: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -2488,7 +2488,7 @@ unsafe impl ::windows::core::Interface for IGetFrame {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IGetFrame_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetFrame: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lpos: i32) -> *mut ::core::ffi::c_void,
     pub Begin: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lstart: i32, lend: i32, lrate: i32) -> ::windows::core::HRESULT,
     pub End: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/Media/PictureAcquisition/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/PictureAcquisition/impl.rs
@@ -37,7 +37,7 @@ impl IPhotoAcquire_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreatePhotoSource: CreatePhotoSource::<Identity, Impl, OFFSET>,
             Acquire: Acquire::<Identity, Impl, OFFSET>,
             EnumResults: EnumResults::<Identity, Impl, OFFSET>,
@@ -74,7 +74,7 @@ impl IPhotoAcquireDeviceSelectionDialog_Vtbl {
             this.DoModal(::core::mem::transmute_copy(&hwndparent), ::core::mem::transmute_copy(&dwdeviceflags), ::core::mem::transmute_copy(&pbstrdeviceid), ::core::mem::transmute_copy(&pndevicetype)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetTitle: SetTitle::<Identity, Impl, OFFSET>,
             SetSubmitButtonText: SetSubmitButtonText::<Identity, Impl, OFFSET>,
             DoModal: DoModal::<Identity, Impl, OFFSET>,
@@ -189,7 +189,7 @@ impl IPhotoAcquireItem_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetItemName: GetItemName::<Identity, Impl, OFFSET>,
             GetThumbnail: GetThumbnail::<Identity, Impl, OFFSET>,
             GetProperty: GetProperty::<Identity, Impl, OFFSET>,
@@ -250,7 +250,7 @@ impl IPhotoAcquireOptionsDialog_Vtbl {
             this.SaveData().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             Create: Create::<Identity, Impl, OFFSET>,
             Destroy: Destroy::<Identity, Impl, OFFSET>,
@@ -295,7 +295,7 @@ impl IPhotoAcquirePlugin_Vtbl {
             this.DisplayConfigureDialog(::core::mem::transmute_copy(&hwndparent)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             ProcessItem: ProcessItem::<Identity, Impl, OFFSET>,
             TransferComplete: TransferComplete::<Identity, Impl, OFFSET>,
@@ -447,7 +447,7 @@ impl IPhotoAcquireProgressCB_Vtbl {
             this.GetUserInput(::core::mem::transmute_copy(&riidtype), ::core::mem::transmute(&punknown), ::core::mem::transmute_copy(&ppropvarresult), ::core::mem::transmute_copy(&ppropvardefault)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Cancelled: Cancelled::<Identity, Impl, OFFSET>,
             StartEnumeration: StartEnumeration::<Identity, Impl, OFFSET>,
             FoundItem: FoundItem::<Identity, Impl, OFFSET>,
@@ -596,7 +596,7 @@ impl IPhotoAcquireSettings_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             InitializeFromRegistry: InitializeFromRegistry::<Identity, Impl, OFFSET>,
             SetFlags: SetFlags::<Identity, Impl, OFFSET>,
             SetOutputFilenameTemplate: SetOutputFilenameTemplate::<Identity, Impl, OFFSET>,
@@ -703,7 +703,7 @@ impl IPhotoAcquireSource_Vtbl {
             this.BindToObject(::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppv)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetFriendlyName: GetFriendlyName::<Identity, Impl, OFFSET>,
             GetDeviceIcons: GetDeviceIcons::<Identity, Impl, OFFSET>,
             InitializeItemList: InitializeItemList::<Identity, Impl, OFFSET>,
@@ -732,7 +732,7 @@ impl IPhotoProgressActionCB_Vtbl {
             let this = (*this).get_impl();
             this.DoAction(::core::mem::transmute_copy(&hwndparent)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), DoAction: DoAction::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), DoAction: DoAction::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IPhotoProgressActionCB as ::windows::core::Interface>::IID
@@ -873,7 +873,7 @@ impl IPhotoProgressDialog_Vtbl {
             this.GetUserInput(::core::mem::transmute_copy(&riidtype), ::core::mem::transmute(&punknown), ::core::mem::transmute_copy(&ppropvarresult), ::core::mem::transmute_copy(&ppropvardefault)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Create: Create::<Identity, Impl, OFFSET>,
             GetWindow: GetWindow::<Identity, Impl, OFFSET>,
             Destroy: Destroy::<Identity, Impl, OFFSET>,
@@ -1021,7 +1021,7 @@ impl IUserInputString_Vtbl {
             this.GetImage(::core::mem::transmute_copy(&nsize), ::core::mem::transmute_copy(&phbitmap), ::core::mem::transmute_copy(&phicon)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSubmitButtonText: GetSubmitButtonText::<Identity, Impl, OFFSET>,
             GetPrompt: GetPrompt::<Identity, Impl, OFFSET>,
             GetStringId: GetStringId::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/Media/PictureAcquisition/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/PictureAcquisition/mod.rs
@@ -66,7 +66,7 @@ unsafe impl ::windows::core::Interface for IPhotoAcquire {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPhotoAcquire_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreatePhotoSource: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszdevice: ::windows::core::PCWSTR, ppphotoacquiresource: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub Acquire: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pphotoacquiresource: *mut ::core::ffi::c_void, fshowprogress: super::super::Foundation::BOOL, hwndparent: super::super::Foundation::HWND, pszapplicationname: ::windows::core::PCWSTR, pphotoacquireprogresscb: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -140,7 +140,7 @@ unsafe impl ::windows::core::Interface for IPhotoAcquireDeviceSelectionDialog {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPhotoAcquireDeviceSelectionDialog_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetTitle: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psztitle: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub SetSubmitButtonText: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszsubmitbuttontext: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -235,7 +235,7 @@ unsafe impl ::windows::core::Interface for IPhotoAcquireItem {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPhotoAcquireItem_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetItemName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstritemname: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
     pub GetThumbnail: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sizethumbnail: super::super::Foundation::SIZE, phbmpthumbnail: *mut super::super::Graphics::Gdi::HBITMAP) -> ::windows::core::HRESULT,
@@ -333,7 +333,7 @@ unsafe impl ::windows::core::Interface for IPhotoAcquireOptionsDialog {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPhotoAcquireOptionsDialog_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszregistryroot: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub Create: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hwndparent: super::super::Foundation::HWND, phwnddialog: *mut super::super::Foundation::HWND) -> ::windows::core::HRESULT,
@@ -418,7 +418,7 @@ unsafe impl ::windows::core::Interface for IPhotoAcquirePlugin {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPhotoAcquirePlugin_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pphotoacquiresource: *mut ::core::ffi::c_void, pphotoacquireprogresscb: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Shell_PropertiesSystem"))]
     pub ProcessItem: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwacquirestage: u32, pphotoacquireitem: *mut ::core::ffi::c_void, poriginalitemstream: *mut ::core::ffi::c_void, pszfinalfilename: ::windows::core::PCWSTR, ppropertystore: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -577,7 +577,7 @@ unsafe impl ::windows::core::Interface for IPhotoAcquireProgressCB {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPhotoAcquireProgressCB_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Cancelled: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfcancelled: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -718,7 +718,7 @@ unsafe impl ::windows::core::Interface for IPhotoAcquireSettings {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPhotoAcquireSettings_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub InitializeFromRegistry: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszregistrykey: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub SetFlags: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwphotoacquireflags: u32) -> ::windows::core::HRESULT,
     pub SetOutputFilenameTemplate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psztemplate: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
@@ -825,7 +825,7 @@ unsafe impl ::windows::core::Interface for IPhotoAcquireSource {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPhotoAcquireSource_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetFriendlyName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstrfriendlyname: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
     pub GetDeviceIcons: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, nsize: u32, phlargeicon: *mut super::super::UI::WindowsAndMessaging::HICON, phsmallicon: *mut super::super::UI::WindowsAndMessaging::HICON) -> ::windows::core::HRESULT,
@@ -892,7 +892,7 @@ unsafe impl ::windows::core::Interface for IPhotoProgressActionCB {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPhotoProgressActionCB_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub DoAction: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hwndparent: super::super::Foundation::HWND) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -1056,7 +1056,7 @@ unsafe impl ::windows::core::Interface for IPhotoProgressDialog {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPhotoProgressDialog_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Create: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hwndparent: super::super::Foundation::HWND) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -1187,7 +1187,7 @@ unsafe impl ::windows::core::Interface for IUserInputString {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUserInputString_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetSubmitButtonText: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstrsubmitbuttontext: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub GetPrompt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstrprompttitle: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub GetStringId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstrstringid: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/Media/Speech/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Speech/impl.rs
@@ -52,7 +52,7 @@ impl IEnumSpObjectTokens_Vtbl {
             this.GetCount(::core::mem::transmute_copy(&pcount)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -283,7 +283,7 @@ impl ISpDataKey_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetData: SetData::<Identity, Impl, OFFSET>,
             GetData: GetData::<Identity, Impl, OFFSET>,
             SetStringValue: SetStringValue::<Identity, Impl, OFFSET>,
@@ -320,7 +320,7 @@ impl ISpDisplayAlternates_Vtbl {
             this.SetFullStopTrailSpace(::core::mem::transmute_copy(&ultrailspace)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDisplayAlternates: GetDisplayAlternates::<Identity, Impl, OFFSET>,
             SetFullStopTrailSpace: SetFullStopTrailSpace::<Identity, Impl, OFFSET>,
         }
@@ -347,7 +347,7 @@ impl ISpEnginePronunciation_Vtbl {
             this.GetPronunciations(::core::mem::transmute(&pszword), ::core::mem::transmute(&pszleftcontext), ::core::mem::transmute(&pszrightcontext), ::core::mem::transmute_copy(&langid), ::core::mem::transmute_copy(&penginepronunciationlist)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Normalize: Normalize::<Identity, Impl, OFFSET>,
             GetPronunciations: GetPronunciations::<Identity, Impl, OFFSET>,
         }
@@ -377,7 +377,7 @@ impl ISpEventSink_Vtbl {
             this.GetEventInterest(::core::mem::transmute_copy(&pulleventinterest)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddEvents: AddEvents::<Identity, Impl, OFFSET>,
             GetEventInterest: GetEventInterest::<Identity, Impl, OFFSET>,
         }
@@ -500,7 +500,7 @@ impl ISpGrammarBuilder_Vtbl {
             this.Commit(::core::mem::transmute_copy(&dwreserved)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ResetGrammar: ResetGrammar::<Identity, Impl, OFFSET>,
             GetRule: GetRule::<Identity, Impl, OFFSET>,
             ClearRule: ClearRule::<Identity, Impl, OFFSET>,
@@ -533,7 +533,7 @@ impl ISpGrammarBuilder2_Vtbl {
             this.SetPhoneticAlphabet(::core::mem::transmute_copy(&phoneticalphabet)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddTextSubset: AddTextSubset::<Identity, Impl, OFFSET>,
             SetPhoneticAlphabet: SetPhoneticAlphabet::<Identity, Impl, OFFSET>,
         }
@@ -584,7 +584,7 @@ impl ISpLexicon_Vtbl {
             this.GetWords(::core::mem::transmute_copy(&dwflags), ::core::mem::transmute_copy(&pdwgeneration), ::core::mem::transmute_copy(&pdwcookie), ::core::mem::transmute_copy(&pwordlist)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetPronunciations: GetPronunciations::<Identity, Impl, OFFSET>,
             AddPronunciation: AddPronunciation::<Identity, Impl, OFFSET>,
             RemovePronunciation: RemovePronunciation::<Identity, Impl, OFFSET>,
@@ -679,7 +679,7 @@ impl ISpNotifySink_Vtbl {
             let this = (*this).get_impl();
             this.Notify().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Notify: Notify::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Notify: Notify::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ISpNotifySink as ::windows::core::Interface>::IID
@@ -736,7 +736,7 @@ impl ISpNotifySource_Vtbl {
             this.GetNotifyEventHandle()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetNotifySink: SetNotifySink::<Identity, Impl, OFFSET>,
             SetNotifyWindowMessage: SetNotifyWindowMessage::<Identity, Impl, OFFSET>,
             SetNotifyCallbackFunction: SetNotifyCallbackFunction::<Identity, Impl, OFFSET>,
@@ -1038,7 +1038,7 @@ impl ISpObjectWithToken_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetObjectToken: SetObjectToken::<Identity, Impl, OFFSET>,
             GetObjectToken: GetObjectToken::<Identity, Impl, OFFSET>,
         }
@@ -1131,7 +1131,7 @@ impl ISpPhoneticAlphabetConverter_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetLangId: GetLangId::<Identity, Impl, OFFSET>,
             SetLangId: SetLangId::<Identity, Impl, OFFSET>,
             SAPI2UPS: SAPI2UPS::<Identity, Impl, OFFSET>,
@@ -1170,7 +1170,7 @@ impl ISpPhoneticAlphabetSelection_Vtbl {
             this.SetAlphabetToUPS(::core::mem::transmute_copy(&fforceups)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             IsAlphabetUPS: IsAlphabetUPS::<Identity, Impl, OFFSET>,
             SetAlphabetToUPS: SetAlphabetToUPS::<Identity, Impl, OFFSET>,
         }
@@ -1224,7 +1224,7 @@ impl ISpPhrase_Vtbl {
             this.Discard(::core::mem::transmute_copy(&dwvaluetypes)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetPhrase: GetPhrase::<Identity, Impl, OFFSET>,
             GetSerializedPhrase: GetSerializedPhrase::<Identity, Impl, OFFSET>,
             GetText: GetText::<Identity, Impl, OFFSET>,
@@ -1344,7 +1344,7 @@ impl ISpProperties_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetPropertyNum: SetPropertyNum::<Identity, Impl, OFFSET>,
             GetPropertyNum: GetPropertyNum::<Identity, Impl, OFFSET>,
             SetPropertyString: SetPropertyString::<Identity, Impl, OFFSET>,
@@ -1545,7 +1545,7 @@ impl ISpRecoContext2_Vtbl {
             this.SetAdaptationData2(::core::mem::transmute(&padaptationdata), ::core::mem::transmute_copy(&cch), ::core::mem::transmute(&ptopicname), ::core::mem::transmute_copy(&eadaptationsettings), ::core::mem::transmute_copy(&erelevance)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetGrammarOptions: SetGrammarOptions::<Identity, Impl, OFFSET>,
             GetGrammarOptions: GetGrammarOptions::<Identity, Impl, OFFSET>,
             SetAdaptationData2: SetAdaptationData2::<Identity, Impl, OFFSET>,
@@ -1766,7 +1766,7 @@ impl ISpRecoGrammar2_Vtbl {
             this.SetSMLSecurityManager(::core::mem::transmute(&psmlsecuritymanager)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetRules: GetRules::<Identity, Impl, OFFSET>,
             LoadCmdFromFile2: LoadCmdFromFile2::<Identity, Impl, OFFSET>,
             LoadCmdFromMemory2: LoadCmdFromMemory2::<Identity, Impl, OFFSET>,
@@ -2086,7 +2086,7 @@ impl ISpRecognizer2_Vtbl {
             this.ResetAcousticModelAdaptation().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             EmulateRecognitionEx: EmulateRecognitionEx::<Identity, Impl, OFFSET>,
             SetTrainingState: SetTrainingState::<Identity, Impl, OFFSET>,
             ResetAcousticModelAdaptation: ResetAcousticModelAdaptation::<Identity, Impl, OFFSET>,
@@ -2164,7 +2164,7 @@ impl ISpSerializeState_Vtbl {
             this.SetSerializedState(::core::mem::transmute_copy(&pbdata), ::core::mem::transmute_copy(&ulsize), ::core::mem::transmute_copy(&dwreserved)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSerializedState: GetSerializedState::<Identity, Impl, OFFSET>,
             SetSerializedState: SetSerializedState::<Identity, Impl, OFFSET>,
         }
@@ -2233,7 +2233,7 @@ impl ISpShortcut_Vtbl {
             this.GetGenerationChange(::core::mem::transmute_copy(&pdwgeneration), ::core::mem::transmute_copy(&pshortcutpairlist)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddShortcut: AddShortcut::<Identity, Impl, OFFSET>,
             RemoveShortcut: RemoveShortcut::<Identity, Impl, OFFSET>,
             GetShortcuts: GetShortcuts::<Identity, Impl, OFFSET>,
@@ -2424,7 +2424,7 @@ impl ISpTranscript_Vtbl {
             this.AppendTranscript(::core::mem::transmute(&psztranscript)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTranscript: GetTranscript::<Identity, Impl, OFFSET>,
             AppendTranscript: AppendTranscript::<Identity, Impl, OFFSET>,
         }

--- a/crates/libs/windows/src/Windows/Win32/Media/Speech/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Speech/mod.rs
@@ -61,7 +61,7 @@ unsafe impl ::windows::core::Interface for IEnumSpObjectTokens {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumSpObjectTokens_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, pelt: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -513,7 +513,7 @@ unsafe impl ::windows::core::Interface for ISpDataKey {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISpDataKey_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszvaluename: ::windows::core::PCWSTR, cbdata: u32, pdata: *const u8) -> ::windows::core::HRESULT,
     pub GetData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszvaluename: ::windows::core::PCWSTR, pcbdata: *mut u32, pdata: *mut u8) -> ::windows::core::HRESULT,
     pub SetStringValue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszvaluename: ::windows::core::PCWSTR, pszvalue: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
@@ -576,7 +576,7 @@ unsafe impl ::windows::core::Interface for ISpDisplayAlternates {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISpDisplayAlternates_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDisplayAlternates: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pphrase: *const SPDISPLAYPHRASE, crequestcount: u32, ppcomemphrases: *mut *mut SPDISPLAYPHRASE, pcphrasesreturned: *mut u32) -> ::windows::core::HRESULT,
     pub SetFullStopTrailSpace: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ultrailspace: u32) -> ::windows::core::HRESULT,
 }
@@ -639,7 +639,7 @@ unsafe impl ::windows::core::Interface for ISpEnginePronunciation {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISpEnginePronunciation_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Normalize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszword: ::windows::core::PCWSTR, pszleftcontext: ::windows::core::PCWSTR, pszrightcontext: ::windows::core::PCWSTR, langid: u16, pnormalizationlist: *mut SPNORMALIZATIONLIST) -> ::windows::core::HRESULT,
     pub GetPronunciations: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszword: ::windows::core::PCWSTR, pszleftcontext: ::windows::core::PCWSTR, pszrightcontext: ::windows::core::PCWSTR, langid: u16, penginepronunciationlist: *mut SPWORDPRONUNCIATIONLIST) -> ::windows::core::HRESULT,
 }
@@ -694,7 +694,7 @@ unsafe impl ::windows::core::Interface for ISpEventSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISpEventSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub AddEvents: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, peventarray: *const SPEVENT, ulcount: u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -1050,7 +1050,7 @@ unsafe impl ::windows::core::Interface for ISpGrammarBuilder {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISpGrammarBuilder_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ResetGrammar: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, newlanguage: u16) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub GetRule: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszrulename: ::windows::core::PCWSTR, dwruleid: u32, dwattributes: u32, fcreateifnotexist: super::super::Foundation::BOOL, phinitialstate: *mut *mut SPSTATEHANDLE__) -> ::windows::core::HRESULT,
@@ -1121,7 +1121,7 @@ unsafe impl ::windows::core::Interface for ISpGrammarBuilder2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISpGrammarBuilder2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddTextSubset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hfromstate: *mut SPSTATEHANDLE__, htostate: *mut SPSTATEHANDLE__, psz: ::windows::core::PCWSTR, ematchmode: SPMATCHINGMODE) -> ::windows::core::HRESULT,
     pub SetPhoneticAlphabet: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, phoneticalphabet: PHONETICALPHABET) -> ::windows::core::HRESULT,
 }
@@ -1195,7 +1195,7 @@ unsafe impl ::windows::core::Interface for ISpLexicon {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISpLexicon_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetPronunciations: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszword: ::windows::core::PCWSTR, langid: u16, dwflags: u32, pwordpronunciationlist: *mut SPWORDPRONUNCIATIONLIST) -> ::windows::core::HRESULT,
     pub AddPronunciation: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszword: ::windows::core::PCWSTR, langid: u16, epartofspeech: SPPARTOFSPEECH, pszpronunciation: *const u16) -> ::windows::core::HRESULT,
     pub RemovePronunciation: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszword: ::windows::core::PCWSTR, langid: u16, epartofspeech: SPPARTOFSPEECH, pszpronunciation: *const u16) -> ::windows::core::HRESULT,
@@ -1544,7 +1544,7 @@ unsafe impl ::windows::core::Interface for ISpNotifySink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISpNotifySink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Notify: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_Speech\"`*"]
@@ -1636,7 +1636,7 @@ unsafe impl ::windows::core::Interface for ISpNotifySource {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISpNotifySource_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetNotifySink: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pnotifysink: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub SetNotifyWindowMessage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hwnd: super::super::Foundation::HWND, msg: u32, wparam: super::super::Foundation::WPARAM, lparam: super::super::Foundation::LPARAM) -> ::windows::core::HRESULT,
@@ -2473,7 +2473,7 @@ unsafe impl ::windows::core::Interface for ISpObjectWithToken {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISpObjectWithToken_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetObjectToken: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptoken: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetObjectToken: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pptoken: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -2624,7 +2624,7 @@ unsafe impl ::windows::core::Interface for ISpPhoneticAlphabetConverter {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISpPhoneticAlphabetConverter_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetLangId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, plangid: *mut u16) -> ::windows::core::HRESULT,
     pub SetLangId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, langid: u16) -> ::windows::core::HRESULT,
     pub SAPI2UPS: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszsapiid: *const u16, pszupsid: *mut u16, cmaxlength: u32) -> ::windows::core::HRESULT,
@@ -2691,7 +2691,7 @@ unsafe impl ::windows::core::Interface for ISpPhoneticAlphabetSelection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISpPhoneticAlphabetSelection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub IsAlphabetUPS: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfisups: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -2765,7 +2765,7 @@ unsafe impl ::windows::core::Interface for ISpPhrase {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISpPhrase_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub GetPhrase: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppcomemphrase: *mut *mut SPPHRASE) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole")))]
@@ -3034,7 +3034,7 @@ unsafe impl ::windows::core::Interface for ISpProperties {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISpProperties_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetPropertyNum: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pname: ::windows::core::PCWSTR, lvalue: i32) -> ::windows::core::HRESULT,
     pub GetPropertyNum: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pname: ::windows::core::PCWSTR, plvalue: *mut i32) -> ::windows::core::HRESULT,
     pub SetPropertyString: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pname: ::windows::core::PCWSTR, pvalue: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
@@ -3334,7 +3334,7 @@ unsafe impl ::windows::core::Interface for ISpRecoContext2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISpRecoContext2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetGrammarOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, egrammaroptions: u32) -> ::windows::core::HRESULT,
     pub GetGrammarOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pegrammaroptions: *mut u32) -> ::windows::core::HRESULT,
     pub SetAdaptationData2: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, padaptationdata: ::windows::core::PCWSTR, cch: u32, ptopicname: ::windows::core::PCWSTR, eadaptationsettings: u32, erelevance: SPADAPTATIONRELEVANCE) -> ::windows::core::HRESULT,
@@ -3643,7 +3643,7 @@ unsafe impl ::windows::core::Interface for ISpRecoGrammar2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISpRecoGrammar2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetRules: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppcomemrules: *mut *mut SPRULE, punumrules: *mut u32) -> ::windows::core::HRESULT,
     pub LoadCmdFromFile2: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszfilename: ::windows::core::PCWSTR, options: SPLOADOPTIONS, pszsharinguri: ::windows::core::PCWSTR, pszbaseuri: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub LoadCmdFromMemory2: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pgrammar: *const SPBINARYGRAMMAR, options: SPLOADOPTIONS, pszsharinguri: ::windows::core::PCWSTR, pszbaseuri: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
@@ -4200,7 +4200,7 @@ unsafe impl ::windows::core::Interface for ISpRecognizer2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISpRecognizer2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub EmulateRecognitionEx: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pphrase: *mut ::core::ffi::c_void, dwcompareflags: u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub SetTrainingState: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fdoingtraining: super::super::Foundation::BOOL, fadaptfromtrainingdata: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -4500,7 +4500,7 @@ unsafe impl ::windows::core::Interface for ISpSerializeState {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISpSerializeState_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetSerializedState: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppbdata: *mut *mut u8, pulsize: *mut u32, dwreserved: u32) -> ::windows::core::HRESULT,
     pub SetSerializedState: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbdata: *const u8, ulsize: u32, dwreserved: u32) -> ::windows::core::HRESULT,
 }
@@ -4580,7 +4580,7 @@ unsafe impl ::windows::core::Interface for ISpShortcut {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISpShortcut_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddShortcut: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszdisplay: ::windows::core::PCWSTR, langid: u16, pszspoken: ::windows::core::PCWSTR, shtype: SPSHORTCUTTYPE) -> ::windows::core::HRESULT,
     pub RemoveShortcut: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszdisplay: ::windows::core::PCWSTR, langid: u16, pszspoken: ::windows::core::PCWSTR, shtype: SPSHORTCUTTYPE) -> ::windows::core::HRESULT,
     pub GetShortcuts: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, langid: u16, pshortcutpairlist: *mut SPSHORTCUTPAIRLIST) -> ::windows::core::HRESULT,
@@ -5242,7 +5242,7 @@ unsafe impl ::windows::core::Interface for ISpTranscript {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISpTranscript_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetTranscript: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppsztranscript: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub AppendTranscript: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psztranscript: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
 }

--- a/crates/libs/windows/src/Windows/Win32/Media/WindowsMediaFormat/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/WindowsMediaFormat/impl.rs
@@ -79,7 +79,7 @@ impl INSNetSourceCreator_Vtbl {
             this.Shutdown().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             CreateNetSource: CreateNetSource::<Identity, Impl, OFFSET>,
             GetNetSourceProperties: GetNetSourceProperties::<Identity, Impl, OFFSET>,
@@ -148,7 +148,7 @@ impl INSSBuffer_Vtbl {
             this.GetBufferAndLength(::core::mem::transmute_copy(&ppdwbuffer), ::core::mem::transmute_copy(&pdwlength)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetLength: GetLength::<Identity, Impl, OFFSET>,
             SetLength: SetLength::<Identity, Impl, OFFSET>,
             GetMaxLength: GetMaxLength::<Identity, Impl, OFFSET>,
@@ -295,7 +295,7 @@ impl IWMAddressAccess_Vtbl {
             this.RemoveAccessEntry(::core::mem::transmute_copy(&aetype), ::core::mem::transmute_copy(&dwentrynum)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetAccessEntryCount: GetAccessEntryCount::<Identity, Impl, OFFSET>,
             GetAccessEntry: GetAccessEntry::<Identity, Impl, OFFSET>,
             AddAccessEntry: AddAccessEntry::<Identity, Impl, OFFSET>,
@@ -375,7 +375,7 @@ impl IWMAuthorizer_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCertCount: GetCertCount::<Identity, Impl, OFFSET>,
             GetCert: GetCert::<Identity, Impl, OFFSET>,
             GetSharedData: GetSharedData::<Identity, Impl, OFFSET>,
@@ -433,7 +433,7 @@ impl IWMBackupRestoreProps_Vtbl {
             this.RemoveAllProps().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetPropCount: GetPropCount::<Identity, Impl, OFFSET>,
             GetPropByIndex: GetPropByIndex::<Identity, Impl, OFFSET>,
             GetPropByName: GetPropByName::<Identity, Impl, OFFSET>,
@@ -523,7 +523,7 @@ impl IWMClientConnections_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetClientCount: GetClientCount::<Identity, Impl, OFFSET>,
             GetClientProperties: GetClientProperties::<Identity, Impl, OFFSET>,
         }
@@ -591,7 +591,7 @@ impl IWMCodecInfo_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCodecInfoCount: GetCodecInfoCount::<Identity, Impl, OFFSET>,
             GetCodecFormatCount: GetCodecFormatCount::<Identity, Impl, OFFSET>,
             GetCodecFormat: GetCodecFormat::<Identity, Impl, OFFSET>,
@@ -680,7 +680,7 @@ impl IWMCredentialCallback_Vtbl {
             let this = (*this).get_impl();
             this.AcquireCredentials(::core::mem::transmute(&pwszrealm), ::core::mem::transmute(&pwszsite), ::core::mem::transmute_copy(&pwszuser), ::core::mem::transmute_copy(&cchuser), ::core::mem::transmute_copy(&pwszpassword), ::core::mem::transmute_copy(&cchpassword), ::core::mem::transmute_copy(&hrstatus), ::core::mem::transmute_copy(&pdwflags)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), AcquireCredentials: AcquireCredentials::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), AcquireCredentials: AcquireCredentials::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWMCredentialCallback as ::windows::core::Interface>::IID
@@ -697,7 +697,7 @@ impl IWMDRMEditor_Vtbl {
             let this = (*this).get_impl();
             this.GetDRMProperty(::core::mem::transmute(&pwstrname), ::core::mem::transmute_copy(&pdwtype), ::core::mem::transmute_copy(&pvalue), ::core::mem::transmute_copy(&pcblength)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetDRMProperty: GetDRMProperty::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetDRMProperty: GetDRMProperty::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWMDRMEditor as ::windows::core::Interface>::IID
@@ -721,7 +721,7 @@ impl IWMDRMMessageParser_Vtbl {
             this.ParseLicenseRequestMsg(::core::mem::transmute_copy(&pblicenserequestmsg), ::core::mem::transmute_copy(&cblicenserequestmsg), ::core::mem::transmute_copy(&ppdevicecert), ::core::mem::transmute_copy(&pdeviceserialnumber), ::core::mem::transmute_copy(&pbstraction)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ParseRegistrationReqMsg: ParseRegistrationReqMsg::<Identity, Impl, OFFSET>,
             ParseLicenseRequestMsg: ParseLicenseRequestMsg::<Identity, Impl, OFFSET>,
         }
@@ -784,7 +784,7 @@ impl IWMDRMReader_Vtbl {
             this.GetDRMProperty(::core::mem::transmute(&pwstrname), ::core::mem::transmute_copy(&pdwtype), ::core::mem::transmute_copy(&pvalue), ::core::mem::transmute_copy(&pcblength)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AcquireLicense: AcquireLicense::<Identity, Impl, OFFSET>,
             CancelLicenseAcquisition: CancelLicenseAcquisition::<Identity, Impl, OFFSET>,
             Individualize: Individualize::<Identity, Impl, OFFSET>,
@@ -880,7 +880,7 @@ impl IWMDRMTranscryptionManager_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CreateTranscryptor: CreateTranscryptor::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CreateTranscryptor: CreateTranscryptor::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWMDRMTranscryptionManager as ::windows::core::Interface>::IID
@@ -916,7 +916,7 @@ impl IWMDRMTranscryptor_Vtbl {
             this.Close().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             Seek: Seek::<Identity, Impl, OFFSET>,
             Read: Read::<Identity, Impl, OFFSET>,
@@ -1013,7 +1013,7 @@ impl IWMDRMWriter_Vtbl {
             this.SetDRMAttribute(::core::mem::transmute_copy(&wstreamnum), ::core::mem::transmute(&pszname), ::core::mem::transmute_copy(&r#type), ::core::mem::transmute_copy(&pvalue), ::core::mem::transmute_copy(&cblength)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GenerateKeySeed: GenerateKeySeed::<Identity, Impl, OFFSET>,
             GenerateKeyID: GenerateKeyID::<Identity, Impl, OFFSET>,
             GenerateSigningKeyPair: GenerateSigningKeyPair::<Identity, Impl, OFFSET>,
@@ -1136,7 +1136,7 @@ impl IWMDeviceRegistration_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RegisterDevice: RegisterDevice::<Identity, Impl, OFFSET>,
             UnregisterDevice: UnregisterDevice::<Identity, Impl, OFFSET>,
             GetRegistrationStats: GetRegistrationStats::<Identity, Impl, OFFSET>,
@@ -1167,7 +1167,7 @@ impl IWMGetSecureChannel_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetPeerSecureChannelInterface: GetPeerSecureChannelInterface::<Identity, Impl, OFFSET>,
         }
     }
@@ -1271,7 +1271,7 @@ impl IWMHeaderInfo_Vtbl {
             this.RemoveScript(::core::mem::transmute_copy(&windex)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetAttributeCount: GetAttributeCount::<Identity, Impl, OFFSET>,
             GetAttributeByIndex: GetAttributeByIndex::<Identity, Impl, OFFSET>,
             GetAttributeByName: GetAttributeByName::<Identity, Impl, OFFSET>,
@@ -1402,7 +1402,7 @@ impl IWMIStreamProps_Vtbl {
             let this = (*this).get_impl();
             this.GetProperty(::core::mem::transmute(&pszname), ::core::mem::transmute_copy(&ptype), ::core::mem::transmute_copy(&pvalue), ::core::mem::transmute_copy(&pdwsize)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetProperty: GetProperty::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetProperty: GetProperty::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWMIStreamProps as ::windows::core::Interface>::IID
@@ -1432,7 +1432,7 @@ impl IWMImageInfo_Vtbl {
             this.GetImage(::core::mem::transmute_copy(&windex), ::core::mem::transmute_copy(&pcchmimetype), ::core::mem::transmute_copy(&pwszmimetype), ::core::mem::transmute_copy(&pcchdescription), ::core::mem::transmute_copy(&pwszdescription), ::core::mem::transmute_copy(&pimagetype), ::core::mem::transmute_copy(&pcbimagedata), ::core::mem::transmute_copy(&pbimagedata)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetImageCount: GetImageCount::<Identity, Impl, OFFSET>,
             GetImage: GetImage::<Identity, Impl, OFFSET>,
         }
@@ -1459,7 +1459,7 @@ impl IWMIndexer_Vtbl {
             this.Cancel().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             StartIndexing: StartIndexing::<Identity, Impl, OFFSET>,
             Cancel: Cancel::<Identity, Impl, OFFSET>,
         }
@@ -1551,7 +1551,7 @@ impl IWMLanguageList_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetLanguageCount: GetLanguageCount::<Identity, Impl, OFFSET>,
             GetLanguageDetails: GetLanguageDetails::<Identity, Impl, OFFSET>,
             AddLanguageByRFC1766String: AddLanguageByRFC1766String::<Identity, Impl, OFFSET>,
@@ -1579,7 +1579,7 @@ impl IWMLicenseBackup_Vtbl {
             this.CancelLicenseBackup().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             BackupLicenses: BackupLicenses::<Identity, Impl, OFFSET>,
             CancelLicenseBackup: CancelLicenseBackup::<Identity, Impl, OFFSET>,
         }
@@ -1606,7 +1606,7 @@ impl IWMLicenseRestore_Vtbl {
             this.CancelLicenseRestore().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RestoreLicenses: RestoreLicenses::<Identity, Impl, OFFSET>,
             CancelLicenseRestore: CancelLicenseRestore::<Identity, Impl, OFFSET>,
         }
@@ -1633,7 +1633,7 @@ impl IWMLicenseRevocationAgent_Vtbl {
             this.ProcessLRB(::core::mem::transmute_copy(&psignedlrb), ::core::mem::transmute_copy(&dwsignedlrblength), ::core::mem::transmute_copy(&psignedack), ::core::mem::transmute_copy(&pdwsignedacklength)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetLRBChallenge: GetLRBChallenge::<Identity, Impl, OFFSET>,
             ProcessLRB: ProcessLRB::<Identity, Impl, OFFSET>,
         }
@@ -1675,7 +1675,7 @@ impl IWMMediaProps_Vtbl {
             this.SetMediaType(::core::mem::transmute_copy(&ptype)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetType: GetType::<Identity, Impl, OFFSET>,
             GetMediaType: GetMediaType::<Identity, Impl, OFFSET>,
             SetMediaType: SetMediaType::<Identity, Impl, OFFSET>,
@@ -1709,7 +1709,7 @@ impl IWMMetadataEditor_Vtbl {
             this.Flush().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Open: Open::<Identity, Impl, OFFSET>,
             Close: Close::<Identity, Impl, OFFSET>,
             Flush: Flush::<Identity, Impl, OFFSET>,
@@ -1912,7 +1912,7 @@ impl IWMPacketSize_Vtbl {
             this.SetMaxPacketSize(::core::mem::transmute_copy(&dwmaxpacketsize)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetMaxPacketSize: GetMaxPacketSize::<Identity, Impl, OFFSET>,
             SetMaxPacketSize: SetMaxPacketSize::<Identity, Impl, OFFSET>,
         }
@@ -1965,7 +1965,7 @@ impl IWMPlayerHook_Vtbl {
             let this = (*this).get_impl();
             this.PreDecode().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), PreDecode: PreDecode::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), PreDecode: PreDecode::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWMPlayerHook as ::windows::core::Interface>::IID
@@ -1988,7 +1988,7 @@ impl IWMPlayerTimestampHook_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), MapTimestamp: MapTimestamp::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), MapTimestamp: MapTimestamp::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWMPlayerTimestampHook as ::windows::core::Interface>::IID
@@ -2156,7 +2156,7 @@ impl IWMProfile_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetVersion: GetVersion::<Identity, Impl, OFFSET>,
             GetName: GetName::<Identity, Impl, OFFSET>,
             SetName: SetName::<Identity, Impl, OFFSET>,
@@ -2415,7 +2415,7 @@ impl IWMProfileManager_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateEmptyProfile: CreateEmptyProfile::<Identity, Impl, OFFSET>,
             LoadProfileByID: LoadProfileByID::<Identity, Impl, OFFSET>,
             LoadProfileByData: LoadProfileByData::<Identity, Impl, OFFSET>,
@@ -2473,7 +2473,7 @@ impl IWMProfileManagerLanguage_Vtbl {
             this.SetUserLanguageID(::core::mem::transmute_copy(&wlangid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetUserLanguageID: GetUserLanguageID::<Identity, Impl, OFFSET>,
             SetUserLanguageID: SetUserLanguageID::<Identity, Impl, OFFSET>,
         }
@@ -2524,7 +2524,7 @@ impl IWMPropertyVault_Vtbl {
             this.Clear().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetPropertyCount: GetPropertyCount::<Identity, Impl, OFFSET>,
             GetPropertyByName: GetPropertyByName::<Identity, Impl, OFFSET>,
             SetProperty: SetProperty::<Identity, Impl, OFFSET>,
@@ -2548,7 +2548,7 @@ impl IWMProximityDetection_Vtbl {
             let this = (*this).get_impl();
             this.StartDetection(::core::mem::transmute_copy(&pbregistrationmsg), ::core::mem::transmute_copy(&cbregistrationmsg), ::core::mem::transmute_copy(&pblocaladdress), ::core::mem::transmute_copy(&cblocaladdress), ::core::mem::transmute_copy(&dwextraportsallowed), ::core::mem::transmute_copy(&ppregistrationresponsemsg), ::core::mem::transmute(&pcallback), ::core::mem::transmute_copy(&pvcontext)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), StartDetection: StartDetection::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), StartDetection: StartDetection::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWMProximityDetection as ::windows::core::Interface>::IID
@@ -2650,7 +2650,7 @@ impl IWMReader_Vtbl {
             this.Resume().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Open: Open::<Identity, Impl, OFFSET>,
             Close: Close::<Identity, Impl, OFFSET>,
             GetOutputCount: GetOutputCount::<Identity, Impl, OFFSET>,
@@ -2689,7 +2689,7 @@ impl IWMReaderAccelerator_Vtbl {
             this.Notify(::core::mem::transmute_copy(&dwoutputnum), ::core::mem::transmute_copy(&psubtype)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCodecInterface: GetCodecInterface::<Identity, Impl, OFFSET>,
             Notify: Notify::<Identity, Impl, OFFSET>,
         }
@@ -2881,7 +2881,7 @@ impl IWMReaderAdvanced_Vtbl {
             this.NotifyLateDelivery(::core::mem::transmute_copy(&cnslateness)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetUserProvidedClock: SetUserProvidedClock::<Identity, Impl, OFFSET>,
             GetUserProvidedClock: GetUserProvidedClock::<Identity, Impl, OFFSET>,
             DeliverTime: DeliverTime::<Identity, Impl, OFFSET>,
@@ -3238,7 +3238,7 @@ impl IWMReaderAllocatorEx_Vtbl {
             this.AllocateForOutputEx(::core::mem::transmute_copy(&dwoutputnum), ::core::mem::transmute_copy(&cbbuffer), ::core::mem::transmute_copy(&ppbuffer), ::core::mem::transmute_copy(&dwflags), ::core::mem::transmute_copy(&cnssampletime), ::core::mem::transmute_copy(&cnssampleduration), ::core::mem::transmute_copy(&pvcontext)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AllocateForStreamEx: AllocateForStreamEx::<Identity, Impl, OFFSET>,
             AllocateForOutputEx: AllocateForOutputEx::<Identity, Impl, OFFSET>,
         }
@@ -3309,7 +3309,7 @@ impl IWMReaderCallbackAdvanced_Vtbl {
             this.AllocateForOutput(::core::mem::transmute_copy(&dwoutputnum), ::core::mem::transmute_copy(&cbbuffer), ::core::mem::transmute_copy(&ppbuffer), ::core::mem::transmute_copy(&pvcontext)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnStreamSample: OnStreamSample::<Identity, Impl, OFFSET>,
             OnTime: OnTime::<Identity, Impl, OFFSET>,
             OnStreamSelection: OnStreamSelection::<Identity, Impl, OFFSET>,
@@ -3601,7 +3601,7 @@ impl IWMReaderNetworkConfig_Vtbl {
             this.ResetLoggingUrlList().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetBufferingTime: GetBufferingTime::<Identity, Impl, OFFSET>,
             SetBufferingTime: SetBufferingTime::<Identity, Impl, OFFSET>,
             GetUDPPortRanges: GetUDPPortRanges::<Identity, Impl, OFFSET>,
@@ -3826,7 +3826,7 @@ impl IWMReaderPlaylistBurn_Vtbl {
             this.EndPlaylistBurn(::core::mem::transmute_copy(&hrburnresult)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             InitPlaylistBurn: InitPlaylistBurn::<Identity, Impl, OFFSET>,
             GetInitResults: GetInitResults::<Identity, Impl, OFFSET>,
             Cancel: Cancel::<Identity, Impl, OFFSET>,
@@ -3867,7 +3867,7 @@ impl IWMReaderStreamClock_Vtbl {
             this.KillTimer(::core::mem::transmute_copy(&dwtimerid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTime: GetTime::<Identity, Impl, OFFSET>,
             SetTimer: SetTimer::<Identity, Impl, OFFSET>,
             KillTimer: KillTimer::<Identity, Impl, OFFSET>,
@@ -3901,7 +3901,7 @@ impl IWMReaderTimecode_Vtbl {
             this.GetTimecodeRangeBounds(::core::mem::transmute_copy(&wstreamnum), ::core::mem::transmute_copy(&wrangenum), ::core::mem::transmute_copy(&pstarttimecode), ::core::mem::transmute_copy(&pendtimecode)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTimecodeRangeCount: GetTimecodeRangeCount::<Identity, Impl, OFFSET>,
             GetTimecodeRangeBounds: GetTimecodeRangeBounds::<Identity, Impl, OFFSET>,
         }
@@ -3921,7 +3921,7 @@ impl IWMReaderTypeNegotiation_Vtbl {
             let this = (*this).get_impl();
             this.TryOutputProps(::core::mem::transmute_copy(&dwoutputnum), ::core::mem::transmute(&poutput)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), TryOutputProps: TryOutputProps::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), TryOutputProps: TryOutputProps::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWMReaderTypeNegotiation as ::windows::core::Interface>::IID
@@ -3945,7 +3945,7 @@ impl IWMRegisterCallback_Vtbl {
             this.Unadvise(::core::mem::transmute(&pcallback), ::core::mem::transmute_copy(&pvcontext)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Advise: Advise::<Identity, Impl, OFFSET>,
             Unadvise: Unadvise::<Identity, Impl, OFFSET>,
         }
@@ -4101,7 +4101,7 @@ impl IWMRegisteredDevice_Vtbl {
             this.Close().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDeviceSerialNumber: GetDeviceSerialNumber::<Identity, Impl, OFFSET>,
             GetDeviceCertificate: GetDeviceCertificate::<Identity, Impl, OFFSET>,
             GetDeviceType: GetDeviceType::<Identity, Impl, OFFSET>,
@@ -4152,7 +4152,7 @@ impl IWMSBufferAllocator_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AllocateBuffer: AllocateBuffer::<Identity, Impl, OFFSET>,
             AllocatePageSizeBuffer: AllocatePageSizeBuffer::<Identity, Impl, OFFSET>,
         }
@@ -4254,7 +4254,7 @@ impl IWMSInternalAdminNetSource_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             GetNetSourceCreator: GetNetSourceCreator::<Identity, Impl, OFFSET>,
             SetCredentials: SetCredentials::<Identity, Impl, OFFSET>,
@@ -4305,7 +4305,7 @@ impl IWMSInternalAdminNetSource2_Vtbl {
             this.FindProxyForURLEx(::core::mem::transmute(&bstrprotocol), ::core::mem::transmute(&bstrhost), ::core::mem::transmute(&bstrurl), ::core::mem::transmute_copy(&pfproxyenabled), ::core::mem::transmute_copy(&pbstrproxyserver), ::core::mem::transmute_copy(&pdwproxyport), ::core::mem::transmute_copy(&pdwproxycontext)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetCredentialsEx: SetCredentialsEx::<Identity, Impl, OFFSET>,
             GetCredentialsEx: GetCredentialsEx::<Identity, Impl, OFFSET>,
             DeleteCredentialsEx: DeleteCredentialsEx::<Identity, Impl, OFFSET>,
@@ -4503,7 +4503,7 @@ impl IWMStatusCallback_Vtbl {
             let this = (*this).get_impl();
             this.OnStatus(::core::mem::transmute_copy(&status), ::core::mem::transmute_copy(&hr), ::core::mem::transmute_copy(&dwtype), ::core::mem::transmute_copy(&pvalue), ::core::mem::transmute_copy(&pvcontext)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnStatus: OnStatus::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnStatus: OnStatus::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWMStatusCallback as ::windows::core::Interface>::IID
@@ -4605,7 +4605,7 @@ impl IWMStreamConfig_Vtbl {
             this.SetBufferWindow(::core::mem::transmute_copy(&msbufferwindow)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetStreamType: GetStreamType::<Identity, Impl, OFFSET>,
             GetStreamNumber: GetStreamNumber::<Identity, Impl, OFFSET>,
             SetStreamNumber: SetStreamNumber::<Identity, Impl, OFFSET>,
@@ -4741,7 +4741,7 @@ impl IWMStreamList_Vtbl {
             this.RemoveStream(::core::mem::transmute_copy(&wstreamnum)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetStreams: GetStreams::<Identity, Impl, OFFSET>,
             AddStream: AddStream::<Identity, Impl, OFFSET>,
             RemoveStream: RemoveStream::<Identity, Impl, OFFSET>,
@@ -4772,7 +4772,7 @@ impl IWMStreamPrioritization_Vtbl {
             this.SetPriorityRecords(::core::mem::transmute_copy(&precordarray), ::core::mem::transmute_copy(&crecords)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetPriorityRecords: GetPriorityRecords::<Identity, Impl, OFFSET>,
             SetPriorityRecords: SetPriorityRecords::<Identity, Impl, OFFSET>,
         }
@@ -4976,7 +4976,7 @@ impl IWMSyncReader_Vtbl {
             this.OpenStream(::core::mem::transmute(&pstream)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Open: Open::<Identity, Impl, OFFSET>,
             Close: Close::<Identity, Impl, OFFSET>,
             SetRange: SetRange::<Identity, Impl, OFFSET>,
@@ -5166,7 +5166,7 @@ impl IWMWatermarkInfo_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetWatermarkEntryCount: GetWatermarkEntryCount::<Identity, Impl, OFFSET>,
             GetWatermarkEntry: GetWatermarkEntry::<Identity, Impl, OFFSET>,
         }
@@ -5289,7 +5289,7 @@ impl IWMWriter_Vtbl {
             this.Flush().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetProfileByID: SetProfileByID::<Identity, Impl, OFFSET>,
             SetProfile: SetProfile::<Identity, Impl, OFFSET>,
             SetOutputFilename: SetOutputFilename::<Identity, Impl, OFFSET>,
@@ -5420,7 +5420,7 @@ impl IWMWriterAdvanced_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSinkCount: GetSinkCount::<Identity, Impl, OFFSET>,
             GetSink: GetSink::<Identity, Impl, OFFSET>,
             AddSink: AddSink::<Identity, Impl, OFFSET>,
@@ -5880,7 +5880,7 @@ impl IWMWriterPostView_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetPostViewCallback: SetPostViewCallback::<Identity, Impl, OFFSET>,
             SetReceivePostViewSamples: SetReceivePostViewSamples::<Identity, Impl, OFFSET>,
             GetReceivePostViewSamples: GetReceivePostViewSamples::<Identity, Impl, OFFSET>,
@@ -5965,7 +5965,7 @@ impl IWMWriterPreprocess_Vtbl {
             this.EndPreprocessingPass(::core::mem::transmute_copy(&dwinputnum), ::core::mem::transmute_copy(&dwflags)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetMaxPreprocessingPasses: GetMaxPreprocessingPasses::<Identity, Impl, OFFSET>,
             SetNumPreprocessingPasses: SetNumPreprocessingPasses::<Identity, Impl, OFFSET>,
             BeginPreprocessingPass: BeginPreprocessingPass::<Identity, Impl, OFFSET>,
@@ -6065,7 +6065,7 @@ impl IWMWriterSink_Vtbl {
             this.OnEndWriting().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnHeader: OnHeader::<Identity, Impl, OFFSET>,
             IsRealTime: IsRealTime::<Identity, Impl, OFFSET>,
             AllocateDataUnit: AllocateDataUnit::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/Media/WindowsMediaFormat/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/WindowsMediaFormat/mod.rs
@@ -208,7 +208,7 @@ unsafe impl ::windows::core::Interface for INSNetSourceCreator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INSNetSourceCreator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CreateNetSource: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszstreamname: ::windows::core::PCWSTR, pmonitor: *mut ::core::ffi::c_void, pdata: *const u8, pusercontext: *mut ::core::ffi::c_void, pcallback: *mut ::core::ffi::c_void, qwcontext: u64) -> ::windows::core::HRESULT,
     pub GetNetSourceProperties: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszstreamname: ::windows::core::PCWSTR, pppropertiesnode: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -282,7 +282,7 @@ unsafe impl ::windows::core::Interface for INSSBuffer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INSSBuffer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetLength: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwlength: *mut u32) -> ::windows::core::HRESULT,
     pub SetLength: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwlength: u32) -> ::windows::core::HRESULT,
     pub GetMaxLength: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwlength: *mut u32) -> ::windows::core::HRESULT,
@@ -671,7 +671,7 @@ unsafe impl ::windows::core::Interface for IWMAddressAccess {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMAddressAccess_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetAccessEntryCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, aetype: WM_AETYPE, pcentries: *mut u32) -> ::windows::core::HRESULT,
     pub GetAccessEntry: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, aetype: WM_AETYPE, dwentrynum: u32, paddraccessentry: *mut WM_ADDRESS_ACCESSENTRY) -> ::windows::core::HRESULT,
     pub AddAccessEntry: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, aetype: WM_AETYPE, paddraccessentry: *const WM_ADDRESS_ACCESSENTRY) -> ::windows::core::HRESULT,
@@ -814,7 +814,7 @@ unsafe impl ::windows::core::Interface for IWMAuthorizer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMAuthorizer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCertCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pccerts: *mut u32) -> ::windows::core::HRESULT,
     pub GetCert: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwindex: u32, ppbcertdata: *mut *mut u8) -> ::windows::core::HRESULT,
     pub GetSharedData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwcertindex: u32, pbshareddata: *const u8, pbcert: *const u8, ppbshareddata: *mut *mut u8) -> ::windows::core::HRESULT,
@@ -890,7 +890,7 @@ unsafe impl ::windows::core::Interface for IWMBackupRestoreProps {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMBackupRestoreProps_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetPropCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcprops: *mut u16) -> ::windows::core::HRESULT,
     pub GetPropByIndex: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, windex: u16, pwszname: ::windows::core::PWSTR, pcchnamelen: *mut u16, ptype: *mut WMT_ATTR_DATATYPE, pvalue: *mut u8, pcblength: *mut u16) -> ::windows::core::HRESULT,
     pub GetPropByName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszname: ::windows::core::PCWSTR, ptype: *mut WMT_ATTR_DATATYPE, pvalue: *mut u8, pcblength: *mut u16) -> ::windows::core::HRESULT,
@@ -1035,7 +1035,7 @@ unsafe impl ::windows::core::Interface for IWMClientConnections {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMClientConnections_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetClientCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcclients: *mut u32) -> ::windows::core::HRESULT,
     pub GetClientProperties: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwclientnum: u32, pclientproperties: *mut WM_CLIENT_PROPERTIES) -> ::windows::core::HRESULT,
 }
@@ -1166,7 +1166,7 @@ unsafe impl ::windows::core::Interface for IWMCodecInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMCodecInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCodecInfoCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, guidtype: *const ::windows::core::GUID, pccodecs: *mut u32) -> ::windows::core::HRESULT,
     pub GetCodecFormatCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, guidtype: *const ::windows::core::GUID, dwcodecindex: u32, pcformat: *mut u32) -> ::windows::core::HRESULT,
     pub GetCodecFormat: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, guidtype: *const ::windows::core::GUID, dwcodecindex: u32, dwformatindex: u32, ppistreamconfig: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1422,7 +1422,7 @@ unsafe impl ::windows::core::Interface for IWMCredentialCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMCredentialCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AcquireCredentials: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszrealm: ::windows::core::PCWSTR, pwszsite: ::windows::core::PCWSTR, pwszuser: ::windows::core::PWSTR, cchuser: u32, pwszpassword: ::windows::core::PWSTR, cchpassword: u32, hrstatus: ::windows::core::HRESULT, pdwflags: *mut u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`*"]
@@ -1474,7 +1474,7 @@ unsafe impl ::windows::core::Interface for IWMDRMEditor {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMDRMEditor_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDRMProperty: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwstrname: ::windows::core::PCWSTR, pdwtype: *mut WMT_ATTR_DATATYPE, pvalue: *mut u8, pcblength: *mut u16) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`*"]
@@ -1526,7 +1526,7 @@ unsafe impl ::windows::core::Interface for IWMDRMMessageParser {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMDRMMessageParser_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ParseRegistrationReqMsg: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbregistrationreqmsg: *const u8, cbregistrationreqmsg: u32, ppdevicecert: *mut *mut ::core::ffi::c_void, pdeviceserialnumber: *mut DRM_VAL16) -> ::windows::core::HRESULT,
     pub ParseLicenseRequestMsg: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pblicenserequestmsg: *const u8, cblicenserequestmsg: u32, ppdevicecert: *mut *mut ::core::ffi::c_void, pdeviceserialnumber: *mut DRM_VAL16, pbstraction: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
 }
@@ -1603,7 +1603,7 @@ unsafe impl ::windows::core::Interface for IWMDRMReader {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMDRMReader_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AcquireLicense: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwflags: u32) -> ::windows::core::HRESULT,
     pub CancelLicenseAcquisition: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Individualize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwflags: u32) -> ::windows::core::HRESULT,
@@ -1900,7 +1900,7 @@ unsafe impl ::windows::core::Interface for IWMDRMTranscryptionManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMDRMTranscryptionManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateTranscryptor: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pptranscryptor: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`*"]
@@ -1961,7 +1961,7 @@ unsafe impl ::windows::core::Interface for IWMDRMTranscryptor {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMDRMTranscryptor_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrfilename: ::core::mem::ManuallyDrop<::windows::core::BSTR>, pblicenserequestmsg: *mut u8, cblicenserequestmsg: u32, pplicenseresponsemsg: *mut *mut ::core::ffi::c_void, pcallback: *mut ::core::ffi::c_void, pvcontext: *const ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Seek: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hnstime: u64) -> ::windows::core::HRESULT,
     pub Read: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbdata: *const u8, pcbdata: *const u32) -> ::windows::core::HRESULT,
@@ -2134,7 +2134,7 @@ unsafe impl ::windows::core::Interface for IWMDRMWriter {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMDRMWriter_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GenerateKeySeed: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszkeyseed: ::windows::core::PWSTR, pcwchlength: *mut u32) -> ::windows::core::HRESULT,
     pub GenerateKeyID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszkeyid: ::windows::core::PWSTR, pcwchlength: *mut u32) -> ::windows::core::HRESULT,
     pub GenerateSigningKeyPair: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszprivkey: ::windows::core::PWSTR, pcwchprivkeylength: *mut u32, pwszpubkey: ::windows::core::PWSTR, pcwchpubkeylength: *mut u32) -> ::windows::core::HRESULT,
@@ -2395,7 +2395,7 @@ unsafe impl ::windows::core::Interface for IWMDeviceRegistration {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMDeviceRegistration_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub RegisterDevice: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwregistertype: u32, pbcertificate: *const u8, cbcertificate: u32, serialnumber: DRM_VAL16, ppdevice: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub UnregisterDevice: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwregistertype: u32, pbcertificate: *const u8, cbcertificate: u32, serialnumber: DRM_VAL16) -> ::windows::core::HRESULT,
     pub GetRegistrationStats: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwregistertype: u32, pcregistereddevices: *mut u32) -> ::windows::core::HRESULT,
@@ -2450,7 +2450,7 @@ unsafe impl ::windows::core::Interface for IWMGetSecureChannel {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMGetSecureChannel_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetPeerSecureChannelInterface: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pppeer: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`*"]
@@ -2548,7 +2548,7 @@ unsafe impl ::windows::core::Interface for IWMHeaderInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMHeaderInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetAttributeCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wstreamnum: u16, pcattributes: *mut u16) -> ::windows::core::HRESULT,
     pub GetAttributeByIndex: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, windex: u16, pwstreamnum: *mut u16, pwszname: ::windows::core::PWSTR, pcchnamelen: *mut u16, ptype: *mut WMT_ATTR_DATATYPE, pvalue: *mut u8, pcblength: *mut u16) -> ::windows::core::HRESULT,
     pub GetAttributeByName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwstreamnum: *mut u16, pszname: ::windows::core::PCWSTR, ptype: *mut WMT_ATTR_DATATYPE, pvalue: *mut u8, pcblength: *mut u16) -> ::windows::core::HRESULT,
@@ -2905,7 +2905,7 @@ unsafe impl ::windows::core::Interface for IWMIStreamProps {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMIStreamProps_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetProperty: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszname: ::windows::core::PCWSTR, ptype: *mut WMT_ATTR_DATATYPE, pvalue: *mut u8, pdwsize: *mut u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`*"]
@@ -2958,7 +2958,7 @@ unsafe impl ::windows::core::Interface for IWMImageInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMImageInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetImageCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcimages: *mut u32) -> ::windows::core::HRESULT,
     pub GetImage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, windex: u32, pcchmimetype: *mut u16, pwszmimetype: ::windows::core::PWSTR, pcchdescription: *mut u16, pwszdescription: ::windows::core::PWSTR, pimagetype: *mut u16, pcbimagedata: *mut u32, pbimagedata: *mut u8) -> ::windows::core::HRESULT,
 }
@@ -3015,7 +3015,7 @@ unsafe impl ::windows::core::Interface for IWMIndexer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMIndexer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub StartIndexing: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszurl: ::windows::core::PCWSTR, pcallback: *mut ::core::ffi::c_void, pvcontext: *const ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Cancel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -3232,7 +3232,7 @@ unsafe impl ::windows::core::Interface for IWMLanguageList {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMLanguageList_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetLanguageCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwcount: *mut u16) -> ::windows::core::HRESULT,
     pub GetLanguageDetails: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, windex: u16, pwszlanguagestring: ::windows::core::PWSTR, pcchlanguagestringlength: *mut u16) -> ::windows::core::HRESULT,
     pub AddLanguageByRFC1766String: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszlanguagestring: ::windows::core::PCWSTR, pwindex: *mut u16) -> ::windows::core::HRESULT,
@@ -3289,7 +3289,7 @@ unsafe impl ::windows::core::Interface for IWMLicenseBackup {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMLicenseBackup_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub BackupLicenses: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwflags: u32, pcallback: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CancelLicenseBackup: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -3345,7 +3345,7 @@ unsafe impl ::windows::core::Interface for IWMLicenseRestore {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMLicenseRestore_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub RestoreLicenses: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwflags: u32, pcallback: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CancelLicenseRestore: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -3398,7 +3398,7 @@ unsafe impl ::windows::core::Interface for IWMLicenseRevocationAgent {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMLicenseRevocationAgent_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetLRBChallenge: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pmachineid: *const u8, dwmachineidlength: u32, pchallenge: *const u8, dwchallengelength: u32, pchallengeoutput: *mut u8, pdwchallengeoutputlength: *mut u32) -> ::windows::core::HRESULT,
     pub ProcessLRB: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psignedlrb: *const u8, dwsignedlrblength: u32, psignedack: *mut u8, pdwsignedacklength: *mut u32) -> ::windows::core::HRESULT,
 }
@@ -3459,7 +3459,7 @@ unsafe impl ::windows::core::Interface for IWMMediaProps {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMMediaProps_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pguidtype: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub GetMediaType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptype: *mut WM_MEDIA_TYPE, pcbtype: *mut u32) -> ::windows::core::HRESULT,
@@ -3525,7 +3525,7 @@ unsafe impl ::windows::core::Interface for IWMMetadataEditor {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMMetadataEditor_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Open: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszfilename: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub Close: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Flush: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -3957,7 +3957,7 @@ unsafe impl ::windows::core::Interface for IWMPacketSize {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMPacketSize_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetMaxPacketSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwmaxpacketsize: *mut u32) -> ::windows::core::HRESULT,
     pub SetMaxPacketSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwmaxpacketsize: u32) -> ::windows::core::HRESULT,
 }
@@ -4083,7 +4083,7 @@ unsafe impl ::windows::core::Interface for IWMPlayerHook {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMPlayerHook_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub PreDecode: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`*"]
@@ -4133,7 +4133,7 @@ unsafe impl ::windows::core::Interface for IWMPlayerTimestampHook {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMPlayerTimestampHook_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub MapTimestamp: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, rtin: i64, prtout: *mut i64) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`*"]
@@ -4262,7 +4262,7 @@ unsafe impl ::windows::core::Interface for IWMProfile {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMProfile_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetVersion: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwversion: *mut WMT_VERSION) -> ::windows::core::HRESULT,
     pub GetName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszname: ::windows::core::PWSTR, pcchname: *mut u32) -> ::windows::core::HRESULT,
     pub SetName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszname: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
@@ -4729,7 +4729,7 @@ unsafe impl ::windows::core::Interface for IWMProfileManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMProfileManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateEmptyProfile: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwversion: WMT_VERSION, ppprofile: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub LoadProfileByID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, guidprofile: *const ::windows::core::GUID, ppprofile: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub LoadProfileByData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszprofile: ::windows::core::PCWSTR, ppprofile: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -4884,7 +4884,7 @@ unsafe impl ::windows::core::Interface for IWMProfileManagerLanguage {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMProfileManagerLanguage_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetUserLanguageID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wlangid: *mut u16) -> ::windows::core::HRESULT,
     pub SetUserLanguageID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wlangid: u16) -> ::windows::core::HRESULT,
 }
@@ -4958,7 +4958,7 @@ unsafe impl ::windows::core::Interface for IWMPropertyVault {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMPropertyVault_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetPropertyCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwcount: *const u32) -> ::windows::core::HRESULT,
     pub GetPropertyByName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszname: ::windows::core::PCWSTR, ptype: *mut WMT_ATTR_DATATYPE, pvalue: *mut u8, pdwsize: *mut u32) -> ::windows::core::HRESULT,
     pub SetProperty: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszname: ::windows::core::PCWSTR, ptype: WMT_ATTR_DATATYPE, pvalue: *const u8, dwsize: u32) -> ::windows::core::HRESULT,
@@ -5015,7 +5015,7 @@ unsafe impl ::windows::core::Interface for IWMProximityDetection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMProximityDetection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub StartDetection: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbregistrationmsg: *const u8, cbregistrationmsg: u32, pblocaladdress: *const u8, cblocaladdress: u32, dwextraportsallowed: u32, ppregistrationresponsemsg: *mut *mut ::core::ffi::c_void, pcallback: *mut ::core::ffi::c_void, pvcontext: *const ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`*"]
@@ -5105,7 +5105,7 @@ unsafe impl ::windows::core::Interface for IWMReader {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMReader_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Open: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszurl: ::windows::core::PCWSTR, pcallback: *mut ::core::ffi::c_void, pvcontext: *const ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Close: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetOutputCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcoutputs: *mut u32) -> ::windows::core::HRESULT,
@@ -5169,7 +5169,7 @@ unsafe impl ::windows::core::Interface for IWMReaderAccelerator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMReaderAccelerator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCodecInterface: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwoutputnum: u32, riid: *const ::windows::core::GUID, ppvcodecinterface: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub Notify: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwoutputnum: u32, psubtype: *const WM_MEDIA_TYPE) -> ::windows::core::HRESULT,
@@ -5332,7 +5332,7 @@ unsafe impl ::windows::core::Interface for IWMReaderAdvanced {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMReaderAdvanced_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub SetUserProvidedClock: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fuserclock: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -7009,7 +7009,7 @@ unsafe impl ::windows::core::Interface for IWMReaderAllocatorEx {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMReaderAllocatorEx_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AllocateForStreamEx: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wstreamnum: u16, cbbuffer: u32, ppbuffer: *mut *mut ::core::ffi::c_void, dwflags: u32, cnssampletime: u64, cnssampleduration: u64, pvcontext: *const ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub AllocateForOutputEx: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwoutputnum: u32, cbbuffer: u32, ppbuffer: *mut *mut ::core::ffi::c_void, dwflags: u32, cnssampletime: u64, cnssampleduration: u64, pvcontext: *const ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -7149,7 +7149,7 @@ unsafe impl ::windows::core::Interface for IWMReaderCallbackAdvanced {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMReaderCallbackAdvanced_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnStreamSample: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wstreamnum: u16, cnssampletime: u64, cnssampleduration: u64, dwflags: u32, psample: *mut ::core::ffi::c_void, pvcontext: *const ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub OnTime: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cnscurrenttime: u64, pvcontext: *const ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub OnStreamSelection: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wstreamcount: u16, pstreamnumbers: *const u16, pselections: *const WMT_STREAM_SELECTION, pvcontext: *const ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -7389,7 +7389,7 @@ unsafe impl ::windows::core::Interface for IWMReaderNetworkConfig {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMReaderNetworkConfig_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetBufferingTime: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcnsbufferingtime: *mut u64) -> ::windows::core::HRESULT,
     pub SetBufferingTime: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cnsbufferingtime: u64) -> ::windows::core::HRESULT,
     pub GetUDPPortRanges: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, prangearray: *mut WM_PORT_NUMBER_RANGE, pcranges: *mut u32) -> ::windows::core::HRESULT,
@@ -7876,7 +7876,7 @@ unsafe impl ::windows::core::Interface for IWMReaderPlaylistBurn {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMReaderPlaylistBurn_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub InitPlaylistBurn: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cfiles: u32, ppwszfilenames: *const ::windows::core::PWSTR, pcallback: *mut ::core::ffi::c_void, pvcontext: *const ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetInitResults: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cfiles: u32, phrstati: *mut ::windows::core::HRESULT) -> ::windows::core::HRESULT,
     pub Cancel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -7935,7 +7935,7 @@ unsafe impl ::windows::core::Interface for IWMReaderStreamClock {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMReaderStreamClock_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetTime: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcnsnow: *const u64) -> ::windows::core::HRESULT,
     pub SetTimer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cnswhen: u64, pvparam: *const ::core::ffi::c_void, pdwtimerid: *mut u32) -> ::windows::core::HRESULT,
     pub KillTimer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwtimerid: u32) -> ::windows::core::HRESULT,
@@ -7990,7 +7990,7 @@ unsafe impl ::windows::core::Interface for IWMReaderTimecode {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMReaderTimecode_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetTimecodeRangeCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wstreamnum: u16, pwrangecount: *mut u16) -> ::windows::core::HRESULT,
     pub GetTimecodeRangeBounds: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wstreamnum: u16, wrangenum: u16, pstarttimecode: *mut u32, pendtimecode: *mut u32) -> ::windows::core::HRESULT,
 }
@@ -8043,7 +8043,7 @@ unsafe impl ::windows::core::Interface for IWMReaderTypeNegotiation {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMReaderTypeNegotiation_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub TryOutputProps: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwoutputnum: u32, poutput: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`*"]
@@ -8101,7 +8101,7 @@ unsafe impl ::windows::core::Interface for IWMRegisterCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMRegisterCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Advise: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcallback: *mut ::core::ffi::c_void, pvcontext: *const ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Unadvise: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcallback: *mut ::core::ffi::c_void, pvcontext: *const ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -8212,7 +8212,7 @@ unsafe impl ::windows::core::Interface for IWMRegisteredDevice {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMRegisteredDevice_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDeviceSerialNumber: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pserialnumber: *mut DRM_VAL16) -> ::windows::core::HRESULT,
     pub GetDeviceCertificate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppcertificate: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetDeviceType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwtype: *mut u32) -> ::windows::core::HRESULT,
@@ -8294,7 +8294,7 @@ unsafe impl ::windows::core::Interface for IWMSBufferAllocator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMSBufferAllocator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AllocateBuffer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwmaxbuffersize: u32, ppbuffer: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub AllocatePageSizeBuffer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwmaxbuffersize: u32, ppbuffer: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -8397,7 +8397,7 @@ unsafe impl ::windows::core::Interface for IWMSInternalAdminNetSource {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMSInternalAdminNetSource_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psharednamespace: *mut ::core::ffi::c_void, pnamespacenode: *mut ::core::ffi::c_void, pnetsourcecreator: *mut ::core::ffi::c_void, fembeddedinserver: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -8499,7 +8499,7 @@ unsafe impl ::windows::core::Interface for IWMSInternalAdminNetSource2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMSInternalAdminNetSource2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub SetCredentialsEx: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrrealm: ::core::mem::ManuallyDrop<::windows::core::BSTR>, bstrurl: ::core::mem::ManuallyDrop<::windows::core::BSTR>, fproxy: super::super::Foundation::BOOL, bstrname: ::core::mem::ManuallyDrop<::windows::core::BSTR>, bstrpassword: ::core::mem::ManuallyDrop<::windows::core::BSTR>, fpersist: super::super::Foundation::BOOL, fconfirmedgood: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -8842,7 +8842,7 @@ unsafe impl ::windows::core::Interface for IWMStatusCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMStatusCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnStatus: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, status: WMT_STATUS, hr: ::windows::core::HRESULT, dwtype: WMT_ATTR_DATATYPE, pvalue: *const u8, pvcontext: *const ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`*"]
@@ -8931,7 +8931,7 @@ unsafe impl ::windows::core::Interface for IWMStreamConfig {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMStreamConfig_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetStreamType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pguidstreamtype: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub GetStreamNumber: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwstreamnum: *mut u16) -> ::windows::core::HRESULT,
     pub SetStreamNumber: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wstreamnum: u16) -> ::windows::core::HRESULT,
@@ -9274,7 +9274,7 @@ unsafe impl ::windows::core::Interface for IWMStreamList {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMStreamList_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetStreams: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwstreamnumarray: *mut u16, pcstreams: *mut u16) -> ::windows::core::HRESULT,
     pub AddStream: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wstreamnum: u16) -> ::windows::core::HRESULT,
     pub RemoveStream: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wstreamnum: u16) -> ::windows::core::HRESULT,
@@ -9332,7 +9332,7 @@ unsafe impl ::windows::core::Interface for IWMStreamPrioritization {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMStreamPrioritization_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetPriorityRecords: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, precordarray: *mut WM_STREAM_PRIORITY_RECORD, pcrecords: *mut u16) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -9482,7 +9482,7 @@ unsafe impl ::windows::core::Interface for IWMSyncReader {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMSyncReader_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Open: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszfilename: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub Close: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetRange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cnsstarttime: u64, cnsduration: i64) -> ::windows::core::HRESULT,
@@ -9847,7 +9847,7 @@ unsafe impl ::windows::core::Interface for IWMWatermarkInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMWatermarkInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetWatermarkEntryCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wmettype: WMT_WATERMARK_ENTRY_TYPE, pdwcount: *mut u32) -> ::windows::core::HRESULT,
     pub GetWatermarkEntry: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wmettype: WMT_WATERMARK_ENTRY_TYPE, dwentrynum: u32, pentry: *mut WMT_WATERMARK_ENTRY) -> ::windows::core::HRESULT,
 }
@@ -9950,7 +9950,7 @@ unsafe impl ::windows::core::Interface for IWMWriter {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMWriter_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetProfileByID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, guidprofile: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub SetProfile: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pprofile: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetOutputFilename: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszfilename: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
@@ -10063,7 +10063,7 @@ unsafe impl ::windows::core::Interface for IWMWriterAdvanced {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMWriterAdvanced_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetSinkCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcsinks: *mut u32) -> ::windows::core::HRESULT,
     pub GetSink: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwsinknum: u32, ppsink: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub AddSink: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psink: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -11036,7 +11036,7 @@ unsafe impl ::windows::core::Interface for IWMWriterPostView {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMWriterPostView_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetPostViewCallback: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcallback: *mut ::core::ffi::c_void, pvcontext: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub SetReceivePostViewSamples: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wstreamnum: u16, freceivepostviewsamples: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -11195,7 +11195,7 @@ unsafe impl ::windows::core::Interface for IWMWriterPreprocess {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMWriterPreprocess_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetMaxPreprocessingPasses: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwinputnum: u32, dwflags: u32, pdwmaxnumpasses: *mut u32) -> ::windows::core::HRESULT,
     pub SetNumPreprocessingPasses: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwinputnum: u32, dwflags: u32, dwnumpasses: u32) -> ::windows::core::HRESULT,
     pub BeginPreprocessingPass: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwinputnum: u32, dwflags: u32) -> ::windows::core::HRESULT,
@@ -11377,7 +11377,7 @@ unsafe impl ::windows::core::Interface for IWMWriterSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWMWriterSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnHeader: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pheader: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub IsRealTime: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfrealtime: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/Media/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/impl.rs
@@ -49,7 +49,7 @@ impl IReferenceClock_Vtbl {
             this.Unadvise(::core::mem::transmute_copy(&dwadvisecookie)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTime: GetTime::<Identity, Impl, OFFSET>,
             AdviseTime: AdviseTime::<Identity, Impl, OFFSET>,
             AdvisePeriodic: AdvisePeriodic::<Identity, Impl, OFFSET>,
@@ -97,7 +97,7 @@ impl IReferenceClockTimerControl_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetDefaultTimerResolution: SetDefaultTimerResolution::<Identity, Impl, OFFSET>,
             GetDefaultTimerResolution: GetDefaultTimerResolution::<Identity, Impl, OFFSET>,
         }

--- a/crates/libs/windows/src/Windows/Win32/Media/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/mod.rs
@@ -155,7 +155,7 @@ unsafe impl ::windows::core::Interface for IReferenceClock {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IReferenceClock_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetTime: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptime: *mut i64) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub AdviseTime: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, basetime: i64, streamtime: i64, hevent: super::Foundation::HANDLE, pdwadvisecookie: *mut usize) -> ::windows::core::HRESULT,
@@ -302,7 +302,7 @@ unsafe impl ::windows::core::Interface for IReferenceClockTimerControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IReferenceClockTimerControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetDefaultTimerResolution: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, timerresolution: i64) -> ::windows::core::HRESULT,
     pub GetDefaultTimerResolution: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptimerresolution: *mut i64) -> ::windows::core::HRESULT,
 }

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/MobileBroadband/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/MobileBroadband/impl.rs
@@ -95,7 +95,7 @@ impl IMbnConnection_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ConnectionID: ConnectionID::<Identity, Impl, OFFSET>,
             InterfaceID: InterfaceID::<Identity, Impl, OFFSET>,
             Connect: Connect::<Identity, Impl, OFFSET>,
@@ -142,7 +142,7 @@ impl IMbnConnectionContext_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetProvisionedContexts: GetProvisionedContexts::<Identity, Impl, OFFSET>,
             SetProvisionedContext: SetProvisionedContext::<Identity, Impl, OFFSET>,
         }
@@ -169,7 +169,7 @@ impl IMbnConnectionContextEvents_Vtbl {
             this.OnSetProvisionedContextComplete(::core::mem::transmute(&newinterface), ::core::mem::transmute_copy(&requestid), ::core::mem::transmute_copy(&status)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnProvisionedContextListChange: OnProvisionedContextListChange::<Identity, Impl, OFFSET>,
             OnSetProvisionedContextComplete: OnSetProvisionedContextComplete::<Identity, Impl, OFFSET>,
         }
@@ -208,7 +208,7 @@ impl IMbnConnectionEvents_Vtbl {
             this.OnVoiceCallStateChange(::core::mem::transmute(&newconnection)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnConnectComplete: OnConnectComplete::<Identity, Impl, OFFSET>,
             OnDisconnectComplete: OnDisconnectComplete::<Identity, Impl, OFFSET>,
             OnConnectStateChange: OnConnectStateChange::<Identity, Impl, OFFSET>,
@@ -252,7 +252,7 @@ impl IMbnConnectionManager_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetConnection: GetConnection::<Identity, Impl, OFFSET>,
             GetConnections: GetConnections::<Identity, Impl, OFFSET>,
         }
@@ -279,7 +279,7 @@ impl IMbnConnectionManagerEvents_Vtbl {
             this.OnConnectionRemoval(::core::mem::transmute(&oldconnection)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnConnectionArrival: OnConnectionArrival::<Identity, Impl, OFFSET>,
             OnConnectionRemoval: OnConnectionRemoval::<Identity, Impl, OFFSET>,
         }
@@ -318,7 +318,7 @@ impl IMbnConnectionProfile_Vtbl {
             this.Delete().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetProfileXmlData: GetProfileXmlData::<Identity, Impl, OFFSET>,
             UpdateProfile: UpdateProfile::<Identity, Impl, OFFSET>,
             Delete: Delete::<Identity, Impl, OFFSET>,
@@ -339,7 +339,7 @@ impl IMbnConnectionProfileEvents_Vtbl {
             let this = (*this).get_impl();
             this.OnProfileUpdate(::core::mem::transmute(&newprofile)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnProfileUpdate: OnProfileUpdate::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnProfileUpdate: OnProfileUpdate::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMbnConnectionProfileEvents as ::windows::core::Interface>::IID
@@ -384,7 +384,7 @@ impl IMbnConnectionProfileManager_Vtbl {
             this.CreateConnectionProfile(::core::mem::transmute(&xmlprofile)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetConnectionProfiles: GetConnectionProfiles::<Identity, Impl, OFFSET>,
             GetConnectionProfile: GetConnectionProfile::<Identity, Impl, OFFSET>,
             CreateConnectionProfile: CreateConnectionProfile::<Identity, Impl, OFFSET>,
@@ -412,7 +412,7 @@ impl IMbnConnectionProfileManagerEvents_Vtbl {
             this.OnConnectionProfileRemoval(::core::mem::transmute(&oldconnectionprofile)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnConnectionProfileArrival: OnConnectionProfileArrival::<Identity, Impl, OFFSET>,
             OnConnectionProfileRemoval: OnConnectionProfileRemoval::<Identity, Impl, OFFSET>,
         }
@@ -574,7 +574,7 @@ impl IMbnDeviceService_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             QuerySupportedCommands: QuerySupportedCommands::<Identity, Impl, OFFSET>,
             OpenCommandSession: OpenCommandSession::<Identity, Impl, OFFSET>,
             CloseCommandSession: CloseCommandSession::<Identity, Impl, OFFSET>,
@@ -604,7 +604,7 @@ impl IMbnDeviceServiceStateEvents_Vtbl {
             let this = (*this).get_impl();
             this.OnSessionsStateChange(::core::mem::transmute(&interfaceid), ::core::mem::transmute_copy(&statechange)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnSessionsStateChange: OnSessionsStateChange::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnSessionsStateChange: OnSessionsStateChange::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMbnDeviceServiceStateEvents as ::windows::core::Interface>::IID
@@ -667,7 +667,7 @@ impl IMbnDeviceServicesContext_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             EnumerateDeviceServices: EnumerateDeviceServices::<Identity, Impl, OFFSET>,
             GetDeviceService: GetDeviceService::<Identity, Impl, OFFSET>,
             MaxCommandSize: MaxCommandSize::<Identity, Impl, OFFSET>,
@@ -753,7 +753,7 @@ impl IMbnDeviceServicesEvents_Vtbl {
             this.OnInterfaceStateChange(::core::mem::transmute(&interfaceid), ::core::mem::transmute_copy(&statechange)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnQuerySupportedCommandsComplete: OnQuerySupportedCommandsComplete::<Identity, Impl, OFFSET>,
             OnOpenCommandSessionComplete: OnOpenCommandSessionComplete::<Identity, Impl, OFFSET>,
             OnCloseCommandSessionComplete: OnCloseCommandSessionComplete::<Identity, Impl, OFFSET>,
@@ -788,7 +788,7 @@ impl IMbnDeviceServicesManager_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetDeviceServicesContext: GetDeviceServicesContext::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetDeviceServicesContext: GetDeviceServicesContext::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMbnDeviceServicesManager as ::windows::core::Interface>::IID
@@ -929,7 +929,7 @@ impl IMbnInterface_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             InterfaceID: InterfaceID::<Identity, Impl, OFFSET>,
             GetInterfaceCapability: GetInterfaceCapability::<Identity, Impl, OFFSET>,
             GetSubscriberInformation: GetSubscriberInformation::<Identity, Impl, OFFSET>,
@@ -1001,7 +1001,7 @@ impl IMbnInterfaceEvents_Vtbl {
             this.OnScanNetworkComplete(::core::mem::transmute(&newinterface), ::core::mem::transmute_copy(&requestid), ::core::mem::transmute_copy(&status)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnInterfaceCapabilityAvailable: OnInterfaceCapabilityAvailable::<Identity, Impl, OFFSET>,
             OnSubscriberInformationChange: OnSubscriberInformationChange::<Identity, Impl, OFFSET>,
             OnReadyStateChange: OnReadyStateChange::<Identity, Impl, OFFSET>,
@@ -1049,7 +1049,7 @@ impl IMbnInterfaceManager_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetInterface: GetInterface::<Identity, Impl, OFFSET>,
             GetInterfaces: GetInterfaces::<Identity, Impl, OFFSET>,
         }
@@ -1076,7 +1076,7 @@ impl IMbnInterfaceManagerEvents_Vtbl {
             this.OnInterfaceRemoval(::core::mem::transmute(&oldinterface)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnInterfaceArrival: OnInterfaceArrival::<Identity, Impl, OFFSET>,
             OnInterfaceRemoval: OnInterfaceRemoval::<Identity, Impl, OFFSET>,
         }
@@ -1160,7 +1160,7 @@ impl IMbnMultiCarrier_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetHomeProvider: SetHomeProvider::<Identity, Impl, OFFSET>,
             GetPreferredProviders: GetPreferredProviders::<Identity, Impl, OFFSET>,
             GetVisibleProviders: GetVisibleProviders::<Identity, Impl, OFFSET>,
@@ -1209,7 +1209,7 @@ impl IMbnMultiCarrierEvents_Vtbl {
             this.OnInterfaceCapabilityChange(::core::mem::transmute(&mbninterface)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnSetHomeProviderComplete: OnSetHomeProviderComplete::<Identity, Impl, OFFSET>,
             OnCurrentCellularClassChange: OnCurrentCellularClassChange::<Identity, Impl, OFFSET>,
             OnPreferredProvidersChange: OnPreferredProvidersChange::<Identity, Impl, OFFSET>,
@@ -1359,7 +1359,7 @@ impl IMbnPin_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             PinType: PinType::<Identity, Impl, OFFSET>,
             PinFormat: PinFormat::<Identity, Impl, OFFSET>,
             PinLengthMin: PinLengthMin::<Identity, Impl, OFFSET>,
@@ -1413,7 +1413,7 @@ impl IMbnPinEvents_Vtbl {
             this.OnUnblockComplete(::core::mem::transmute(&pin), ::core::mem::transmute_copy(&pininfo), ::core::mem::transmute_copy(&requestid), ::core::mem::transmute_copy(&status)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnEnableComplete: OnEnableComplete::<Identity, Impl, OFFSET>,
             OnDisableComplete: OnDisableComplete::<Identity, Impl, OFFSET>,
             OnEnterComplete: OnEnterComplete::<Identity, Impl, OFFSET>,
@@ -1470,7 +1470,7 @@ impl IMbnPinManager_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetPinList: GetPinList::<Identity, Impl, OFFSET>,
             GetPin: GetPin::<Identity, Impl, OFFSET>,
             GetPinState: GetPinState::<Identity, Impl, OFFSET>,
@@ -1498,7 +1498,7 @@ impl IMbnPinManagerEvents_Vtbl {
             this.OnGetPinStateComplete(::core::mem::transmute(&pinmanager), ::core::mem::transmute(&pininfo), ::core::mem::transmute_copy(&requestid), ::core::mem::transmute_copy(&status)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnPinListAvailable: OnPinListAvailable::<Identity, Impl, OFFSET>,
             OnGetPinStateComplete: OnGetPinStateComplete::<Identity, Impl, OFFSET>,
         }
@@ -1549,7 +1549,7 @@ impl IMbnRadio_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SoftwareRadioState: SoftwareRadioState::<Identity, Impl, OFFSET>,
             HardwareRadioState: HardwareRadioState::<Identity, Impl, OFFSET>,
             SetSoftwareRadioState: SetSoftwareRadioState::<Identity, Impl, OFFSET>,
@@ -1577,7 +1577,7 @@ impl IMbnRadioEvents_Vtbl {
             this.OnSetSoftwareRadioStateComplete(::core::mem::transmute(&newinterface), ::core::mem::transmute_copy(&requestid), ::core::mem::transmute_copy(&status)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnRadioStateChange: OnRadioStateChange::<Identity, Impl, OFFSET>,
             OnSetSoftwareRadioStateComplete: OnSetSoftwareRadioStateComplete::<Identity, Impl, OFFSET>,
         }
@@ -1712,7 +1712,7 @@ impl IMbnRegistration_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetRegisterState: GetRegisterState::<Identity, Impl, OFFSET>,
             GetRegisterMode: GetRegisterMode::<Identity, Impl, OFFSET>,
             GetProviderID: GetProviderID::<Identity, Impl, OFFSET>,
@@ -1759,7 +1759,7 @@ impl IMbnRegistrationEvents_Vtbl {
             this.OnSetRegisterModeComplete(::core::mem::transmute(&newinterface), ::core::mem::transmute_copy(&requestid), ::core::mem::transmute_copy(&status)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnRegisterModeAvailable: OnRegisterModeAvailable::<Identity, Impl, OFFSET>,
             OnRegisterStateChange: OnRegisterStateChange::<Identity, Impl, OFFSET>,
             OnPacketServiceStateChange: OnPacketServiceStateChange::<Identity, Impl, OFFSET>,
@@ -1790,7 +1790,7 @@ impl IMbnServiceActivation_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Activate: Activate::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Activate: Activate::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMbnServiceActivation as ::windows::core::Interface>::IID
@@ -1810,7 +1810,7 @@ impl IMbnServiceActivationEvents_Vtbl {
             let this = (*this).get_impl();
             this.OnActivationComplete(::core::mem::transmute(&serviceactivation), ::core::mem::transmute_copy(&vendorspecificdata), ::core::mem::transmute_copy(&requestid), ::core::mem::transmute_copy(&status), ::core::mem::transmute_copy(&networkerror)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnActivationComplete: OnActivationComplete::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnActivationComplete: OnActivationComplete::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMbnServiceActivationEvents as ::windows::core::Interface>::IID
@@ -1846,7 +1846,7 @@ impl IMbnSignal_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSignalStrength: GetSignalStrength::<Identity, Impl, OFFSET>,
             GetSignalError: GetSignalError::<Identity, Impl, OFFSET>,
         }
@@ -1866,7 +1866,7 @@ impl IMbnSignalEvents_Vtbl {
             let this = (*this).get_impl();
             this.OnSignalStateChange(::core::mem::transmute(&newinterface)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnSignalStateChange: OnSignalStateChange::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnSignalStateChange: OnSignalStateChange::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMbnSignalEvents as ::windows::core::Interface>::IID
@@ -1977,7 +1977,7 @@ impl IMbnSms_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSmsConfiguration: GetSmsConfiguration::<Identity, Impl, OFFSET>,
             SetSmsConfiguration: SetSmsConfiguration::<Identity, Impl, OFFSET>,
             SmsSendPdu: SmsSendPdu::<Identity, Impl, OFFSET>,
@@ -2058,7 +2058,7 @@ impl IMbnSmsConfiguration_Vtbl {
             this.SetSmsFormat(::core::mem::transmute_copy(&smsformat)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ServiceCenterAddress: ServiceCenterAddress::<Identity, Impl, OFFSET>,
             SetServiceCenterAddress: SetServiceCenterAddress::<Identity, Impl, OFFSET>,
             MaxMessageIndex: MaxMessageIndex::<Identity, Impl, OFFSET>,
@@ -2122,7 +2122,7 @@ impl IMbnSmsEvents_Vtbl {
             this.OnSmsStatusChange(::core::mem::transmute(&sms)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnSmsConfigurationChange: OnSmsConfigurationChange::<Identity, Impl, OFFSET>,
             OnSetSmsConfigurationComplete: OnSetSmsConfigurationComplete::<Identity, Impl, OFFSET>,
             OnSmsSendComplete: OnSmsSendComplete::<Identity, Impl, OFFSET>,
@@ -2193,7 +2193,7 @@ impl IMbnSmsReadMsgPdu_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Index: Index::<Identity, Impl, OFFSET>,
             Status: Status::<Identity, Impl, OFFSET>,
             PduData: PduData::<Identity, Impl, OFFSET>,
@@ -2309,7 +2309,7 @@ impl IMbnSmsReadMsgTextCdma_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Index: Index::<Identity, Impl, OFFSET>,
             Status: Status::<Identity, Impl, OFFSET>,
             Address: Address::<Identity, Impl, OFFSET>,
@@ -2369,7 +2369,7 @@ impl IMbnSubscriberInformation_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SubscriberID: SubscriberID::<Identity, Impl, OFFSET>,
             SimIccID: SimIccID::<Identity, Impl, OFFSET>,
             TelephoneNumbers: TelephoneNumbers::<Identity, Impl, OFFSET>,
@@ -2400,7 +2400,7 @@ impl IMbnVendorSpecificEvents_Vtbl {
             this.OnSetVendorSpecificComplete(::core::mem::transmute(&vendoroperation), ::core::mem::transmute_copy(&vendorspecificdata), ::core::mem::transmute_copy(&requestid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnEventNotification: OnEventNotification::<Identity, Impl, OFFSET>,
             OnSetVendorSpecificComplete: OnSetVendorSpecificComplete::<Identity, Impl, OFFSET>,
         }
@@ -2429,7 +2429,7 @@ impl IMbnVendorSpecificOperation_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SetVendorSpecific: SetVendorSpecific::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SetVendorSpecific: SetVendorSpecific::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMbnVendorSpecificOperation as ::windows::core::Interface>::IID

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/MobileBroadband/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/MobileBroadband/mod.rs
@@ -144,7 +144,7 @@ unsafe impl ::windows::core::Interface for IMbnConnection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMbnConnection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ConnectionID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, connectionid: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub InterfaceID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, interfaceid: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub Connect: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, connectionmode: MBN_CONNECTION_MODE, strprofile: ::windows::core::PCWSTR, requestid: *mut u32) -> ::windows::core::HRESULT,
@@ -210,7 +210,7 @@ unsafe impl ::windows::core::Interface for IMbnConnectionContext {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMbnConnectionContext_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub GetProvisionedContexts: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, provisionedcontexts: *mut *mut super::super::System::Com::SAFEARRAY) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -272,7 +272,7 @@ unsafe impl ::windows::core::Interface for IMbnConnectionContextEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMbnConnectionContextEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnProvisionedContextListChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, newinterface: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub OnSetProvisionedContextComplete: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, newinterface: *mut ::core::ffi::c_void, requestid: u32, status: ::windows::core::HRESULT) -> ::windows::core::HRESULT,
 }
@@ -343,7 +343,7 @@ unsafe impl ::windows::core::Interface for IMbnConnectionEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMbnConnectionEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnConnectComplete: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, newconnection: *mut ::core::ffi::c_void, requestid: u32, status: ::windows::core::HRESULT) -> ::windows::core::HRESULT,
     pub OnDisconnectComplete: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, newconnection: *mut ::core::ffi::c_void, requestid: u32, status: ::windows::core::HRESULT) -> ::windows::core::HRESULT,
     pub OnConnectStateChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, newconnection: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -405,7 +405,7 @@ unsafe impl ::windows::core::Interface for IMbnConnectionManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMbnConnectionManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetConnection: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, connectionid: ::windows::core::PCWSTR, mbnconnection: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
     pub GetConnections: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, mbnconnections: *mut *mut super::super::System::Com::SAFEARRAY) -> ::windows::core::HRESULT,
@@ -467,7 +467,7 @@ unsafe impl ::windows::core::Interface for IMbnConnectionManagerEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMbnConnectionManagerEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnConnectionArrival: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, newconnection: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub OnConnectionRemoval: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, oldconnection: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -527,7 +527,7 @@ unsafe impl ::windows::core::Interface for IMbnConnectionProfile {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMbnConnectionProfile_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetProfileXmlData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, profiledata: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub UpdateProfile: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, strprofile: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub Delete: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -581,7 +581,7 @@ unsafe impl ::windows::core::Interface for IMbnConnectionProfileEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMbnConnectionProfileEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnProfileUpdate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, newprofile: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_NetworkManagement_MobileBroadband\"`*"]
@@ -650,7 +650,7 @@ unsafe impl ::windows::core::Interface for IMbnConnectionProfileManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMbnConnectionProfileManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub GetConnectionProfiles: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, mbninterface: *mut ::core::ffi::c_void, connectionprofiles: *mut *mut super::super::System::Com::SAFEARRAY) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -713,7 +713,7 @@ unsafe impl ::windows::core::Interface for IMbnConnectionProfileManagerEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMbnConnectionProfileManagerEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnConnectionProfileArrival: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, newconnectionprofile: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub OnConnectionProfileRemoval: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, oldconnectionprofile: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -818,7 +818,7 @@ unsafe impl ::windows::core::Interface for IMbnDeviceService {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMbnDeviceService_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub QuerySupportedCommands: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, requestid: *mut u32) -> ::windows::core::HRESULT,
     pub OpenCommandSession: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, requestid: *mut u32) -> ::windows::core::HRESULT,
     pub CloseCommandSession: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, requestid: *mut u32) -> ::windows::core::HRESULT,
@@ -893,7 +893,7 @@ unsafe impl ::windows::core::Interface for IMbnDeviceServiceStateEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMbnDeviceServiceStateEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnSessionsStateChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, interfaceid: ::core::mem::ManuallyDrop<::windows::core::BSTR>, statechange: MBN_DEVICE_SERVICE_SESSIONS_STATE) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_NetworkManagement_MobileBroadband\"`*"]
@@ -957,7 +957,7 @@ unsafe impl ::windows::core::Interface for IMbnDeviceServicesContext {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMbnDeviceServicesContext_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub EnumerateDeviceServices: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, deviceservices: *mut *mut super::super::System::Com::SAFEARRAY) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -1082,7 +1082,7 @@ unsafe impl ::windows::core::Interface for IMbnDeviceServicesEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMbnDeviceServicesEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub OnQuerySupportedCommandsComplete: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, deviceservice: *mut ::core::ffi::c_void, commandidlist: *const super::super::System::Com::SAFEARRAY, status: ::windows::core::HRESULT, requestid: u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -1157,7 +1157,7 @@ unsafe impl ::windows::core::Interface for IMbnDeviceServicesManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMbnDeviceServicesManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDeviceServicesContext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, networkinterfaceid: ::core::mem::ManuallyDrop<::windows::core::BSTR>, mbndevicescontext: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_NetworkManagement_MobileBroadband\"`*"]
@@ -1252,7 +1252,7 @@ unsafe impl ::windows::core::Interface for IMbnInterface {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMbnInterface_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub InterfaceID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, interfaceid: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub GetInterfaceCapability: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, interfacecaps: *mut MBN_INTERFACE_CAPS) -> ::windows::core::HRESULT,
     pub GetSubscriberInformation: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, subscriberinformation: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1365,7 +1365,7 @@ unsafe impl ::windows::core::Interface for IMbnInterfaceEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMbnInterfaceEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnInterfaceCapabilityAvailable: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, newinterface: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub OnSubscriberInformationChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, newinterface: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub OnReadyStateChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, newinterface: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1431,7 +1431,7 @@ unsafe impl ::windows::core::Interface for IMbnInterfaceManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMbnInterfaceManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetInterface: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, interfaceid: ::windows::core::PCWSTR, mbninterface: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
     pub GetInterfaces: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, mbninterfaces: *mut *mut super::super::System::Com::SAFEARRAY) -> ::windows::core::HRESULT,
@@ -1493,7 +1493,7 @@ unsafe impl ::windows::core::Interface for IMbnInterfaceManagerEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMbnInterfaceManagerEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnInterfaceArrival: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, newinterface: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub OnInterfaceRemoval: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, oldinterface: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -1569,7 +1569,7 @@ unsafe impl ::windows::core::Interface for IMbnMultiCarrier {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMbnMultiCarrier_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetHomeProvider: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, homeprovider: *const MBN_PROVIDER2, requestid: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
     pub GetPreferredProviders: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, preferredmulticarrierproviders: *mut *mut super::super::System::Com::SAFEARRAY) -> ::windows::core::HRESULT,
@@ -1659,7 +1659,7 @@ unsafe impl ::windows::core::Interface for IMbnMultiCarrierEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMbnMultiCarrierEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnSetHomeProviderComplete: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, mbninterface: *mut ::core::ffi::c_void, requestid: u32, status: ::windows::core::HRESULT) -> ::windows::core::HRESULT,
     pub OnCurrentCellularClassChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, mbninterface: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub OnPreferredProvidersChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, mbninterface: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1770,7 +1770,7 @@ unsafe impl ::windows::core::Interface for IMbnPin {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMbnPin_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub PinType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pintype: *mut MBN_PIN_TYPE) -> ::windows::core::HRESULT,
     pub PinFormat: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinformat: *mut MBN_PIN_FORMAT) -> ::windows::core::HRESULT,
     pub PinLengthMin: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinlengthmin: *mut u32) -> ::windows::core::HRESULT,
@@ -1856,7 +1856,7 @@ unsafe impl ::windows::core::Interface for IMbnPinEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMbnPinEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnEnableComplete: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pin: *mut ::core::ffi::c_void, pininfo: *const MBN_PIN_INFO, requestid: u32, status: ::windows::core::HRESULT) -> ::windows::core::HRESULT,
     pub OnDisableComplete: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pin: *mut ::core::ffi::c_void, pininfo: *const MBN_PIN_INFO, requestid: u32, status: ::windows::core::HRESULT) -> ::windows::core::HRESULT,
     pub OnEnterComplete: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pin: *mut ::core::ffi::c_void, pininfo: *const MBN_PIN_INFO, requestid: u32, status: ::windows::core::HRESULT) -> ::windows::core::HRESULT,
@@ -1920,7 +1920,7 @@ unsafe impl ::windows::core::Interface for IMbnPinManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMbnPinManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub GetPinList: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinlist: *mut *mut super::super::System::Com::SAFEARRAY) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -1983,7 +1983,7 @@ unsafe impl ::windows::core::Interface for IMbnPinManagerEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMbnPinManagerEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnPinListAvailable: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinmanager: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub OnGetPinStateComplete: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinmanager: *mut ::core::ffi::c_void, pininfo: MBN_PIN_INFO, requestid: u32, status: ::windows::core::HRESULT) -> ::windows::core::HRESULT,
 }
@@ -2042,7 +2042,7 @@ unsafe impl ::windows::core::Interface for IMbnRadio {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMbnRadio_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SoftwareRadioState: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, softwareradiostate: *mut MBN_RADIO) -> ::windows::core::HRESULT,
     pub HardwareRadioState: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hardwareradiostate: *mut MBN_RADIO) -> ::windows::core::HRESULT,
     pub SetSoftwareRadioState: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, radiostate: MBN_RADIO, requestid: *mut u32) -> ::windows::core::HRESULT,
@@ -2102,7 +2102,7 @@ unsafe impl ::windows::core::Interface for IMbnRadioEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMbnRadioEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnRadioStateChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, newinterface: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub OnSetSoftwareRadioStateComplete: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, newinterface: *mut ::core::ffi::c_void, requestid: u32, status: ::windows::core::HRESULT) -> ::windows::core::HRESULT,
 }
@@ -2192,7 +2192,7 @@ unsafe impl ::windows::core::Interface for IMbnRegistration {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMbnRegistration_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetRegisterState: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, registerstate: *mut MBN_REGISTER_STATE) -> ::windows::core::HRESULT,
     pub GetRegisterMode: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, registermode: *mut MBN_REGISTER_MODE) -> ::windows::core::HRESULT,
     pub GetProviderID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, providerid: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
@@ -2271,7 +2271,7 @@ unsafe impl ::windows::core::Interface for IMbnRegistrationEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMbnRegistrationEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnRegisterModeAvailable: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, newinterface: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub OnRegisterStateChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, newinterface: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub OnPacketServiceStateChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, newinterface: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -2326,7 +2326,7 @@ unsafe impl ::windows::core::Interface for IMbnServiceActivation {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMbnServiceActivation_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub Activate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, vendorspecificdata: *const super::super::System::Com::SAFEARRAY, requestid: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -2383,7 +2383,7 @@ unsafe impl ::windows::core::Interface for IMbnServiceActivationEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMbnServiceActivationEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub OnActivationComplete: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, serviceactivation: *mut ::core::ffi::c_void, vendorspecificdata: *const super::super::System::Com::SAFEARRAY, requestid: u32, status: ::windows::core::HRESULT, networkerror: u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -2440,7 +2440,7 @@ unsafe impl ::windows::core::Interface for IMbnSignal {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMbnSignal_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetSignalStrength: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, signalstrength: *mut u32) -> ::windows::core::HRESULT,
     pub GetSignalError: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, signalerror: *mut u32) -> ::windows::core::HRESULT,
 }
@@ -2493,7 +2493,7 @@ unsafe impl ::windows::core::Interface for IMbnSignalEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMbnSignalEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnSignalStateChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, newinterface: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_NetworkManagement_MobileBroadband\"`*"]
@@ -2584,7 +2584,7 @@ unsafe impl ::windows::core::Interface for IMbnSms {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMbnSms_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetSmsConfiguration: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, smsconfiguration: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetSmsConfiguration: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, smsconfiguration: *mut ::core::ffi::c_void, requestid: *mut u32) -> ::windows::core::HRESULT,
     pub SmsSendPdu: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdudata: ::windows::core::PCWSTR, size: u8, requestid: *mut u32) -> ::windows::core::HRESULT,
@@ -2668,7 +2668,7 @@ unsafe impl ::windows::core::Interface for IMbnSmsConfiguration {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMbnSmsConfiguration_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ServiceCenterAddress: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, scaddress: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub SetServiceCenterAddress: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, scaddress: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub MaxMessageIndex: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: *mut u32) -> ::windows::core::HRESULT,
@@ -2765,7 +2765,7 @@ unsafe impl ::windows::core::Interface for IMbnSmsEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMbnSmsEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnSmsConfigurationChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sms: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub OnSetSmsConfigurationComplete: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sms: *mut ::core::ffi::c_void, requestid: u32, status: ::windows::core::HRESULT) -> ::windows::core::HRESULT,
     pub OnSmsSendComplete: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sms: *mut ::core::ffi::c_void, requestid: u32, status: ::windows::core::HRESULT) -> ::windows::core::HRESULT,
@@ -2841,7 +2841,7 @@ unsafe impl ::windows::core::Interface for IMbnSmsReadMsgPdu {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMbnSmsReadMsgPdu_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Index: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: *mut u32) -> ::windows::core::HRESULT,
     pub Status: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, status: *mut MBN_MSG_STATUS) -> ::windows::core::HRESULT,
     pub PduData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdudata: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
@@ -2927,7 +2927,7 @@ unsafe impl ::windows::core::Interface for IMbnSmsReadMsgTextCdma {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMbnSmsReadMsgTextCdma_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Index: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: *mut u32) -> ::windows::core::HRESULT,
     pub Status: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, status: *mut MBN_MSG_STATUS) -> ::windows::core::HRESULT,
     pub Address: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, address: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
@@ -2997,7 +2997,7 @@ unsafe impl ::windows::core::Interface for IMbnSubscriberInformation {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMbnSubscriberInformation_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SubscriberID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, subscriberid: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub SimIccID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, simiccid: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
@@ -3064,7 +3064,7 @@ unsafe impl ::windows::core::Interface for IMbnVendorSpecificEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMbnVendorSpecificEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub OnEventNotification: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, vendoroperation: *mut ::core::ffi::c_void, vendorspecificdata: *const super::super::System::Com::SAFEARRAY) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -3123,7 +3123,7 @@ unsafe impl ::windows::core::Interface for IMbnVendorSpecificOperation {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMbnVendorSpecificOperation_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub SetVendorSpecific: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, vendorspecificdata: *const super::super::System::Com::SAFEARRAY, requestid: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetManagement/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetManagement/impl.rs
@@ -34,7 +34,7 @@ impl IEnumNetCfgBindingInterface_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -81,7 +81,7 @@ impl IEnumNetCfgBindingPath_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -128,7 +128,7 @@ impl IEnumNetCfgComponent_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -199,7 +199,7 @@ impl INetCfg_Vtbl {
             this.QueryNetCfgClass(::core::mem::transmute_copy(&pguidclass), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppvobject)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             Uninitialize: Uninitialize::<Identity, Impl, OFFSET>,
             Apply: Apply::<Identity, Impl, OFFSET>,
@@ -255,7 +255,7 @@ impl INetCfgBindingInterface_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetName: GetName::<Identity, Impl, OFFSET>,
             GetUpperComponent: GetUpperComponent::<Identity, Impl, OFFSET>,
             GetLowerComponent: GetLowerComponent::<Identity, Impl, OFFSET>,
@@ -346,7 +346,7 @@ impl INetCfgBindingPath_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             IsSamePathAs: IsSamePathAs::<Identity, Impl, OFFSET>,
             IsSubPathOf: IsSubPathOf::<Identity, Impl, OFFSET>,
             IsEnabled: IsEnabled::<Identity, Impl, OFFSET>,
@@ -391,7 +391,7 @@ impl INetCfgClass_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             FindComponent: FindComponent::<Identity, Impl, OFFSET>,
             EnumComponents: EnumComponents::<Identity, Impl, OFFSET>,
         }
@@ -439,7 +439,7 @@ impl INetCfgClassSetup_Vtbl {
             this.DeInstall(::core::mem::transmute(&pcomponent), ::core::mem::transmute_copy(&pobotoken), ::core::mem::transmute_copy(&pmszwrefs)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SelectAndInstall: SelectAndInstall::<Identity, Impl, OFFSET>,
             Install: Install::<Identity, Impl, OFFSET>,
             DeInstall: DeInstall::<Identity, Impl, OFFSET>,
@@ -613,7 +613,7 @@ impl INetCfgComponent_Vtbl {
             this.RaisePropertyUi(::core::mem::transmute_copy(&hwndparent), ::core::mem::transmute_copy(&dwflags), ::core::mem::transmute(&punkcontext)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDisplayName: GetDisplayName::<Identity, Impl, OFFSET>,
             SetDisplayName: SetDisplayName::<Identity, Impl, OFFSET>,
             GetHelpText: GetHelpText::<Identity, Impl, OFFSET>,
@@ -692,7 +692,7 @@ impl INetCfgComponentBindings_Vtbl {
             this.MoveAfter(::core::mem::transmute(&pncbitemsrc), ::core::mem::transmute(&pncbitemdest)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             BindTo: BindTo::<Identity, Impl, OFFSET>,
             UnbindFrom: UnbindFrom::<Identity, Impl, OFFSET>,
             SupportsBindingInterface: SupportsBindingInterface::<Identity, Impl, OFFSET>,
@@ -740,7 +740,7 @@ impl INetCfgComponentControl_Vtbl {
             this.CancelChanges().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             ApplyRegistryChanges: ApplyRegistryChanges::<Identity, Impl, OFFSET>,
             ApplyPnpChanges: ApplyPnpChanges::<Identity, Impl, OFFSET>,
@@ -769,7 +769,7 @@ impl INetCfgComponentNotifyBinding_Vtbl {
             this.NotifyBindingPath(::core::mem::transmute_copy(&dwchangeflag), ::core::mem::transmute(&pipath)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             QueryBindingPath: QueryBindingPath::<Identity, Impl, OFFSET>,
             NotifyBindingPath: NotifyBindingPath::<Identity, Impl, OFFSET>,
         }
@@ -814,7 +814,7 @@ impl INetCfgComponentNotifyGlobal_Vtbl {
             this.SysNotifyComponent(::core::mem::transmute_copy(&dwchangeflag), ::core::mem::transmute(&picomp)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSupportedNotifications: GetSupportedNotifications::<Identity, Impl, OFFSET>,
             SysQueryBindingPath: SysQueryBindingPath::<Identity, Impl, OFFSET>,
             SysNotifyBindingPath: SysNotifyBindingPath::<Identity, Impl, OFFSET>,
@@ -870,7 +870,7 @@ impl INetCfgComponentPropertyUi_Vtbl {
             this.CancelProperties().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             QueryPropertyUi: QueryPropertyUi::<Identity, Impl, OFFSET>,
             SetContext: SetContext::<Identity, Impl, OFFSET>,
             MergePropPages: MergePropPages::<Identity, Impl, OFFSET>,
@@ -913,7 +913,7 @@ impl INetCfgComponentSetup_Vtbl {
             this.Removing().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Install: Install::<Identity, Impl, OFFSET>,
             Upgrade: Upgrade::<Identity, Impl, OFFSET>,
             ReadAnswerFile: ReadAnswerFile::<Identity, Impl, OFFSET>,
@@ -942,7 +942,7 @@ impl INetCfgComponentSysPrep_Vtbl {
             this.RestoreAdapterParameters(::core::mem::transmute(&pszwanswerfile), ::core::mem::transmute(&pszwanswersection), ::core::mem::transmute_copy(&padapterinstanceguid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SaveAdapterParameters: SaveAdapterParameters::<Identity, Impl, OFFSET>,
             RestoreAdapterParameters: RestoreAdapterParameters::<Identity, Impl, OFFSET>,
         }
@@ -975,7 +975,7 @@ impl INetCfgComponentUpperEdge_Vtbl {
             this.RemoveInterfacesFromAdapter(::core::mem::transmute(&padapter), ::core::mem::transmute_copy(&dwnuminterfaces), ::core::mem::transmute_copy(&pguidinterfaceids)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetInterfaceIdsForAdapter: GetInterfaceIdsForAdapter::<Identity, Impl, OFFSET>,
             AddInterfacesToAdapter: AddInterfacesToAdapter::<Identity, Impl, OFFSET>,
             RemoveInterfacesFromAdapter: RemoveInterfacesFromAdapter::<Identity, Impl, OFFSET>,
@@ -1021,7 +1021,7 @@ impl INetCfgLock_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AcquireWriteLock: AcquireWriteLock::<Identity, Impl, OFFSET>,
             ReleaseWriteLock: ReleaseWriteLock::<Identity, Impl, OFFSET>,
             IsWriteLocked: IsWriteLocked::<Identity, Impl, OFFSET>,
@@ -1042,7 +1042,7 @@ impl INetCfgPnpReconfigCallback_Vtbl {
             let this = (*this).get_impl();
             this.SendPnpReconfig(::core::mem::transmute_copy(&layer), ::core::mem::transmute(&pszwupper), ::core::mem::transmute(&pszwlower), ::core::mem::transmute_copy(&pvdata), ::core::mem::transmute_copy(&dwsizeofdata)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SendPnpReconfig: SendPnpReconfig::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SendPnpReconfig: SendPnpReconfig::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<INetCfgPnpReconfigCallback as ::windows::core::Interface>::IID
@@ -1081,7 +1081,7 @@ impl INetCfgSysPrep_Vtbl {
             this.HrSetupSetFirstMultiSzField(::core::mem::transmute(&pwszsection), ::core::mem::transmute(&pwszkey), ::core::mem::transmute(&pmszvalue)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             HrSetupSetFirstDword: HrSetupSetFirstDword::<Identity, Impl, OFFSET>,
             HrSetupSetFirstString: HrSetupSetFirstString::<Identity, Impl, OFFSET>,
             HrSetupSetFirstStringAsBool: HrSetupSetFirstStringAsBool::<Identity, Impl, OFFSET>,
@@ -1109,7 +1109,7 @@ impl INetLanConnectionUiInfo_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetDeviceGuid: GetDeviceGuid::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetDeviceGuid: GetDeviceGuid::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<INetLanConnectionUiInfo as ::windows::core::Interface>::IID
@@ -1135,7 +1135,7 @@ impl INetRasConnectionIpUiInfo_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetUiInfo: GetUiInfo::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetUiInfo: GetUiInfo::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<INetRasConnectionIpUiInfo as ::windows::core::Interface>::IID
@@ -1167,7 +1167,7 @@ impl IProvisioningDomain_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Add: Add::<Identity, Impl, OFFSET>, Query: Query::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Add: Add::<Identity, Impl, OFFSET>, Query: Query::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IProvisioningDomain as ::windows::core::Interface>::IID
@@ -1190,7 +1190,7 @@ impl IProvisioningProfileWireless_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CreateProfile: CreateProfile::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CreateProfile: CreateProfile::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IProvisioningProfileWireless as ::windows::core::Interface>::IID

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetManagement/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetManagement/mod.rs
@@ -2225,7 +2225,7 @@ unsafe impl ::windows::core::Interface for IEnumNetCfgBindingInterface {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumNetCfgBindingInterface_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -2287,7 +2287,7 @@ unsafe impl ::windows::core::Interface for IEnumNetCfgBindingPath {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumNetCfgBindingPath_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -2349,7 +2349,7 @@ unsafe impl ::windows::core::Interface for IEnumNetCfgComponent {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumNetCfgComponent_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -2424,7 +2424,7 @@ unsafe impl ::windows::core::Interface for INetCfg {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INetCfg_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pvreserved: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Uninitialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Apply: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -2488,7 +2488,7 @@ unsafe impl ::windows::core::Interface for INetCfgBindingInterface {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INetCfgBindingInterface_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppszwinterfacename: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetUpperComponent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppnccitem: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetLowerComponent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppnccitem: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -2575,7 +2575,7 @@ unsafe impl ::windows::core::Interface for INetCfgBindingPath {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INetCfgBindingPath_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub IsSamePathAs: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppath: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub IsSubPathOf: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppath: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub IsEnabled: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -2642,7 +2642,7 @@ unsafe impl ::windows::core::Interface for INetCfgClass {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INetCfgClass_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub FindComponent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszwinfid: ::windows::core::PCWSTR, ppnccitem: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub EnumComponents: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppenumcomponent: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -2717,7 +2717,7 @@ unsafe impl ::windows::core::Interface for INetCfgClassSetup {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INetCfgClassSetup_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub SelectAndInstall: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hwndparent: super::super::Foundation::HWND, pobotoken: *const OBO_TOKEN, ppnccitem: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -2926,7 +2926,7 @@ unsafe impl ::windows::core::Interface for INetCfgComponent {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INetCfgComponent_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDisplayName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppszwdisplayname: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub SetDisplayName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszwdisplayname: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub GetHelpText: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszwhelptext: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
@@ -3037,7 +3037,7 @@ unsafe impl ::windows::core::Interface for INetCfgComponentBindings {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INetCfgComponentBindings_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub BindTo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pnccitem: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub UnbindFrom: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pnccitem: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SupportsBindingInterface: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwflags: u32, pszwinterfacename: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
@@ -3112,7 +3112,7 @@ unsafe impl ::windows::core::Interface for INetCfgComponentControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INetCfgComponentControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, picomp: *mut ::core::ffi::c_void, pinetcfg: *mut ::core::ffi::c_void, finstalling: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -3176,7 +3176,7 @@ unsafe impl ::windows::core::Interface for INetCfgComponentNotifyBinding {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INetCfgComponentNotifyBinding_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub QueryBindingPath: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwchangeflag: u32, pipath: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub NotifyBindingPath: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwchangeflag: u32, pipath: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -3245,7 +3245,7 @@ unsafe impl ::windows::core::Interface for INetCfgComponentNotifyGlobal {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INetCfgComponentNotifyGlobal_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetSupportedNotifications: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwnotifications: *mut u32) -> ::windows::core::HRESULT,
     pub SysQueryBindingPath: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwchangeflag: u32, pipath: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SysNotifyBindingPath: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwchangeflag: u32, pipath: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -3328,7 +3328,7 @@ unsafe impl ::windows::core::Interface for INetCfgComponentPropertyUi {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INetCfgComponentPropertyUi_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub QueryPropertyUi: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punkreserved: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetContext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punkreserved: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -3401,7 +3401,7 @@ unsafe impl ::windows::core::Interface for INetCfgComponentSetup {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INetCfgComponentSetup_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Install: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwsetupflags: u32) -> ::windows::core::HRESULT,
     pub Upgrade: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwsetupflags: u32, dwupgradefombuildno: u32) -> ::windows::core::HRESULT,
     pub ReadAnswerFile: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszwanswerfile: ::windows::core::PCWSTR, pszwanswersections: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
@@ -3464,7 +3464,7 @@ unsafe impl ::windows::core::Interface for INetCfgComponentSysPrep {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INetCfgComponentSysPrep_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SaveAdapterParameters: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pncsp: *mut ::core::ffi::c_void, pszwanswersections: ::windows::core::PCWSTR, padapterinstanceguid: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub RestoreAdapterParameters: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszwanswerfile: ::windows::core::PCWSTR, pszwanswersection: ::windows::core::PCWSTR, padapterinstanceguid: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
 }
@@ -3529,7 +3529,7 @@ unsafe impl ::windows::core::Interface for INetCfgComponentUpperEdge {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INetCfgComponentUpperEdge_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetInterfaceIdsForAdapter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, padapter: *mut ::core::ffi::c_void, pdwnuminterfaces: *mut u32, ppguidinterfaceids: *mut *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub AddInterfacesToAdapter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, padapter: *mut ::core::ffi::c_void, dwnuminterfaces: u32) -> ::windows::core::HRESULT,
     pub RemoveInterfacesFromAdapter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, padapter: *mut ::core::ffi::c_void, dwnuminterfaces: u32, pguidinterfaceids: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
@@ -3591,7 +3591,7 @@ unsafe impl ::windows::core::Interface for INetCfgLock {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INetCfgLock_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AcquireWriteLock: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cmstimeout: u32, pszwclientdescription: ::windows::core::PCWSTR, ppszwclientdescription: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub ReleaseWriteLock: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub IsWriteLocked: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppszwclientdescription: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
@@ -3646,7 +3646,7 @@ unsafe impl ::windows::core::Interface for INetCfgPnpReconfigCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INetCfgPnpReconfigCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SendPnpReconfig: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, layer: NCPNP_RECONFIG_LAYER, pszwupper: ::windows::core::PCWSTR, pszwlower: ::windows::core::PCWSTR, pvdata: *const ::core::ffi::c_void, dwsizeofdata: u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_NetworkManagement_NetManagement\"`*"]
@@ -3725,7 +3725,7 @@ unsafe impl ::windows::core::Interface for INetCfgSysPrep {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INetCfgSysPrep_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub HrSetupSetFirstDword: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszsection: ::windows::core::PCWSTR, pwszkey: ::windows::core::PCWSTR, dwvalue: u32) -> ::windows::core::HRESULT,
     pub HrSetupSetFirstString: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszsection: ::windows::core::PCWSTR, pwszkey: ::windows::core::PCWSTR, pwszvalue: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -3781,7 +3781,7 @@ unsafe impl ::windows::core::Interface for INetLanConnectionUiInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INetLanConnectionUiInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDeviceGuid: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pguid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_NetworkManagement_NetManagement\"`*"]
@@ -3833,7 +3833,7 @@ unsafe impl ::windows::core::Interface for INetRasConnectionIpUiInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INetRasConnectionIpUiInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetUiInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *mut RASCON_IPUI) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -3899,7 +3899,7 @@ unsafe impl ::windows::core::Interface for IProvisioningDomain {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IProvisioningDomain_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Add: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszwpathtofolder: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Data_Xml_MsXml", feature = "Win32_System_Com"))]
     pub Query: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszwdomain: ::windows::core::PCWSTR, pszwlanguage: ::windows::core::PCWSTR, pszwxpathquery: ::windows::core::PCWSTR, nodes: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -3953,7 +3953,7 @@ unsafe impl ::windows::core::Interface for IProvisioningProfileWireless {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IProvisioningProfileWireless_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateProfile: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrxmlwirelessconfigprofile: ::core::mem::ManuallyDrop<::windows::core::BSTR>, bstrxmlconnectionconfigprofile: ::core::mem::ManuallyDrop<::windows::core::BSTR>, padapterinstanceguid: *const ::windows::core::GUID, pulstatus: *mut u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_NetworkManagement_NetManagement\"`*"]

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetworkDiagnosticsFramework/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetworkDiagnosticsFramework/impl.rs
@@ -12,7 +12,7 @@ impl INetDiagExtensibleHelper_Vtbl {
             let this = (*this).get_impl();
             this.ResolveAttributes(::core::mem::transmute_copy(&celt), ::core::mem::transmute_copy(&rgkeyattributes), ::core::mem::transmute_copy(&pcelt), ::core::mem::transmute_copy(&prgmatchvalues)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), ResolveAttributes: ResolveAttributes::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), ResolveAttributes: ResolveAttributes::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<INetDiagExtensibleHelper as ::windows::core::Interface>::IID
@@ -153,7 +153,7 @@ impl INetDiagHelper_Vtbl {
             this.Cleanup().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             GetDiagnosticsInfo: GetDiagnosticsInfo::<Identity, Impl, OFFSET>,
             GetKeyAttributes: GetKeyAttributes::<Identity, Impl, OFFSET>,
@@ -205,7 +205,7 @@ impl INetDiagHelperEx_Vtbl {
             this.ReproduceFailure().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ReconfirmLowHealth: ReconfirmLowHealth::<Identity, Impl, OFFSET>,
             SetUtilities: SetUtilities::<Identity, Impl, OFFSET>,
             ReproduceFailure: ReproduceFailure::<Identity, Impl, OFFSET>,
@@ -226,7 +226,7 @@ impl INetDiagHelperInfo_Vtbl {
             let this = (*this).get_impl();
             this.GetAttributeInfo(::core::mem::transmute_copy(&pcelt), ::core::mem::transmute_copy(&pprgattributeinfos)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetAttributeInfo: GetAttributeInfo::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetAttributeInfo: GetAttributeInfo::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<INetDiagHelperInfo as ::windows::core::Interface>::IID
@@ -243,7 +243,7 @@ impl INetDiagHelperUtilFactory_Vtbl {
             let this = (*this).get_impl();
             this.CreateUtilityInstance(::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppvobject)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CreateUtilityInstance: CreateUtilityInstance::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CreateUtilityInstance: CreateUtilityInstance::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<INetDiagHelperUtilFactory as ::windows::core::Interface>::IID

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetworkDiagnosticsFramework/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetworkDiagnosticsFramework/mod.rs
@@ -235,7 +235,7 @@ unsafe impl ::windows::core::Interface for INetDiagExtensibleHelper {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INetDiagExtensibleHelper_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub ResolveAttributes: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgkeyattributes: *const HELPER_ATTRIBUTE, pcelt: *mut u32, prgmatchvalues: *mut *mut HELPER_ATTRIBUTE) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -367,7 +367,7 @@ unsafe impl ::windows::core::Interface for INetDiagHelper {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INetDiagHelper_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgattributes: *const HELPER_ATTRIBUTE) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -474,7 +474,7 @@ unsafe impl ::windows::core::Interface for INetDiagHelperEx {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INetDiagHelperEx_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub ReconfirmLowHealth: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, presults: *const HypothesisResult, ppwszupdateddescription: *mut ::windows::core::PWSTR, pupdatedstatus: *mut DIAGNOSIS_STATUS) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -528,7 +528,7 @@ unsafe impl ::windows::core::Interface for INetDiagHelperInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INetDiagHelperInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetAttributeInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcelt: *mut u32, pprgattributeinfos: *mut *mut HelperAttributeInfo) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_NetworkManagement_NetworkDiagnosticsFramework\"`*"]
@@ -581,7 +581,7 @@ unsafe impl ::windows::core::Interface for INetDiagHelperUtilFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INetDiagHelperUtilFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateUtilityInstance: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_NetworkManagement_NetworkDiagnosticsFramework\"`*"]

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/WiFi/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/WiFi/impl.rs
@@ -82,7 +82,7 @@ impl IDot11AdHocInterface_Vtbl {
             this.GetStatus(::core::mem::transmute_copy(&pstate)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDeviceSignature: GetDeviceSignature::<Identity, Impl, OFFSET>,
             GetFriendlyName: GetFriendlyName::<Identity, Impl, OFFSET>,
             IsDot11d: IsDot11d::<Identity, Impl, OFFSET>,
@@ -109,7 +109,7 @@ impl IDot11AdHocInterfaceNotificationSink_Vtbl {
             let this = (*this).get_impl();
             this.OnConnectionStatusChange(::core::mem::transmute_copy(&estatus)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnConnectionStatusChange: OnConnectionStatusChange::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnConnectionStatusChange: OnConnectionStatusChange::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDot11AdHocInterfaceNotificationSink as ::windows::core::Interface>::IID
@@ -178,7 +178,7 @@ impl IDot11AdHocManager_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateNetwork: CreateNetwork::<Identity, Impl, OFFSET>,
             CommitCreatedNetwork: CommitCreatedNetwork::<Identity, Impl, OFFSET>,
             GetIEnumDot11AdHocNetworks: GetIEnumDot11AdHocNetworks::<Identity, Impl, OFFSET>,
@@ -220,7 +220,7 @@ impl IDot11AdHocManagerNotificationSink_Vtbl {
             this.OnInterfaceRemove(::core::mem::transmute_copy(&signature)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnNetworkAdd: OnNetworkAdd::<Identity, Impl, OFFSET>,
             OnNetworkRemove: OnNetworkRemove::<Identity, Impl, OFFSET>,
             OnInterfaceAdd: OnInterfaceAdd::<Identity, Impl, OFFSET>,
@@ -336,7 +336,7 @@ impl IDot11AdHocNetwork_Vtbl {
             this.Disconnect().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetStatus: GetStatus::<Identity, Impl, OFFSET>,
             GetSSID: GetSSID::<Identity, Impl, OFFSET>,
             HasProfile: HasProfile::<Identity, Impl, OFFSET>,
@@ -373,7 +373,7 @@ impl IDot11AdHocNetworkNotificationSink_Vtbl {
             this.OnConnectFail(::core::mem::transmute_copy(&efailreason)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnStatusChange: OnStatusChange::<Identity, Impl, OFFSET>,
             OnConnectFail: OnConnectFail::<Identity, Impl, OFFSET>,
         }
@@ -400,7 +400,7 @@ impl IDot11AdHocSecuritySettings_Vtbl {
             this.GetDot11CipherAlgorithm(::core::mem::transmute_copy(&pcipher)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDot11AuthAlgorithm: GetDot11AuthAlgorithm::<Identity, Impl, OFFSET>,
             GetDot11CipherAlgorithm: GetDot11CipherAlgorithm::<Identity, Impl, OFFSET>,
         }
@@ -445,7 +445,7 @@ impl IEnumDot11AdHocInterfaces_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -492,7 +492,7 @@ impl IEnumDot11AdHocNetworks_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -539,7 +539,7 @@ impl IEnumDot11AdHocSecuritySettings_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/WiFi/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/WiFi/mod.rs
@@ -868,7 +868,7 @@ unsafe impl ::windows::core::Interface for IDot11AdHocInterface {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDot11AdHocInterface_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDeviceSignature: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psignature: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub GetFriendlyName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppszname: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub IsDot11d: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pf11d: *mut u8) -> ::windows::core::HRESULT,
@@ -925,7 +925,7 @@ unsafe impl ::windows::core::Interface for IDot11AdHocInterfaceNotificationSink 
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDot11AdHocInterfaceNotificationSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnConnectionStatusChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, estatus: DOT11_ADHOC_NETWORK_CONNECTION_STATUS) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_NetworkManagement_WiFi\"`*"]
@@ -1003,7 +1003,7 @@ unsafe impl ::windows::core::Interface for IDot11AdHocManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDot11AdHocManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateNetwork: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, name: ::windows::core::PCWSTR, password: ::windows::core::PCWSTR, geographicalid: i32, pinterface: *mut ::core::ffi::c_void, psecurity: *mut ::core::ffi::c_void, pcontextguid: *const ::windows::core::GUID, piadhoc: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub CommitCreatedNetwork: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, piadhoc: *mut ::core::ffi::c_void, fsaveprofile: super::super::Foundation::BOOLEAN, fmakesavedprofileuserspecific: super::super::Foundation::BOOLEAN) -> ::windows::core::HRESULT,
@@ -1074,7 +1074,7 @@ unsafe impl ::windows::core::Interface for IDot11AdHocManagerNotificationSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDot11AdHocManagerNotificationSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnNetworkAdd: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, piadhocnetwork: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub OnNetworkRemove: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, signature: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub OnInterfaceAdd: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, piadhocinterface: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1170,7 +1170,7 @@ unsafe impl ::windows::core::Interface for IDot11AdHocNetwork {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDot11AdHocNetwork_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetStatus: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, estatus: *mut DOT11_ADHOC_NETWORK_CONNECTION_STATUS) -> ::windows::core::HRESULT,
     pub GetSSID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppszwssid: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub HasProfile: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pf11d: *mut u8) -> ::windows::core::HRESULT,
@@ -1236,7 +1236,7 @@ unsafe impl ::windows::core::Interface for IDot11AdHocNetworkNotificationSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDot11AdHocNetworkNotificationSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnStatusChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, estatus: DOT11_ADHOC_NETWORK_CONNECTION_STATUS) -> ::windows::core::HRESULT,
     pub OnConnectFail: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, efailreason: DOT11_ADHOC_CONNECT_FAIL_REASON) -> ::windows::core::HRESULT,
 }
@@ -1289,7 +1289,7 @@ unsafe impl ::windows::core::Interface for IDot11AdHocSecuritySettings {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDot11AdHocSecuritySettings_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDot11AuthAlgorithm: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pauth: *mut DOT11_ADHOC_AUTH_ALGORITHM) -> ::windows::core::HRESULT,
     pub GetDot11CipherAlgorithm: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcipher: *mut DOT11_ADHOC_CIPHER_ALGORITHM) -> ::windows::core::HRESULT,
 }
@@ -1349,7 +1349,7 @@ unsafe impl ::windows::core::Interface for IEnumDot11AdHocInterfaces {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumDot11AdHocInterfaces_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1411,7 +1411,7 @@ unsafe impl ::windows::core::Interface for IEnumDot11AdHocNetworks {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumDot11AdHocNetworks_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1473,7 +1473,7 @@ unsafe impl ::windows::core::Interface for IEnumDot11AdHocSecuritySettings {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumDot11AdHocSecuritySettings_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsConnectNow/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsConnectNow/impl.rs
@@ -16,7 +16,7 @@ impl IWCNConnectNotify_Vtbl {
             this.ConnectFailed(::core::mem::transmute_copy(&hrfailure)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ConnectSucceeded: ConnectSucceeded::<Identity, Impl, OFFSET>,
             ConnectFailed: ConnectFailed::<Identity, Impl, OFFSET>,
         }
@@ -103,7 +103,7 @@ impl IWCNDevice_Vtbl {
             this.SetNFCPasswordParams(::core::mem::transmute_copy(&r#type), ::core::mem::transmute_copy(&dwoobpasswordid), ::core::mem::transmute_copy(&dwpasswordlength), ::core::mem::transmute_copy(&pbpassword), ::core::mem::transmute_copy(&dwremotepublickeyhashlength), ::core::mem::transmute_copy(&pbremotepublickeyhash), ::core::mem::transmute_copy(&dwdhkeybloblength), ::core::mem::transmute_copy(&pbdhkeyblob)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetPassword: SetPassword::<Identity, Impl, OFFSET>,
             Connect: Connect::<Identity, Impl, OFFSET>,
             GetAttribute: GetAttribute::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsConnectNow/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsConnectNow/mod.rs
@@ -47,7 +47,7 @@ unsafe impl ::windows::core::Interface for IWCNConnectNotify {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWCNConnectNotify_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ConnectSucceeded: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub ConnectFailed: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hrfailure: ::windows::core::HRESULT) -> ::windows::core::HRESULT,
 }
@@ -145,7 +145,7 @@ unsafe impl ::windows::core::Interface for IWCNDevice {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWCNDevice_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetPassword: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, r#type: WCN_PASSWORD_TYPE, dwpasswordlength: u32, pbpassword: *const u8) -> ::windows::core::HRESULT,
     pub Connect: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pnotify: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetAttribute: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, attributetype: WCN_ATTRIBUTE_TYPE, dwmaxbuffersize: u32, pbbuffer: *mut u8, pdwbufferused: *mut u32) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsFirewall/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsFirewall/impl.rs
@@ -283,7 +283,7 @@ impl IEnumNetConnection_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -333,7 +333,7 @@ impl IEnumNetSharingEveryConnection_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -383,7 +383,7 @@ impl IEnumNetSharingPortMapping_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -433,7 +433,7 @@ impl IEnumNetSharingPrivateConnection_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -483,7 +483,7 @@ impl IEnumNetSharingPublicConnection_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -535,7 +535,7 @@ impl INATExternalIPAddressCallback_Vtbl {
             let this = (*this).get_impl();
             this.NewExternalIPAddress(::core::mem::transmute(&bstrnewexternalipaddress)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), NewExternalIPAddress: NewExternalIPAddress::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), NewExternalIPAddress: NewExternalIPAddress::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<INATExternalIPAddressCallback as ::windows::core::Interface>::IID
@@ -552,7 +552,7 @@ impl INATNumberOfEntriesCallback_Vtbl {
             let this = (*this).get_impl();
             this.NewNumberOfEntries(::core::mem::transmute_copy(&lnewnumberofentries)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), NewNumberOfEntries: NewNumberOfEntries::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), NewNumberOfEntries: NewNumberOfEntries::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<INATNumberOfEntriesCallback as ::windows::core::Interface>::IID
@@ -624,7 +624,7 @@ impl INetConnection_Vtbl {
             this.Rename(::core::mem::transmute(&pszwnewname)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Connect: Connect::<Identity, Impl, OFFSET>,
             Disconnect: Disconnect::<Identity, Impl, OFFSET>,
             Delete: Delete::<Identity, Impl, OFFSET>,
@@ -665,7 +665,7 @@ impl INetConnectionConnectUi_Vtbl {
             this.Disconnect(::core::mem::transmute_copy(&hwndparent), ::core::mem::transmute_copy(&dwflags)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetConnection: SetConnection::<Identity, Impl, OFFSET>,
             Connect: Connect::<Identity, Impl, OFFSET>,
             Disconnect: Disconnect::<Identity, Impl, OFFSET>,
@@ -692,7 +692,7 @@ impl INetConnectionManager_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), EnumConnections: EnumConnections::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), EnumConnections: EnumConnections::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<INetConnectionManager as ::windows::core::Interface>::IID

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsFirewall/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsFirewall/mod.rs
@@ -394,7 +394,7 @@ unsafe impl ::windows::core::Interface for IEnumNetConnection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumNetConnection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -458,7 +458,7 @@ unsafe impl ::windows::core::Interface for IEnumNetSharingEveryConnection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumNetSharingEveryConnection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgvar: *mut super::super::System::Com::VARIANT, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole")))]
@@ -525,7 +525,7 @@ unsafe impl ::windows::core::Interface for IEnumNetSharingPortMapping {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumNetSharingPortMapping_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgvar: *mut super::super::System::Com::VARIANT, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole")))]
@@ -592,7 +592,7 @@ unsafe impl ::windows::core::Interface for IEnumNetSharingPrivateConnection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumNetSharingPrivateConnection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgvar: *mut super::super::System::Com::VARIANT, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole")))]
@@ -659,7 +659,7 @@ unsafe impl ::windows::core::Interface for IEnumNetSharingPublicConnection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumNetSharingPublicConnection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgvar: *mut super::super::System::Com::VARIANT, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole")))]
@@ -802,7 +802,7 @@ unsafe impl ::windows::core::Interface for INATExternalIPAddressCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INATExternalIPAddressCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub NewExternalIPAddress: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrnewexternalipaddress: ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_NetworkManagement_WindowsFirewall\"`*"]
@@ -851,7 +851,7 @@ unsafe impl ::windows::core::Interface for INATNumberOfEntriesCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INATNumberOfEntriesCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub NewNumberOfEntries: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lnewnumberofentries: i32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_NetworkManagement_WindowsFirewall\"`*"]
@@ -927,7 +927,7 @@ unsafe impl ::windows::core::Interface for INetConnection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INetConnection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Connect: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Disconnect: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Delete: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1001,7 +1001,7 @@ unsafe impl ::windows::core::Interface for INetConnectionConnectUi {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INetConnectionConnectUi_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetConnection: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcon: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub Connect: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hwndparent: super::super::Foundation::HWND, dwflags: u32) -> ::windows::core::HRESULT,
@@ -1059,7 +1059,7 @@ unsafe impl ::windows::core::Interface for INetConnectionManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INetConnectionManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub EnumConnections: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, flags: NETCONMGR_ENUM_FLAGS, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_NetworkManagement_WindowsFirewall\"`, `\"Win32_System_Com\"`*"]

--- a/crates/libs/windows/src/Windows/Win32/Networking/ActiveDirectory/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/ActiveDirectory/impl.rs
@@ -703,7 +703,7 @@ impl IADsAggregatee_Vtbl {
             this.RestoreInterface(::core::mem::transmute_copy(&riid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ConnectAsAggregatee: ConnectAsAggregatee::<Identity, Impl, OFFSET>,
             DisconnectAsAggregatee: DisconnectAsAggregatee::<Identity, Impl, OFFSET>,
             RelinquishInterface: RelinquishInterface::<Identity, Impl, OFFSET>,
@@ -732,7 +732,7 @@ impl IADsAggregator_Vtbl {
             this.DisconnectAsAggregator().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ConnectAsAggregator: ConnectAsAggregator::<Identity, Impl, OFFSET>,
             DisconnectAsAggregator: DisconnectAsAggregator::<Identity, Impl, OFFSET>,
         }
@@ -2136,7 +2136,7 @@ impl IADsExtension_Vtbl {
             this.PrivateInvoke(::core::mem::transmute_copy(&dispidmember), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&lcid), ::core::mem::transmute_copy(&wflags), ::core::mem::transmute_copy(&pdispparams), ::core::mem::transmute_copy(&pvarresult), ::core::mem::transmute_copy(&pexcepinfo), ::core::mem::transmute_copy(&puargerr)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Operate: Operate::<Identity, Impl, OFFSET>,
             PrivateGetIDsOfNames: PrivateGetIDsOfNames::<Identity, Impl, OFFSET>,
             PrivateInvoke: PrivateInvoke::<Identity, Impl, OFFSET>,
@@ -6906,7 +6906,7 @@ impl ICommonQuery_Vtbl {
             let this = (*this).get_impl();
             this.OpenQueryWindow(::core::mem::transmute_copy(&hwndparent), ::core::mem::transmute_copy(&pquerywnd), ::core::mem::transmute_copy(&ppdataobject)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OpenQueryWindow: OpenQueryWindow::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OpenQueryWindow: OpenQueryWindow::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ICommonQuery as ::windows::core::Interface>::IID
@@ -6969,7 +6969,7 @@ impl IDirectoryObject_Vtbl {
             this.DeleteDSObject(::core::mem::transmute(&pszrdnname)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetObjectInformation: GetObjectInformation::<Identity, Impl, OFFSET>,
             GetObjectAttributes: GetObjectAttributes::<Identity, Impl, OFFSET>,
             SetObjectAttributes: SetObjectAttributes::<Identity, Impl, OFFSET>,
@@ -7038,7 +7038,7 @@ impl IDirectorySchemaMgmt_Vtbl {
             this.DeleteClassDefinition(::core::mem::transmute(&pszclassname)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             EnumAttributes: EnumAttributes::<Identity, Impl, OFFSET>,
             CreateAttributeDefinition: CreateAttributeDefinition::<Identity, Impl, OFFSET>,
             WriteAttributeDefinition: WriteAttributeDefinition::<Identity, Impl, OFFSET>,
@@ -7134,7 +7134,7 @@ impl IDirectorySearch_Vtbl {
             this.CloseSearchHandle(::core::mem::transmute_copy(&hsearchresult)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetSearchPreference: SetSearchPreference::<Identity, Impl, OFFSET>,
             ExecuteSearch: ExecuteSearch::<Identity, Impl, OFFSET>,
             AbandonSearch: AbandonSearch::<Identity, Impl, OFFSET>,
@@ -7178,7 +7178,7 @@ impl IDsAdminCreateObj_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             CreateModal: CreateModal::<Identity, Impl, OFFSET>,
         }
@@ -7208,7 +7208,7 @@ impl IDsAdminNewObj_Vtbl {
             this.GetPageCounts(::core::mem::transmute_copy(&pntotal), ::core::mem::transmute_copy(&pnstartindex)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetButtons: SetButtons::<Identity, Impl, OFFSET>,
             GetPageCounts: GetPageCounts::<Identity, Impl, OFFSET>,
         }
@@ -7262,7 +7262,7 @@ impl IDsAdminNewObjExt_Vtbl {
             this.GetSummaryInfo(::core::mem::transmute_copy(&pbstrtext)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             AddPages: AddPages::<Identity, Impl, OFFSET>,
             SetObject: SetObject::<Identity, Impl, OFFSET>,
@@ -7293,7 +7293,7 @@ impl IDsAdminNewObjPrimarySite_Vtbl {
             this.Commit().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateNew: CreateNew::<Identity, Impl, OFFSET>,
             Commit: Commit::<Identity, Impl, OFFSET>,
         }
@@ -7335,7 +7335,7 @@ impl IDsAdminNotifyHandler_Vtbl {
             this.End().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             Begin: Begin::<Identity, Impl, OFFSET>,
             Notify: Notify::<Identity, Impl, OFFSET>,
@@ -7385,7 +7385,7 @@ impl IDsBrowseDomainTree_Vtbl {
             this.SetComputer(::core::mem::transmute(&pszcomputername), ::core::mem::transmute(&pszusername), ::core::mem::transmute(&pszpassword)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             BrowseTo: BrowseTo::<Identity, Impl, OFFSET>,
             GetDomains: GetDomains::<Identity, Impl, OFFSET>,
             FreeDomains: FreeDomains::<Identity, Impl, OFFSET>,
@@ -7472,7 +7472,7 @@ impl IDsDisplaySpecifier_Vtbl {
             this.GetAttributeADsType(::core::mem::transmute(&pszattributename))
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetServer: SetServer::<Identity, Impl, OFFSET>,
             SetLanguageID: SetLanguageID::<Identity, Impl, OFFSET>,
             GetDisplaySpecifier: GetDisplaySpecifier::<Identity, Impl, OFFSET>,
@@ -7517,7 +7517,7 @@ impl IDsObjectPicker_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             InvokeDialog: InvokeDialog::<Identity, Impl, OFFSET>,
         }
@@ -7668,7 +7668,7 @@ impl IPrivateDispatch_Vtbl {
             this.ADSIInvoke(::core::mem::transmute_copy(&dispidmember), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&lcid), ::core::mem::transmute_copy(&wflags), ::core::mem::transmute_copy(&pdispparams), ::core::mem::transmute_copy(&pvarresult), ::core::mem::transmute_copy(&pexcepinfo), ::core::mem::transmute_copy(&puargerr)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ADSIInitializeDispatchManager: ADSIInitializeDispatchManager::<Identity, Impl, OFFSET>,
             ADSIGetTypeInfoCount: ADSIGetTypeInfoCount::<Identity, Impl, OFFSET>,
             ADSIGetTypeInfo: ADSIGetTypeInfo::<Identity, Impl, OFFSET>,
@@ -7698,7 +7698,7 @@ impl IPrivateUnknown_Vtbl {
             this.ADSIReleaseObject().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ADSIInitializeObject: ADSIInitializeObject::<Identity, Impl, OFFSET>,
             ADSIReleaseObject: ADSIReleaseObject::<Identity, Impl, OFFSET>,
         }
@@ -7734,7 +7734,7 @@ impl IQueryForm_Vtbl {
             this.AddPages(::core::mem::transmute(&paddpagesproc), ::core::mem::transmute_copy(&lparam)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             AddForms: AddForms::<Identity, Impl, OFFSET>,
             AddPages: AddPages::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/Networking/ActiveDirectory/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/ActiveDirectory/mod.rs
@@ -2763,7 +2763,7 @@ unsafe impl ::windows::core::Interface for IADsAggregatee {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IADsAggregatee_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ConnectAsAggregatee: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pouterunknown: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub DisconnectAsAggregatee: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub RelinquishInterface: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
@@ -2821,7 +2821,7 @@ unsafe impl ::windows::core::Interface for IADsAggregator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IADsAggregator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ConnectAsAggregator: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, paggregatee: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub DisconnectAsAggregator: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -4832,7 +4832,7 @@ unsafe impl ::windows::core::Interface for IADsExtension {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IADsExtension_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub Operate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwcode: u32, vardata1: ::core::mem::ManuallyDrop<super::super::System::Com::VARIANT>, vardata2: ::core::mem::ManuallyDrop<super::super::System::Com::VARIANT>, vardata3: ::core::mem::ManuallyDrop<super::super::System::Com::VARIANT>) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole")))]
@@ -12040,7 +12040,7 @@ unsafe impl ::windows::core::Interface for ICommonQuery {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICommonQuery_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
     pub OpenQueryWindow: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hwndparent: super::super::Foundation::HWND, pquerywnd: *mut OPENQUERYWINDOW, ppdataobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage")))]
@@ -12119,7 +12119,7 @@ unsafe impl ::windows::core::Interface for IDirectoryObject {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectoryObject_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetObjectInformation: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppobjinfo: *mut *mut ADS_OBJECT_INFO) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub GetObjectAttributes: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pattributenames: *const ::windows::core::PWSTR, dwnumberattributes: u32, ppattributeentries: *mut *mut ADS_ATTR_INFO, pdwnumattributesreturned: *mut u32) -> ::windows::core::HRESULT,
@@ -12232,7 +12232,7 @@ unsafe impl ::windows::core::Interface for IDirectorySchemaMgmt {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectorySchemaMgmt_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub EnumAttributes: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppszattrnames: *const ::windows::core::PWSTR, dwnumattributes: u32, ppattrdefinition: *const *const ADS_ATTR_DEF, pdwnumattributes: *const u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -12366,7 +12366,7 @@ unsafe impl ::windows::core::Interface for IDirectorySearch {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectorySearch_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub SetSearchPreference: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psearchprefs: *const ADS_SEARCHPREF_INFO, dwnumprefs: u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -12449,7 +12449,7 @@ unsafe impl ::windows::core::Interface for IDsAdminCreateObj {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDsAdminCreateObj_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, padscontainerobj: *mut ::core::ffi::c_void, padscopysource: *mut ::core::ffi::c_void, lpszclassname: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -12513,7 +12513,7 @@ unsafe impl ::windows::core::Interface for IDsAdminNewObj {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDsAdminNewObj_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub SetButtons: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ncurrindex: u32, bvalid: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -12609,7 +12609,7 @@ unsafe impl ::windows::core::Interface for IDsAdminNewObjExt {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDsAdminNewObjExt_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_WindowsAndMessaging"))]
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, padscontainerobj: *mut ::core::ffi::c_void, padscopysource: *mut ::core::ffi::c_void, lpszclassname: ::windows::core::PCWSTR, pdsadminnewobj: *mut ::core::ffi::c_void, pdispinfo: *mut DSA_NEWOBJ_DISPINFO) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_System_Com", feature = "Win32_UI_WindowsAndMessaging")))]
@@ -12684,7 +12684,7 @@ unsafe impl ::windows::core::Interface for IDsAdminNewObjPrimarySite {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDsAdminNewObjPrimarySite_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateNew: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszname: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub Commit: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -12754,7 +12754,7 @@ unsafe impl ::windows::core::Interface for IDsAdminNotifyHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDsAdminNotifyHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pextrainfo: *mut ::core::ffi::c_void, pueventflags: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -12838,7 +12838,7 @@ unsafe impl ::windows::core::Interface for IDsBrowseDomainTree {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDsBrowseDomainTree_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub BrowseTo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hwndparent: super::super::Foundation::HWND, ppsztargetpath: *mut ::windows::core::PWSTR, dwflags: u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -12971,7 +12971,7 @@ unsafe impl ::windows::core::Interface for IDsDisplaySpecifier {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDsDisplaySpecifier_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetServer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszserver: ::windows::core::PCWSTR, pszusername: ::windows::core::PCWSTR, pszpassword: ::windows::core::PCWSTR, dwflags: u32) -> ::windows::core::HRESULT,
     pub SetLanguageID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, langid: u16) -> ::windows::core::HRESULT,
     pub GetDisplaySpecifier: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszobjectclass: ::windows::core::PCWSTR, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -13048,7 +13048,7 @@ unsafe impl ::windows::core::Interface for IDsObjectPicker {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDsObjectPicker_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinitinfo: *mut DSOP_INIT_INFO) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
     pub InvokeDialog: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hwndparent: super::super::Foundation::HWND, ppdoselections: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -13333,7 +13333,7 @@ unsafe impl ::windows::core::Interface for IPrivateDispatch {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPrivateDispatch_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ADSIInitializeDispatchManager: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwextensionid: i32) -> ::windows::core::HRESULT,
     pub ADSIGetTypeInfoCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pctinfo: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
@@ -13395,7 +13395,7 @@ unsafe impl ::windows::core::Interface for IPrivateUnknown {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPrivateUnknown_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ADSIInitializeObject: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lpszusername: ::core::mem::ManuallyDrop<::windows::core::BSTR>, lpszpassword: ::core::mem::ManuallyDrop<::windows::core::BSTR>, lnreserved: i32) -> ::windows::core::HRESULT,
     pub ADSIReleaseObject: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -13466,7 +13466,7 @@ unsafe impl ::windows::core::Interface for IQueryForm {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IQueryForm_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Registry")]
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hkform: super::super::System::Registry::HKEY) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Registry"))]

--- a/crates/libs/windows/src/Windows/Win32/Networking/BackgroundIntelligentTransferService/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/BackgroundIntelligentTransferService/impl.rs
@@ -40,7 +40,7 @@ impl AsyncIBackgroundCopyCallback_Vtbl {
             this.Finish_JobModification().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Begin_JobTransferred: Begin_JobTransferred::<Identity, Impl, OFFSET>,
             Finish_JobTransferred: Finish_JobTransferred::<Identity, Impl, OFFSET>,
             Begin_JobError: Begin_JobError::<Identity, Impl, OFFSET>,
@@ -159,7 +159,7 @@ impl IBackgroundCopyCallback_Vtbl {
             this.JobModification(::core::mem::transmute(&pjob), ::core::mem::transmute_copy(&dwreserved)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             JobTransferred: JobTransferred::<Identity, Impl, OFFSET>,
             JobError: JobError::<Identity, Impl, OFFSET>,
             JobModification: JobModification::<Identity, Impl, OFFSET>,
@@ -193,7 +193,7 @@ impl IBackgroundCopyCallback1_Vtbl {
             this.OnProgressEx(::core::mem::transmute_copy(&progresstype), ::core::mem::transmute(&pgroup), ::core::mem::transmute(&pjob), ::core::mem::transmute_copy(&dwfileindex), ::core::mem::transmute_copy(&dwprogressvalue), ::core::mem::transmute_copy(&dwbytearraysize), ::core::mem::transmute_copy(&pbyte)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnStatus: OnStatus::<Identity, Impl, OFFSET>,
             OnProgress: OnProgress::<Identity, Impl, OFFSET>,
             OnProgressEx: OnProgressEx::<Identity, Impl, OFFSET>,
@@ -297,7 +297,7 @@ impl IBackgroundCopyError_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetError: GetError::<Identity, Impl, OFFSET>,
             GetFile: GetFile::<Identity, Impl, OFFSET>,
             GetErrorDescription: GetErrorDescription::<Identity, Impl, OFFSET>,
@@ -354,7 +354,7 @@ impl IBackgroundCopyFile_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetRemoteName: GetRemoteName::<Identity, Impl, OFFSET>,
             GetLocalName: GetLocalName::<Identity, Impl, OFFSET>,
             GetProgress: GetProgress::<Identity, Impl, OFFSET>,
@@ -696,7 +696,7 @@ impl IBackgroundCopyGroup_Vtbl {
             this.SetNotificationPointer(::core::mem::transmute_copy(&iid), ::core::mem::transmute(&punk)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetProp: GetProp::<Identity, Impl, OFFSET>,
             SetProp: SetProp::<Identity, Impl, OFFSET>,
             GetProgress: GetProgress::<Identity, Impl, OFFSET>,
@@ -1015,7 +1015,7 @@ impl IBackgroundCopyJob_Vtbl {
             this.TakeOwnership().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddFileSet: AddFileSet::<Identity, Impl, OFFSET>,
             AddFile: AddFile::<Identity, Impl, OFFSET>,
             EnumFiles: EnumFiles::<Identity, Impl, OFFSET>,
@@ -1132,7 +1132,7 @@ impl IBackgroundCopyJob1_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CancelJob: CancelJob::<Identity, Impl, OFFSET>,
             GetProgress: GetProgress::<Identity, Impl, OFFSET>,
             GetStatus: GetStatus::<Identity, Impl, OFFSET>,
@@ -1459,7 +1459,7 @@ impl IBackgroundCopyJobHttpOptions_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetClientCertificateByID: SetClientCertificateByID::<Identity, Impl, OFFSET>,
             SetClientCertificateByName: SetClientCertificateByName::<Identity, Impl, OFFSET>,
             RemoveClientCertificate: RemoveClientCertificate::<Identity, Impl, OFFSET>,
@@ -1582,7 +1582,7 @@ impl IBackgroundCopyManager_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateJob: CreateJob::<Identity, Impl, OFFSET>,
             GetJob: GetJob::<Identity, Impl, OFFSET>,
             EnumJobs: EnumJobs::<Identity, Impl, OFFSET>,
@@ -1635,7 +1635,7 @@ impl IBackgroundCopyQMgr_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateGroup: CreateGroup::<Identity, Impl, OFFSET>,
             GetGroup: GetGroup::<Identity, Impl, OFFSET>,
             EnumGroups: EnumGroups::<Identity, Impl, OFFSET>,
@@ -1656,7 +1656,10 @@ impl IBackgroundCopyServerCertificateValidationCallback_Vtbl {
             let this = (*this).get_impl();
             this.ValidateServerCertificate(::core::mem::transmute(&job), ::core::mem::transmute(&file), ::core::mem::transmute_copy(&certlength), ::core::mem::transmute_copy(&certdata), ::core::mem::transmute_copy(&certencodingtype), ::core::mem::transmute_copy(&certstorelength), ::core::mem::transmute_copy(&certstoredata)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), ValidateServerCertificate: ValidateServerCertificate::<Identity, Impl, OFFSET> }
+        Self {
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
+            ValidateServerCertificate: ValidateServerCertificate::<Identity, Impl, OFFSET>,
+        }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IBackgroundCopyServerCertificateValidationCallback as ::windows::core::Interface>::IID
@@ -1707,7 +1710,7 @@ impl IBitsPeer_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetPeerName: GetPeerName::<Identity, Impl, OFFSET>,
             IsAuthenticated: IsAuthenticated::<Identity, Impl, OFFSET>,
             IsAvailable: IsAvailable::<Identity, Impl, OFFSET>,
@@ -1843,7 +1846,7 @@ impl IBitsPeerCacheAdministration_Vtbl {
             this.DiscoverPeers().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetMaximumCacheSize: GetMaximumCacheSize::<Identity, Impl, OFFSET>,
             SetMaximumCacheSize: SetMaximumCacheSize::<Identity, Impl, OFFSET>,
             GetMaximumContentAge: GetMaximumContentAge::<Identity, Impl, OFFSET>,
@@ -1945,7 +1948,7 @@ impl IBitsPeerCacheRecord_Vtbl {
             this.GetFileRanges(::core::mem::transmute_copy(&prangecount), ::core::mem::transmute_copy(&ppranges)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetId: GetId::<Identity, Impl, OFFSET>,
             GetOriginUrl: GetOriginUrl::<Identity, Impl, OFFSET>,
             GetFileSize: GetFileSize::<Identity, Impl, OFFSET>,
@@ -2007,7 +2010,7 @@ impl IBitsTokenOptions_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetHelperTokenFlags: SetHelperTokenFlags::<Identity, Impl, OFFSET>,
             GetHelperTokenFlags: GetHelperTokenFlags::<Identity, Impl, OFFSET>,
             SetHelperToken: SetHelperToken::<Identity, Impl, OFFSET>,
@@ -2067,7 +2070,7 @@ impl IEnumBackgroundCopyFiles_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -2127,7 +2130,7 @@ impl IEnumBackgroundCopyGroups_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -2187,7 +2190,7 @@ impl IEnumBackgroundCopyJobs_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -2247,7 +2250,7 @@ impl IEnumBackgroundCopyJobs1_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -2307,7 +2310,7 @@ impl IEnumBitsPeerCacheRecords_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -2367,7 +2370,7 @@ impl IEnumBitsPeers_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/Networking/BackgroundIntelligentTransferService/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/BackgroundIntelligentTransferService/mod.rs
@@ -69,7 +69,7 @@ unsafe impl ::windows::core::Interface for AsyncIBackgroundCopyCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct AsyncIBackgroundCopyCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Begin_JobTransferred: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pjob: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Finish_JobTransferred: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Begin_JobError: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pjob: *mut ::core::ffi::c_void, perror: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -315,7 +315,7 @@ unsafe impl ::windows::core::Interface for IBackgroundCopyCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IBackgroundCopyCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub JobTransferred: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pjob: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub JobError: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pjob: *mut ::core::ffi::c_void, perror: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub JobModification: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pjob: *mut ::core::ffi::c_void, dwreserved: u32) -> ::windows::core::HRESULT,
@@ -384,7 +384,7 @@ unsafe impl ::windows::core::Interface for IBackgroundCopyCallback1 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IBackgroundCopyCallback1_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnStatus: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pgroup: *mut ::core::ffi::c_void, pjob: *mut ::core::ffi::c_void, dwfileindex: u32, dwstatus: u32, dwnumofretries: u32, dwwin32result: u32, dwtransportresult: u32) -> ::windows::core::HRESULT,
     pub OnProgress: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, progresstype: u32, pgroup: *mut ::core::ffi::c_void, pjob: *mut ::core::ffi::c_void, dwfileindex: u32, dwprogressvalue: u32) -> ::windows::core::HRESULT,
     pub OnProgressEx: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, progresstype: u32, pgroup: *mut ::core::ffi::c_void, pjob: *mut ::core::ffi::c_void, dwfileindex: u32, dwprogressvalue: u32, dwbytearraysize: u32, pbyte: *const u8) -> ::windows::core::HRESULT,
@@ -647,7 +647,7 @@ unsafe impl ::windows::core::Interface for IBackgroundCopyError {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IBackgroundCopyError_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetError: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcontext: *mut BG_ERROR_CONTEXT, pcode: *mut ::windows::core::HRESULT) -> ::windows::core::HRESULT,
     pub GetFile: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pval: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetErrorDescription: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, languageid: u32, perrordescription: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
@@ -711,7 +711,7 @@ unsafe impl ::windows::core::Interface for IBackgroundCopyFile {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IBackgroundCopyFile_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetRemoteName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pval: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetLocalName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pval: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -1536,7 +1536,7 @@ unsafe impl ::windows::core::Interface for IBackgroundCopyGroup {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IBackgroundCopyGroup_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub GetProp: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, propid: GROUPPROP, pvarval: *mut super::super::System::Com::VARIANT) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole")))]
@@ -1733,7 +1733,7 @@ unsafe impl ::windows::core::Interface for IBackgroundCopyJob {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IBackgroundCopyJob_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddFileSet: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cfilecount: u32, pfileset: *const BG_FILE_INFO) -> ::windows::core::HRESULT,
     pub AddFile: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, remoteurl: ::windows::core::PCWSTR, localname: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub EnumFiles: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, penum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1841,7 +1841,7 @@ unsafe impl ::windows::core::Interface for IBackgroundCopyJob1 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IBackgroundCopyJob1_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CancelJob: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetProgress: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwflags: u32, pdwprogress: *mut u32) -> ::windows::core::HRESULT,
     pub GetStatus: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwstatus: *mut u32, pdwwin32result: *mut u32, pdwtransportresult: *mut u32, pdwnumofretries: *mut u32) -> ::windows::core::HRESULT,
@@ -3063,7 +3063,7 @@ unsafe impl ::windows::core::Interface for IBackgroundCopyJobHttpOptions {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IBackgroundCopyJobHttpOptions_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetClientCertificateByID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, storelocation: BG_CERT_STORE_LOCATION, storename: ::windows::core::PCWSTR, pcerthashblob: *const u8) -> ::windows::core::HRESULT,
     pub SetClientCertificateByName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, storelocation: BG_CERT_STORE_LOCATION, storename: ::windows::core::PCWSTR, subjectname: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub RemoveClientCertificate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -3374,7 +3374,7 @@ unsafe impl ::windows::core::Interface for IBackgroundCopyManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IBackgroundCopyManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateJob: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, displayname: ::windows::core::PCWSTR, r#type: BG_JOB_TYPE, pjobid: *mut ::windows::core::GUID, ppjob: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetJob: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, jobid: *const ::windows::core::GUID, ppjob: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub EnumJobs: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwflags: u32, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -3435,7 +3435,7 @@ unsafe impl ::windows::core::Interface for IBackgroundCopyQMgr {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IBackgroundCopyQMgr_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateGroup: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, guidgroupid: ::windows::core::GUID, ppgroup: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetGroup: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, groupid: ::windows::core::GUID, ppgroup: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub EnumGroups: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwflags: u32, ppenumgroups: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -3490,7 +3490,7 @@ unsafe impl ::windows::core::Interface for IBackgroundCopyServerCertificateValid
 #[repr(C)]
 #[doc(hidden)]
 pub struct IBackgroundCopyServerCertificateValidationCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ValidateServerCertificate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, job: *mut ::core::ffi::c_void, file: *mut ::core::ffi::c_void, certlength: u32, certdata: *const u8, certencodingtype: u32, certstorelength: u32, certstoredata: *const u8) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Networking_BackgroundIntelligentTransferService\"`*"]
@@ -3552,7 +3552,7 @@ unsafe impl ::windows::core::Interface for IBitsPeer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IBitsPeer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetPeerName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pname: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub IsAuthenticated: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pauth: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -3657,7 +3657,7 @@ unsafe impl ::windows::core::Interface for IBitsPeerCacheAdministration {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IBitsPeerCacheAdministration_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetMaximumCacheSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbytes: *mut u32) -> ::windows::core::HRESULT,
     pub SetMaximumCacheSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bytes: u32) -> ::windows::core::HRESULT,
     pub GetMaximumContentAge: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pseconds: *mut u32) -> ::windows::core::HRESULT,
@@ -3746,7 +3746,7 @@ unsafe impl ::windows::core::Interface for IBitsPeerCacheRecord {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IBitsPeerCacheRecord_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pval: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub GetOriginUrl: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pval: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetFileSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pval: *mut u64) -> ::windows::core::HRESULT,
@@ -3821,7 +3821,7 @@ unsafe impl ::windows::core::Interface for IBitsTokenOptions {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IBitsTokenOptions_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetHelperTokenFlags: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, usageflags: BG_TOKEN) -> ::windows::core::HRESULT,
     pub GetHelperTokenFlags: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pflags: *mut BG_TOKEN) -> ::windows::core::HRESULT,
     pub SetHelperToken: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -3888,7 +3888,7 @@ unsafe impl ::windows::core::Interface for IEnumBackgroundCopyFiles {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumBackgroundCopyFiles_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -3955,7 +3955,7 @@ unsafe impl ::windows::core::Interface for IEnumBackgroundCopyGroups {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumBackgroundCopyGroups_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut ::windows::core::GUID, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -4022,7 +4022,7 @@ unsafe impl ::windows::core::Interface for IEnumBackgroundCopyJobs {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumBackgroundCopyJobs_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -4089,7 +4089,7 @@ unsafe impl ::windows::core::Interface for IEnumBackgroundCopyJobs1 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumBackgroundCopyJobs1_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut ::windows::core::GUID, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -4156,7 +4156,7 @@ unsafe impl ::windows::core::Interface for IEnumBitsPeerCacheRecords {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumBitsPeerCacheRecords_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -4223,7 +4223,7 @@ unsafe impl ::windows::core::Interface for IEnumBitsPeers {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumBitsPeers_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/Networking/Clustering/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/Clustering/impl.rs
@@ -22,7 +22,7 @@ impl IGetClusterDataInfo_Vtbl {
             this.GetObjectCount()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetClusterName: GetClusterName::<Identity, Impl, OFFSET>,
             GetClusterHandle: GetClusterHandle::<Identity, Impl, OFFSET>,
             GetObjectCount: GetObjectCount::<Identity, Impl, OFFSET>,
@@ -43,7 +43,7 @@ impl IGetClusterGroupInfo_Vtbl {
             let this = (*this).get_impl();
             this.GetGroupHandle(::core::mem::transmute_copy(&lobjindex))
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetGroupHandle: GetGroupHandle::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetGroupHandle: GetGroupHandle::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IGetClusterGroupInfo as ::windows::core::Interface>::IID
@@ -60,7 +60,7 @@ impl IGetClusterNetInterfaceInfo_Vtbl {
             let this = (*this).get_impl();
             this.GetNetInterfaceHandle(::core::mem::transmute_copy(&lobjindex))
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetNetInterfaceHandle: GetNetInterfaceHandle::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetNetInterfaceHandle: GetNetInterfaceHandle::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IGetClusterNetInterfaceInfo as ::windows::core::Interface>::IID
@@ -77,7 +77,7 @@ impl IGetClusterNetworkInfo_Vtbl {
             let this = (*this).get_impl();
             this.GetNetworkHandle(::core::mem::transmute_copy(&lobjindex))
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetNetworkHandle: GetNetworkHandle::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetNetworkHandle: GetNetworkHandle::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IGetClusterNetworkInfo as ::windows::core::Interface>::IID
@@ -94,7 +94,7 @@ impl IGetClusterNodeInfo_Vtbl {
             let this = (*this).get_impl();
             this.GetNodeHandle(::core::mem::transmute_copy(&lobjindex))
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetNodeHandle: GetNodeHandle::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetNodeHandle: GetNodeHandle::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IGetClusterNodeInfo as ::windows::core::Interface>::IID
@@ -118,7 +118,7 @@ impl IGetClusterObjectInfo_Vtbl {
             this.GetObjectType(::core::mem::transmute_copy(&lobjindex))
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetObjectName: GetObjectName::<Identity, Impl, OFFSET>,
             GetObjectType: GetObjectType::<Identity, Impl, OFFSET>,
         }
@@ -154,7 +154,7 @@ impl IGetClusterResourceInfo_Vtbl {
             this.GetResourceNetworkName(::core::mem::transmute_copy(&lobjindex), ::core::mem::transmute_copy(&lpsznetname), ::core::mem::transmute_copy(&pcchnetname))
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetResourceHandle: GetResourceHandle::<Identity, Impl, OFFSET>,
             GetResourceTypeName: GetResourceTypeName::<Identity, Impl, OFFSET>,
             GetResourceNetworkName: GetResourceNetworkName::<Identity, Impl, OFFSET>,
@@ -197,7 +197,7 @@ impl IGetClusterUIInfo_Vtbl {
             this.GetIcon()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetClusterName: GetClusterName::<Identity, Impl, OFFSET>,
             GetLocale: GetLocale::<Identity, Impl, OFFSET>,
             GetFont: GetFont::<Identity, Impl, OFFSET>,
@@ -4382,7 +4382,7 @@ impl IWCContextMenuCallback_Vtbl {
             let this = (*this).get_impl();
             this.AddExtensionMenuItem(::core::mem::transmute(&lpszname), ::core::mem::transmute(&lpszstatusbartext), ::core::mem::transmute_copy(&ncommandid), ::core::mem::transmute_copy(&nsubmenucommandid), ::core::mem::transmute_copy(&uflags)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), AddExtensionMenuItem: AddExtensionMenuItem::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), AddExtensionMenuItem: AddExtensionMenuItem::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWCContextMenuCallback as ::windows::core::Interface>::IID
@@ -4399,7 +4399,7 @@ impl IWCPropertySheetCallback_Vtbl {
             let this = (*this).get_impl();
             this.AddPropertySheetPage(::core::mem::transmute_copy(&hpage)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), AddPropertySheetPage: AddPropertySheetPage::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), AddPropertySheetPage: AddPropertySheetPage::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWCPropertySheetCallback as ::windows::core::Interface>::IID
@@ -4426,7 +4426,7 @@ impl IWCWizard97Callback_Vtbl {
             this.EnableNext(::core::mem::transmute_copy(&hpage), ::core::mem::transmute_copy(&benable)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddWizard97Page: AddWizard97Page::<Identity, Impl, OFFSET>,
             EnableNext: EnableNext::<Identity, Impl, OFFSET>,
         }
@@ -4456,7 +4456,7 @@ impl IWCWizardCallback_Vtbl {
             this.EnableNext(::core::mem::transmute_copy(&hpage), ::core::mem::transmute_copy(&benable)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddWizardPage: AddWizardPage::<Identity, Impl, OFFSET>,
             EnableNext: EnableNext::<Identity, Impl, OFFSET>,
         }
@@ -4476,7 +4476,7 @@ impl IWEExtendContextMenu_Vtbl {
             let this = (*this).get_impl();
             this.AddContextMenuItems(::core::mem::transmute(&pidata), ::core::mem::transmute(&picallback)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), AddContextMenuItems: AddContextMenuItems::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), AddContextMenuItems: AddContextMenuItems::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWEExtendContextMenu as ::windows::core::Interface>::IID
@@ -4493,7 +4493,7 @@ impl IWEExtendPropertySheet_Vtbl {
             let this = (*this).get_impl();
             this.CreatePropertySheetPages(::core::mem::transmute(&pidata), ::core::mem::transmute(&picallback)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CreatePropertySheetPages: CreatePropertySheetPages::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CreatePropertySheetPages: CreatePropertySheetPages::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWEExtendPropertySheet as ::windows::core::Interface>::IID
@@ -4510,7 +4510,7 @@ impl IWEExtendWizard_Vtbl {
             let this = (*this).get_impl();
             this.CreateWizardPages(::core::mem::transmute(&pidata), ::core::mem::transmute(&picallback)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CreateWizardPages: CreateWizardPages::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CreateWizardPages: CreateWizardPages::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWEExtendWizard as ::windows::core::Interface>::IID
@@ -4527,7 +4527,7 @@ impl IWEExtendWizard97_Vtbl {
             let this = (*this).get_impl();
             this.CreateWizard97Pages(::core::mem::transmute(&pidata), ::core::mem::transmute(&picallback)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CreateWizard97Pages: CreateWizard97Pages::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CreateWizard97Pages: CreateWizard97Pages::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWEExtendWizard97 as ::windows::core::Interface>::IID
@@ -4544,7 +4544,7 @@ impl IWEInvokeCommand_Vtbl {
             let this = (*this).get_impl();
             this.InvokeCommand(::core::mem::transmute_copy(&ncommandid), ::core::mem::transmute(&pidata)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), InvokeCommand: InvokeCommand::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), InvokeCommand: InvokeCommand::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWEInvokeCommand as ::windows::core::Interface>::IID

--- a/crates/libs/windows/src/Windows/Win32/Networking/Clustering/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/Clustering/mod.rs
@@ -3872,7 +3872,7 @@ unsafe impl ::windows::core::Interface for IGetClusterDataInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IGetClusterDataInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetClusterName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lpszname: ::core::mem::ManuallyDrop<::windows::core::BSTR>, pcchname: *mut i32) -> ::windows::core::HRESULT,
     pub GetClusterHandle: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> *mut _HCLUSTER,
     pub GetObjectCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> i32,
@@ -3923,7 +3923,7 @@ unsafe impl ::windows::core::Interface for IGetClusterGroupInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IGetClusterGroupInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetGroupHandle: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lobjindex: i32) -> *mut _HGROUP,
 }
 #[doc = "*Required features: `\"Win32_Networking_Clustering\"`*"]
@@ -3972,7 +3972,7 @@ unsafe impl ::windows::core::Interface for IGetClusterNetInterfaceInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IGetClusterNetInterfaceInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetNetInterfaceHandle: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lobjindex: i32) -> *mut _HNETINTERFACE,
 }
 #[doc = "*Required features: `\"Win32_Networking_Clustering\"`*"]
@@ -4021,7 +4021,7 @@ unsafe impl ::windows::core::Interface for IGetClusterNetworkInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IGetClusterNetworkInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetNetworkHandle: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lobjindex: i32) -> *mut _HNETWORK,
 }
 #[doc = "*Required features: `\"Win32_Networking_Clustering\"`*"]
@@ -4070,7 +4070,7 @@ unsafe impl ::windows::core::Interface for IGetClusterNodeInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IGetClusterNodeInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetNodeHandle: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lobjindex: i32) -> *mut _HNODE,
 }
 #[doc = "*Required features: `\"Win32_Networking_Clustering\"`*"]
@@ -4122,7 +4122,7 @@ unsafe impl ::windows::core::Interface for IGetClusterObjectInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IGetClusterObjectInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetObjectName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lobjindex: i32, lpszname: ::core::mem::ManuallyDrop<::windows::core::BSTR>, pcchname: *mut i32) -> ::windows::core::HRESULT,
     pub GetObjectType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lobjindex: i32) -> CLUADMEX_OBJECT_TYPE,
 }
@@ -4180,7 +4180,7 @@ unsafe impl ::windows::core::Interface for IGetClusterResourceInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IGetClusterResourceInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetResourceHandle: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lobjindex: i32) -> *mut _HRESOURCE,
     pub GetResourceTypeName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lobjindex: i32, lpszrestypename: ::core::mem::ManuallyDrop<::windows::core::BSTR>, pcchrestypename: *mut i32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -4247,7 +4247,7 @@ unsafe impl ::windows::core::Interface for IGetClusterUIInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IGetClusterUIInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetClusterName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lpszname: ::core::mem::ManuallyDrop<::windows::core::BSTR>, pcchname: *mut i32) -> ::windows::core::HRESULT,
     pub GetLocale: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32,
     #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -9709,7 +9709,7 @@ unsafe impl ::windows::core::Interface for IWCContextMenuCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWCContextMenuCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddExtensionMenuItem: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lpszname: ::core::mem::ManuallyDrop<::windows::core::BSTR>, lpszstatusbartext: ::core::mem::ManuallyDrop<::windows::core::BSTR>, ncommandid: u32, nsubmenucommandid: u32, uflags: u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Networking_Clustering\"`*"]
@@ -9758,7 +9758,7 @@ unsafe impl ::windows::core::Interface for IWCPropertySheetCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWCPropertySheetCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddPropertySheetPage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hpage: *const i32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Networking_Clustering\"`*"]
@@ -9815,7 +9815,7 @@ unsafe impl ::windows::core::Interface for IWCWizard97Callback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWCWizard97Callback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddWizard97Page: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hpage: *const i32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub EnableNext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hpage: *const i32, benable: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -9876,7 +9876,7 @@ unsafe impl ::windows::core::Interface for IWCWizardCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWCWizardCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddWizardPage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hpage: *const i32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub EnableNext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hpage: *const i32, benable: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -9933,7 +9933,7 @@ unsafe impl ::windows::core::Interface for IWEExtendContextMenu {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWEExtendContextMenu_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddContextMenuItems: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pidata: *mut ::core::ffi::c_void, picallback: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Networking_Clustering\"`*"]
@@ -9986,7 +9986,7 @@ unsafe impl ::windows::core::Interface for IWEExtendPropertySheet {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWEExtendPropertySheet_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreatePropertySheetPages: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pidata: *mut ::core::ffi::c_void, picallback: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Networking_Clustering\"`*"]
@@ -10039,7 +10039,7 @@ unsafe impl ::windows::core::Interface for IWEExtendWizard {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWEExtendWizard_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateWizardPages: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pidata: *mut ::core::ffi::c_void, picallback: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Networking_Clustering\"`*"]
@@ -10092,7 +10092,7 @@ unsafe impl ::windows::core::Interface for IWEExtendWizard97 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWEExtendWizard97_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateWizard97Pages: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pidata: *mut ::core::ffi::c_void, picallback: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Networking_Clustering\"`*"]
@@ -10144,7 +10144,7 @@ unsafe impl ::windows::core::Interface for IWEInvokeCommand {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWEInvokeCommand_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub InvokeCommand: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ncommandid: u32, pidata: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Networking_Clustering\"`*"]

--- a/crates/libs/windows/src/Windows/Win32/Networking/NetworkListManager/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/NetworkListManager/impl.rs
@@ -425,7 +425,7 @@ impl INetworkConnectionCost_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCost: GetCost::<Identity, Impl, OFFSET>,
             GetDataPlanStatus: GetDataPlanStatus::<Identity, Impl, OFFSET>,
         }
@@ -452,7 +452,7 @@ impl INetworkConnectionCostEvents_Vtbl {
             this.ConnectionDataPlanStatusChanged(::core::mem::transmute(&connectionid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ConnectionCostChanged: ConnectionCostChanged::<Identity, Impl, OFFSET>,
             ConnectionDataPlanStatusChanged: ConnectionDataPlanStatusChanged::<Identity, Impl, OFFSET>,
         }
@@ -479,7 +479,7 @@ impl INetworkConnectionEvents_Vtbl {
             this.NetworkConnectionPropertyChanged(::core::mem::transmute(&connectionid), ::core::mem::transmute_copy(&flags)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             NetworkConnectionConnectivityChanged: NetworkConnectionConnectivityChanged::<Identity, Impl, OFFSET>,
             NetworkConnectionPropertyChanged: NetworkConnectionPropertyChanged::<Identity, Impl, OFFSET>,
         }
@@ -515,7 +515,7 @@ impl INetworkCostManager_Vtbl {
             this.SetDestinationAddresses(::core::mem::transmute_copy(&length), ::core::mem::transmute_copy(&pdestipaddrlist), ::core::mem::transmute_copy(&bappend)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCost: GetCost::<Identity, Impl, OFFSET>,
             GetDataPlanStatus: GetDataPlanStatus::<Identity, Impl, OFFSET>,
             SetDestinationAddresses: SetDestinationAddresses::<Identity, Impl, OFFSET>,
@@ -543,7 +543,7 @@ impl INetworkCostManagerEvents_Vtbl {
             this.DataPlanStatusChanged(::core::mem::transmute_copy(&pdestaddr)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CostChanged: CostChanged::<Identity, Impl, OFFSET>,
             DataPlanStatusChanged: DataPlanStatusChanged::<Identity, Impl, OFFSET>,
         }
@@ -582,7 +582,7 @@ impl INetworkEvents_Vtbl {
             this.NetworkPropertyChanged(::core::mem::transmute(&networkid), ::core::mem::transmute_copy(&flags)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             NetworkAdded: NetworkAdded::<Identity, Impl, OFFSET>,
             NetworkDeleted: NetworkDeleted::<Identity, Impl, OFFSET>,
             NetworkConnectivityChanged: NetworkConnectivityChanged::<Identity, Impl, OFFSET>,
@@ -725,7 +725,7 @@ impl INetworkListManagerEvents_Vtbl {
             let this = (*this).get_impl();
             this.ConnectivityChanged(::core::mem::transmute_copy(&newconnectivity)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), ConnectivityChanged: ConnectivityChanged::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), ConnectivityChanged: ConnectivityChanged::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<INetworkListManagerEvents as ::windows::core::Interface>::IID

--- a/crates/libs/windows/src/Windows/Win32/Networking/NetworkListManager/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/NetworkListManager/mod.rs
@@ -527,7 +527,7 @@ unsafe impl ::windows::core::Interface for INetworkConnectionCost {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INetworkConnectionCost_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCost: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcost: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub GetDataPlanStatus: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdataplanstatus: *mut NLM_DATAPLAN_STATUS) -> ::windows::core::HRESULT,
@@ -583,7 +583,7 @@ unsafe impl ::windows::core::Interface for INetworkConnectionCostEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INetworkConnectionCostEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ConnectionCostChanged: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, connectionid: ::windows::core::GUID, newcost: u32) -> ::windows::core::HRESULT,
     pub ConnectionDataPlanStatusChanged: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, connectionid: ::windows::core::GUID) -> ::windows::core::HRESULT,
 }
@@ -636,7 +636,7 @@ unsafe impl ::windows::core::Interface for INetworkConnectionEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INetworkConnectionEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub NetworkConnectionConnectivityChanged: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, connectionid: ::windows::core::GUID, newconnectivity: NLM_CONNECTIVITY) -> ::windows::core::HRESULT,
     pub NetworkConnectionPropertyChanged: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, connectionid: ::windows::core::GUID, flags: NLM_CONNECTION_PROPERTY_CHANGE) -> ::windows::core::HRESULT,
 }
@@ -694,7 +694,7 @@ unsafe impl ::windows::core::Interface for INetworkCostManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INetworkCostManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCost: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcost: *mut u32, pdestipaddr: *const NLM_SOCKADDR) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub GetDataPlanStatus: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdataplanstatus: *mut NLM_DATAPLAN_STATUS, pdestipaddr: *const NLM_SOCKADDR) -> ::windows::core::HRESULT,
@@ -751,7 +751,7 @@ unsafe impl ::windows::core::Interface for INetworkCostManagerEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INetworkCostManagerEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CostChanged: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, newcost: u32, pdestaddr: *const NLM_SOCKADDR) -> ::windows::core::HRESULT,
     pub DataPlanStatusChanged: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdestaddr: *const NLM_SOCKADDR) -> ::windows::core::HRESULT,
 }
@@ -810,7 +810,7 @@ unsafe impl ::windows::core::Interface for INetworkEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INetworkEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub NetworkAdded: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, networkid: ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub NetworkDeleted: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, networkid: ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub NetworkConnectivityChanged: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, networkid: ::windows::core::GUID, newconnectivity: NLM_CONNECTIVITY) -> ::windows::core::HRESULT,
@@ -999,7 +999,7 @@ unsafe impl ::windows::core::Interface for INetworkListManagerEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INetworkListManagerEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ConnectivityChanged: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, newconnectivity: NLM_CONNECTIVITY) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Networking_NetworkListManager\"`*"]

--- a/crates/libs/windows/src/Windows/Win32/Networking/RemoteDifferentialCompression/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/RemoteDifferentialCompression/impl.rs
@@ -22,7 +22,7 @@ impl IFindSimilarResults_Vtbl {
             this.GetNextFileId(::core::mem::transmute_copy(&numtraitsmatched), ::core::mem::transmute_copy(&similarityfileid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSize: GetSize::<Identity, Impl, OFFSET>,
             GetNextFileId: GetNextFileId::<Identity, Impl, OFFSET>,
         }
@@ -45,7 +45,7 @@ impl IRdcComparator_Vtbl {
             let this = (*this).get_impl();
             this.Process(::core::mem::transmute_copy(&endofinput), ::core::mem::transmute_copy(&endofoutput), ::core::mem::transmute_copy(&inputbuffer), ::core::mem::transmute_copy(&outputbuffer), ::core::mem::transmute_copy(&rdc_errorcode)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Process: Process::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Process: Process::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IRdcComparator as ::windows::core::Interface>::IID
@@ -90,7 +90,7 @@ impl IRdcFileReader_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetFileSize: GetFileSize::<Identity, Impl, OFFSET>,
             Read: Read::<Identity, Impl, OFFSET>,
             GetFilePosition: GetFilePosition::<Identity, Impl, OFFSET>,
@@ -170,7 +170,7 @@ impl IRdcGenerator_Vtbl {
             this.Process(::core::mem::transmute_copy(&endofinput), ::core::mem::transmute_copy(&endofoutput), ::core::mem::transmute_copy(&inputbuffer), ::core::mem::transmute_copy(&depth), ::core::mem::transmute_copy(&outputbuffers), ::core::mem::transmute_copy(&rdc_errorcode)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetGeneratorParameters: GetGeneratorParameters::<Identity, Impl, OFFSET>,
             Process: Process::<Identity, Impl, OFFSET>,
         }
@@ -221,7 +221,7 @@ impl IRdcGeneratorFilterMaxParameters_Vtbl {
             this.SetHashWindowSize(::core::mem::transmute_copy(&hashwindowsize)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetHorizonSize: GetHorizonSize::<Identity, Impl, OFFSET>,
             SetHorizonSize: SetHorizonSize::<Identity, Impl, OFFSET>,
             GetHashWindowSize: GetHashWindowSize::<Identity, Impl, OFFSET>,
@@ -274,7 +274,7 @@ impl IRdcGeneratorParameters_Vtbl {
             this.Serialize(::core::mem::transmute_copy(&size), ::core::mem::transmute_copy(&parametersblob), ::core::mem::transmute_copy(&byteswritten)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetGeneratorParametersType: GetGeneratorParametersType::<Identity, Impl, OFFSET>,
             GetParametersVersion: GetParametersVersion::<Identity, Impl, OFFSET>,
             GetSerializeSize: GetSerializeSize::<Identity, Impl, OFFSET>,
@@ -369,7 +369,7 @@ impl IRdcLibrary_Vtbl {
             this.GetRDCVersion(::core::mem::transmute_copy(&currentversion), ::core::mem::transmute_copy(&minimumcompatibleappversion)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ComputeDefaultRecursionDepth: ComputeDefaultRecursionDepth::<Identity, Impl, OFFSET>,
             CreateGeneratorParameters: CreateGeneratorParameters::<Identity, Impl, OFFSET>,
             OpenGeneratorParameters: OpenGeneratorParameters::<Identity, Impl, OFFSET>,
@@ -410,7 +410,7 @@ impl IRdcSignatureReader_Vtbl {
             this.ReadSignatures(::core::mem::transmute_copy(&rdcsignaturepointer), ::core::mem::transmute_copy(&endofoutput)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ReadHeader: ReadHeader::<Identity, Impl, OFFSET>,
             ReadSignatures: ReadSignatures::<Identity, Impl, OFFSET>,
         }
@@ -443,7 +443,7 @@ impl IRdcSimilarityGenerator_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             EnableSimilarity: EnableSimilarity::<Identity, Impl, OFFSET>,
             Results: Results::<Identity, Impl, OFFSET>,
         }
@@ -527,7 +527,7 @@ impl ISimilarity_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateTable: CreateTable::<Identity, Impl, OFFSET>,
             CreateTableIndirect: CreateTableIndirect::<Identity, Impl, OFFSET>,
             CloseTable: CloseTable::<Identity, Impl, OFFSET>,
@@ -622,7 +622,7 @@ impl ISimilarityFileIdTable_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateTable: CreateTable::<Identity, Impl, OFFSET>,
             CreateTableIndirect: CreateTableIndirect::<Identity, Impl, OFFSET>,
             CloseTable: CloseTable::<Identity, Impl, OFFSET>,
@@ -647,7 +647,7 @@ impl ISimilarityReportProgress_Vtbl {
             let this = (*this).get_impl();
             this.ReportProgress(::core::mem::transmute_copy(&percentcompleted)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), ReportProgress: ReportProgress::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), ReportProgress: ReportProgress::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ISimilarityReportProgress as ::windows::core::Interface>::IID
@@ -667,7 +667,7 @@ impl ISimilarityTableDumpState_Vtbl {
             let this = (*this).get_impl();
             this.GetNextData(::core::mem::transmute_copy(&resultssize), ::core::mem::transmute_copy(&resultsused), ::core::mem::transmute_copy(&eof), ::core::mem::transmute_copy(&results)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetNextData: GetNextData::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetNextData: GetNextData::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ISimilarityTableDumpState as ::windows::core::Interface>::IID
@@ -712,7 +712,7 @@ impl ISimilarityTraitsMappedView_Vtbl {
             this.GetView(::core::mem::transmute_copy(&mappedpagebegin), ::core::mem::transmute_copy(&mappedpageend))
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Flush: Flush::<Identity, Impl, OFFSET>,
             Unmap: Unmap::<Identity, Impl, OFFSET>,
             Get: Get::<Identity, Impl, OFFSET>,
@@ -795,7 +795,7 @@ impl ISimilarityTraitsMapping_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CloseMapping: CloseMapping::<Identity, Impl, OFFSET>,
             SetFileSize: SetFileSize::<Identity, Impl, OFFSET>,
             GetFileSize: GetFileSize::<Identity, Impl, OFFSET>,
@@ -884,7 +884,7 @@ impl ISimilarityTraitsTable_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateTable: CreateTable::<Identity, Impl, OFFSET>,
             CreateTableIndirect: CreateTableIndirect::<Identity, Impl, OFFSET>,
             CloseTable: CloseTable::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/Networking/RemoteDifferentialCompression/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/RemoteDifferentialCompression/mod.rs
@@ -48,7 +48,7 @@ unsafe impl ::windows::core::Interface for IFindSimilarResults {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IFindSimilarResults_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, size: *mut u32) -> ::windows::core::HRESULT,
     pub GetNextFileId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, numtraitsmatched: *mut u32, similarityfileid: *mut SimilarityFileId) -> ::windows::core::HRESULT,
 }
@@ -103,7 +103,7 @@ unsafe impl ::windows::core::Interface for IRdcComparator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRdcComparator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Process: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, endofinput: super::super::Foundation::BOOL, endofoutput: *mut super::super::Foundation::BOOL, inputbuffer: *mut RdcBufferPointer, outputbuffer: *mut RdcNeedPointer, rdc_errorcode: *mut RDC_ErrorCode) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -165,7 +165,7 @@ unsafe impl ::windows::core::Interface for IRdcFileReader {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRdcFileReader_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetFileSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, filesize: *mut u64) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub Read: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, offsetfilestart: u64, bytestoread: u32, bytesactuallyread: *mut u32, buffer: *mut u8, eof: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -314,7 +314,7 @@ unsafe impl ::windows::core::Interface for IRdcGenerator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRdcGenerator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetGeneratorParameters: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, level: u32, igeneratorparameters: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub Process: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, endofinput: super::super::Foundation::BOOL, endofoutput: *mut super::super::Foundation::BOOL, inputbuffer: *mut RdcBufferPointer, depth: u32, outputbuffers: *mut *mut RdcBufferPointer, rdc_errorcode: *mut RDC_ErrorCode) -> ::windows::core::HRESULT,
@@ -378,7 +378,7 @@ unsafe impl ::windows::core::Interface for IRdcGeneratorFilterMaxParameters {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRdcGeneratorFilterMaxParameters_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetHorizonSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, horizonsize: *mut u32) -> ::windows::core::HRESULT,
     pub SetHorizonSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, horizonsize: u32) -> ::windows::core::HRESULT,
     pub GetHashWindowSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hashwindowsize: *mut u32) -> ::windows::core::HRESULT,
@@ -441,7 +441,7 @@ unsafe impl ::windows::core::Interface for IRdcGeneratorParameters {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRdcGeneratorParameters_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetGeneratorParametersType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, parameterstype: *mut GeneratorParametersType) -> ::windows::core::HRESULT,
     pub GetParametersVersion: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, currentversion: *mut u32, minimumcompatibleappversion: *mut u32) -> ::windows::core::HRESULT,
     pub GetSerializeSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, size: *mut u32) -> ::windows::core::HRESULT,
@@ -523,7 +523,7 @@ unsafe impl ::windows::core::Interface for IRdcLibrary {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRdcLibrary_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ComputeDefaultRecursionDepth: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, filesize: u64, depth: *mut u32) -> ::windows::core::HRESULT,
     pub CreateGeneratorParameters: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, parameterstype: GeneratorParametersType, level: u32, igeneratorparameters: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub OpenGeneratorParameters: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, size: u32, parametersblob: *const u8, igeneratorparameters: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -584,7 +584,7 @@ unsafe impl ::windows::core::Interface for IRdcSignatureReader {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRdcSignatureReader_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ReadHeader: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, rdc_errorcode: *mut RDC_ErrorCode) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub ReadSignatures: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, rdcsignaturepointer: *mut RdcSignaturePointer, endofoutput: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -641,7 +641,7 @@ unsafe impl ::windows::core::Interface for IRdcSimilarityGenerator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRdcSimilarityGenerator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub EnableSimilarity: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Results: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, similaritydata: *mut SimilarityData) -> ::windows::core::HRESULT,
 }
@@ -735,7 +735,7 @@ unsafe impl ::windows::core::Interface for ISimilarity {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISimilarity_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub CreateTable: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, path: ::windows::core::PCWSTR, truncate: super::super::Foundation::BOOL, securitydescriptor: *const u8, recordsize: u32, isnew: *mut RdcCreatedTables) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -839,7 +839,7 @@ unsafe impl ::windows::core::Interface for ISimilarityFileIdTable {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISimilarityFileIdTable_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub CreateTable: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, path: ::windows::core::PCWSTR, truncate: super::super::Foundation::BOOL, securitydescriptor: *const u8, recordsize: u32, isnew: *mut RdcCreatedTables) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -903,7 +903,7 @@ unsafe impl ::windows::core::Interface for ISimilarityReportProgress {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISimilarityReportProgress_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ReportProgress: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, percentcompleted: u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Networking_RemoteDifferentialCompression\"`*"]
@@ -954,7 +954,7 @@ unsafe impl ::windows::core::Interface for ISimilarityTableDumpState {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISimilarityTableDumpState_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetNextData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, resultssize: u32, resultsused: *mut u32, eof: *mut super::super::Foundation::BOOL, results: *mut SimilarityDumpData) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -1021,7 +1021,7 @@ unsafe impl ::windows::core::Interface for ISimilarityTraitsMappedView {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISimilarityTraitsMappedView_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Flush: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Unmap: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -1098,7 +1098,7 @@ unsafe impl ::windows::core::Interface for ISimilarityTraitsMapping {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISimilarityTraitsMapping_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CloseMapping: unsafe extern "system" fn(this: *mut ::core::ffi::c_void),
     pub SetFileSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, filesize: u64) -> ::windows::core::HRESULT,
     pub GetFileSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, filesize: *mut u64) -> ::windows::core::HRESULT,
@@ -1192,7 +1192,7 @@ unsafe impl ::windows::core::Interface for ISimilarityTraitsTable {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISimilarityTraitsTable_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub CreateTable: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, path: ::windows::core::PCWSTR, truncate: super::super::Foundation::BOOL, securitydescriptor: *const u8, isnew: *mut RdcCreatedTables) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]

--- a/crates/libs/windows/src/Windows/Win32/Networking/WinInet/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/WinInet/impl.rs
@@ -25,7 +25,7 @@ impl IDialBranding_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             GetBitmap: GetBitmap::<Identity, Impl, OFFSET>,
         }
@@ -94,7 +94,7 @@ impl IDialEngine_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             GetProperty: GetProperty::<Identity, Impl, OFFSET>,
             SetProperty: SetProperty::<Identity, Impl, OFFSET>,
@@ -119,7 +119,7 @@ impl IDialEventSink_Vtbl {
             let this = (*this).get_impl();
             this.OnEvent(::core::mem::transmute_copy(&dwevent), ::core::mem::transmute_copy(&dwstatus)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnEvent: OnEvent::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnEvent: OnEvent::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDialEventSink as ::windows::core::Interface>::IID
@@ -136,7 +136,7 @@ impl IProofOfPossessionCookieInfoManager_Vtbl {
             let this = (*this).get_impl();
             this.GetCookieInfoForUri(::core::mem::transmute(&uri), ::core::mem::transmute_copy(&cookieinfocount), ::core::mem::transmute_copy(&cookieinfo)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetCookieInfoForUri: GetCookieInfoForUri::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetCookieInfoForUri: GetCookieInfoForUri::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IProofOfPossessionCookieInfoManager as ::windows::core::Interface>::IID
@@ -154,7 +154,7 @@ impl IProofOfPossessionCookieInfoManager2_Vtbl {
             this.GetCookieInfoWithUriForAccount(::core::mem::transmute(&webaccount), ::core::mem::transmute(&uri), ::core::mem::transmute_copy(&cookieinfocount), ::core::mem::transmute_copy(&cookieinfo)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCookieInfoWithUriForAccount: GetCookieInfoWithUriForAccount::<Identity, Impl, OFFSET>,
         }
     }

--- a/crates/libs/windows/src/Windows/Win32/Networking/WinInet/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/WinInet/mod.rs
@@ -3601,7 +3601,7 @@ unsafe impl ::windows::core::Interface for IDialBranding {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDialBranding_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwzconnectoid: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Graphics_Gdi")]
     pub GetBitmap: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwindex: u32, phbitmap: *mut super::super::Graphics::Gdi::HBITMAP) -> ::windows::core::HRESULT,
@@ -3686,7 +3686,7 @@ unsafe impl ::windows::core::Interface for IDialEngine {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDialEngine_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwzconnectoid: ::windows::core::PCWSTR, pides: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetProperty: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwzproperty: ::windows::core::PCWSTR, pwzvalue: ::windows::core::PCWSTR, dwbufsize: u32) -> ::windows::core::HRESULT,
     pub SetProperty: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwzproperty: ::windows::core::PCWSTR, pwzvalue: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
@@ -3741,7 +3741,7 @@ unsafe impl ::windows::core::Interface for IDialEventSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDialEventSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnEvent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwevent: u32, dwstatus: u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Networking_WinInet\"`*"]
@@ -3793,7 +3793,7 @@ unsafe impl ::windows::core::Interface for IProofOfPossessionCookieInfoManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IProofOfPossessionCookieInfoManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCookieInfoForUri: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, uri: ::windows::core::PCWSTR, cookieinfocount: *mut u32, cookieinfo: *mut *mut ProofOfPossessionCookieInfo) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Networking_WinInet\"`*"]
@@ -3846,7 +3846,7 @@ unsafe impl ::windows::core::Interface for IProofOfPossessionCookieInfoManager2 
 #[repr(C)]
 #[doc(hidden)]
 pub struct IProofOfPossessionCookieInfoManager2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCookieInfoWithUriForAccount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, webaccount: *mut ::core::ffi::c_void, uri: ::windows::core::PCWSTR, cookieinfocount: *mut u32, cookieinfo: *mut *mut ProofOfPossessionCookieInfo) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Networking_WinInet\"`*"]

--- a/crates/libs/windows/src/Windows/Win32/Security/Authentication/Identity/Provider/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Authentication/Identity/Provider/impl.rs
@@ -49,7 +49,7 @@ impl AsyncIAssociatedIdentityProvider_Vtbl {
             this.Finish_ChangeCredential().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Begin_AssociateIdentity: Begin_AssociateIdentity::<Identity, Impl, OFFSET>,
             Finish_AssociateIdentity: Finish_AssociateIdentity::<Identity, Impl, OFFSET>,
             Begin_DisassociateIdentity: Begin_DisassociateIdentity::<Identity, Impl, OFFSET>,
@@ -143,7 +143,7 @@ impl AsyncIConnectedIdentityProvider_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Begin_ConnectIdentity: Begin_ConnectIdentity::<Identity, Impl, OFFSET>,
             Finish_ConnectIdentity: Finish_ConnectIdentity::<Identity, Impl, OFFSET>,
             Begin_DisconnectIdentity: Begin_DisconnectIdentity::<Identity, Impl, OFFSET>,
@@ -178,7 +178,7 @@ impl AsyncIIdentityAdvise_Vtbl {
             this.Finish_IdentityUpdated().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Begin_IdentityUpdated: Begin_IdentityUpdated::<Identity, Impl, OFFSET>,
             Finish_IdentityUpdated: Finish_IdentityUpdated::<Identity, Impl, OFFSET>,
         }
@@ -220,7 +220,7 @@ impl AsyncIIdentityAuthentication_Vtbl {
             this.Finish_ValidateIdentityCredential(::core::mem::transmute_copy(&ppidentityproperties)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Begin_SetIdentityCredential: Begin_SetIdentityCredential::<Identity, Impl, OFFSET>,
             Finish_SetIdentityCredential: Finish_SetIdentityCredential::<Identity, Impl, OFFSET>,
             Begin_ValidateIdentityCredential: Begin_ValidateIdentityCredential::<Identity, Impl, OFFSET>,
@@ -366,7 +366,7 @@ impl AsyncIIdentityProvider_Vtbl {
             this.Finish_UnAdvise().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Begin_GetIdentityEnum: Begin_GetIdentityEnum::<Identity, Impl, OFFSET>,
             Finish_GetIdentityEnum: Finish_GetIdentityEnum::<Identity, Impl, OFFSET>,
             Begin_Create: Begin_Create::<Identity, Impl, OFFSET>,
@@ -482,7 +482,7 @@ impl AsyncIIdentityStore_Vtbl {
             this.Finish_Reset().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Begin_GetCount: Begin_GetCount::<Identity, Impl, OFFSET>,
             Finish_GetCount: Finish_GetCount::<Identity, Impl, OFFSET>,
             Begin_GetAt: Begin_GetAt::<Identity, Impl, OFFSET>,
@@ -531,7 +531,7 @@ impl AsyncIIdentityStoreEx_Vtbl {
             this.Finish_DeleteConnectedIdentity().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Begin_CreateConnectedIdentity: Begin_CreateConnectedIdentity::<Identity, Impl, OFFSET>,
             Finish_CreateConnectedIdentity: Finish_CreateConnectedIdentity::<Identity, Impl, OFFSET>,
             Begin_DeleteConnectedIdentity: Begin_DeleteConnectedIdentity::<Identity, Impl, OFFSET>,
@@ -575,7 +575,7 @@ impl IAssociatedIdentityProvider_Vtbl {
             this.ChangeCredential(::core::mem::transmute_copy(&hwndparent), ::core::mem::transmute(&lpszuniqueid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AssociateIdentity: AssociateIdentity::<Identity, Impl, OFFSET>,
             DisassociateIdentity: DisassociateIdentity::<Identity, Impl, OFFSET>,
             ChangeCredential: ChangeCredential::<Identity, Impl, OFFSET>,
@@ -636,7 +636,7 @@ impl IConnectedIdentityProvider_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ConnectIdentity: ConnectIdentity::<Identity, Impl, OFFSET>,
             DisconnectIdentity: DisconnectIdentity::<Identity, Impl, OFFSET>,
             IsConnected: IsConnected::<Identity, Impl, OFFSET>,
@@ -659,7 +659,7 @@ impl IIdentityAdvise_Vtbl {
             let this = (*this).get_impl();
             this.IdentityUpdated(::core::mem::transmute_copy(&dwidentityupdateevents), ::core::mem::transmute(&lpszuniqueid)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), IdentityUpdated: IdentityUpdated::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), IdentityUpdated: IdentityUpdated::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IIdentityAdvise as ::windows::core::Interface>::IID
@@ -686,7 +686,7 @@ impl IIdentityAuthentication_Vtbl {
             this.ValidateIdentityCredential(::core::mem::transmute_copy(&credbuffer), ::core::mem::transmute_copy(&credbufferlength), ::core::mem::transmute_copy(&ppidentityproperties)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetIdentityCredential: SetIdentityCredential::<Identity, Impl, OFFSET>,
             ValidateIdentityCredential: ValidateIdentityCredential::<Identity, Impl, OFFSET>,
         }
@@ -776,7 +776,7 @@ impl IIdentityProvider_Vtbl {
             this.UnAdvise(::core::mem::transmute_copy(&dwcookie)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetIdentityEnum: GetIdentityEnum::<Identity, Impl, OFFSET>,
             Create: Create::<Identity, Impl, OFFSET>,
             Import: Import::<Identity, Impl, OFFSET>,
@@ -848,7 +848,7 @@ impl IIdentityStore_Vtbl {
             this.Reset().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCount: GetCount::<Identity, Impl, OFFSET>,
             GetAt: GetAt::<Identity, Impl, OFFSET>,
             AddToCache: AddToCache::<Identity, Impl, OFFSET>,
@@ -879,7 +879,7 @@ impl IIdentityStoreEx_Vtbl {
             this.DeleteConnectedIdentity(::core::mem::transmute(&connectedname), ::core::mem::transmute_copy(&providerguid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateConnectedIdentity: CreateConnectedIdentity::<Identity, Impl, OFFSET>,
             DeleteConnectedIdentity: DeleteConnectedIdentity::<Identity, Impl, OFFSET>,
         }

--- a/crates/libs/windows/src/Windows/Win32/Security/Authentication/Identity/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Authentication/Identity/Provider/mod.rs
@@ -79,7 +79,7 @@ unsafe impl ::windows::core::Interface for AsyncIAssociatedIdentityProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct AsyncIAssociatedIdentityProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Begin_AssociateIdentity: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hwndparent: super::super::super::super::Foundation::HWND) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -183,7 +183,7 @@ unsafe impl ::windows::core::Interface for AsyncIConnectedIdentityProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct AsyncIConnectedIdentityProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Begin_ConnectIdentity: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, authbuffer: *const u8, authbuffersize: u32) -> ::windows::core::HRESULT,
     pub Finish_ConnectIdentity: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Begin_DisconnectIdentity: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -256,7 +256,7 @@ unsafe impl ::windows::core::Interface for AsyncIIdentityAdvise {
 #[repr(C)]
 #[doc(hidden)]
 pub struct AsyncIIdentityAdvise_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Begin_IdentityUpdated: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwidentityupdateevents: u32, lpszuniqueid: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub Finish_IdentityUpdated: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -319,7 +319,7 @@ unsafe impl ::windows::core::Interface for AsyncIIdentityAuthentication {
 #[repr(C)]
 #[doc(hidden)]
 pub struct AsyncIIdentityAuthentication_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Begin_SetIdentityCredential: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, credbuffer: *const u8, credbufferlength: u32) -> ::windows::core::HRESULT,
     pub Finish_SetIdentityCredential: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
@@ -458,7 +458,7 @@ unsafe impl ::windows::core::Interface for AsyncIIdentityProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct AsyncIIdentityProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
     pub Begin_GetIdentityEnum: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, eidentitytype: IDENTITY_TYPE, pfilterkey: *const super::super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY, pfilterpropvarvalue: *const super::super::super::super::System::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem")))]
@@ -591,7 +591,7 @@ unsafe impl ::windows::core::Interface for AsyncIIdentityStore {
 #[repr(C)]
 #[doc(hidden)]
 pub struct AsyncIIdentityStore_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Begin_GetCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Finish_GetCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwproviders: *mut u32) -> ::windows::core::HRESULT,
     pub Begin_GetAt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwprovider: u32, pprovguid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
@@ -673,7 +673,7 @@ unsafe impl ::windows::core::Interface for AsyncIIdentityStoreEx {
 #[repr(C)]
 #[doc(hidden)]
 pub struct AsyncIIdentityStoreEx_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Begin_CreateConnectedIdentity: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, localname: ::windows::core::PCWSTR, connectedname: ::windows::core::PCWSTR, providerguid: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub Finish_CreateConnectedIdentity: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Begin_DeleteConnectedIdentity: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, connectedname: ::windows::core::PCWSTR, providerguid: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
@@ -749,7 +749,7 @@ unsafe impl ::windows::core::Interface for IAssociatedIdentityProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAssociatedIdentityProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_PropertiesSystem"))]
     pub AssociateIdentity: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hwndparent: super::super::super::super::Foundation::HWND, pppropertystore: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_PropertiesSystem")))]
@@ -830,7 +830,7 @@ unsafe impl ::windows::core::Interface for IConnectedIdentityProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IConnectedIdentityProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ConnectIdentity: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, authbuffer: *const u8, authbuffersize: u32) -> ::windows::core::HRESULT,
     pub DisconnectIdentity: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -892,7 +892,7 @@ unsafe impl ::windows::core::Interface for IIdentityAdvise {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IIdentityAdvise_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub IdentityUpdated: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwidentityupdateevents: IdentityUpdateEvent, lpszuniqueid: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Security_Authentication_Identity_Provider\"`*"]
@@ -946,7 +946,7 @@ unsafe impl ::windows::core::Interface for IIdentityAuthentication {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IIdentityAuthentication_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetIdentityCredential: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, credbuffer: *const u8, credbufferlength: u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
     pub ValidateIdentityCredential: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, credbuffer: *const u8, credbufferlength: u32, ppidentityproperties: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1051,7 +1051,7 @@ unsafe impl ::windows::core::Interface for IIdentityProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IIdentityProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
     pub GetIdentityEnum: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, eidentitytype: IDENTITY_TYPE, pfilterkey: *const super::super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY, pfilterpropvarvalue: *const super::super::super::super::System::Com::StructuredStorage::PROPVARIANT, ppidentityenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem")))]
@@ -1150,7 +1150,7 @@ unsafe impl ::windows::core::Interface for IIdentityStore {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IIdentityStore_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwproviders: *mut u32) -> ::windows::core::HRESULT,
     pub GetAt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwprovider: u32, pprovguid: *mut ::windows::core::GUID, ppidentityprovider: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub AddToCache: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lpszuniqueid: ::windows::core::PCWSTR, providerguid: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
@@ -1217,7 +1217,7 @@ unsafe impl ::windows::core::Interface for IIdentityStoreEx {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IIdentityStoreEx_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateConnectedIdentity: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, localname: ::windows::core::PCWSTR, connectedname: ::windows::core::PCWSTR, providerguid: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub DeleteConnectedIdentity: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, connectedname: ::windows::core::PCWSTR, providerguid: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
 }

--- a/crates/libs/windows/src/Windows/Win32/Security/Authentication/Identity/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Authentication/Identity/impl.rs
@@ -9,7 +9,7 @@ impl ICcgDomainAuthCredentials_Vtbl {
             let this = (*this).get_impl();
             this.GetPasswordCredentials(::core::mem::transmute(&plugininput), ::core::mem::transmute_copy(&domainname), ::core::mem::transmute_copy(&username), ::core::mem::transmute_copy(&password)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetPasswordCredentials: GetPasswordCredentials::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetPasswordCredentials: GetPasswordCredentials::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ICcgDomainAuthCredentials as ::windows::core::Interface>::IID

--- a/crates/libs/windows/src/Windows/Win32/Security/Authentication/Identity/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Authentication/Identity/mod.rs
@@ -2431,7 +2431,7 @@ unsafe impl ::windows::core::Interface for ICcgDomainAuthCredentials {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICcgDomainAuthCredentials_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetPasswordCredentials: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, plugininput: ::windows::core::PCWSTR, domainname: *mut ::windows::core::PWSTR, username: *mut ::windows::core::PWSTR, password: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Security_Authentication_Identity\"`*"]

--- a/crates/libs/windows/src/Windows/Win32/Security/Authorization/UI/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Authorization/UI/impl.rs
@@ -12,7 +12,7 @@ impl IEffectivePermission_Vtbl {
             let this = (*this).get_impl();
             this.GetEffectivePermission(::core::mem::transmute_copy(&pguidobjecttype), ::core::mem::transmute_copy(&pusersid), ::core::mem::transmute(&pszservername), ::core::mem::transmute_copy(&psd), ::core::mem::transmute_copy(&ppobjecttypelist), ::core::mem::transmute_copy(&pcobjecttypelistlength), ::core::mem::transmute_copy(&ppgrantedaccesslist), ::core::mem::transmute_copy(&pcgrantedaccesslistlength)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetEffectivePermission: GetEffectivePermission::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetEffectivePermission: GetEffectivePermission::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IEffectivePermission as ::windows::core::Interface>::IID
@@ -81,7 +81,7 @@ impl IEffectivePermission2_Vtbl {
             .into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ComputeEffectivePermissionWithSecondarySecurity: ComputeEffectivePermissionWithSecondarySecurity::<Identity, Impl, OFFSET>,
         }
     }
@@ -140,7 +140,7 @@ impl ISecurityInformation_Vtbl {
             this.PropertySheetPageCallback(::core::mem::transmute_copy(&hwnd), ::core::mem::transmute_copy(&umsg), ::core::mem::transmute_copy(&upage)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetObjectInformation: GetObjectInformation::<Identity, Impl, OFFSET>,
             GetSecurity: GetSecurity::<Identity, Impl, OFFSET>,
             SetSecurity: SetSecurity::<Identity, Impl, OFFSET>,
@@ -175,7 +175,7 @@ impl ISecurityInformation2_Vtbl {
             this.LookupSids(::core::mem::transmute_copy(&csids), ::core::mem::transmute_copy(&rgpsids), ::core::mem::transmute_copy(&ppdo)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             IsDaclCanonical: IsDaclCanonical::<Identity, Impl, OFFSET>,
             LookupSids: LookupSids::<Identity, Impl, OFFSET>,
         }
@@ -211,7 +211,7 @@ impl ISecurityInformation3_Vtbl {
             this.OpenElevatedEditor(::core::mem::transmute_copy(&hwnd), ::core::mem::transmute_copy(&upage)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetFullResourceName: GetFullResourceName::<Identity, Impl, OFFSET>,
             OpenElevatedEditor: OpenElevatedEditor::<Identity, Impl, OFFSET>,
         }
@@ -234,7 +234,7 @@ impl ISecurityInformation4_Vtbl {
             let this = (*this).get_impl();
             this.GetSecondarySecurity(::core::mem::transmute_copy(&psecurityobjects), ::core::mem::transmute_copy(&psecurityobjectcount)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetSecondarySecurity: GetSecondarySecurity::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetSecondarySecurity: GetSecondarySecurity::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ISecurityInformation4 as ::windows::core::Interface>::IID
@@ -251,7 +251,7 @@ impl ISecurityObjectTypeInfo_Vtbl {
             let this = (*this).get_impl();
             this.GetInheritSource(::core::mem::transmute_copy(&si), ::core::mem::transmute_copy(&pacl), ::core::mem::transmute_copy(&ppinheritarray)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetInheritSource: GetInheritSource::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetInheritSource: GetInheritSource::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ISecurityObjectTypeInfo as ::windows::core::Interface>::IID

--- a/crates/libs/windows/src/Windows/Win32/Security/Authorization/UI/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Authorization/UI/mod.rs
@@ -93,7 +93,7 @@ unsafe impl ::windows::core::Interface for IEffectivePermission {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEffectivePermission_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetEffectivePermission: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pguidobjecttype: *const ::windows::core::GUID, pusersid: super::super::super::Foundation::PSID, pszservername: ::windows::core::PCWSTR, psd: super::super::PSECURITY_DESCRIPTOR, ppobjecttypelist: *mut *mut super::super::OBJECT_TYPE_LIST, pcobjecttypelistlength: *mut u32, ppgrantedaccesslist: *mut *mut u32, pcgrantedaccesslistlength: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -185,7 +185,7 @@ unsafe impl ::windows::core::Interface for IEffectivePermission2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEffectivePermission2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub ComputeEffectivePermissionWithSecondarySecurity: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
@@ -286,7 +286,7 @@ unsafe impl ::windows::core::Interface for ISecurityInformation {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISecurityInformation_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetObjectInformation: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pobjectinfo: *mut SI_OBJECT_INFO) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -357,7 +357,7 @@ unsafe impl ::windows::core::Interface for ISecurityInformation2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISecurityInformation2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub IsDaclCanonical: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdacl: *mut super::super::ACL) -> super::super::super::Foundation::BOOL,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -422,7 +422,7 @@ unsafe impl ::windows::core::Interface for ISecurityInformation3 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISecurityInformation3_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetFullResourceName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppszresourcename: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub OpenElevatedEditor: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hwnd: super::super::super::Foundation::HWND, upage: SI_PAGE_TYPE) -> ::windows::core::HRESULT,
@@ -477,7 +477,7 @@ unsafe impl ::windows::core::Interface for ISecurityInformation4 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISecurityInformation4_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetSecondarySecurity: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psecurityobjects: *mut *mut SECURITY_OBJECT, psecurityobjectcount: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -529,7 +529,7 @@ unsafe impl ::windows::core::Interface for ISecurityObjectTypeInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISecurityObjectTypeInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetInheritSource: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, si: u32, pacl: *mut super::super::ACL, ppinheritarray: *mut *mut super::INHERITED_FROMA) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Security_Authorization_UI\"`*"]

--- a/crates/libs/windows/src/Windows/Win32/Security/ConfigurationSnapin/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/ConfigurationSnapin/impl.rs
@@ -28,7 +28,7 @@ impl ISceSvcAttachmentData_Vtbl {
             this.CloseHandle(::core::mem::transmute_copy(&scesvchandle)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetData: GetData::<Identity, Impl, OFFSET>,
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             FreeBuffer: FreeBuffer::<Identity, Impl, OFFSET>,
@@ -66,7 +66,7 @@ impl ISceSvcAttachmentPersistInfo_Vtbl {
             this.FreeBuffer(::core::mem::transmute_copy(&pvdata)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Save: Save::<Identity, Impl, OFFSET>,
             IsDirty: IsDirty::<Identity, Impl, OFFSET>,
             FreeBuffer: FreeBuffer::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/Security/ConfigurationSnapin/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/ConfigurationSnapin/mod.rs
@@ -56,7 +56,7 @@ unsafe impl ::windows::core::Interface for ISceSvcAttachmentData {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISceSvcAttachmentData_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, scesvchandle: *mut ::core::ffi::c_void, scetype: SCESVC_INFO_TYPE, ppvdata: *mut *mut ::core::ffi::c_void, psceenumhandle: *mut u32) -> ::windows::core::HRESULT,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lpservicename: *mut i8, lptemplatename: *mut i8, lpscesvcpersistinfo: *mut ::core::ffi::c_void, pscesvchandle: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub FreeBuffer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pvdata: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -116,7 +116,7 @@ unsafe impl ::windows::core::Interface for ISceSvcAttachmentPersistInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISceSvcAttachmentPersistInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Save: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lptemplatename: *mut i8, scesvchandle: *mut *mut ::core::ffi::c_void, ppvdata: *mut *mut ::core::ffi::c_void, pboverwriteall: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]

--- a/crates/libs/windows/src/Windows/Win32/Security/Cryptography/Certificates/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Cryptography/Certificates/impl.rs
@@ -3763,7 +3763,7 @@ impl ICertRequestD_Vtbl {
             this.Ping(::core::mem::transmute(&pwszauthority)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Request: Request::<Identity, Impl, OFFSET>,
             GetCACert: GetCACert::<Identity, Impl, OFFSET>,
             Ping: Ping::<Identity, Impl, OFFSET>,
@@ -5973,7 +5973,7 @@ impl IEnroll_Vtbl {
             this.CreatePKCS7RequestFromRequest(::core::mem::transmute_copy(&prequest), ::core::mem::transmute_copy(&psigningcertcontext), ::core::mem::transmute_copy(&ppkcs7blob)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             createFilePKCS10WStr: createFilePKCS10WStr::<Identity, Impl, OFFSET>,
             acceptFilePKCS7WStr: acceptFilePKCS7WStr::<Identity, Impl, OFFSET>,
             createPKCS10WStr: createPKCS10WStr::<Identity, Impl, OFFSET>,
@@ -6800,7 +6800,7 @@ impl INDESPolicy_Vtbl {
             this.Notify(::core::mem::transmute(&pwszchallenge), ::core::mem::transmute(&pwsztransactionid), ::core::mem::transmute_copy(&disposition), ::core::mem::transmute_copy(&lasthresult), ::core::mem::transmute_copy(&pctbissuedcertencoded)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             Uninitialize: Uninitialize::<Identity, Impl, OFFSET>,
             GenerateChallenge: GenerateChallenge::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/Security/Cryptography/Certificates/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Cryptography/Certificates/mod.rs
@@ -7362,7 +7362,7 @@ unsafe impl ::windows::core::Interface for ICertRequestD {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICertRequestD_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Request: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwflags: u32, pwszauthority: ::windows::core::PCWSTR, pdwrequestid: *mut u32, pdwdisposition: *mut u32, pwszattributes: ::windows::core::PCWSTR, pctbrequest: *const CERTTRANSBLOB, pctbcertchain: *mut CERTTRANSBLOB, pctbencodedcert: *mut CERTTRANSBLOB, pctbdispositionmessage: *mut CERTTRANSBLOB) -> ::windows::core::HRESULT,
     pub GetCACert: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fchain: u32, pwszauthority: ::windows::core::PCWSTR, pctbout: *mut CERTTRANSBLOB) -> ::windows::core::HRESULT,
     pub Ping: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszauthority: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
@@ -10188,7 +10188,7 @@ unsafe impl ::windows::core::Interface for IEnroll {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnroll_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub createFilePKCS10WStr: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dnname: ::windows::core::PCWSTR, usage: ::windows::core::PCWSTR, wszpkcs10filename: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub acceptFilePKCS7WStr: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wszpkcs7filename: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub createPKCS10WStr: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dnname: ::windows::core::PCWSTR, usage: ::windows::core::PCWSTR, ppkcs10blob: *mut super::CRYPTOAPI_BLOB) -> ::windows::core::HRESULT,
@@ -12054,7 +12054,7 @@ unsafe impl ::windows::core::Interface for INDESPolicy {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INDESPolicy_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Uninitialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GenerateChallenge: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwsztemplate: ::windows::core::PCWSTR, pwszparams: ::windows::core::PCWSTR, ppwszresponse: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/Security/ExtensibleAuthenticationProtocol/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/ExtensibleAuthenticationProtocol/impl.rs
@@ -43,7 +43,7 @@ impl IAccountingProviderConfig_Vtbl {
             this.Deactivate(::core::mem::transmute_copy(&uconnectionparam), ::core::mem::transmute_copy(&ureserved1), ::core::mem::transmute_copy(&ureserved2)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             Uninitialize: Uninitialize::<Identity, Impl, OFFSET>,
             Configure: Configure::<Identity, Impl, OFFSET>,
@@ -100,7 +100,7 @@ impl IAuthenticationProviderConfig_Vtbl {
             this.Deactivate(::core::mem::transmute_copy(&uconnectionparam), ::core::mem::transmute_copy(&ureserved1), ::core::mem::transmute_copy(&ureserved2)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             Uninitialize: Uninitialize::<Identity, Impl, OFFSET>,
             Configure: Configure::<Identity, Impl, OFFSET>,
@@ -158,7 +158,7 @@ impl IEAPProviderConfig_Vtbl {
                 .into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             Uninitialize: Uninitialize::<Identity, Impl, OFFSET>,
             ServerInvokeConfigUI: ServerInvokeConfigUI::<Identity, Impl, OFFSET>,
@@ -244,7 +244,7 @@ impl IRouterProtocolConfig_Vtbl {
             this.RemoveProtocol(::core::mem::transmute(&pszmachinename), ::core::mem::transmute_copy(&dwtransportid), ::core::mem::transmute_copy(&dwprotocolid), ::core::mem::transmute_copy(&hwnd), ::core::mem::transmute_copy(&dwflags), ::core::mem::transmute(&prouter), ::core::mem::transmute_copy(&ureserved1)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddProtocol: AddProtocol::<Identity, Impl, OFFSET>,
             RemoveProtocol: RemoveProtocol::<Identity, Impl, OFFSET>,
         }

--- a/crates/libs/windows/src/Windows/Win32/Security/ExtensibleAuthenticationProtocol/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/ExtensibleAuthenticationProtocol/mod.rs
@@ -428,7 +428,7 @@ unsafe impl ::windows::core::Interface for IAccountingProviderConfig {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAccountingProviderConfig_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszmachinename: ::windows::core::PCWSTR, puconnectionparam: *mut usize) -> ::windows::core::HRESULT,
     pub Uninitialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, uconnectionparam: usize) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -505,7 +505,7 @@ unsafe impl ::windows::core::Interface for IAuthenticationProviderConfig {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAuthenticationProviderConfig_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszmachinename: ::windows::core::PCWSTR, puconnectionparam: *mut usize) -> ::windows::core::HRESULT,
     pub Uninitialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, uconnectionparam: usize) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -592,7 +592,7 @@ unsafe impl ::windows::core::Interface for IEAPProviderConfig {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEAPProviderConfig_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszmachinename: ::windows::core::PCWSTR, dweaptypeid: u32, puconnectionparam: *mut usize) -> ::windows::core::HRESULT,
     pub Uninitialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dweaptypeid: u32, uconnectionparam: usize) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -913,7 +913,7 @@ unsafe impl ::windows::core::Interface for IRouterProtocolConfig {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRouterProtocolConfig_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub AddProtocol: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszmachinename: ::windows::core::PCWSTR, dwtransportid: u32, dwprotocolid: u32, hwnd: super::super::Foundation::HWND, dwflags: u32, prouter: *mut ::core::ffi::c_void, ureserved1: usize) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]

--- a/crates/libs/windows/src/Windows/Win32/Security/Isolation/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Isolation/impl.rs
@@ -12,7 +12,7 @@ impl IIsolatedAppLauncher_Vtbl {
             let this = (*this).get_impl();
             this.Launch(::core::mem::transmute(&appusermodelid), ::core::mem::transmute(&arguments), ::core::mem::transmute_copy(&telemetryparameters)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Launch: Launch::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Launch: Launch::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IIsolatedAppLauncher as ::windows::core::Interface>::IID

--- a/crates/libs/windows/src/Windows/Win32/Security/Isolation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Isolation/mod.rs
@@ -178,7 +178,7 @@ unsafe impl ::windows::core::Interface for IIsolatedAppLauncher {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IIsolatedAppLauncher_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Launch: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, appusermodelid: ::windows::core::PCWSTR, arguments: ::windows::core::PCWSTR, telemetryparameters: *const IsolatedAppLauncherTelemetryParameters) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]

--- a/crates/libs/windows/src/Windows/Win32/Security/Tpm/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Tpm/impl.rs
@@ -41,7 +41,7 @@ impl ITpmVirtualSmartCardManager_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateVirtualSmartCard: CreateVirtualSmartCard::<Identity, Impl, OFFSET>,
             DestroyVirtualSmartCard: DestroyVirtualSmartCard::<Identity, Impl, OFFSET>,
         }
@@ -154,7 +154,7 @@ impl ITpmVirtualSmartCardManagerStatusCallback_Vtbl {
             this.ReportError(::core::mem::transmute_copy(&error)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ReportProgress: ReportProgress::<Identity, Impl, OFFSET>,
             ReportError: ReportError::<Identity, Impl, OFFSET>,
         }

--- a/crates/libs/windows/src/Windows/Win32/Security/Tpm/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Tpm/mod.rs
@@ -61,7 +61,7 @@ unsafe impl ::windows::core::Interface for ITpmVirtualSmartCardManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITpmVirtualSmartCardManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub CreateVirtualSmartCard: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszfriendlyname: ::windows::core::PCWSTR, badminalgid: u8, pbadminkey: *const u8, cbadminkey: u32, pbadminkcv: *const u8, cbadminkcv: u32, pbpuk: *const u8, cbpuk: u32, pbpin: *const u8, cbpin: u32, fgenerate: super::super::Foundation::BOOL, pstatuscallback: *mut ::core::ffi::c_void, ppszinstanceid: *mut ::windows::core::PWSTR, pfneedreboot: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -391,7 +391,7 @@ unsafe impl ::windows::core::Interface for ITpmVirtualSmartCardManagerStatusCall
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITpmVirtualSmartCardManagerStatusCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ReportProgress: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, status: TPMVSCMGR_STATUS) -> ::windows::core::HRESULT,
     pub ReportError: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, error: TPMVSCMGR_ERROR) -> ::windows::core::HRESULT,
 }

--- a/crates/libs/windows/src/Windows/Win32/Storage/DataDeduplication/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/DataDeduplication/impl.rs
@@ -15,7 +15,7 @@ impl IDedupBackupSupport_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), RestoreFiles: RestoreFiles::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), RestoreFiles: RestoreFiles::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDedupBackupSupport as ::windows::core::Interface>::IID
@@ -60,7 +60,7 @@ impl IDedupChunkLibrary_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             InitializeForPushBuffers: InitializeForPushBuffers::<Identity, Impl, OFFSET>,
             Uninitialize: Uninitialize::<Identity, Impl, OFFSET>,
             SetParameter: SetParameter::<Identity, Impl, OFFSET>,
@@ -200,7 +200,7 @@ impl IDedupDataPort_Vtbl {
             this.GetRequestResults(::core::mem::transmute(&requestid), ::core::mem::transmute_copy(&maxwaitms), ::core::mem::transmute_copy(&pbatchresult), ::core::mem::transmute_copy(&pbatchcount), ::core::mem::transmute_copy(&pstatus), ::core::mem::transmute_copy(&ppitemresults)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetStatus: GetStatus::<Identity, Impl, OFFSET>,
             LookupChunks: LookupChunks::<Identity, Impl, OFFSET>,
             InsertChunks: InsertChunks::<Identity, Impl, OFFSET>,
@@ -255,7 +255,7 @@ impl IDedupDataPortManager_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetConfiguration: GetConfiguration::<Identity, Impl, OFFSET>,
             GetVolumeStatus: GetVolumeStatus::<Identity, Impl, OFFSET>,
             GetVolumeDataPort: GetVolumeDataPort::<Identity, Impl, OFFSET>,
@@ -295,7 +295,7 @@ impl IDedupIterateChunksHash32_Vtbl {
             this.Reset().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             PushBuffer: PushBuffer::<Identity, Impl, OFFSET>,
             Next: Next::<Identity, Impl, OFFSET>,
             Drain: Drain::<Identity, Impl, OFFSET>,
@@ -330,7 +330,7 @@ impl IDedupReadFileCallback_Vtbl {
             this.PreviewContainerRead(::core::mem::transmute(&filefullpath), ::core::mem::transmute_copy(&numberofreads), ::core::mem::transmute_copy(&readoffsets)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ReadBackupFile: ReadBackupFile::<Identity, Impl, OFFSET>,
             OrderContainersRestore: OrderContainersRestore::<Identity, Impl, OFFSET>,
             PreviewContainerRead: PreviewContainerRead::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/Storage/DataDeduplication/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/DataDeduplication/mod.rs
@@ -48,7 +48,7 @@ unsafe impl ::windows::core::Interface for IDedupBackupSupport {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDedupBackupSupport_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub RestoreFiles: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, numberoffiles: u32, filefullpaths: *const ::core::mem::ManuallyDrop<::windows::core::BSTR>, store: *mut ::core::ffi::c_void, flags: u32, fileresults: *mut ::windows::core::HRESULT) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Storage_DataDeduplication\"`*"]
@@ -112,7 +112,7 @@ unsafe impl ::windows::core::Interface for IDedupChunkLibrary {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDedupChunkLibrary_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub InitializeForPushBuffers: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Uninitialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -218,7 +218,7 @@ unsafe impl ::windows::core::Interface for IDedupDataPort {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDedupDataPort_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetStatus: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pstatus: *mut DedupDataPortVolumeStatus, pdataheadroommb: *mut u32) -> ::windows::core::HRESULT,
     pub LookupChunks: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, count: u32, phashes: *const DedupHash, prequestid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub InsertChunks: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, chunkcount: u32, pchunkmetadata: *const DedupChunk, databytecount: u32, pchunkdata: *const u8, prequestid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
@@ -292,7 +292,7 @@ unsafe impl ::windows::core::Interface for IDedupDataPortManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDedupDataPortManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetConfiguration: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pminchunksize: *mut u32, pmaxchunksize: *mut u32, pchunkingalgorithm: *mut DedupChunkingAlgorithm, phashingalgorithm: *mut DedupHashingAlgorithm, pcompressionalgorithm: *mut DedupCompressionAlgorithm) -> ::windows::core::HRESULT,
     pub GetVolumeStatus: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, options: u32, path: ::core::mem::ManuallyDrop<::windows::core::BSTR>, pstatus: *mut DedupDataPortVolumeStatus) -> ::windows::core::HRESULT,
     pub GetVolumeDataPort: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, options: u32, path: ::core::mem::ManuallyDrop<::windows::core::BSTR>, ppdataport: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -352,7 +352,7 @@ unsafe impl ::windows::core::Interface for IDedupIterateChunksHash32 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDedupIterateChunksHash32_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub PushBuffer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbuffer: *const u8, ulbufferlength: u32) -> ::windows::core::HRESULT,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ulmaxchunks: u32, parrchunks: *mut DEDUP_CHUNK_INFO_HASH32, pulfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Drain: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -410,7 +410,7 @@ unsafe impl ::windows::core::Interface for IDedupReadFileCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDedupReadFileCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ReadBackupFile: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, filefullpath: ::core::mem::ManuallyDrop<::windows::core::BSTR>, fileoffset: i64, sizetoread: u32, filebuffer: *mut u8, returnedsize: *mut u32, flags: u32) -> ::windows::core::HRESULT,
     pub OrderContainersRestore: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, numberofcontainers: u32, containerpaths: *const ::core::mem::ManuallyDrop<::windows::core::BSTR>, readplanentries: *mut u32, readplan: *mut *mut DEDUP_CONTAINER_EXTENT) -> ::windows::core::HRESULT,
     pub PreviewContainerRead: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, filefullpath: ::core::mem::ManuallyDrop<::windows::core::BSTR>, numberofreads: u32, readoffsets: *const DDP_FILE_EXTENT) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/Storage/EnhancedStorage/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/EnhancedStorage/impl.rs
@@ -58,7 +58,7 @@ impl IEnhancedStorageACT_Vtbl {
             this.GetSilos(::core::mem::transmute_copy(&pppienhancedstoragesilos), ::core::mem::transmute_copy(&pcenhancedstoragesilos)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Authorize: Authorize::<Identity, Impl, OFFSET>,
             Unauthorize: Unauthorize::<Identity, Impl, OFFSET>,
             GetAuthorizationState: GetAuthorizationState::<Identity, Impl, OFFSET>,
@@ -219,7 +219,7 @@ impl IEnhancedStorageSilo_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetInfo: GetInfo::<Identity, Impl, OFFSET>,
             GetActions: GetActions::<Identity, Impl, OFFSET>,
             SendCommand: SendCommand::<Identity, Impl, OFFSET>,
@@ -267,7 +267,7 @@ impl IEnhancedStorageSiloAction_Vtbl {
             this.Invoke().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetName: GetName::<Identity, Impl, OFFSET>,
             GetDescription: GetDescription::<Identity, Impl, OFFSET>,
             Invoke: Invoke::<Identity, Impl, OFFSET>,
@@ -301,7 +301,7 @@ impl IEnumEnhancedStorageACT_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetACTs: GetACTs::<Identity, Impl, OFFSET>,
             GetMatchingACT: GetMatchingACT::<Identity, Impl, OFFSET>,
         }

--- a/crates/libs/windows/src/Windows/Win32/Storage/EnhancedStorage/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/EnhancedStorage/mod.rs
@@ -62,7 +62,7 @@ unsafe impl ::windows::core::Interface for IEnhancedStorageACT {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnhancedStorageACT_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Authorize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hwndparent: u32, dwflags: u32) -> ::windows::core::HRESULT,
     pub Unauthorize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetAuthorizationState: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pstate: *mut ACT_AUTHORIZATION_STATE) -> ::windows::core::HRESULT,
@@ -359,7 +359,7 @@ unsafe impl ::windows::core::Interface for IEnhancedStorageSilo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnhancedStorageSilo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psiloinfo: *mut SILO_INFO) -> ::windows::core::HRESULT,
     pub GetActions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pppienhancedstoragesiloactions: *mut *mut *mut ::core::ffi::c_void, pcenhancedstoragesiloactions: *mut u32) -> ::windows::core::HRESULT,
     pub SendCommand: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, command: u8, pbcommandbuffer: *const u8, cbcommandbuffer: u32, pbresponsebuffer: *mut u8, pcbresponsebuffer: *mut u32) -> ::windows::core::HRESULT,
@@ -423,7 +423,7 @@ unsafe impl ::windows::core::Interface for IEnhancedStorageSiloAction {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnhancedStorageSiloAction_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppwszactionname: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetDescription: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppwszactiondescription: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -481,7 +481,7 @@ unsafe impl ::windows::core::Interface for IEnumEnhancedStorageACT {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumEnhancedStorageACT_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetACTs: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pppienhancedstorageacts: *mut *mut *mut ::core::ffi::c_void, pcenhancedstorageacts: *mut u32) -> ::windows::core::HRESULT,
     pub GetMatchingACT: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, szvolume: ::windows::core::PCWSTR, ppienhancedstorageact: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }

--- a/crates/libs/windows/src/Windows/Win32/Storage/FileHistory/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/FileHistory/impl.rs
@@ -121,7 +121,7 @@ impl IFhConfigMgr_Vtbl {
             this.QueryProtectionStatus(::core::mem::transmute_copy(&protectionstate), ::core::mem::transmute_copy(&protecteduntiltime)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             LoadConfiguration: LoadConfiguration::<Identity, Impl, OFFSET>,
             CreateDefaultConfiguration: CreateDefaultConfiguration::<Identity, Impl, OFFSET>,
             SaveConfiguration: SaveConfiguration::<Identity, Impl, OFFSET>,
@@ -187,7 +187,7 @@ impl IFhReassociation_Vtbl {
             this.PerformReassociation(::core::mem::transmute_copy(&overwriteifexists)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ValidateTarget: ValidateTarget::<Identity, Impl, OFFSET>,
             ScanTargetForConfigurations: ScanTargetForConfigurations::<Identity, Impl, OFFSET>,
             GetConfigurationDetails: GetConfigurationDetails::<Identity, Impl, OFFSET>,
@@ -223,7 +223,7 @@ impl IFhScopeIterator_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             MoveToNextItem: MoveToNextItem::<Identity, Impl, OFFSET>,
             GetItem: GetItem::<Identity, Impl, OFFSET>,
         }
@@ -262,7 +262,7 @@ impl IFhTarget_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetStringProperty: GetStringProperty::<Identity, Impl, OFFSET>,
             GetNumericalProperty: GetNumericalProperty::<Identity, Impl, OFFSET>,
         }

--- a/crates/libs/windows/src/Windows/Win32/Storage/FileHistory/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/FileHistory/mod.rs
@@ -202,7 +202,7 @@ unsafe impl ::windows::core::Interface for IFhConfigMgr {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IFhConfigMgr_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub LoadConfiguration: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub CreateDefaultConfiguration: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, overwriteifexists: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -296,7 +296,7 @@ unsafe impl ::windows::core::Interface for IFhReassociation {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IFhReassociation_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ValidateTarget: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, targeturl: ::core::mem::ManuallyDrop<::windows::core::BSTR>, validationresult: *mut FH_DEVICE_VALIDATION_RESULT) -> ::windows::core::HRESULT,
     pub ScanTargetForConfigurations: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, targeturl: ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -359,7 +359,7 @@ unsafe impl ::windows::core::Interface for IFhScopeIterator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IFhScopeIterator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub MoveToNextItem: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetItem: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, item: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
 }
@@ -414,7 +414,7 @@ unsafe impl ::windows::core::Interface for IFhTarget {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IFhTarget_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetStringProperty: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, propertytype: FH_TARGET_PROPERTY_TYPE, propertyvalue: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub GetNumericalProperty: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, propertytype: FH_TARGET_PROPERTY_TYPE, propertyvalue: *mut u64) -> ::windows::core::HRESULT,
 }

--- a/crates/libs/windows/src/Windows/Win32/Storage/FileSystem/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/FileSystem/impl.rs
@@ -202,7 +202,7 @@ impl IDiskQuotaEvents_Vtbl {
             let this = (*this).get_impl();
             this.OnUserNameChanged(::core::mem::transmute(&puser)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnUserNameChanged: OnUserNameChanged::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnUserNameChanged: OnUserNameChanged::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDiskQuotaEvents as ::windows::core::Interface>::IID
@@ -307,7 +307,7 @@ impl IDiskQuotaUser_Vtbl {
             this.GetAccountStatus(::core::mem::transmute_copy(&pdwstatus)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetID: GetID::<Identity, Impl, OFFSET>,
             GetName: GetName::<Identity, Impl, OFFSET>,
             GetSidLength: GetSidLength::<Identity, Impl, OFFSET>,
@@ -359,7 +359,7 @@ impl IDiskQuotaUserBatch_Vtbl {
             this.FlushToDisk().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Add: Add::<Identity, Impl, OFFSET>,
             Remove: Remove::<Identity, Impl, OFFSET>,
             RemoveAll: RemoveAll::<Identity, Impl, OFFSET>,
@@ -406,7 +406,7 @@ impl IEnumDiskQuotaUsers_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/Storage/FileSystem/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/FileSystem/mod.rs
@@ -5472,7 +5472,7 @@ unsafe impl ::windows::core::Interface for IDiskQuotaEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDiskQuotaEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnUserNameChanged: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, puser: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Storage_FileSystem\"`*"]
@@ -5587,7 +5587,7 @@ unsafe impl ::windows::core::Interface for IDiskQuotaUser {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDiskQuotaUser_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pulid: *mut u32) -> ::windows::core::HRESULT,
     pub GetName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszaccountcontainer: ::windows::core::PCWSTR, cchaccountcontainer: u32, pszlogonname: ::windows::core::PCWSTR, cchlogonname: u32, pszdisplayname: ::windows::core::PCWSTR, cchdisplayname: u32) -> ::windows::core::HRESULT,
     pub GetSidLength: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwlength: *mut u32) -> ::windows::core::HRESULT,
@@ -5671,7 +5671,7 @@ unsafe impl ::windows::core::Interface for IDiskQuotaUserBatch {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDiskQuotaUserBatch_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Add: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, puser: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Remove: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, puser: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub RemoveAll: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -5733,7 +5733,7 @@ unsafe impl ::windows::core::Interface for IEnumDiskQuotaUsers {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumDiskQuotaUsers_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cusers: u32, rgusers: *mut *mut ::core::ffi::c_void, pcusersfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cusers: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/Storage/Imapi/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Imapi/impl.rs
@@ -369,7 +369,7 @@ impl IBurnVerification_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetBurnVerificationLevel: SetBurnVerificationLevel::<Identity, Impl, OFFSET>,
             BurnVerificationLevel: BurnVerificationLevel::<Identity, Impl, OFFSET>,
         }
@@ -1781,7 +1781,7 @@ impl IDiscMaster_Vtbl {
             this.Close().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Open: Open::<Identity, Impl, OFFSET>,
             EnumDiscMasterFormats: EnumDiscMasterFormats::<Identity, Impl, OFFSET>,
             GetActiveDiscMasterFormat: GetActiveDiscMasterFormat::<Identity, Impl, OFFSET>,
@@ -1934,7 +1934,7 @@ impl IDiscMasterProgressEvents_Vtbl {
             this.NotifyEraseComplete(::core::mem::transmute_copy(&status)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             QueryCancel: QueryCancel::<Identity, Impl, OFFSET>,
             NotifyPnPActivity: NotifyPnPActivity::<Identity, Impl, OFFSET>,
             NotifyAddProgress: NotifyAddProgress::<Identity, Impl, OFFSET>,
@@ -2079,7 +2079,7 @@ impl IDiscRecorder_Vtbl {
             this.Close().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Init: Init::<Identity, Impl, OFFSET>,
             GetRecorderGUID: GetRecorderGUID::<Identity, Impl, OFFSET>,
             GetRecorderType: GetRecorderType::<Identity, Impl, OFFSET>,
@@ -2483,7 +2483,7 @@ impl IDiscRecorder2Ex_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SendCommandNoData: SendCommandNoData::<Identity, Impl, OFFSET>,
             SendCommandSendDataToDevice: SendCommandSendDataToDevice::<Identity, Impl, OFFSET>,
             SendCommandGetDataFromDevice: SendCommandGetDataFromDevice::<Identity, Impl, OFFSET>,
@@ -2544,7 +2544,7 @@ impl IEnumDiscMasterFormats_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -2591,7 +2591,7 @@ impl IEnumDiscRecorders_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -2641,7 +2641,7 @@ impl IEnumFsiItems_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -2691,7 +2691,7 @@ impl IEnumProgressItems_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -4081,7 +4081,7 @@ impl IJolietDiscMaster_Vtbl {
             this.SetJolietProperties(::core::mem::transmute(&ppropstg)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTotalDataBlocks: GetTotalDataBlocks::<Identity, Impl, OFFSET>,
             GetUsedDataBlocks: GetUsedDataBlocks::<Identity, Impl, OFFSET>,
             GetDataBlockSize: GetDataBlockSize::<Identity, Impl, OFFSET>,
@@ -4940,7 +4940,7 @@ impl IRedbookDiscMaster_Vtbl {
             this.CloseAudioTrack().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTotalAudioTracks: GetTotalAudioTracks::<Identity, Impl, OFFSET>,
             GetTotalAudioBlocks: GetTotalAudioBlocks::<Identity, Impl, OFFSET>,
             GetUsedAudioBlocks: GetUsedAudioBlocks::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/Storage/Imapi/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Imapi/mod.rs
@@ -1113,7 +1113,7 @@ unsafe impl ::windows::core::Interface for IBurnVerification {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IBurnVerification_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetBurnVerificationLevel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: IMAPI_BURN_VERIFICATION_LEVEL) -> ::windows::core::HRESULT,
     pub BurnVerificationLevel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: *mut IMAPI_BURN_VERIFICATION_LEVEL) -> ::windows::core::HRESULT,
 }
@@ -2779,7 +2779,7 @@ unsafe impl ::windows::core::Interface for IDiscMaster {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDiscMaster_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Open: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub EnumDiscMasterFormats: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetActiveDiscMasterFormat: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lpiid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
@@ -2963,7 +2963,7 @@ unsafe impl ::windows::core::Interface for IDiscMasterProgressEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDiscMasterProgressEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub QueryCancel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbcancel: *mut u8) -> ::windows::core::HRESULT,
     pub NotifyPnPActivity: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub NotifyAddProgress: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ncompletedsteps: i32, ntotalsteps: i32) -> ::windows::core::HRESULT,
@@ -3074,7 +3074,7 @@ unsafe impl ::windows::core::Interface for IDiscRecorder {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDiscRecorder_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Init: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbyuniqueid: *const u8, nulidsize: u32, nuldrivenumber: u32) -> ::windows::core::HRESULT,
     pub GetRecorderGUID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbyuniqueid: *mut u8, ulbuffersize: u32, pulreturnsizerequired: *mut u32) -> ::windows::core::HRESULT,
     pub GetRecorderType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ftypecode: *mut RECORDER_TYPES) -> ::windows::core::HRESULT,
@@ -3414,7 +3414,7 @@ unsafe impl ::windows::core::Interface for IDiscRecorder2Ex {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDiscRecorder2Ex_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SendCommandNoData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cdb: *const u8, cdbsize: u32, sensebuffer: *mut u8, timeout: u32) -> ::windows::core::HRESULT,
     pub SendCommandSendDataToDevice: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cdb: *const u8, cdbsize: u32, sensebuffer: *mut u8, timeout: u32, buffer: *const u8, buffersize: u32) -> ::windows::core::HRESULT,
     pub SendCommandGetDataFromDevice: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cdb: *const u8, cdbsize: u32, sensebuffer: *mut u8, timeout: u32, buffer: *mut u8, buffersize: u32, bufferfetched: *mut u32) -> ::windows::core::HRESULT,
@@ -3499,7 +3499,7 @@ unsafe impl ::windows::core::Interface for IEnumDiscMasterFormats {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumDiscMasterFormats_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cformats: u32, lpiidformatid: *mut ::windows::core::GUID, pcfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cformats: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -3561,7 +3561,7 @@ unsafe impl ::windows::core::Interface for IEnumDiscRecorders {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumDiscRecorders_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, crecorders: u32, pprecorder: *mut *mut ::core::ffi::c_void, pcfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, crecorders: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -3625,7 +3625,7 @@ unsafe impl ::windows::core::Interface for IEnumFsiItems {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumFsiItems_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -3692,7 +3692,7 @@ unsafe impl ::windows::core::Interface for IEnumProgressItems {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumProgressItems_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -6230,7 +6230,7 @@ unsafe impl ::windows::core::Interface for IJolietDiscMaster {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IJolietDiscMaster_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetTotalDataBlocks: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pnblocks: *mut i32) -> ::windows::core::HRESULT,
     pub GetUsedDataBlocks: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pnblocks: *mut i32) -> ::windows::core::HRESULT,
     pub GetDataBlockSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pnblockbytes: *mut i32) -> ::windows::core::HRESULT,
@@ -7385,7 +7385,7 @@ unsafe impl ::windows::core::Interface for IRedbookDiscMaster {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRedbookDiscMaster_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetTotalAudioTracks: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pntracks: *mut i32) -> ::windows::core::HRESULT,
     pub GetTotalAudioBlocks: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pnblocks: *mut i32) -> ::windows::core::HRESULT,
     pub GetUsedAudioBlocks: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pnblocks: *mut i32) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/Storage/IndexServer/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/IndexServer/impl.rs
@@ -37,7 +37,7 @@ impl IFilter_Vtbl {
             this.BindRegion(::core::mem::transmute(&origpos), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppunk))
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Init: Init::<Identity, Impl, OFFSET>,
             GetChunk: GetChunk::<Identity, Impl, OFFSET>,
             GetText: GetText::<Identity, Impl, OFFSET>,
@@ -67,7 +67,7 @@ impl IPhraseSink_Vtbl {
             this.PutPhrase(::core::mem::transmute(&pwcphrase), ::core::mem::transmute_copy(&cwcphrase)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             PutSmallPhrase: PutSmallPhrase::<Identity, Impl, OFFSET>,
             PutPhrase: PutPhrase::<Identity, Impl, OFFSET>,
         }

--- a/crates/libs/windows/src/Windows/Win32/Storage/IndexServer/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/IndexServer/mod.rs
@@ -115,7 +115,7 @@ unsafe impl ::windows::core::Interface for IFilter {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IFilter_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com_StructuredStorage")]
     pub Init: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, grfflags: u32, cattributes: u32, aattributes: *const FULLPROPSPEC, pflags: *mut u32) -> i32,
     #[cfg(not(feature = "Win32_System_Com_StructuredStorage"))]
@@ -187,7 +187,7 @@ unsafe impl ::windows::core::Interface for IPhraseSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPhraseSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub PutSmallPhrase: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwcnoun: ::windows::core::PCWSTR, cwcnoun: u32, pwcmodifier: ::windows::core::PCWSTR, cwcmodifier: u32, ulattachmenttype: u32) -> ::windows::core::HRESULT,
     pub PutPhrase: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwcphrase: ::windows::core::PCWSTR, cwcphrase: u32) -> ::windows::core::HRESULT,
 }

--- a/crates/libs/windows/src/Windows/Win32/Storage/OfflineFiles/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/OfflineFiles/impl.rs
@@ -34,7 +34,7 @@ impl IEnumOfflineFilesItems_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -81,7 +81,7 @@ impl IEnumOfflineFilesSettings_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -233,7 +233,7 @@ impl IOfflineFilesCache_Vtbl {
             this.IsPathCacheable(::core::mem::transmute(&pszpath), ::core::mem::transmute_copy(&pbcacheable), ::core::mem::transmute_copy(&psharecachingmode)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Synchronize: Synchronize::<Identity, Impl, OFFSET>,
             DeleteItems: DeleteItems::<Identity, Impl, OFFSET>,
             DeleteItemsForUser: DeleteItemsForUser::<Identity, Impl, OFFSET>,
@@ -352,7 +352,7 @@ impl IOfflineFilesChangeInfo_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             IsDirty: IsDirty::<Identity, Impl, OFFSET>,
             IsDeletedOffline: IsDeletedOffline::<Identity, Impl, OFFSET>,
             IsCreatedOffline: IsCreatedOffline::<Identity, Impl, OFFSET>,
@@ -404,7 +404,7 @@ impl IOfflineFilesConnectionInfo_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetConnectState: GetConnectState::<Identity, Impl, OFFSET>,
             SetConnectState: SetConnectState::<Identity, Impl, OFFSET>,
             TransitionOnline: TransitionOnline::<Identity, Impl, OFFSET>,
@@ -458,7 +458,7 @@ impl IOfflineFilesDirtyInfo_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             LocalDirtyByteCount: LocalDirtyByteCount::<Identity, Impl, OFFSET>,
             RemoteDirtyByteCount: RemoteDirtyByteCount::<Identity, Impl, OFFSET>,
         }
@@ -500,7 +500,7 @@ impl IOfflineFilesErrorInfo_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetRawData: GetRawData::<Identity, Impl, OFFSET>,
             GetDescription: GetDescription::<Identity, Impl, OFFSET>,
         }
@@ -668,7 +668,7 @@ impl IOfflineFilesEvents_Vtbl {
             this.Ping().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CacheMoved: CacheMoved::<Identity, Impl, OFFSET>,
             CacheIsFull: CacheIsFull::<Identity, Impl, OFFSET>,
             CacheIsCorrupted: CacheIsCorrupted::<Identity, Impl, OFFSET>,
@@ -870,7 +870,7 @@ impl IOfflineFilesEventsFilter_Vtbl {
             this.GetExcludedEvents(::core::mem::transmute_copy(&celements), ::core::mem::transmute_copy(&prgevents), ::core::mem::transmute_copy(&pcevents)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetPathFilter: GetPathFilter::<Identity, Impl, OFFSET>,
             GetIncludedEvents: GetIncludedEvents::<Identity, Impl, OFFSET>,
             GetExcludedEvents: GetExcludedEvents::<Identity, Impl, OFFSET>,
@@ -961,7 +961,7 @@ impl IOfflineFilesFileSysInfo_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetAttributes: GetAttributes::<Identity, Impl, OFFSET>,
             GetTimes: GetTimes::<Identity, Impl, OFFSET>,
             GetFileSize: GetFileSize::<Identity, Impl, OFFSET>,
@@ -991,7 +991,7 @@ impl IOfflineFilesGhostInfo_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), IsGhosted: IsGhosted::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), IsGhosted: IsGhosted::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IOfflineFilesGhostInfo as ::windows::core::Interface>::IID
@@ -1060,7 +1060,7 @@ impl IOfflineFilesItem_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetItemType: GetItemType::<Identity, Impl, OFFSET>,
             GetPath: GetPath::<Identity, Impl, OFFSET>,
             GetParentItem: GetParentItem::<Identity, Impl, OFFSET>,
@@ -1102,7 +1102,7 @@ impl IOfflineFilesItemContainer_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             EnumItems: EnumItems::<Identity, Impl, OFFSET>,
             EnumItemsEx: EnumItemsEx::<Identity, Impl, OFFSET>,
         }
@@ -1138,7 +1138,7 @@ impl IOfflineFilesItemFilter_Vtbl {
             this.GetPatternFilter(::core::mem::transmute_copy(&pszpattern), ::core::mem::transmute_copy(&cchpattern)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetFilterFlags: GetFilterFlags::<Identity, Impl, OFFSET>,
             GetTimeFilter: GetTimeFilter::<Identity, Impl, OFFSET>,
             GetPatternFilter: GetPatternFilter::<Identity, Impl, OFFSET>,
@@ -1193,7 +1193,7 @@ impl IOfflineFilesPinInfo_Vtbl {
             this.IsPinnedForFolderRedirection(::core::mem::transmute_copy(&pbpinnedforfolderredirection), ::core::mem::transmute_copy(&pbinherit)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             IsPinned: IsPinned::<Identity, Impl, OFFSET>,
             IsPinnedForUser: IsPinnedForUser::<Identity, Impl, OFFSET>,
             IsPinnedForUserByPolicy: IsPinnedForUserByPolicy::<Identity, Impl, OFFSET>,
@@ -1270,7 +1270,7 @@ impl IOfflineFilesProgress_Vtbl {
             this.End(::core::mem::transmute_copy(&hrresult)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Begin: Begin::<Identity, Impl, OFFSET>,
             QueryAbort: QueryAbort::<Identity, Impl, OFFSET>,
             End: End::<Identity, Impl, OFFSET>,
@@ -1380,7 +1380,7 @@ impl IOfflineFilesSetting_Vtbl {
             this.GetValue(::core::mem::transmute_copy(&pvarvalue), ::core::mem::transmute_copy(&pbsetbypolicy)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetName: GetName::<Identity, Impl, OFFSET>,
             GetValueType: GetValueType::<Identity, Impl, OFFSET>,
             GetPreference: GetPreference::<Identity, Impl, OFFSET>,
@@ -1441,7 +1441,7 @@ impl IOfflineFilesShareInfo_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetShareItem: GetShareItem::<Identity, Impl, OFFSET>,
             GetShareCachingMode: GetShareCachingMode::<Identity, Impl, OFFSET>,
             IsShareDfsJunction: IsShareDfsJunction::<Identity, Impl, OFFSET>,
@@ -1520,7 +1520,7 @@ impl IOfflineFilesSuspend_Vtbl {
             let this = (*this).get_impl();
             this.SuspendRoot(::core::mem::transmute_copy(&bsuspend)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SuspendRoot: SuspendRoot::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SuspendRoot: SuspendRoot::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IOfflineFilesSuspend as ::windows::core::Interface>::IID
@@ -1540,7 +1540,7 @@ impl IOfflineFilesSuspendInfo_Vtbl {
             let this = (*this).get_impl();
             this.IsSuspended(::core::mem::transmute_copy(&pbsuspended), ::core::mem::transmute_copy(&pbsuspendedroot)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), IsSuspended: IsSuspended::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), IsSuspended: IsSuspended::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IOfflineFilesSuspendInfo as ::windows::core::Interface>::IID
@@ -1557,7 +1557,7 @@ impl IOfflineFilesSyncConflictHandler_Vtbl {
             let this = (*this).get_impl();
             this.ResolveConflict(::core::mem::transmute(&pszpath), ::core::mem::transmute_copy(&fstateknown), ::core::mem::transmute_copy(&state), ::core::mem::transmute_copy(&fchangedetails), ::core::mem::transmute_copy(&pconflictresolution), ::core::mem::transmute_copy(&ppsznewname)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), ResolveConflict: ResolveConflict::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), ResolveConflict: ResolveConflict::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IOfflineFilesSyncConflictHandler as ::windows::core::Interface>::IID
@@ -1697,7 +1697,7 @@ impl IOfflineFilesSyncErrorItemInfo_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetFileAttributes: GetFileAttributes::<Identity, Impl, OFFSET>,
             GetFileTimes: GetFileTimes::<Identity, Impl, OFFSET>,
             GetFileSize: GetFileSize::<Identity, Impl, OFFSET>,
@@ -1769,7 +1769,7 @@ impl IOfflineFilesTransparentCacheInfo_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), IsTransparentlyCached: IsTransparentlyCached::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), IsTransparentlyCached: IsTransparentlyCached::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IOfflineFilesTransparentCacheInfo as ::windows::core::Interface>::IID

--- a/crates/libs/windows/src/Windows/Win32/Storage/OfflineFiles/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/OfflineFiles/mod.rs
@@ -96,7 +96,7 @@ unsafe impl ::windows::core::Interface for IEnumOfflineFilesItems {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumOfflineFilesItems_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -158,7 +158,7 @@ unsafe impl ::windows::core::Interface for IEnumOfflineFilesSettings {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumOfflineFilesSettings_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -339,7 +339,7 @@ unsafe impl ::windows::core::Interface for IOfflineFilesCache {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOfflineFilesCache_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Synchronize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hwndparent: super::super::Foundation::HWND, rgpszpaths: *const ::windows::core::PWSTR, cpaths: u32, basync: super::super::Foundation::BOOL, dwsynccontrol: u32, pisyncconflicthandler: *mut ::core::ffi::c_void, piprogress: *mut ::core::ffi::c_void, psyncid: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -669,7 +669,7 @@ unsafe impl ::windows::core::Interface for IOfflineFilesChangeInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOfflineFilesChangeInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub IsDirty: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbdirty: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -767,7 +767,7 @@ unsafe impl ::windows::core::Interface for IOfflineFilesConnectionInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOfflineFilesConnectionInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetConnectState: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pconnectstate: *mut OFFLINEFILES_CONNECT_STATE, pofflinereason: *mut OFFLINEFILES_OFFLINE_REASON) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub SetConnectState: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hwndparent: super::super::Foundation::HWND, dwflags: u32, connectstate: OFFLINEFILES_CONNECT_STATE) -> ::windows::core::HRESULT,
@@ -914,7 +914,7 @@ unsafe impl ::windows::core::Interface for IOfflineFilesDirtyInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOfflineFilesDirtyInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub LocalDirtyByteCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdirtybytecount: *mut i64) -> ::windows::core::HRESULT,
     pub RemoteDirtyByteCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdirtybytecount: *mut i64) -> ::windows::core::HRESULT,
 }
@@ -971,7 +971,7 @@ unsafe impl ::windows::core::Interface for IOfflineFilesErrorInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOfflineFilesErrorInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub GetRawData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppblob: *mut *mut super::super::System::Com::BYTE_BLOB) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -1166,7 +1166,7 @@ unsafe impl ::windows::core::Interface for IOfflineFilesEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOfflineFilesEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CacheMoved: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszoldpath: ::windows::core::PCWSTR, psznewpath: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub CacheIsFull: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CacheIsCorrupted: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -2073,7 +2073,7 @@ unsafe impl ::windows::core::Interface for IOfflineFilesEventsFilter {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOfflineFilesEventsFilter_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetPathFilter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppszfilter: *mut ::windows::core::PWSTR, pmatch: *mut OFFLINEFILES_PATHFILTER_MATCH) -> ::windows::core::HRESULT,
     pub GetIncludedEvents: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celements: u32, prgevents: *mut OFFLINEFILES_EVENTS, pcevents: *mut u32) -> ::windows::core::HRESULT,
     pub GetExcludedEvents: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celements: u32, prgevents: *mut OFFLINEFILES_EVENTS, pcevents: *mut u32) -> ::windows::core::HRESULT,
@@ -2235,7 +2235,7 @@ unsafe impl ::windows::core::Interface for IOfflineFilesFileSysInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOfflineFilesFileSysInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetAttributes: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, copy: OFFLINEFILES_ITEM_COPY, pdwattributes: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub GetTimes: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, copy: OFFLINEFILES_ITEM_COPY, pftcreationtime: *mut super::super::Foundation::FILETIME, pftlastwritetime: *mut super::super::Foundation::FILETIME, pftchangetime: *mut super::super::Foundation::FILETIME, pftlastaccesstime: *mut super::super::Foundation::FILETIME) -> ::windows::core::HRESULT,
@@ -2292,7 +2292,7 @@ unsafe impl ::windows::core::Interface for IOfflineFilesGhostInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOfflineFilesGhostInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub IsGhosted: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbghosted: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -2362,7 +2362,7 @@ unsafe impl ::windows::core::Interface for IOfflineFilesItem {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOfflineFilesItem_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetItemType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pitemtype: *mut OFFLINEFILES_ITEM_TYPE) -> ::windows::core::HRESULT,
     pub GetPath: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppszpath: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetParentItem: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppitem: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -2429,7 +2429,7 @@ unsafe impl ::windows::core::Interface for IOfflineFilesItemContainer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOfflineFilesItemContainer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub EnumItems: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwqueryflags: u32, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub EnumItemsEx: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pincludefilefilter: *mut ::core::ffi::c_void, pincludedirfilter: *mut ::core::ffi::c_void, pexcludefilefilter: *mut ::core::ffi::c_void, pexcludedirfilter: *mut ::core::ffi::c_void, dwenumflags: u32, dwqueryflags: u32, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -2487,7 +2487,7 @@ unsafe impl ::windows::core::Interface for IOfflineFilesItemFilter {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOfflineFilesItemFilter_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetFilterFlags: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pullflags: *mut u64, pullmask: *mut u64) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub GetTimeFilter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfttime: *mut super::super::Foundation::FILETIME, pbevaltimeofday: *mut super::super::Foundation::BOOL, ptimetype: *mut OFFLINEFILES_ITEM_TIME, pcompare: *mut OFFLINEFILES_COMPARE) -> ::windows::core::HRESULT,
@@ -2564,7 +2564,7 @@ unsafe impl ::windows::core::Interface for IOfflineFilesPinInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOfflineFilesPinInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub IsPinned: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbpinned: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -2740,7 +2740,7 @@ unsafe impl ::windows::core::Interface for IOfflineFilesProgress {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOfflineFilesProgress_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Begin: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbabort: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -2914,7 +2914,7 @@ unsafe impl ::windows::core::Interface for IOfflineFilesSetting {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOfflineFilesSetting_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppszname: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetValueType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptype: *mut OFFLINEFILES_SETTING_VALUE_TYPE) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -2994,7 +2994,7 @@ unsafe impl ::windows::core::Interface for IOfflineFilesShareInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOfflineFilesShareInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetShareItem: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppshareitem: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetShareCachingMode: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcachingmode: *mut OFFLINEFILES_CACHING_MODE) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -3225,7 +3225,7 @@ unsafe impl ::windows::core::Interface for IOfflineFilesSuspend {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOfflineFilesSuspend_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub SuspendRoot: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bsuspend: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -3279,7 +3279,7 @@ unsafe impl ::windows::core::Interface for IOfflineFilesSuspendInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOfflineFilesSuspendInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub IsSuspended: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbsuspended: *mut super::super::Foundation::BOOL, pbsuspendedroot: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -3334,7 +3334,7 @@ unsafe impl ::windows::core::Interface for IOfflineFilesSyncConflictHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOfflineFilesSyncConflictHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ResolveConflict: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszpath: ::windows::core::PCWSTR, fstateknown: u32, state: OFFLINEFILES_SYNC_STATE, fchangedetails: u32, pconflictresolution: *mut OFFLINEFILES_SYNC_CONFLICT_RESOLVE, ppsznewname: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Storage_OfflineFiles\"`*"]
@@ -3506,7 +3506,7 @@ unsafe impl ::windows::core::Interface for IOfflineFilesSyncErrorItemInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOfflineFilesSyncErrorItemInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetFileAttributes: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwattributes: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub GetFileTimes: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pftlastwrite: *mut super::super::Foundation::FILETIME, pftchange: *mut super::super::Foundation::FILETIME) -> ::windows::core::HRESULT,
@@ -3655,7 +3655,7 @@ unsafe impl ::windows::core::Interface for IOfflineFilesTransparentCacheInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOfflineFilesTransparentCacheInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub IsTransparentlyCached: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbtransparentlycached: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]

--- a/crates/libs/windows/src/Windows/Win32/Storage/Packaging/Appx/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Packaging/Appx/impl.rs
@@ -22,7 +22,7 @@ impl IAppxBlockMapBlock_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetHash: GetHash::<Identity, Impl, OFFSET>,
             GetCompressedSize: GetCompressedSize::<Identity, Impl, OFFSET>,
         }
@@ -76,7 +76,7 @@ impl IAppxBlockMapBlocksEnumerator_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCurrent: GetCurrent::<Identity, Impl, OFFSET>,
             GetHasCurrent: GetHasCurrent::<Identity, Impl, OFFSET>,
             MoveNext: MoveNext::<Identity, Impl, OFFSET>,
@@ -155,7 +155,7 @@ impl IAppxBlockMapFile_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetBlocks: GetBlocks::<Identity, Impl, OFFSET>,
             GetLocalFileHeaderSize: GetLocalFileHeaderSize::<Identity, Impl, OFFSET>,
             GetName: GetName::<Identity, Impl, OFFSET>,
@@ -212,7 +212,7 @@ impl IAppxBlockMapFilesEnumerator_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCurrent: GetCurrent::<Identity, Impl, OFFSET>,
             GetHasCurrent: GetHasCurrent::<Identity, Impl, OFFSET>,
             MoveNext: MoveNext::<Identity, Impl, OFFSET>,
@@ -279,7 +279,7 @@ impl IAppxBlockMapReader_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetFile: GetFile::<Identity, Impl, OFFSET>,
             GetFiles: GetFiles::<Identity, Impl, OFFSET>,
             GetHashMethod: GetHashMethod::<Identity, Impl, OFFSET>,
@@ -335,7 +335,7 @@ impl IAppxBundleFactory_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateBundleWriter: CreateBundleWriter::<Identity, Impl, OFFSET>,
             CreateBundleReader: CreateBundleReader::<Identity, Impl, OFFSET>,
             CreateBundleManifestReader: CreateBundleManifestReader::<Identity, Impl, OFFSET>,
@@ -387,7 +387,7 @@ impl IAppxBundleManifestOptionalBundleInfo_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetPackageId: GetPackageId::<Identity, Impl, OFFSET>,
             GetFileName: GetFileName::<Identity, Impl, OFFSET>,
             GetPackageInfoItems: GetPackageInfoItems::<Identity, Impl, OFFSET>,
@@ -442,7 +442,7 @@ impl IAppxBundleManifestOptionalBundleInfoEnumerator_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCurrent: GetCurrent::<Identity, Impl, OFFSET>,
             GetHasCurrent: GetHasCurrent::<Identity, Impl, OFFSET>,
             MoveNext: MoveNext::<Identity, Impl, OFFSET>,
@@ -530,7 +530,7 @@ impl IAppxBundleManifestPackageInfo_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetPackageType: GetPackageType::<Identity, Impl, OFFSET>,
             GetPackageId: GetPackageId::<Identity, Impl, OFFSET>,
             GetFileName: GetFileName::<Identity, Impl, OFFSET>,
@@ -588,7 +588,7 @@ impl IAppxBundleManifestPackageInfo2_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetIsPackageReference: GetIsPackageReference::<Identity, Impl, OFFSET>,
             GetIsNonQualifiedResourcePackage: GetIsNonQualifiedResourcePackage::<Identity, Impl, OFFSET>,
             GetIsDefaultApplicablePackage: GetIsDefaultApplicablePackage::<Identity, Impl, OFFSET>,
@@ -615,7 +615,7 @@ impl IAppxBundleManifestPackageInfo3_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetTargetDeviceFamilies: GetTargetDeviceFamilies::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetTargetDeviceFamilies: GetTargetDeviceFamilies::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IAppxBundleManifestPackageInfo3 as ::windows::core::Interface>::IID
@@ -641,7 +641,7 @@ impl IAppxBundleManifestPackageInfo4_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetIsStub: GetIsStub::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetIsStub: GetIsStub::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IAppxBundleManifestPackageInfo4 as ::windows::core::Interface>::IID
@@ -692,7 +692,7 @@ impl IAppxBundleManifestPackageInfoEnumerator_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCurrent: GetCurrent::<Identity, Impl, OFFSET>,
             GetHasCurrent: GetHasCurrent::<Identity, Impl, OFFSET>,
             MoveNext: MoveNext::<Identity, Impl, OFFSET>,
@@ -747,7 +747,7 @@ impl IAppxBundleManifestReader_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetPackageId: GetPackageId::<Identity, Impl, OFFSET>,
             GetPackageInfoItems: GetPackageInfoItems::<Identity, Impl, OFFSET>,
             GetStream: GetStream::<Identity, Impl, OFFSET>,
@@ -774,7 +774,7 @@ impl IAppxBundleManifestReader2_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetOptionalBundles: GetOptionalBundles::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetOptionalBundles: GetOptionalBundles::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IAppxBundleManifestReader2 as ::windows::core::Interface>::IID
@@ -846,7 +846,7 @@ impl IAppxBundleReader_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetFootprintFile: GetFootprintFile::<Identity, Impl, OFFSET>,
             GetBlockMap: GetBlockMap::<Identity, Impl, OFFSET>,
             GetManifest: GetManifest::<Identity, Impl, OFFSET>,
@@ -879,7 +879,7 @@ impl IAppxBundleWriter_Vtbl {
             this.Close().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddPayloadPackage: AddPayloadPackage::<Identity, Impl, OFFSET>,
             Close: Close::<Identity, Impl, OFFSET>,
         }
@@ -903,7 +903,7 @@ impl IAppxBundleWriter2_Vtbl {
             this.AddExternalPackageReference(::core::mem::transmute(&filename), ::core::mem::transmute(&inputstream)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddExternalPackageReference: AddExternalPackageReference::<Identity, Impl, OFFSET>,
         }
     }
@@ -932,7 +932,7 @@ impl IAppxBundleWriter3_Vtbl {
             this.Close(::core::mem::transmute(&hashmethodstring)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddPackageReference: AddPackageReference::<Identity, Impl, OFFSET>,
             Close: Close::<Identity, Impl, OFFSET>,
         }
@@ -968,7 +968,7 @@ impl IAppxBundleWriter4_Vtbl {
             this.AddExternalPackageReference(::core::mem::transmute(&filename), ::core::mem::transmute(&inputstream), ::core::mem::transmute_copy(&isdefaultapplicablepackage)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddPayloadPackage: AddPayloadPackage::<Identity, Impl, OFFSET>,
             AddPackageReference: AddPackageReference::<Identity, Impl, OFFSET>,
             AddExternalPackageReference: AddExternalPackageReference::<Identity, Impl, OFFSET>,
@@ -1008,7 +1008,7 @@ impl IAppxContentGroup_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetName: GetName::<Identity, Impl, OFFSET>,
             GetFiles: GetFiles::<Identity, Impl, OFFSET>,
         }
@@ -1062,7 +1062,7 @@ impl IAppxContentGroupFilesEnumerator_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCurrent: GetCurrent::<Identity, Impl, OFFSET>,
             GetHasCurrent: GetHasCurrent::<Identity, Impl, OFFSET>,
             MoveNext: MoveNext::<Identity, Impl, OFFSET>,
@@ -1102,7 +1102,7 @@ impl IAppxContentGroupMapReader_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetRequiredGroup: GetRequiredGroup::<Identity, Impl, OFFSET>,
             GetAutomaticGroups: GetAutomaticGroups::<Identity, Impl, OFFSET>,
         }
@@ -1135,7 +1135,7 @@ impl IAppxContentGroupMapWriter_Vtbl {
             this.Close().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddAutomaticGroup: AddAutomaticGroup::<Identity, Impl, OFFSET>,
             AddAutomaticFile: AddAutomaticFile::<Identity, Impl, OFFSET>,
             Close: Close::<Identity, Impl, OFFSET>,
@@ -1190,7 +1190,7 @@ impl IAppxContentGroupsEnumerator_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCurrent: GetCurrent::<Identity, Impl, OFFSET>,
             GetHasCurrent: GetHasCurrent::<Identity, Impl, OFFSET>,
             MoveNext: MoveNext::<Identity, Impl, OFFSET>,
@@ -1221,7 +1221,7 @@ impl IAppxEncryptedBundleWriter_Vtbl {
             this.Close().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddPayloadPackageEncrypted: AddPayloadPackageEncrypted::<Identity, Impl, OFFSET>,
             Close: Close::<Identity, Impl, OFFSET>,
         }
@@ -1245,7 +1245,7 @@ impl IAppxEncryptedBundleWriter2_Vtbl {
             this.AddExternalPackageReference(::core::mem::transmute(&filename), ::core::mem::transmute(&inputstream)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddExternalPackageReference: AddExternalPackageReference::<Identity, Impl, OFFSET>,
         }
     }
@@ -1274,7 +1274,7 @@ impl IAppxEncryptedBundleWriter3_Vtbl {
             this.AddExternalPackageReference(::core::mem::transmute(&filename), ::core::mem::transmute(&inputstream), ::core::mem::transmute_copy(&isdefaultapplicablepackage)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddPayloadPackageEncrypted: AddPayloadPackageEncrypted::<Identity, Impl, OFFSET>,
             AddExternalPackageReference: AddExternalPackageReference::<Identity, Impl, OFFSET>,
         }
@@ -1304,7 +1304,7 @@ impl IAppxEncryptedPackageWriter_Vtbl {
             this.Close().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddPayloadFileEncrypted: AddPayloadFileEncrypted::<Identity, Impl, OFFSET>,
             Close: Close::<Identity, Impl, OFFSET>,
         }
@@ -1327,7 +1327,7 @@ impl IAppxEncryptedPackageWriter2_Vtbl {
             let this = (*this).get_impl();
             this.AddPayloadFilesEncrypted(::core::mem::transmute_copy(&filecount), ::core::mem::transmute_copy(&payloadfiles), ::core::mem::transmute_copy(&memorylimit)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), AddPayloadFilesEncrypted: AddPayloadFilesEncrypted::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), AddPayloadFilesEncrypted: AddPayloadFilesEncrypted::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IAppxEncryptedPackageWriter2 as ::windows::core::Interface>::IID
@@ -1414,7 +1414,7 @@ impl IAppxEncryptionFactory_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             EncryptPackage: EncryptPackage::<Identity, Impl, OFFSET>,
             DecryptPackage: DecryptPackage::<Identity, Impl, OFFSET>,
             CreateEncryptedPackageWriter: CreateEncryptedPackageWriter::<Identity, Impl, OFFSET>,
@@ -1450,7 +1450,7 @@ impl IAppxEncryptionFactory2_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateEncryptedPackageWriter: CreateEncryptedPackageWriter::<Identity, Impl, OFFSET>,
         }
     }
@@ -1503,7 +1503,7 @@ impl IAppxEncryptionFactory3_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             EncryptPackage: EncryptPackage::<Identity, Impl, OFFSET>,
             CreateEncryptedPackageWriter: CreateEncryptedPackageWriter::<Identity, Impl, OFFSET>,
             EncryptBundle: EncryptBundle::<Identity, Impl, OFFSET>,
@@ -1528,7 +1528,7 @@ impl IAppxEncryptionFactory4_Vtbl {
             let this = (*this).get_impl();
             this.EncryptPackage(::core::mem::transmute(&inputstream), ::core::mem::transmute(&outputstream), ::core::mem::transmute_copy(&settings), ::core::mem::transmute_copy(&keyinfo), ::core::mem::transmute_copy(&exemptedfiles), ::core::mem::transmute_copy(&memorylimit)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), EncryptPackage: EncryptPackage::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), EncryptPackage: EncryptPackage::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IAppxEncryptionFactory4 as ::windows::core::Interface>::IID
@@ -1603,7 +1603,7 @@ impl IAppxFactory_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreatePackageWriter: CreatePackageWriter::<Identity, Impl, OFFSET>,
             CreatePackageReader: CreatePackageReader::<Identity, Impl, OFFSET>,
             CreateManifestReader: CreateManifestReader::<Identity, Impl, OFFSET>,
@@ -1660,7 +1660,7 @@ impl IAppxFactory2_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateContentGroupMapReader: CreateContentGroupMapReader::<Identity, Impl, OFFSET>,
             CreateSourceContentGroupMapReader: CreateSourceContentGroupMapReader::<Identity, Impl, OFFSET>,
             CreateContentGroupMapWriter: CreateContentGroupMapWriter::<Identity, Impl, OFFSET>,
@@ -1739,7 +1739,7 @@ impl IAppxFile_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCompressionOption: GetCompressionOption::<Identity, Impl, OFFSET>,
             GetContentType: GetContentType::<Identity, Impl, OFFSET>,
             GetName: GetName::<Identity, Impl, OFFSET>,
@@ -1796,7 +1796,7 @@ impl IAppxFilesEnumerator_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCurrent: GetCurrent::<Identity, Impl, OFFSET>,
             GetHasCurrent: GetHasCurrent::<Identity, Impl, OFFSET>,
             MoveNext: MoveNext::<Identity, Impl, OFFSET>,
@@ -1836,7 +1836,7 @@ impl IAppxManifestApplication_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetStringValue: GetStringValue::<Identity, Impl, OFFSET>,
             GetAppUserModelId: GetAppUserModelId::<Identity, Impl, OFFSET>,
         }
@@ -1890,7 +1890,7 @@ impl IAppxManifestApplicationsEnumerator_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCurrent: GetCurrent::<Identity, Impl, OFFSET>,
             GetHasCurrent: GetHasCurrent::<Identity, Impl, OFFSET>,
             MoveNext: MoveNext::<Identity, Impl, OFFSET>,
@@ -1945,7 +1945,7 @@ impl IAppxManifestCapabilitiesEnumerator_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCurrent: GetCurrent::<Identity, Impl, OFFSET>,
             GetHasCurrent: GetHasCurrent::<Identity, Impl, OFFSET>,
             MoveNext: MoveNext::<Identity, Impl, OFFSET>,
@@ -2000,7 +2000,7 @@ impl IAppxManifestDeviceCapabilitiesEnumerator_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCurrent: GetCurrent::<Identity, Impl, OFFSET>,
             GetHasCurrent: GetHasCurrent::<Identity, Impl, OFFSET>,
             MoveNext: MoveNext::<Identity, Impl, OFFSET>,
@@ -2052,7 +2052,7 @@ impl IAppxManifestDriverConstraint_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetName: GetName::<Identity, Impl, OFFSET>,
             GetMinVersion: GetMinVersion::<Identity, Impl, OFFSET>,
             GetMinDate: GetMinDate::<Identity, Impl, OFFSET>,
@@ -2107,7 +2107,7 @@ impl IAppxManifestDriverConstraintsEnumerator_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCurrent: GetCurrent::<Identity, Impl, OFFSET>,
             GetHasCurrent: GetHasCurrent::<Identity, Impl, OFFSET>,
             MoveNext: MoveNext::<Identity, Impl, OFFSET>,
@@ -2162,7 +2162,7 @@ impl IAppxManifestDriverDependenciesEnumerator_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCurrent: GetCurrent::<Identity, Impl, OFFSET>,
             GetHasCurrent: GetHasCurrent::<Identity, Impl, OFFSET>,
             MoveNext: MoveNext::<Identity, Impl, OFFSET>,
@@ -2189,7 +2189,7 @@ impl IAppxManifestDriverDependency_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetDriverConstraints: GetDriverConstraints::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetDriverConstraints: GetDriverConstraints::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IAppxManifestDriverDependency as ::windows::core::Interface>::IID
@@ -2240,7 +2240,7 @@ impl IAppxManifestHostRuntimeDependenciesEnumerator_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCurrent: GetCurrent::<Identity, Impl, OFFSET>,
             GetHasCurrent: GetHasCurrent::<Identity, Impl, OFFSET>,
             MoveNext: MoveNext::<Identity, Impl, OFFSET>,
@@ -2292,7 +2292,7 @@ impl IAppxManifestHostRuntimeDependency_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetName: GetName::<Identity, Impl, OFFSET>,
             GetPublisher: GetPublisher::<Identity, Impl, OFFSET>,
             GetMinVersion: GetMinVersion::<Identity, Impl, OFFSET>,
@@ -2319,7 +2319,7 @@ impl IAppxManifestHostRuntimeDependency2_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetPackageFamilyName: GetPackageFamilyName::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetPackageFamilyName: GetPackageFamilyName::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IAppxManifestHostRuntimeDependency2 as ::windows::core::Interface>::IID
@@ -2370,7 +2370,7 @@ impl IAppxManifestMainPackageDependenciesEnumerator_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCurrent: GetCurrent::<Identity, Impl, OFFSET>,
             GetHasCurrent: GetHasCurrent::<Identity, Impl, OFFSET>,
             MoveNext: MoveNext::<Identity, Impl, OFFSET>,
@@ -2422,7 +2422,7 @@ impl IAppxManifestMainPackageDependency_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetName: GetName::<Identity, Impl, OFFSET>,
             GetPublisher: GetPublisher::<Identity, Impl, OFFSET>,
             GetPackageFamilyName: GetPackageFamilyName::<Identity, Impl, OFFSET>,
@@ -2477,7 +2477,7 @@ impl IAppxManifestOSPackageDependenciesEnumerator_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCurrent: GetCurrent::<Identity, Impl, OFFSET>,
             GetHasCurrent: GetHasCurrent::<Identity, Impl, OFFSET>,
             MoveNext: MoveNext::<Identity, Impl, OFFSET>,
@@ -2517,7 +2517,7 @@ impl IAppxManifestOSPackageDependency_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetName: GetName::<Identity, Impl, OFFSET>,
             GetVersion: GetVersion::<Identity, Impl, OFFSET>,
         }
@@ -2559,7 +2559,7 @@ impl IAppxManifestOptionalPackageInfo_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetIsOptionalPackage: GetIsOptionalPackage::<Identity, Impl, OFFSET>,
             GetMainPackageName: GetMainPackageName::<Identity, Impl, OFFSET>,
         }
@@ -2613,7 +2613,7 @@ impl IAppxManifestPackageDependenciesEnumerator_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCurrent: GetCurrent::<Identity, Impl, OFFSET>,
             GetHasCurrent: GetHasCurrent::<Identity, Impl, OFFSET>,
             MoveNext: MoveNext::<Identity, Impl, OFFSET>,
@@ -2665,7 +2665,7 @@ impl IAppxManifestPackageDependency_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetName: GetName::<Identity, Impl, OFFSET>,
             GetPublisher: GetPublisher::<Identity, Impl, OFFSET>,
             GetMinVersion: GetMinVersion::<Identity, Impl, OFFSET>,
@@ -2721,7 +2721,7 @@ impl IAppxManifestPackageDependency3_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetIsOptional: GetIsOptional::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetIsOptional: GetIsOptional::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IAppxManifestPackageDependency3 as ::windows::core::Interface>::IID
@@ -2832,7 +2832,7 @@ impl IAppxManifestPackageId_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetName: GetName::<Identity, Impl, OFFSET>,
             GetArchitecture: GetArchitecture::<Identity, Impl, OFFSET>,
             GetPublisher: GetPublisher::<Identity, Impl, OFFSET>,
@@ -2906,7 +2906,7 @@ impl IAppxManifestProperties_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetBoolValue: GetBoolValue::<Identity, Impl, OFFSET>,
             GetStringValue: GetStringValue::<Identity, Impl, OFFSET>,
         }
@@ -2957,7 +2957,7 @@ impl IAppxManifestQualifiedResource_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetLanguage: GetLanguage::<Identity, Impl, OFFSET>,
             GetScale: GetScale::<Identity, Impl, OFFSET>,
             GetDXFeatureLevel: GetDXFeatureLevel::<Identity, Impl, OFFSET>,
@@ -3012,7 +3012,7 @@ impl IAppxManifestQualifiedResourcesEnumerator_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCurrent: GetCurrent::<Identity, Impl, OFFSET>,
             GetHasCurrent: GetHasCurrent::<Identity, Impl, OFFSET>,
             MoveNext: MoveNext::<Identity, Impl, OFFSET>,
@@ -3139,7 +3139,7 @@ impl IAppxManifestReader_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetPackageId: GetPackageId::<Identity, Impl, OFFSET>,
             GetProperties: GetProperties::<Identity, Impl, OFFSET>,
             GetPackageDependencies: GetPackageDependencies::<Identity, Impl, OFFSET>,
@@ -3267,7 +3267,7 @@ impl IAppxManifestReader5_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetMainPackageDependencies: GetMainPackageDependencies::<Identity, Impl, OFFSET>,
         }
     }
@@ -3296,7 +3296,7 @@ impl IAppxManifestReader6_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetIsNonQualifiedResourcePackage: GetIsNonQualifiedResourcePackage::<Identity, Impl, OFFSET>,
         }
     }
@@ -3346,7 +3346,7 @@ impl IAppxManifestReader7_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDriverDependencies: GetDriverDependencies::<Identity, Impl, OFFSET>,
             GetOSPackageDependencies: GetOSPackageDependencies::<Identity, Impl, OFFSET>,
             GetHostRuntimeDependencies: GetHostRuntimeDependencies::<Identity, Impl, OFFSET>,
@@ -3401,7 +3401,7 @@ impl IAppxManifestResourcesEnumerator_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCurrent: GetCurrent::<Identity, Impl, OFFSET>,
             GetHasCurrent: GetHasCurrent::<Identity, Impl, OFFSET>,
             MoveNext: MoveNext::<Identity, Impl, OFFSET>,
@@ -3456,7 +3456,7 @@ impl IAppxManifestTargetDeviceFamiliesEnumerator_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCurrent: GetCurrent::<Identity, Impl, OFFSET>,
             GetHasCurrent: GetHasCurrent::<Identity, Impl, OFFSET>,
             MoveNext: MoveNext::<Identity, Impl, OFFSET>,
@@ -3508,7 +3508,7 @@ impl IAppxManifestTargetDeviceFamily_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetName: GetName::<Identity, Impl, OFFSET>,
             GetMinVersion: GetMinVersion::<Identity, Impl, OFFSET>,
             GetMaxVersionTested: GetMaxVersionTested::<Identity, Impl, OFFSET>,
@@ -3563,7 +3563,7 @@ impl IAppxPackageEditor_Vtbl {
             this.UpdatePackageManifest(::core::mem::transmute(&packagestream), ::core::mem::transmute(&updatedmanifeststream), ::core::mem::transmute_copy(&ispackageencrypted), ::core::mem::transmute_copy(&options)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetWorkingDirectory: SetWorkingDirectory::<Identity, Impl, OFFSET>,
             CreateDeltaPackage: CreateDeltaPackage::<Identity, Impl, OFFSET>,
             CreateDeltaPackageUsingBaselineBlockMap: CreateDeltaPackageUsingBaselineBlockMap::<Identity, Impl, OFFSET>,
@@ -3642,7 +3642,7 @@ impl IAppxPackageReader_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetBlockMap: GetBlockMap::<Identity, Impl, OFFSET>,
             GetFootprintFile: GetFootprintFile::<Identity, Impl, OFFSET>,
             GetPayloadFile: GetPayloadFile::<Identity, Impl, OFFSET>,
@@ -3675,7 +3675,7 @@ impl IAppxPackageWriter_Vtbl {
             this.Close(::core::mem::transmute(&manifest)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddPayloadFile: AddPayloadFile::<Identity, Impl, OFFSET>,
             Close: Close::<Identity, Impl, OFFSET>,
         }
@@ -3698,7 +3698,7 @@ impl IAppxPackageWriter2_Vtbl {
             let this = (*this).get_impl();
             this.Close(::core::mem::transmute(&manifest), ::core::mem::transmute(&contentgroupmap)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Close: Close::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Close: Close::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IAppxPackageWriter2 as ::windows::core::Interface>::IID
@@ -3718,7 +3718,7 @@ impl IAppxPackageWriter3_Vtbl {
             let this = (*this).get_impl();
             this.AddPayloadFiles(::core::mem::transmute_copy(&filecount), ::core::mem::transmute_copy(&payloadfiles), ::core::mem::transmute_copy(&memorylimit)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), AddPayloadFiles: AddPayloadFiles::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), AddPayloadFiles: AddPayloadFiles::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IAppxPackageWriter3 as ::windows::core::Interface>::IID
@@ -3742,7 +3742,7 @@ impl IAppxPackagingDiagnosticEventSink_Vtbl {
             this.ReportError(::core::mem::transmute(&errormessage)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ReportContextChange: ReportContextChange::<Identity, Impl, OFFSET>,
             ReportError: ReportError::<Identity, Impl, OFFSET>,
         }
@@ -3762,7 +3762,7 @@ impl IAppxPackagingDiagnosticEventSinkManager_Vtbl {
             let this = (*this).get_impl();
             this.SetSinkForProcess(::core::mem::transmute(&sink)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SetSinkForProcess: SetSinkForProcess::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SetSinkForProcess: SetSinkForProcess::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IAppxPackagingDiagnosticEventSinkManager as ::windows::core::Interface>::IID
@@ -3798,7 +3798,7 @@ impl IAppxSourceContentGroupMapReader_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetRequiredGroup: GetRequiredGroup::<Identity, Impl, OFFSET>,
             GetAutomaticGroups: GetAutomaticGroups::<Identity, Impl, OFFSET>,
         }

--- a/crates/libs/windows/src/Windows/Win32/Storage/Packaging/Appx/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Packaging/Appx/mod.rs
@@ -798,7 +798,7 @@ unsafe impl ::windows::core::Interface for IAppxBlockMapBlock {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxBlockMapBlock_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetHash: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, buffersize: *mut u32, buffer: *mut *mut u8) -> ::windows::core::HRESULT,
     pub GetCompressedSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, size: *mut u32) -> ::windows::core::HRESULT,
 }
@@ -861,7 +861,7 @@ unsafe impl ::windows::core::Interface for IAppxBlockMapBlocksEnumerator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxBlockMapBlocksEnumerator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCurrent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, block: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub GetHasCurrent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hascurrent: *mut super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -940,7 +940,7 @@ unsafe impl ::windows::core::Interface for IAppxBlockMapFile {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxBlockMapFile_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetBlocks: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, blocks: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetLocalFileHeaderSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lfhsize: *mut u32) -> ::windows::core::HRESULT,
     pub GetName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, name: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
@@ -1009,7 +1009,7 @@ unsafe impl ::windows::core::Interface for IAppxBlockMapFilesEnumerator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxBlockMapFilesEnumerator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCurrent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, file: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub GetHasCurrent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hascurrent: *mut super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -1086,7 +1086,7 @@ unsafe impl ::windows::core::Interface for IAppxBlockMapReader {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxBlockMapReader_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetFile: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, filename: ::windows::core::PCWSTR, file: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetFiles: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, enumerator: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
@@ -1168,7 +1168,7 @@ unsafe impl ::windows::core::Interface for IAppxBundleFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxBundleFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub CreateBundleWriter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, outputstream: *mut ::core::ffi::c_void, bundleversion: u64, bundlewriter: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -1237,7 +1237,7 @@ unsafe impl ::windows::core::Interface for IAppxBundleManifestOptionalBundleInfo
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxBundleManifestOptionalBundleInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetPackageId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, packageid: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetFileName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, filename: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetPackageInfoItems: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, packageinfoitems: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1301,7 +1301,7 @@ unsafe impl ::windows::core::Interface for IAppxBundleManifestOptionalBundleInfo
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxBundleManifestOptionalBundleInfoEnumerator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCurrent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, optionalbundle: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub GetHasCurrent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hascurrent: *mut super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -1379,7 +1379,7 @@ unsafe impl ::windows::core::Interface for IAppxBundleManifestPackageInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxBundleManifestPackageInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetPackageType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, packagetype: *mut APPX_BUNDLE_PAYLOAD_PACKAGE_TYPE) -> ::windows::core::HRESULT,
     pub GetPackageId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, packageid: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetFileName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, filename: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
@@ -1448,7 +1448,7 @@ unsafe impl ::windows::core::Interface for IAppxBundleManifestPackageInfo2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxBundleManifestPackageInfo2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetIsPackageReference: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ispackagereference: *mut super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -1509,7 +1509,7 @@ unsafe impl ::windows::core::Interface for IAppxBundleManifestPackageInfo3 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxBundleManifestPackageInfo3_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetTargetDeviceFamilies: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, targetdevicefamilies: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`*"]
@@ -1561,7 +1561,7 @@ unsafe impl ::windows::core::Interface for IAppxBundleManifestPackageInfo4 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxBundleManifestPackageInfo4_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetIsStub: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, isstub: *mut super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -1626,7 +1626,7 @@ unsafe impl ::windows::core::Interface for IAppxBundleManifestPackageInfoEnumera
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxBundleManifestPackageInfoEnumerator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCurrent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, packageinfo: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub GetHasCurrent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hascurrent: *mut super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -1694,7 +1694,7 @@ unsafe impl ::windows::core::Interface for IAppxBundleManifestReader {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxBundleManifestReader_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetPackageId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, packageid: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetPackageInfoItems: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, packageinfoitems: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
@@ -1749,7 +1749,7 @@ unsafe impl ::windows::core::Interface for IAppxBundleManifestReader2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxBundleManifestReader2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetOptionalBundles: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, optionalbundles: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`*"]
@@ -1818,7 +1818,7 @@ unsafe impl ::windows::core::Interface for IAppxBundleReader {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxBundleReader_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetFootprintFile: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, filetype: APPX_BUNDLE_FOOTPRINT_FILE_TYPE, footprintfile: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetBlockMap: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, blockmapreader: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetManifest: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, manifestreader: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1880,7 +1880,7 @@ unsafe impl ::windows::core::Interface for IAppxBundleWriter {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxBundleWriter_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub AddPayloadPackage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, filename: ::windows::core::PCWSTR, packagestream: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -1939,7 +1939,7 @@ unsafe impl ::windows::core::Interface for IAppxBundleWriter2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxBundleWriter2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub AddExternalPackageReference: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, filename: ::windows::core::PCWSTR, inputstream: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -2003,7 +2003,7 @@ unsafe impl ::windows::core::Interface for IAppxBundleWriter3 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxBundleWriter3_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub AddPackageReference: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, filename: ::windows::core::PCWSTR, inputstream: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -2083,7 +2083,7 @@ unsafe impl ::windows::core::Interface for IAppxBundleWriter4 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxBundleWriter4_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
     pub AddPayloadPackage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, filename: ::windows::core::PCWSTR, packagestream: *mut ::core::ffi::c_void, isdefaultapplicablepackage: super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com")))]
@@ -2148,7 +2148,7 @@ unsafe impl ::windows::core::Interface for IAppxContentGroup {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxContentGroup_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, groupname: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetFiles: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, enumerator: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -2211,7 +2211,7 @@ unsafe impl ::windows::core::Interface for IAppxContentGroupFilesEnumerator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxContentGroupFilesEnumerator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCurrent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, file: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub GetHasCurrent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hascurrent: *mut super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -2273,7 +2273,7 @@ unsafe impl ::windows::core::Interface for IAppxContentGroupMapReader {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxContentGroupMapReader_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetRequiredGroup: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, requiredgroup: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetAutomaticGroups: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, automaticgroupsenumerator: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -2335,7 +2335,7 @@ unsafe impl ::windows::core::Interface for IAppxContentGroupMapWriter {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxContentGroupMapWriter_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddAutomaticGroup: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, groupname: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub AddAutomaticFile: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, filename: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub Close: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -2399,7 +2399,7 @@ unsafe impl ::windows::core::Interface for IAppxContentGroupsEnumerator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxContentGroupsEnumerator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCurrent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, stream: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub GetHasCurrent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hascurrent: *mut super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -2465,7 +2465,7 @@ unsafe impl ::windows::core::Interface for IAppxEncryptedBundleWriter {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxEncryptedBundleWriter_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub AddPayloadPackageEncrypted: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, filename: ::windows::core::PCWSTR, packagestream: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -2524,7 +2524,7 @@ unsafe impl ::windows::core::Interface for IAppxEncryptedBundleWriter2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxEncryptedBundleWriter2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub AddExternalPackageReference: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, filename: ::windows::core::PCWSTR, inputstream: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -2593,7 +2593,7 @@ unsafe impl ::windows::core::Interface for IAppxEncryptedBundleWriter3 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxEncryptedBundleWriter3_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
     pub AddPayloadPackageEncrypted: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, filename: ::windows::core::PCWSTR, packagestream: *mut ::core::ffi::c_void, isdefaultapplicablepackage: super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com")))]
@@ -2658,7 +2658,7 @@ unsafe impl ::windows::core::Interface for IAppxEncryptedPackageWriter {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxEncryptedPackageWriter_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub AddPayloadFileEncrypted: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, filename: ::windows::core::PCWSTR, compressionoption: APPX_COMPRESSION_OPTION, inputstream: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -2713,7 +2713,7 @@ unsafe impl ::windows::core::Interface for IAppxEncryptedPackageWriter2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxEncryptedPackageWriter2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub AddPayloadFilesEncrypted: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, filecount: u32, payloadfiles: *const APPX_PACKAGE_WRITER_PAYLOAD_STREAM, memorylimit: u64) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -2835,7 +2835,7 @@ unsafe impl ::windows::core::Interface for IAppxEncryptionFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxEncryptionFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
     pub EncryptPackage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, inputstream: *mut ::core::ffi::c_void, outputstream: *mut ::core::ffi::c_void, settings: *const APPX_ENCRYPTED_PACKAGE_SETTINGS, keyinfo: *const APPX_KEY_INFO, exemptedfiles: *const APPX_ENCRYPTED_EXEMPTIONS) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com")))]
@@ -2923,7 +2923,7 @@ unsafe impl ::windows::core::Interface for IAppxEncryptionFactory2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxEncryptionFactory2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
     pub CreateEncryptedPackageWriter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, outputstream: *mut ::core::ffi::c_void, manifeststream: *mut ::core::ffi::c_void, contentgroupmapstream: *mut ::core::ffi::c_void, settings: *const APPX_ENCRYPTED_PACKAGE_SETTINGS, keyinfo: *const APPX_KEY_INFO, exemptedfiles: *const APPX_ENCRYPTED_EXEMPTIONS, packagewriter: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com")))]
@@ -3010,7 +3010,7 @@ unsafe impl ::windows::core::Interface for IAppxEncryptionFactory3 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxEncryptionFactory3_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub EncryptPackage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, inputstream: *mut ::core::ffi::c_void, outputstream: *mut ::core::ffi::c_void, settings: *const APPX_ENCRYPTED_PACKAGE_SETTINGS2, keyinfo: *const APPX_KEY_INFO, exemptedfiles: *const APPX_ENCRYPTED_EXEMPTIONS) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -3080,7 +3080,7 @@ unsafe impl ::windows::core::Interface for IAppxEncryptionFactory4 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxEncryptionFactory4_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub EncryptPackage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, inputstream: *mut ::core::ffi::c_void, outputstream: *mut ::core::ffi::c_void, settings: *const APPX_ENCRYPTED_PACKAGE_SETTINGS2, keyinfo: *const APPX_KEY_INFO, exemptedfiles: *const APPX_ENCRYPTED_EXEMPTIONS, memorylimit: u64) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -3175,7 +3175,7 @@ unsafe impl ::windows::core::Interface for IAppxFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
     pub CreatePackageWriter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, outputstream: *mut ::core::ffi::c_void, settings: *const APPX_PACKAGE_SETTINGS, packagewriter: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com")))]
@@ -3267,7 +3267,7 @@ unsafe impl ::windows::core::Interface for IAppxFactory2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxFactory2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub CreateContentGroupMapReader: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, inputstream: *mut ::core::ffi::c_void, contentgroupmapreader: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -3346,7 +3346,7 @@ unsafe impl ::windows::core::Interface for IAppxFile {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxFile_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCompressionOption: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, compressionoption: *mut APPX_COMPRESSION_OPTION) -> ::windows::core::HRESULT,
     pub GetContentType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, contenttype: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, filename: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
@@ -3415,7 +3415,7 @@ unsafe impl ::windows::core::Interface for IAppxFilesEnumerator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxFilesEnumerator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCurrent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, file: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub GetHasCurrent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hascurrent: *mut super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -3480,7 +3480,7 @@ unsafe impl ::windows::core::Interface for IAppxManifestApplication {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxManifestApplication_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetStringValue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, name: ::windows::core::PCWSTR, value: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetAppUserModelId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, appusermodelid: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
 }
@@ -3543,7 +3543,7 @@ unsafe impl ::windows::core::Interface for IAppxManifestApplicationsEnumerator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxManifestApplicationsEnumerator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCurrent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, application: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub GetHasCurrent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hascurrent: *mut super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -3613,7 +3613,7 @@ unsafe impl ::windows::core::Interface for IAppxManifestCapabilitiesEnumerator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxManifestCapabilitiesEnumerator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCurrent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, capability: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub GetHasCurrent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hascurrent: *mut super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -3683,7 +3683,7 @@ unsafe impl ::windows::core::Interface for IAppxManifestDeviceCapabilitiesEnumer
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxManifestDeviceCapabilitiesEnumerator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCurrent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, devicecapability: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub GetHasCurrent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hascurrent: *mut super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -3749,7 +3749,7 @@ unsafe impl ::windows::core::Interface for IAppxManifestDriverConstraint {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxManifestDriverConstraint_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, name: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetMinVersion: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, minversion: *mut u64) -> ::windows::core::HRESULT,
     pub GetMinDate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, mindate: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
@@ -3813,7 +3813,7 @@ unsafe impl ::windows::core::Interface for IAppxManifestDriverConstraintsEnumera
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxManifestDriverConstraintsEnumerator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCurrent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, driverconstraint: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub GetHasCurrent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hascurrent: *mut super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -3883,7 +3883,7 @@ unsafe impl ::windows::core::Interface for IAppxManifestDriverDependenciesEnumer
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxManifestDriverDependenciesEnumerator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCurrent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, driverdependency: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub GetHasCurrent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hascurrent: *mut super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -3941,7 +3941,7 @@ unsafe impl ::windows::core::Interface for IAppxManifestDriverDependency {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxManifestDriverDependency_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDriverConstraints: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, driverconstraints: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`*"]
@@ -4003,7 +4003,7 @@ unsafe impl ::windows::core::Interface for IAppxManifestHostRuntimeDependenciesE
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxManifestHostRuntimeDependenciesEnumerator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCurrent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hostruntimedependency: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub GetHasCurrent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hascurrent: *mut super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -4069,7 +4069,7 @@ unsafe impl ::windows::core::Interface for IAppxManifestHostRuntimeDependency {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxManifestHostRuntimeDependency_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, name: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetPublisher: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, publisher: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetMinVersion: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, minversion: *mut u64) -> ::windows::core::HRESULT,
@@ -4121,7 +4121,7 @@ unsafe impl ::windows::core::Interface for IAppxManifestHostRuntimeDependency2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxManifestHostRuntimeDependency2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetPackageFamilyName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, packagefamilyname: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`*"]
@@ -4183,7 +4183,7 @@ unsafe impl ::windows::core::Interface for IAppxManifestMainPackageDependenciesE
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxManifestMainPackageDependenciesEnumerator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCurrent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, mainpackagedependency: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub GetHasCurrent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hascurrent: *mut super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -4249,7 +4249,7 @@ unsafe impl ::windows::core::Interface for IAppxManifestMainPackageDependency {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxManifestMainPackageDependency_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, name: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetPublisher: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, publisher: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetPackageFamilyName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, packagefamilyname: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
@@ -4313,7 +4313,7 @@ unsafe impl ::windows::core::Interface for IAppxManifestOSPackageDependenciesEnu
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxManifestOSPackageDependenciesEnumerator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCurrent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ospackagedependency: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub GetHasCurrent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hascurrent: *mut super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -4375,7 +4375,7 @@ unsafe impl ::windows::core::Interface for IAppxManifestOSPackageDependency {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxManifestOSPackageDependency_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, name: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetVersion: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, version: *mut u64) -> ::windows::core::HRESULT,
 }
@@ -4432,7 +4432,7 @@ unsafe impl ::windows::core::Interface for IAppxManifestOptionalPackageInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxManifestOptionalPackageInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetIsOptionalPackage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, isoptionalpackage: *mut super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -4498,7 +4498,7 @@ unsafe impl ::windows::core::Interface for IAppxManifestPackageDependenciesEnume
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxManifestPackageDependenciesEnumerator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCurrent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dependency: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub GetHasCurrent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hascurrent: *mut super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -4564,7 +4564,7 @@ unsafe impl ::windows::core::Interface for IAppxManifestPackageDependency {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxManifestPackageDependency_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, name: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetPublisher: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, publisher: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetMinVersion: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, minversion: *mut u64) -> ::windows::core::HRESULT,
@@ -4695,7 +4695,7 @@ unsafe impl ::windows::core::Interface for IAppxManifestPackageDependency3 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxManifestPackageDependency3_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetIsOptional: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, isoptional: *mut super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -4781,7 +4781,7 @@ unsafe impl ::windows::core::Interface for IAppxManifestPackageId {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxManifestPackageId_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, name: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetArchitecture: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, architecture: *mut APPX_PACKAGE_ARCHITECTURE) -> ::windows::core::HRESULT,
     pub GetPublisher: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, publisher: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
@@ -4955,7 +4955,7 @@ unsafe impl ::windows::core::Interface for IAppxManifestProperties {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxManifestProperties_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetBoolValue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, name: ::windows::core::PCWSTR, value: *mut super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -5017,7 +5017,7 @@ unsafe impl ::windows::core::Interface for IAppxManifestQualifiedResource {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxManifestQualifiedResource_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetLanguage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, language: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetScale: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, scale: *mut u32) -> ::windows::core::HRESULT,
     pub GetDXFeatureLevel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dxfeaturelevel: *mut DX_FEATURE_LEVEL) -> ::windows::core::HRESULT,
@@ -5081,7 +5081,7 @@ unsafe impl ::windows::core::Interface for IAppxManifestQualifiedResourcesEnumer
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxManifestQualifiedResourcesEnumerator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCurrent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, resource: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub GetHasCurrent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hascurrent: *mut super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -5176,7 +5176,7 @@ unsafe impl ::windows::core::Interface for IAppxManifestReader {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxManifestReader_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetPackageId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, packageid: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetProperties: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, packageproperties: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetPackageDependencies: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dependencies: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -5621,7 +5621,7 @@ unsafe impl ::windows::core::Interface for IAppxManifestReader5 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxManifestReader5_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetMainPackageDependencies: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, mainpackagedependencies: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`*"]
@@ -5673,7 +5673,7 @@ unsafe impl ::windows::core::Interface for IAppxManifestReader6 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxManifestReader6_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetIsNonQualifiedResourcePackage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, isnonqualifiedresourcepackage: *mut super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -5734,7 +5734,7 @@ unsafe impl ::windows::core::Interface for IAppxManifestReader7 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxManifestReader7_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDriverDependencies: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, driverdependencies: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetOSPackageDependencies: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ospackagedependencies: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetHostRuntimeDependencies: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hostruntimedependencies: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -5798,7 +5798,7 @@ unsafe impl ::windows::core::Interface for IAppxManifestResourcesEnumerator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxManifestResourcesEnumerator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCurrent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, resource: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub GetHasCurrent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hascurrent: *mut super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -5868,7 +5868,7 @@ unsafe impl ::windows::core::Interface for IAppxManifestTargetDeviceFamiliesEnum
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxManifestTargetDeviceFamiliesEnumerator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCurrent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, targetdevicefamily: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub GetHasCurrent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hascurrent: *mut super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -5934,7 +5934,7 @@ unsafe impl ::windows::core::Interface for IAppxManifestTargetDeviceFamily {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxManifestTargetDeviceFamily_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, name: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetMinVersion: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, minversion: *mut u64) -> ::windows::core::HRESULT,
     pub GetMaxVersionTested: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, maxversiontested: *mut u64) -> ::windows::core::HRESULT,
@@ -6037,7 +6037,7 @@ unsafe impl ::windows::core::Interface for IAppxPackageEditor {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxPackageEditor_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetWorkingDirectory: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, workingdirectory: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
     pub CreateDeltaPackage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, updatedpackagestream: *mut ::core::ffi::c_void, baselinepackagestream: *mut ::core::ffi::c_void, deltapackagestream: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -6126,7 +6126,7 @@ unsafe impl ::windows::core::Interface for IAppxPackageReader {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxPackageReader_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetBlockMap: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, blockmapreader: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetFootprintFile: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, r#type: APPX_FOOTPRINT_FILE_TYPE, file: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetPayloadFile: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, filename: ::windows::core::PCWSTR, file: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -6194,7 +6194,7 @@ unsafe impl ::windows::core::Interface for IAppxPackageWriter {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxPackageWriter_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub AddPayloadFile: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, filename: ::windows::core::PCWSTR, contenttype: ::windows::core::PCWSTR, compressionoption: APPX_COMPRESSION_OPTION, inputstream: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -6256,7 +6256,7 @@ unsafe impl ::windows::core::Interface for IAppxPackageWriter2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxPackageWriter2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub Close: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, manifest: *mut ::core::ffi::c_void, contentgroupmap: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -6310,7 +6310,7 @@ unsafe impl ::windows::core::Interface for IAppxPackageWriter3 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxPackageWriter3_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub AddPayloadFiles: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, filecount: u32, payloadfiles: *const APPX_PACKAGE_WRITER_PAYLOAD_STREAM, memorylimit: u64) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -6373,7 +6373,7 @@ unsafe impl ::windows::core::Interface for IAppxPackagingDiagnosticEventSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxPackagingDiagnosticEventSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ReportContextChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, changetype: APPX_PACKAGING_CONTEXT_CHANGE_TYPE, contextid: i32, contextname: ::windows::core::PCSTR, contextmessage: ::windows::core::PCWSTR, detailsmessage: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub ReportError: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, errormessage: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
 }
@@ -6426,7 +6426,7 @@ unsafe impl ::windows::core::Interface for IAppxPackagingDiagnosticEventSinkMana
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxPackagingDiagnosticEventSinkManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetSinkForProcess: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sink: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`*"]
@@ -6480,7 +6480,7 @@ unsafe impl ::windows::core::Interface for IAppxSourceContentGroupMapReader {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppxSourceContentGroupMapReader_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetRequiredGroup: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, requiredgroup: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetAutomaticGroups: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, automaticgroupsenumerator: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }

--- a/crates/libs/windows/src/Windows/Win32/Storage/Packaging/Opc/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Packaging/Opc/impl.rs
@@ -37,7 +37,7 @@ impl IOpcCertificateEnumerator_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             MoveNext: MoveNext::<Identity, Impl, OFFSET>,
             MovePrevious: MovePrevious::<Identity, Impl, OFFSET>,
             GetCurrent: GetCurrent::<Identity, Impl, OFFSET>,
@@ -81,7 +81,7 @@ impl IOpcCertificateSet_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Add: Add::<Identity, Impl, OFFSET>,
             Remove: Remove::<Identity, Impl, OFFSET>,
             GetEnumerator: GetEnumerator::<Identity, Impl, OFFSET>,
@@ -250,7 +250,7 @@ impl IOpcDigitalSignature_Vtbl {
             this.GetSignatureXml(::core::mem::transmute_copy(&signaturexml), ::core::mem::transmute_copy(&count)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetNamespaces: GetNamespaces::<Identity, Impl, OFFSET>,
             GetSignatureId: GetSignatureId::<Identity, Impl, OFFSET>,
             GetSignaturePartName: GetSignaturePartName::<Identity, Impl, OFFSET>,
@@ -329,7 +329,7 @@ impl IOpcDigitalSignatureEnumerator_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             MoveNext: MoveNext::<Identity, Impl, OFFSET>,
             MovePrevious: MovePrevious::<Identity, Impl, OFFSET>,
             GetCurrent: GetCurrent::<Identity, Impl, OFFSET>,
@@ -427,7 +427,7 @@ impl IOpcDigitalSignatureManager_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSignatureOriginPartName: GetSignatureOriginPartName::<Identity, Impl, OFFSET>,
             SetSignatureOriginPartName: SetSignatureOriginPartName::<Identity, Impl, OFFSET>,
             GetSignatureEnumerator: GetSignatureEnumerator::<Identity, Impl, OFFSET>,
@@ -529,7 +529,7 @@ impl IOpcFactory_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreatePackageRootUri: CreatePackageRootUri::<Identity, Impl, OFFSET>,
             CreatePartUri: CreatePartUri::<Identity, Impl, OFFSET>,
             CreateStreamOnFile: CreateStreamOnFile::<Identity, Impl, OFFSET>,
@@ -573,7 +573,7 @@ impl IOpcPackage_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetPartSet: GetPartSet::<Identity, Impl, OFFSET>,
             GetRelationshipSet: GetRelationshipSet::<Identity, Impl, OFFSET>,
         }
@@ -651,7 +651,7 @@ impl IOpcPart_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetRelationshipSet: GetRelationshipSet::<Identity, Impl, OFFSET>,
             GetContentStream: GetContentStream::<Identity, Impl, OFFSET>,
             GetName: GetName::<Identity, Impl, OFFSET>,
@@ -720,7 +720,7 @@ impl IOpcPartEnumerator_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             MoveNext: MoveNext::<Identity, Impl, OFFSET>,
             MovePrevious: MovePrevious::<Identity, Impl, OFFSET>,
             GetCurrent: GetCurrent::<Identity, Impl, OFFSET>,
@@ -794,7 +794,7 @@ impl IOpcPartSet_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetPart: GetPart::<Identity, Impl, OFFSET>,
             CreatePart: CreatePart::<Identity, Impl, OFFSET>,
             DeletePart: DeletePart::<Identity, Impl, OFFSET>,
@@ -930,7 +930,7 @@ impl IOpcRelationship_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetId: GetId::<Identity, Impl, OFFSET>,
             GetRelationshipType: GetRelationshipType::<Identity, Impl, OFFSET>,
             GetSourceUri: GetSourceUri::<Identity, Impl, OFFSET>,
@@ -999,7 +999,7 @@ impl IOpcRelationshipEnumerator_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             MoveNext: MoveNext::<Identity, Impl, OFFSET>,
             MovePrevious: MovePrevious::<Identity, Impl, OFFSET>,
             GetCurrent: GetCurrent::<Identity, Impl, OFFSET>,
@@ -1040,7 +1040,7 @@ impl IOpcRelationshipSelector_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSelectorType: GetSelectorType::<Identity, Impl, OFFSET>,
             GetSelectionCriterion: GetSelectionCriterion::<Identity, Impl, OFFSET>,
         }
@@ -1106,7 +1106,7 @@ impl IOpcRelationshipSelectorEnumerator_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             MoveNext: MoveNext::<Identity, Impl, OFFSET>,
             MovePrevious: MovePrevious::<Identity, Impl, OFFSET>,
             GetCurrent: GetCurrent::<Identity, Impl, OFFSET>,
@@ -1153,7 +1153,7 @@ impl IOpcRelationshipSelectorSet_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Create: Create::<Identity, Impl, OFFSET>,
             Delete: Delete::<Identity, Impl, OFFSET>,
             GetEnumerator: GetEnumerator::<Identity, Impl, OFFSET>,
@@ -1250,7 +1250,7 @@ impl IOpcRelationshipSet_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetRelationship: GetRelationship::<Identity, Impl, OFFSET>,
             CreateRelationship: CreateRelationship::<Identity, Impl, OFFSET>,
             DeleteRelationship: DeleteRelationship::<Identity, Impl, OFFSET>,
@@ -1275,7 +1275,7 @@ impl IOpcSignatureCustomObject_Vtbl {
             let this = (*this).get_impl();
             this.GetXml(::core::mem::transmute_copy(&xmlmarkup), ::core::mem::transmute_copy(&count)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetXml: GetXml::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetXml: GetXml::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IOpcSignatureCustomObject as ::windows::core::Interface>::IID
@@ -1338,7 +1338,7 @@ impl IOpcSignatureCustomObjectEnumerator_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             MoveNext: MoveNext::<Identity, Impl, OFFSET>,
             MovePrevious: MovePrevious::<Identity, Impl, OFFSET>,
             GetCurrent: GetCurrent::<Identity, Impl, OFFSET>,
@@ -1385,7 +1385,7 @@ impl IOpcSignatureCustomObjectSet_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Create: Create::<Identity, Impl, OFFSET>,
             Delete: Delete::<Identity, Impl, OFFSET>,
             GetEnumerator: GetEnumerator::<Identity, Impl, OFFSET>,
@@ -1458,7 +1458,7 @@ impl IOpcSignaturePartReference_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetPartName: GetPartName::<Identity, Impl, OFFSET>,
             GetContentType: GetContentType::<Identity, Impl, OFFSET>,
             GetDigestMethod: GetDigestMethod::<Identity, Impl, OFFSET>,
@@ -1527,7 +1527,7 @@ impl IOpcSignaturePartReferenceEnumerator_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             MoveNext: MoveNext::<Identity, Impl, OFFSET>,
             MovePrevious: MovePrevious::<Identity, Impl, OFFSET>,
             GetCurrent: GetCurrent::<Identity, Impl, OFFSET>,
@@ -1577,7 +1577,7 @@ impl IOpcSignaturePartReferenceSet_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Create: Create::<Identity, Impl, OFFSET>,
             Delete: Delete::<Identity, Impl, OFFSET>,
             GetEnumerator: GetEnumerator::<Identity, Impl, OFFSET>,
@@ -1662,7 +1662,7 @@ impl IOpcSignatureReference_Vtbl {
             this.GetDigestValue(::core::mem::transmute_copy(&digestvalue), ::core::mem::transmute_copy(&count)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetId: GetId::<Identity, Impl, OFFSET>,
             GetUri: GetUri::<Identity, Impl, OFFSET>,
             GetType: GetType::<Identity, Impl, OFFSET>,
@@ -1732,7 +1732,7 @@ impl IOpcSignatureReferenceEnumerator_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             MoveNext: MoveNext::<Identity, Impl, OFFSET>,
             MovePrevious: MovePrevious::<Identity, Impl, OFFSET>,
             GetCurrent: GetCurrent::<Identity, Impl, OFFSET>,
@@ -1782,7 +1782,7 @@ impl IOpcSignatureReferenceSet_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Create: Create::<Identity, Impl, OFFSET>,
             Delete: Delete::<Identity, Impl, OFFSET>,
             GetEnumerator: GetEnumerator::<Identity, Impl, OFFSET>,
@@ -1867,7 +1867,7 @@ impl IOpcSignatureRelationshipReference_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSourceUri: GetSourceUri::<Identity, Impl, OFFSET>,
             GetDigestMethod: GetDigestMethod::<Identity, Impl, OFFSET>,
             GetDigestValue: GetDigestValue::<Identity, Impl, OFFSET>,
@@ -1937,7 +1937,7 @@ impl IOpcSignatureRelationshipReferenceEnumerator_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             MoveNext: MoveNext::<Identity, Impl, OFFSET>,
             MovePrevious: MovePrevious::<Identity, Impl, OFFSET>,
             GetCurrent: GetCurrent::<Identity, Impl, OFFSET>,
@@ -1999,7 +1999,7 @@ impl IOpcSignatureRelationshipReferenceSet_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Create: Create::<Identity, Impl, OFFSET>,
             CreateRelationshipSelectorSet: CreateRelationshipSelectorSet::<Identity, Impl, OFFSET>,
             Delete: Delete::<Identity, Impl, OFFSET>,
@@ -2187,7 +2187,7 @@ impl IOpcSigningOptions_Vtbl {
             this.SetSignaturePartName(::core::mem::transmute(&signaturepartname)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSignatureId: GetSignatureId::<Identity, Impl, OFFSET>,
             SetSignatureId: SetSignatureId::<Identity, Impl, OFFSET>,
             GetSignatureMethod: GetSignatureMethod::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/Storage/Packaging/Opc/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Packaging/Opc/mod.rs
@@ -60,7 +60,7 @@ unsafe impl ::windows::core::Interface for IOpcCertificateEnumerator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOpcCertificateEnumerator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub MoveNext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hasnext: *mut super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -132,7 +132,7 @@ unsafe impl ::windows::core::Interface for IOpcCertificateSet {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOpcCertificateSet_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
     pub Add: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, certificate: *const super::super::super::Security::Cryptography::CERT_CONTEXT) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography")))]
@@ -243,7 +243,7 @@ unsafe impl ::windows::core::Interface for IOpcDigitalSignature {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOpcDigitalSignature_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetNamespaces: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, prefixes: *mut *mut ::windows::core::PWSTR, namespaces: *mut *mut ::windows::core::PWSTR, count: *mut u32) -> ::windows::core::HRESULT,
     pub GetSignatureId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, signatureid: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
@@ -326,7 +326,7 @@ unsafe impl ::windows::core::Interface for IOpcDigitalSignatureEnumerator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOpcDigitalSignatureEnumerator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub MoveNext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hasnext: *mut super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -437,7 +437,7 @@ unsafe impl ::windows::core::Interface for IOpcDigitalSignatureManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOpcDigitalSignatureManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub GetSignatureOriginPartName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, signatureoriginpartname: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -561,7 +561,7 @@ unsafe impl ::windows::core::Interface for IOpcFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOpcFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub CreatePackageRootUri: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, rooturi: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -636,7 +636,7 @@ unsafe impl ::windows::core::Interface for IOpcPackage {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOpcPackage_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetPartSet: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, partset: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetRelationshipSet: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, relationshipset: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -707,7 +707,7 @@ unsafe impl ::windows::core::Interface for IOpcPart {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOpcPart_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetRelationshipSet: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, relationshipset: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
     pub GetContentStream: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, stream: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -783,7 +783,7 @@ unsafe impl ::windows::core::Interface for IOpcPartEnumerator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOpcPartEnumerator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub MoveNext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hasnext: *mut super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -878,7 +878,7 @@ unsafe impl ::windows::core::Interface for IOpcPartSet {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOpcPartSet_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub GetPart: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, name: *mut ::core::ffi::c_void, part: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -1263,7 +1263,7 @@ unsafe impl ::windows::core::Interface for IOpcRelationship {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOpcRelationship_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, relationshipidentifier: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetRelationshipType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, relationshiptype: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
@@ -1339,7 +1339,7 @@ unsafe impl ::windows::core::Interface for IOpcRelationshipEnumerator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOpcRelationshipEnumerator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub MoveNext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hasnext: *mut super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -1402,7 +1402,7 @@ unsafe impl ::windows::core::Interface for IOpcRelationshipSelector {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOpcRelationshipSelector_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetSelectorType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, selector: *mut OPC_RELATIONSHIP_SELECTOR) -> ::windows::core::HRESULT,
     pub GetSelectionCriterion: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, selectioncriterion: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
 }
@@ -1469,7 +1469,7 @@ unsafe impl ::windows::core::Interface for IOpcRelationshipSelectorEnumerator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOpcRelationshipSelectorEnumerator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub MoveNext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hasnext: *mut super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -1541,7 +1541,7 @@ unsafe impl ::windows::core::Interface for IOpcRelationshipSelectorSet {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOpcRelationshipSelectorSet_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Create: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, selector: OPC_RELATIONSHIP_SELECTOR, selectioncriterion: ::windows::core::PCWSTR, relationshipselector: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Delete: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, relationshipselector: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetEnumerator: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, relationshipselectorenumerator: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1639,7 +1639,7 @@ unsafe impl ::windows::core::Interface for IOpcRelationshipSet {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOpcRelationshipSet_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetRelationship: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, relationshipidentifier: ::windows::core::PCWSTR, relationship: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
     pub CreateRelationship: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, relationshipidentifier: ::windows::core::PCWSTR, relationshiptype: ::windows::core::PCWSTR, targeturi: *mut ::core::ffi::c_void, targetmode: OPC_URI_TARGET_MODE, relationship: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1703,7 +1703,7 @@ unsafe impl ::windows::core::Interface for IOpcSignatureCustomObject {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOpcSignatureCustomObject_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetXml: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, xmlmarkup: *mut *mut u8, count: *mut u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Storage_Packaging_Opc\"`*"]
@@ -1769,7 +1769,7 @@ unsafe impl ::windows::core::Interface for IOpcSignatureCustomObjectEnumerator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOpcSignatureCustomObjectEnumerator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub MoveNext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hasnext: *mut super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -1838,7 +1838,7 @@ unsafe impl ::windows::core::Interface for IOpcSignatureCustomObjectSet {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOpcSignatureCustomObjectSet_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Create: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, xmlmarkup: *const u8, count: u32, customobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Delete: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, customobject: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetEnumerator: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, customobjectenumerator: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1907,7 +1907,7 @@ unsafe impl ::windows::core::Interface for IOpcSignaturePartReference {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOpcSignaturePartReference_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub GetPartName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, partname: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -1980,7 +1980,7 @@ unsafe impl ::windows::core::Interface for IOpcSignaturePartReferenceEnumerator 
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOpcSignaturePartReferenceEnumerator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub MoveNext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hasnext: *mut super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -2055,7 +2055,7 @@ unsafe impl ::windows::core::Interface for IOpcSignaturePartReferenceSet {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOpcSignaturePartReferenceSet_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub Create: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, parturi: *mut ::core::ffi::c_void, digestmethod: ::windows::core::PCWSTR, transformmethod: OPC_CANONICALIZATION_METHOD, partreference: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -2131,7 +2131,7 @@ unsafe impl ::windows::core::Interface for IOpcSignatureReference {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOpcSignatureReference_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, referenceid: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
     pub GetUri: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, referenceuri: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -2205,7 +2205,7 @@ unsafe impl ::windows::core::Interface for IOpcSignatureReferenceEnumerator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOpcSignatureReferenceEnumerator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub MoveNext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hasnext: *mut super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -2282,7 +2282,7 @@ unsafe impl ::windows::core::Interface for IOpcSignatureReferenceSet {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOpcSignatureReferenceSet_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub Create: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, referenceuri: *mut ::core::ffi::c_void, referenceid: ::windows::core::PCWSTR, r#type: ::windows::core::PCWSTR, digestmethod: ::windows::core::PCWSTR, transformmethod: OPC_CANONICALIZATION_METHOD, reference: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -2358,7 +2358,7 @@ unsafe impl ::windows::core::Interface for IOpcSignatureRelationshipReference {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOpcSignatureRelationshipReference_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub GetSourceUri: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sourceuri: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -2432,7 +2432,7 @@ unsafe impl ::windows::core::Interface for IOpcSignatureRelationshipReferenceEnu
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOpcSignatureRelationshipReferenceEnumerator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub MoveNext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hasnext: *mut super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -2512,7 +2512,7 @@ unsafe impl ::windows::core::Interface for IOpcSignatureRelationshipReferenceSet
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOpcSignatureRelationshipReferenceSet_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub Create: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sourceuri: *mut ::core::ffi::c_void, digestmethod: ::windows::core::PCWSTR, relationshipsigningoption: OPC_RELATIONSHIPS_SIGNING_OPTION, selectorset: *mut ::core::ffi::c_void, transformmethod: OPC_CANONICALIZATION_METHOD, relationshipreference: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -2642,7 +2642,7 @@ unsafe impl ::windows::core::Interface for IOpcSigningOptions {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOpcSigningOptions_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetSignatureId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, signatureid: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub SetSignatureId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, signatureid: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub GetSignatureMethod: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, signaturemethod: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/Storage/VirtualDiskService/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/VirtualDiskService/impl.rs
@@ -34,7 +34,7 @@ impl IEnumVdsObject_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -63,7 +63,7 @@ impl IVdsAdmin_Vtbl {
             this.UnregisterProvider(::core::mem::transmute(&providerid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RegisterProvider: RegisterProvider::<Identity, Impl, OFFSET>,
             UnregisterProvider: UnregisterProvider::<Identity, Impl, OFFSET>,
         }
@@ -83,7 +83,7 @@ impl IVdsAdviseSink_Vtbl {
             let this = (*this).get_impl();
             this.OnNotify(::core::mem::transmute_copy(&lnumberofnotifications), ::core::mem::transmute_copy(&pnotificationarray)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnNotify: OnNotify::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnNotify: OnNotify::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IVdsAdviseSink as ::windows::core::Interface>::IID
@@ -113,7 +113,7 @@ impl IVdsAsync_Vtbl {
             this.QueryStatus(::core::mem::transmute_copy(&phrresult), ::core::mem::transmute_copy(&pulpercentcompleted)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Cancel: Cancel::<Identity, Impl, OFFSET>,
             Wait: Wait::<Identity, Impl, OFFSET>,
             QueryStatus: QueryStatus::<Identity, Impl, OFFSET>,
@@ -201,7 +201,7 @@ impl IVdsController_Vtbl {
             this.SetStatus(::core::mem::transmute_copy(&status)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetProperties: GetProperties::<Identity, Impl, OFFSET>,
             GetSubSystem: GetSubSystem::<Identity, Impl, OFFSET>,
             GetPortProperties: GetPortProperties::<Identity, Impl, OFFSET>,
@@ -233,7 +233,7 @@ impl IVdsControllerControllerPort_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), QueryControllerPorts: QueryControllerPorts::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), QueryControllerPorts: QueryControllerPorts::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IVdsControllerControllerPort as ::windows::core::Interface>::IID
@@ -293,7 +293,7 @@ impl IVdsControllerPort_Vtbl {
             this.SetStatus(::core::mem::transmute_copy(&status)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetProperties: GetProperties::<Identity, Impl, OFFSET>,
             GetController: GetController::<Identity, Impl, OFFSET>,
             QueryAssociatedLuns: QueryAssociatedLuns::<Identity, Impl, OFFSET>,
@@ -362,7 +362,7 @@ impl IVdsDrive_Vtbl {
             this.SetStatus(::core::mem::transmute_copy(&status)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetProperties: GetProperties::<Identity, Impl, OFFSET>,
             GetSubSystem: GetSubSystem::<Identity, Impl, OFFSET>,
             QueryExtents: QueryExtents::<Identity, Impl, OFFSET>,
@@ -392,7 +392,7 @@ impl IVdsDrive2_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetProperties2: GetProperties2::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetProperties2: GetProperties2::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IVdsDrive2 as ::windows::core::Interface>::IID
@@ -428,7 +428,7 @@ impl IVdsHwProvider_Vtbl {
             this.Refresh().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             QuerySubSystems: QuerySubSystems::<Identity, Impl, OFFSET>,
             Reenumerate: Reenumerate::<Identity, Impl, OFFSET>,
             Refresh: Refresh::<Identity, Impl, OFFSET>,
@@ -458,7 +458,7 @@ impl IVdsHwProviderPrivate_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), QueryIfCreatedLun: QueryIfCreatedLun::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), QueryIfCreatedLun: QueryIfCreatedLun::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IVdsHwProviderPrivate as ::windows::core::Interface>::IID
@@ -476,7 +476,7 @@ impl IVdsHwProviderPrivateMpio_Vtbl {
             this.SetAllPathStatusesFromHbaPort(::core::mem::transmute(&hbaportprop), ::core::mem::transmute_copy(&status)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetAllPathStatusesFromHbaPort: SetAllPathStatusesFromHbaPort::<Identity, Impl, OFFSET>,
         }
     }
@@ -529,7 +529,7 @@ impl IVdsHwProviderStoragePools_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             QueryStoragePools: QueryStoragePools::<Identity, Impl, OFFSET>,
             CreateLunInStoragePool: CreateLunInStoragePool::<Identity, Impl, OFFSET>,
             QueryMaxLunCreateSizeInStoragePool: QueryMaxLunCreateSizeInStoragePool::<Identity, Impl, OFFSET>,
@@ -556,7 +556,7 @@ impl IVdsHwProviderType_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetProviderType: GetProviderType::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetProviderType: GetProviderType::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IVdsHwProviderType as ::windows::core::Interface>::IID
@@ -579,7 +579,7 @@ impl IVdsHwProviderType2_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetProviderType2: GetProviderType2::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetProviderType2: GetProviderType2::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IVdsHwProviderType2 as ::windows::core::Interface>::IID
@@ -657,7 +657,7 @@ impl IVdsIscsiPortal_Vtbl {
             this.SetIpsecSecurity(::core::mem::transmute_copy(&pinitiatorportaladdress), ::core::mem::transmute_copy(&ullsecurityflags), ::core::mem::transmute_copy(&pipseckey)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetProperties: GetProperties::<Identity, Impl, OFFSET>,
             GetSubSystem: GetSubSystem::<Identity, Impl, OFFSET>,
             QueryAssociatedPortalGroups: QueryAssociatedPortalGroups::<Identity, Impl, OFFSET>,
@@ -749,7 +749,7 @@ impl IVdsIscsiPortalGroup_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetProperties: GetProperties::<Identity, Impl, OFFSET>,
             GetTarget: GetTarget::<Identity, Impl, OFFSET>,
             QueryAssociatedPortals: QueryAssociatedPortals::<Identity, Impl, OFFSET>,
@@ -867,7 +867,7 @@ impl IVdsIscsiTarget_Vtbl {
             this.GetConnectedInitiators(::core::mem::transmute_copy(&pppwszinitiatorlist), ::core::mem::transmute_copy(&plnumberofinitiators)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetProperties: GetProperties::<Identity, Impl, OFFSET>,
             GetSubSystem: GetSubSystem::<Identity, Impl, OFFSET>,
             QueryPortalGroups: QueryPortalGroups::<Identity, Impl, OFFSET>,
@@ -1067,7 +1067,7 @@ impl IVdsLun_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetProperties: GetProperties::<Identity, Impl, OFFSET>,
             GetSubSystem: GetSubSystem::<Identity, Impl, OFFSET>,
             GetIdentificationData: GetIdentificationData::<Identity, Impl, OFFSET>,
@@ -1118,7 +1118,7 @@ impl IVdsLun2_Vtbl {
             this.ApplyHints2(::core::mem::transmute_copy(&phints2)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             QueryHints2: QueryHints2::<Identity, Impl, OFFSET>,
             ApplyHints2: ApplyHints2::<Identity, Impl, OFFSET>,
         }
@@ -1151,7 +1151,7 @@ impl IVdsLunControllerPorts_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AssociateControllerPorts: AssociateControllerPorts::<Identity, Impl, OFFSET>,
             QueryActiveControllerPorts: QueryActiveControllerPorts::<Identity, Impl, OFFSET>,
         }
@@ -1184,7 +1184,7 @@ impl IVdsLunIscsi_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AssociateTargets: AssociateTargets::<Identity, Impl, OFFSET>,
             QueryAssociatedTargets: QueryAssociatedTargets::<Identity, Impl, OFFSET>,
         }
@@ -1232,7 +1232,7 @@ impl IVdsLunMpio_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetPathInfo: GetPathInfo::<Identity, Impl, OFFSET>,
             GetLoadBalancePolicy: GetLoadBalancePolicy::<Identity, Impl, OFFSET>,
             SetLoadBalancePolicy: SetLoadBalancePolicy::<Identity, Impl, OFFSET>,
@@ -1254,7 +1254,7 @@ impl IVdsLunNaming_Vtbl {
             let this = (*this).get_impl();
             this.SetFriendlyName(::core::mem::transmute(&pwszfriendlyname)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SetFriendlyName: SetFriendlyName::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SetFriendlyName: SetFriendlyName::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IVdsLunNaming as ::windows::core::Interface>::IID
@@ -1277,7 +1277,7 @@ impl IVdsLunNumber_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetLunNumber: GetLunNumber::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetLunNumber: GetLunNumber::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IVdsLunNumber as ::windows::core::Interface>::IID
@@ -1340,7 +1340,7 @@ impl IVdsLunPlex_Vtbl {
             this.ApplyHints(::core::mem::transmute_copy(&phints)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetProperties: GetProperties::<Identity, Impl, OFFSET>,
             GetLun: GetLun::<Identity, Impl, OFFSET>,
             QueryExtents: QueryExtents::<Identity, Impl, OFFSET>,
@@ -1376,7 +1376,7 @@ impl IVdsMaintenance_Vtbl {
             this.PulseMaintenance(::core::mem::transmute_copy(&operation), ::core::mem::transmute_copy(&ulcount)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             StartMaintenance: StartMaintenance::<Identity, Impl, OFFSET>,
             StopMaintenance: StopMaintenance::<Identity, Impl, OFFSET>,
             PulseMaintenance: PulseMaintenance::<Identity, Impl, OFFSET>,
@@ -1403,7 +1403,7 @@ impl IVdsProvider_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetProperties: GetProperties::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetProperties: GetProperties::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IVdsProvider as ::windows::core::Interface>::IID
@@ -1442,7 +1442,7 @@ impl IVdsProviderPrivate_Vtbl {
             this.OnUnload(::core::mem::transmute_copy(&bforceunload)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetObject: GetObject::<Identity, Impl, OFFSET>,
             OnLoad: OnLoad::<Identity, Impl, OFFSET>,
             OnUnload: OnUnload::<Identity, Impl, OFFSET>,
@@ -1469,7 +1469,7 @@ impl IVdsProviderSupport_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetVersionSupport: GetVersionSupport::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetVersionSupport: GetVersionSupport::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IVdsProviderSupport as ::windows::core::Interface>::IID
@@ -1550,7 +1550,7 @@ impl IVdsStoragePool_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetProvider: GetProvider::<Identity, Impl, OFFSET>,
             GetProperties: GetProperties::<Identity, Impl, OFFSET>,
             GetAttributes: GetAttributes::<Identity, Impl, OFFSET>,
@@ -1692,7 +1692,7 @@ impl IVdsSubSystem_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetProperties: GetProperties::<Identity, Impl, OFFSET>,
             GetProvider: GetProvider::<Identity, Impl, OFFSET>,
             QueryControllers: QueryControllers::<Identity, Impl, OFFSET>,
@@ -1768,7 +1768,7 @@ impl IVdsSubSystem2_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetProperties2: GetProperties2::<Identity, Impl, OFFSET>,
             GetDrive2: GetDrive2::<Identity, Impl, OFFSET>,
             CreateLun2: CreateLun2::<Identity, Impl, OFFSET>,
@@ -1796,7 +1796,10 @@ impl IVdsSubSystemInterconnect_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetSupportedInterconnects: GetSupportedInterconnects::<Identity, Impl, OFFSET> }
+        Self {
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
+            GetSupportedInterconnects: GetSupportedInterconnects::<Identity, Impl, OFFSET>,
+        }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IVdsSubSystemInterconnect as ::windows::core::Interface>::IID
@@ -1850,7 +1853,7 @@ impl IVdsSubSystemIscsi_Vtbl {
             this.SetIpsecGroupPresharedKey(::core::mem::transmute_copy(&pipseckey)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             QueryTargets: QueryTargets::<Identity, Impl, OFFSET>,
             QueryPortals: QueryPortals::<Identity, Impl, OFFSET>,
             CreateTarget: CreateTarget::<Identity, Impl, OFFSET>,
@@ -1872,7 +1875,7 @@ impl IVdsSubSystemNaming_Vtbl {
             let this = (*this).get_impl();
             this.SetFriendlyName(::core::mem::transmute(&pwszfriendlyname)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SetFriendlyName: SetFriendlyName::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SetFriendlyName: SetFriendlyName::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IVdsSubSystemNaming as ::windows::core::Interface>::IID

--- a/crates/libs/windows/src/Windows/Win32/Storage/VirtualDiskService/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/VirtualDiskService/mod.rs
@@ -54,7 +54,7 @@ unsafe impl ::windows::core::Interface for IEnumVdsObject {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumVdsObject_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, ppobjectarray: *mut *mut ::core::ffi::c_void, pcfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -114,7 +114,7 @@ unsafe impl ::windows::core::Interface for IVdsAdmin {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVdsAdmin_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub RegisterProvider: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, providerid: ::windows::core::GUID, providerclsid: ::windows::core::GUID, pwszname: ::windows::core::PCWSTR, r#type: VDS_PROVIDER_TYPE, pwszmachinename: ::windows::core::PCWSTR, pwszversion: ::windows::core::PCWSTR, guidversionid: ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub UnregisterProvider: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, providerid: ::windows::core::GUID) -> ::windows::core::HRESULT,
 }
@@ -164,7 +164,7 @@ unsafe impl ::windows::core::Interface for IVdsAdviseSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVdsAdviseSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnNotify: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lnumberofnotifications: i32, pnotificationarray: *const VDS_NOTIFICATION) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Storage_VirtualDiskService\"`*"]
@@ -219,7 +219,7 @@ unsafe impl ::windows::core::Interface for IVdsAsync {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVdsAsync_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Cancel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Wait: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, phrresult: *mut ::windows::core::HRESULT, pasyncout: *mut VDS_ASYNC_OUTPUT) -> ::windows::core::HRESULT,
     pub QueryStatus: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, phrresult: *mut ::windows::core::HRESULT, pulpercentcompleted: *mut u32) -> ::windows::core::HRESULT,
@@ -295,7 +295,7 @@ unsafe impl ::windows::core::Interface for IVdsController {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVdsController_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetProperties: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcontrollerprop: *mut VDS_CONTROLLER_PROP) -> ::windows::core::HRESULT,
     pub GetSubSystem: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppsubsystem: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetPortProperties: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sportnumber: i16, pportprop: *mut VDS_PORT_PROP) -> ::windows::core::HRESULT,
@@ -352,7 +352,7 @@ unsafe impl ::windows::core::Interface for IVdsControllerControllerPort {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVdsControllerControllerPort_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub QueryControllerPorts: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Storage_VirtualDiskService\"`*"]
@@ -416,7 +416,7 @@ unsafe impl ::windows::core::Interface for IVdsControllerPort {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVdsControllerPort_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetProperties: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pportprop: *mut VDS_PORT_PROP) -> ::windows::core::HRESULT,
     pub GetController: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppcontroller: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub QueryAssociatedLuns: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -488,7 +488,7 @@ unsafe impl ::windows::core::Interface for IVdsDrive {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVdsDrive_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetProperties: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdriveprop: *mut VDS_DRIVE_PROP) -> ::windows::core::HRESULT,
     pub GetSubSystem: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppsubsystem: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -546,7 +546,7 @@ unsafe impl ::windows::core::Interface for IVdsDrive2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVdsDrive2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetProperties2: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdriveprop2: *mut VDS_DRIVE_PROP2) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Storage_VirtualDiskService\"`*"]
@@ -602,7 +602,7 @@ unsafe impl ::windows::core::Interface for IVdsHwProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVdsHwProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub QuerySubSystems: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Reenumerate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Refresh: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -659,7 +659,7 @@ unsafe impl ::windows::core::Interface for IVdsHwProviderPrivate {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVdsHwProviderPrivate_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub QueryIfCreatedLun: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszdevicepath: ::windows::core::PCWSTR, pvdsluninformation: *const VDS_LUN_INFORMATION, plunid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -711,7 +711,7 @@ unsafe impl ::windows::core::Interface for IVdsHwProviderPrivateMpio {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVdsHwProviderPrivateMpio_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetAllPathStatusesFromHbaPort: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hbaportprop: VDS_HBAPORT_PROP, status: VDS_PATH_STATUS) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Storage_VirtualDiskService\"`*"]
@@ -778,7 +778,7 @@ unsafe impl ::windows::core::Interface for IVdsHwProviderStoragePools {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVdsHwProviderStoragePools_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub QueryStoragePools: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ulflags: u32, ullremainingfreespace: u64, ppoolattributes: *const VDS_POOL_ATTRIBUTES, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -839,7 +839,7 @@ unsafe impl ::windows::core::Interface for IVdsHwProviderType {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVdsHwProviderType_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetProviderType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptype: *mut VDS_HWPROVIDER_TYPE) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Storage_VirtualDiskService\"`*"]
@@ -889,7 +889,7 @@ unsafe impl ::windows::core::Interface for IVdsHwProviderType2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVdsHwProviderType2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetProviderType2: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptype: *mut VDS_HWPROVIDER_TYPE) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Storage_VirtualDiskService\"`*"]
@@ -960,7 +960,7 @@ unsafe impl ::windows::core::Interface for IVdsIscsiPortal {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVdsIscsiPortal_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetProperties: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pportalprop: *mut VDS_ISCSI_PORTAL_PROP) -> ::windows::core::HRESULT,
     pub GetSubSystem: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppsubsystem: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub QueryAssociatedPortalGroups: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1036,7 +1036,7 @@ unsafe impl ::windows::core::Interface for IVdsIscsiPortalGroup {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVdsIscsiPortalGroup_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetProperties: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pportalgroupprop: *mut VDS_ISCSI_PORTALGROUP_PROP) -> ::windows::core::HRESULT,
     pub GetTarget: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pptarget: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub QueryAssociatedPortals: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1134,7 +1134,7 @@ unsafe impl ::windows::core::Interface for IVdsIscsiTarget {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVdsIscsiTarget_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetProperties: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptargetprop: *mut VDS_ISCSI_TARGET_PROP) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -1264,7 +1264,7 @@ unsafe impl ::windows::core::Interface for IVdsLun {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVdsLun_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetProperties: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, plunprop: *mut VDS_LUN_PROP) -> ::windows::core::HRESULT,
     pub GetSubSystem: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppsubsystem: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -1346,7 +1346,7 @@ unsafe impl ::windows::core::Interface for IVdsLun2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVdsLun2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub QueryHints2: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, phints2: *mut VDS_HINTS2) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -1406,7 +1406,7 @@ unsafe impl ::windows::core::Interface for IVdsLunControllerPorts {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVdsLunControllerPorts_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AssociateControllerPorts: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pactivecontrollerportidarray: *const ::windows::core::GUID, lnumberofactivecontrollerports: i32, pinactivecontrollerportidarray: *const ::windows::core::GUID, lnumberofinactivecontrollerports: i32) -> ::windows::core::HRESULT,
     pub QueryActiveControllerPorts: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -1460,7 +1460,7 @@ unsafe impl ::windows::core::Interface for IVdsLunIscsi {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVdsLunIscsi_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AssociateTargets: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptargetidarray: *const ::windows::core::GUID, lnumberoftargets: i32) -> ::windows::core::HRESULT,
     pub QueryAssociatedTargets: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -1524,7 +1524,7 @@ unsafe impl ::windows::core::Interface for IVdsLunMpio {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVdsLunMpio_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetPathInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pppaths: *mut *mut VDS_PATH_INFO, plnumberofpaths: *mut i32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub GetLoadBalancePolicy: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppolicy: *mut VDS_LOADBALANCE_POLICY_ENUM, pppaths: *mut *mut VDS_PATH_POLICY, plnumberofpaths: *mut i32) -> ::windows::core::HRESULT,
@@ -1585,7 +1585,7 @@ unsafe impl ::windows::core::Interface for IVdsLunNaming {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVdsLunNaming_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetFriendlyName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszfriendlyname: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Storage_VirtualDiskService\"`*"]
@@ -1635,7 +1635,7 @@ unsafe impl ::windows::core::Interface for IVdsLunNumber {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVdsLunNumber_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetLunNumber: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pullunnumber: *mut u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Storage_VirtualDiskService\"`*"]
@@ -1705,7 +1705,7 @@ unsafe impl ::windows::core::Interface for IVdsLunPlex {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVdsLunPlex_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetProperties: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pplexprop: *mut VDS_LUN_PLEX_PROP) -> ::windows::core::HRESULT,
     pub GetLun: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pplun: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -1773,7 +1773,7 @@ unsafe impl ::windows::core::Interface for IVdsMaintenance {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVdsMaintenance_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub StartMaintenance: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, operation: VDS_MAINTENANCE_OPERATION) -> ::windows::core::HRESULT,
     pub StopMaintenance: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, operation: VDS_MAINTENANCE_OPERATION) -> ::windows::core::HRESULT,
     pub PulseMaintenance: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, operation: VDS_MAINTENANCE_OPERATION, ulcount: u32) -> ::windows::core::HRESULT,
@@ -1825,7 +1825,7 @@ unsafe impl ::windows::core::Interface for IVdsProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVdsProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetProperties: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pproviderprop: *mut VDS_PROVIDER_PROP) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Storage_VirtualDiskService\"`*"]
@@ -1890,7 +1890,7 @@ unsafe impl ::windows::core::Interface for IVdsProviderPrivate {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVdsProviderPrivate_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetObject: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, objectid: ::windows::core::GUID, r#type: VDS_OBJECT_TYPE, ppobjectunk: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub OnLoad: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszmachinename: ::windows::core::PCWSTR, pcallbackobject: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -1945,7 +1945,7 @@ unsafe impl ::windows::core::Interface for IVdsProviderSupport {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVdsProviderSupport_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetVersionSupport: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ulversionsupport: *mut u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Storage_VirtualDiskService\"`*"]
@@ -2018,7 +2018,7 @@ unsafe impl ::windows::core::Interface for IVdsStoragePool {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVdsStoragePool_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetProvider: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppprovider: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetProperties: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pstoragepoolprop: *mut VDS_STORAGE_POOL_PROP) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -2126,7 +2126,7 @@ unsafe impl ::windows::core::Interface for IVdsSubSystem {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVdsSubSystem_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetProperties: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psubsystemprop: *mut VDS_SUB_SYSTEM_PROP) -> ::windows::core::HRESULT,
     pub GetProvider: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppprovider: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub QueryControllers: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -2212,7 +2212,7 @@ unsafe impl ::windows::core::Interface for IVdsSubSystem2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVdsSubSystem2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetProperties2: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psubsystemprop2: *mut VDS_SUB_SYSTEM_PROP2) -> ::windows::core::HRESULT,
     pub GetDrive2: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sbusnumber: i16, sslotnumber: i16, ulenclosurenumber: u32, ppdrive: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -2271,7 +2271,7 @@ unsafe impl ::windows::core::Interface for IVdsSubSystemInterconnect {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVdsSubSystemInterconnect_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetSupportedInterconnects: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pulsupportedinterconnectsflag: *mut u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Storage_VirtualDiskService\"`*"]
@@ -2336,7 +2336,7 @@ unsafe impl ::windows::core::Interface for IVdsSubSystemIscsi {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVdsSubSystemIscsi_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub QueryTargets: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub QueryPortals: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CreateTarget: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwsziscsiname: ::windows::core::PCWSTR, pwszfriendlyname: ::windows::core::PCWSTR, ppasync: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -2391,7 +2391,7 @@ unsafe impl ::windows::core::Interface for IVdsSubSystemNaming {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVdsSubSystemNaming_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetFriendlyName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszfriendlyname: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
 }
 pub const CLSID_VdsLoader: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9c38ed61_d565_4728_aeee_c80952f0ecde);

--- a/crates/libs/windows/src/Windows/Win32/Storage/Vss/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Vss/impl.rs
@@ -34,7 +34,7 @@ impl IVssAdmin_Vtbl {
             this.AbortAllSnapshotsInProgress().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RegisterProvider: RegisterProvider::<Identity, Impl, OFFSET>,
             UnregisterProvider: UnregisterProvider::<Identity, Impl, OFFSET>,
             QueryProviders: QueryProviders::<Identity, Impl, OFFSET>,
@@ -115,7 +115,7 @@ impl IVssAsync_Vtbl {
             this.QueryStatus(::core::mem::transmute_copy(&phrresult), ::core::mem::transmute_copy(&preserved)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Cancel: Cancel::<Identity, Impl, OFFSET>,
             Wait: Wait::<Identity, Impl, OFFSET>,
             QueryStatus: QueryStatus::<Identity, Impl, OFFSET>,
@@ -374,7 +374,7 @@ impl IVssComponent_Vtbl {
             this.GetDifferencedFile(::core::mem::transmute_copy(&idifferencedfile), ::core::mem::transmute_copy(&pbstrpath), ::core::mem::transmute_copy(&pbstrfilespec), ::core::mem::transmute_copy(&pbrecursive), ::core::mem::transmute_copy(&pbstrlsnstring), ::core::mem::transmute_copy(&pftlastmodifytime)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetLogicalPath: GetLogicalPath::<Identity, Impl, OFFSET>,
             GetComponentType: GetComponentType::<Identity, Impl, OFFSET>,
             GetComponentName: GetComponentName::<Identity, Impl, OFFSET>,
@@ -593,7 +593,7 @@ impl IVssCreateExpressWriterMetadata_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddExcludeFiles: AddExcludeFiles::<Identity, Impl, OFFSET>,
             AddComponent: AddComponent::<Identity, Impl, OFFSET>,
             AddFilesToFileGroup: AddFilesToFileGroup::<Identity, Impl, OFFSET>,
@@ -779,7 +779,7 @@ impl IVssDifferentialSoftwareSnapshotMgmt_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddDiffArea: AddDiffArea::<Identity, Impl, OFFSET>,
             ChangeDiffAreaMaximumSize: ChangeDiffAreaMaximumSize::<Identity, Impl, OFFSET>,
             QueryVolumesSupportedForDiffAreas: QueryVolumesSupportedForDiffAreas::<Identity, Impl, OFFSET>,
@@ -929,7 +929,7 @@ impl IVssEnumMgmtObject_Vtbl {
             this.Clone(::core::mem::transmute_copy(&ppenum)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -970,7 +970,7 @@ impl IVssEnumObject_Vtbl {
             this.Clone(::core::mem::transmute_copy(&ppenum)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -1017,7 +1017,7 @@ impl IVssExpressWriter_Vtbl {
             this.Unregister(::core::mem::transmute(&writerid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateMetadata: CreateMetadata::<Identity, Impl, OFFSET>,
             LoadMetadata: LoadMetadata::<Identity, Impl, OFFSET>,
             Register: Register::<Identity, Impl, OFFSET>,
@@ -1103,7 +1103,7 @@ impl IVssFileShareSnapshotProvider_Vtbl {
             this.SetSnapshotProperty(::core::mem::transmute(&snapshotid), ::core::mem::transmute_copy(&esnapshotpropertyid), ::core::mem::transmute(&vproperty)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetContext: SetContext::<Identity, Impl, OFFSET>,
             GetSnapshotProperties: GetSnapshotProperties::<Identity, Impl, OFFSET>,
             Query: Query::<Identity, Impl, OFFSET>,
@@ -1163,7 +1163,7 @@ impl IVssHardwareSnapshotProvider_Vtbl {
             this.OnLunEmpty(::core::mem::transmute_copy(&wszdevicename), ::core::mem::transmute_copy(&pinformation)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AreLunsSupported: AreLunsSupported::<Identity, Impl, OFFSET>,
             FillInLunInfo: FillInLunInfo::<Identity, Impl, OFFSET>,
             BeginPrepareSnapshot: BeginPrepareSnapshot::<Identity, Impl, OFFSET>,
@@ -1280,7 +1280,7 @@ impl IVssProviderCreateSnapshotSet_Vtbl {
             this.AbortSnapshots(::core::mem::transmute(&snapshotsetid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             EndPrepareSnapshots: EndPrepareSnapshots::<Identity, Impl, OFFSET>,
             PreCommitSnapshots: PreCommitSnapshots::<Identity, Impl, OFFSET>,
             CommitSnapshots: CommitSnapshots::<Identity, Impl, OFFSET>,
@@ -1315,7 +1315,7 @@ impl IVssProviderNotifications_Vtbl {
             this.OnUnload(::core::mem::transmute_copy(&bforceunload)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnLoad: OnLoad::<Identity, Impl, OFFSET>,
             OnUnload: OnUnload::<Identity, Impl, OFFSET>,
         }
@@ -1366,7 +1366,7 @@ impl IVssSnapshotMgmt_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetProviderMgmtInterface: GetProviderMgmtInterface::<Identity, Impl, OFFSET>,
             QueryVolumesSupportedForSnapshots: QueryVolumesSupportedForSnapshots::<Identity, Impl, OFFSET>,
             QuerySnapshotsByVolume: QuerySnapshotsByVolume::<Identity, Impl, OFFSET>,
@@ -1393,7 +1393,7 @@ impl IVssSnapshotMgmt2_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetMinDiffAreaSize: GetMinDiffAreaSize::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetMinDiffAreaSize: GetMinDiffAreaSize::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IVssSnapshotMgmt2 as ::windows::core::Interface>::IID
@@ -1492,7 +1492,7 @@ impl IVssSoftwareSnapshotProvider_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetContext: SetContext::<Identity, Impl, OFFSET>,
             GetSnapshotProperties: GetSnapshotProperties::<Identity, Impl, OFFSET>,
             Query: Query::<Identity, Impl, OFFSET>,
@@ -1533,7 +1533,7 @@ impl IVssWMDependency_Vtbl {
             this.GetComponentName(::core::mem::transmute_copy(&pbstrcomponentname)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetWriterId: GetWriterId::<Identity, Impl, OFFSET>,
             GetLogicalPath: GetLogicalPath::<Identity, Impl, OFFSET>,
             GetComponentName: GetComponentName::<Identity, Impl, OFFSET>,
@@ -1609,7 +1609,7 @@ impl IVssWMFiledesc_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetPath: GetPath::<Identity, Impl, OFFSET>,
             GetFilespec: GetFilespec::<Identity, Impl, OFFSET>,
             GetRecursive: GetRecursive::<Identity, Impl, OFFSET>,
@@ -1810,7 +1810,7 @@ impl IVssWriterImpl_Vtbl {
             this.IsWriterShuttingDown()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             Subscribe: Subscribe::<Identity, Impl, OFFSET>,
             Unsubscribe: Unsubscribe::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/Storage/Vss/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Vss/mod.rs
@@ -64,7 +64,7 @@ unsafe impl ::windows::core::Interface for IVssAdmin {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVssAdmin_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub RegisterProvider: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pproviderid: ::windows::core::GUID, classid: ::windows::core::GUID, pwszprovidername: *const u16, eprovidertype: VSS_PROVIDER_TYPE, pwszproviderversion: *const u16, providerversionid: ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub UnregisterProvider: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, providerid: ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub QueryProviders: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -209,7 +209,7 @@ unsafe impl ::windows::core::Interface for IVssAsync {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVssAsync_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Cancel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Wait: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwmilliseconds: u32) -> ::windows::core::HRESULT,
     pub QueryStatus: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, phrresult: *mut ::windows::core::HRESULT, preserved: *mut i32) -> ::windows::core::HRESULT,
@@ -418,7 +418,7 @@ unsafe impl ::windows::core::Interface for IVssComponent {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVssComponent_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetLogicalPath: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstrpath: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub GetComponentType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pct: *mut VSS_COMPONENT_TYPE) -> ::windows::core::HRESULT,
     pub GetComponentName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstrname: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
@@ -1095,7 +1095,7 @@ unsafe impl ::windows::core::Interface for IVssCreateExpressWriterMetadata {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVssCreateExpressWriterMetadata_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddExcludeFiles: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wszpath: ::windows::core::PCWSTR, wszfilespec: ::windows::core::PCWSTR, brecursive: u8) -> ::windows::core::HRESULT,
     pub AddComponent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ct: VSS_COMPONENT_TYPE, wszlogicalpath: ::windows::core::PCWSTR, wszcomponentname: ::windows::core::PCWSTR, wszcaption: ::windows::core::PCWSTR, pbicon: *const u8, cbicon: u32, brestoremetadata: u8, bnotifyonbackupcomplete: u8, bselectable: u8, bselectableforrestore: u8, dwcomponentflags: u32) -> ::windows::core::HRESULT,
     pub AddFilesToFileGroup: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wszlogicalpath: ::windows::core::PCWSTR, wszgroupname: ::windows::core::PCWSTR, wszpath: ::windows::core::PCWSTR, wszfilespec: ::windows::core::PCWSTR, brecursive: u8, wszalternatelocation: ::windows::core::PCWSTR, dwbackuptypemask: u32) -> ::windows::core::HRESULT,
@@ -1300,7 +1300,7 @@ unsafe impl ::windows::core::Interface for IVssDifferentialSoftwareSnapshotMgmt 
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVssDifferentialSoftwareSnapshotMgmt_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddDiffArea: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszvolumename: *const u16, pwszdiffareavolumename: *const u16, llmaximumdiffspace: i64) -> ::windows::core::HRESULT,
     pub ChangeDiffAreaMaximumSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszvolumename: *const u16, pwszdiffareavolumename: *const u16, llmaximumdiffspace: i64) -> ::windows::core::HRESULT,
     pub QueryVolumesSupportedForDiffAreas: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszoriginalvolumename: *const u16, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1611,7 +1611,7 @@ unsafe impl ::windows::core::Interface for IVssEnumMgmtObject {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVssEnumMgmtObject_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut VSS_MGMT_OBJECT_PROP, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1672,7 +1672,7 @@ unsafe impl ::windows::core::Interface for IVssEnumObject {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVssEnumObject_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut VSS_OBJECT_PROP, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1740,7 +1740,7 @@ unsafe impl ::windows::core::Interface for IVssExpressWriter {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVssExpressWriter_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateMetadata: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, writerid: ::windows::core::GUID, writername: ::windows::core::PCWSTR, usagetype: VSS_USAGE_TYPE, versionmajor: u32, versionminor: u32, reserved: u32, ppmetadata: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub LoadMetadata: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, metadata: ::windows::core::PCWSTR, reserved: u32) -> ::windows::core::HRESULT,
     pub Register: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1830,7 +1830,7 @@ unsafe impl ::windows::core::Interface for IVssFileShareSnapshotProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVssFileShareSnapshotProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetContext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lcontext: i32) -> ::windows::core::HRESULT,
     pub GetSnapshotProperties: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, snapshotid: ::windows::core::GUID, pprop: *mut VSS_SNAPSHOT_PROP) -> ::windows::core::HRESULT,
     pub Query: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, queriedobjectid: ::windows::core::GUID, equeriedobjecttype: VSS_OBJECT_TYPE, ereturnedobjectstype: VSS_OBJECT_TYPE, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1925,7 +1925,7 @@ unsafe impl ::windows::core::Interface for IVssHardwareSnapshotProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVssHardwareSnapshotProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_VirtualDiskService"))]
     pub AreLunsSupported: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lluncount: i32, lcontext: i32, rgwszdevices: *const *const u16, pluninformation: *mut super::VirtualDiskService::VDS_LUN_INFORMATION, pbissupported: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_Storage_VirtualDiskService")))]
@@ -2138,7 +2138,7 @@ unsafe impl ::windows::core::Interface for IVssProviderCreateSnapshotSet {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVssProviderCreateSnapshotSet_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub EndPrepareSnapshots: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, snapshotsetid: ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub PreCommitSnapshots: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, snapshotsetid: ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub CommitSnapshots: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, snapshotsetid: ::windows::core::GUID) -> ::windows::core::HRESULT,
@@ -2204,7 +2204,7 @@ unsafe impl ::windows::core::Interface for IVssProviderNotifications {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVssProviderNotifications_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnLoad: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcallback: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub OnUnload: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bforceunload: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -2266,7 +2266,7 @@ unsafe impl ::windows::core::Interface for IVssSnapshotMgmt {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVssSnapshotMgmt_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetProviderMgmtInterface: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, providerid: ::windows::core::GUID, interfaceid: *const ::windows::core::GUID, ppitf: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub QueryVolumesSupportedForSnapshots: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, providerid: ::windows::core::GUID, lcontext: i32, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub QuerySnapshotsByVolume: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszvolumename: *const u16, providerid: ::windows::core::GUID, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -2318,7 +2318,7 @@ unsafe impl ::windows::core::Interface for IVssSnapshotMgmt2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVssSnapshotMgmt2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetMinDiffAreaSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pllmindiffareasize: *mut i64) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_Storage_Vss\"`*"]
@@ -2412,7 +2412,7 @@ unsafe impl ::windows::core::Interface for IVssSoftwareSnapshotProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVssSoftwareSnapshotProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetContext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lcontext: i32) -> ::windows::core::HRESULT,
     pub GetSnapshotProperties: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, snapshotid: ::windows::core::GUID, pprop: *mut VSS_SNAPSHOT_PROP) -> ::windows::core::HRESULT,
     pub Query: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, queriedobjectid: ::windows::core::GUID, equeriedobjecttype: VSS_OBJECT_TYPE, ereturnedobjectstype: VSS_OBJECT_TYPE, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -2488,7 +2488,7 @@ unsafe impl ::windows::core::Interface for IVssWMDependency {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVssWMDependency_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetWriterId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwriterid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub GetLogicalPath: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstrlogicalpath: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub GetComponentName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstrcomponentname: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
@@ -2556,7 +2556,7 @@ unsafe impl ::windows::core::Interface for IVssWMFiledesc {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVssWMFiledesc_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetPath: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstrpath: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub GetFilespec: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstrfilespec: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub GetRecursive: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbrecursive: *mut bool) -> ::windows::core::HRESULT,
@@ -2731,7 +2731,7 @@ unsafe impl ::windows::core::Interface for IVssWriterImpl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVssWriterImpl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, writerid: ::windows::core::GUID, wszwritername: ::windows::core::PCWSTR, wszwriterinstancename: ::windows::core::PCWSTR, dwmajorversion: u32, dwminorversion: u32, ut: VSS_USAGE_TYPE, st: VSS_SOURCE_TYPE, nlevel: VSS_APPLICATION_LEVEL, dwtimeout: u32, aws: VSS_ALTERNATE_WRITER_STATE, biothrottlingonly: u8) -> ::windows::core::HRESULT,
     pub Subscribe: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwsubscribetimeout: u32, dweventflags: u32) -> ::windows::core::HRESULT,
     pub Unsubscribe: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/Storage/Xps/Printing/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Xps/Printing/impl.rs
@@ -45,7 +45,7 @@ impl IPrintDocumentPackageTarget_Vtbl {
             this.Cancel().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetPackageTargetTypes: GetPackageTargetTypes::<Identity, Impl, OFFSET>,
             GetPackageTarget: GetPackageTarget::<Identity, Impl, OFFSET>,
             Cancel: Cancel::<Identity, Impl, OFFSET>,
@@ -76,7 +76,7 @@ impl IPrintDocumentPackageTargetFactory_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateDocumentPackageTargetForPrintJob: CreateDocumentPackageTargetForPrintJob::<Identity, Impl, OFFSET>,
         }
     }
@@ -108,7 +108,7 @@ impl IXpsPrintJob_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Cancel: Cancel::<Identity, Impl, OFFSET>,
             GetJobStatus: GetJobStatus::<Identity, Impl, OFFSET>,
         }

--- a/crates/libs/windows/src/Windows/Win32/Storage/Xps/Printing/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Xps/Printing/mod.rs
@@ -166,7 +166,7 @@ unsafe impl ::windows::core::Interface for IPrintDocumentPackageTarget {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPrintDocumentPackageTarget_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetPackageTargetTypes: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, targetcount: *mut u32, targettypes: *mut *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub GetPackageTarget: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, guidtargettype: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, ppvtarget: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Cancel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -226,7 +226,7 @@ unsafe impl ::windows::core::Interface for IPrintDocumentPackageTargetFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPrintDocumentPackageTargetFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub CreateDocumentPackageTargetForPrintJob: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, printername: ::windows::core::PCWSTR, jobname: ::windows::core::PCWSTR, joboutputstream: *mut ::core::ffi::c_void, jobprintticketstream: *mut ::core::ffi::c_void, docpackagetarget: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -282,7 +282,7 @@ unsafe impl ::windows::core::Interface for IXpsPrintJob {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXpsPrintJob_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Cancel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetJobStatus: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, jobstatus: *mut XPS_JOB_STATUS) -> ::windows::core::HRESULT,
 }

--- a/crates/libs/windows/src/Windows/Win32/Storage/Xps/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Xps/impl.rs
@@ -43,7 +43,7 @@ impl IXpsDocumentPackageTarget_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetXpsOMPackageWriter: GetXpsOMPackageWriter::<Identity, Impl, OFFSET>,
             GetXpsOMFactory: GetXpsOMFactory::<Identity, Impl, OFFSET>,
             GetXpsType: GetXpsType::<Identity, Impl, OFFSET>,
@@ -86,7 +86,7 @@ impl IXpsDocumentPackageTarget3D_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetXpsOMPackageWriter3D: GetXpsOMPackageWriter3D::<Identity, Impl, OFFSET>,
             GetXpsOMFactory: GetXpsOMFactory::<Identity, Impl, OFFSET>,
         }
@@ -388,7 +388,7 @@ impl IXpsOMColorProfileResourceCollection_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCount: GetCount::<Identity, Impl, OFFSET>,
             GetAt: GetAt::<Identity, Impl, OFFSET>,
             InsertAt: InsertAt::<Identity, Impl, OFFSET>,
@@ -818,7 +818,7 @@ impl IXpsOMDashCollection_Vtbl {
             this.Append(::core::mem::transmute_copy(&dash)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCount: GetCount::<Identity, Impl, OFFSET>,
             GetAt: GetAt::<Identity, Impl, OFFSET>,
             InsertAt: InsertAt::<Identity, Impl, OFFSET>,
@@ -927,7 +927,7 @@ impl IXpsOMDictionary_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetOwner: GetOwner::<Identity, Impl, OFFSET>,
             GetCount: GetCount::<Identity, Impl, OFFSET>,
             GetAt: GetAt::<Identity, Impl, OFFSET>,
@@ -1106,7 +1106,7 @@ impl IXpsOMDocumentCollection_Vtbl {
             this.Append(::core::mem::transmute(&document)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCount: GetCount::<Identity, Impl, OFFSET>,
             GetAt: GetAt::<Identity, Impl, OFFSET>,
             InsertAt: InsertAt::<Identity, Impl, OFFSET>,
@@ -1348,7 +1348,7 @@ impl IXpsOMFontResourceCollection_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCount: GetCount::<Identity, Impl, OFFSET>,
             GetAt: GetAt::<Identity, Impl, OFFSET>,
             SetAt: SetAt::<Identity, Impl, OFFSET>,
@@ -1621,7 +1621,7 @@ impl IXpsOMGeometryFigure_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetOwner: GetOwner::<Identity, Impl, OFFSET>,
             GetSegmentData: GetSegmentData::<Identity, Impl, OFFSET>,
             GetSegmentTypes: GetSegmentTypes::<Identity, Impl, OFFSET>,
@@ -1697,7 +1697,7 @@ impl IXpsOMGeometryFigureCollection_Vtbl {
             this.Append(::core::mem::transmute(&geometryfigure)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCount: GetCount::<Identity, Impl, OFFSET>,
             GetAt: GetAt::<Identity, Impl, OFFSET>,
             InsertAt: InsertAt::<Identity, Impl, OFFSET>,
@@ -2176,7 +2176,7 @@ impl IXpsOMGlyphsEditor_Vtbl {
             this.SetDeviceFontName(::core::mem::transmute(&devicefontname)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ApplyEdits: ApplyEdits::<Identity, Impl, OFFSET>,
             GetUnicodeString: GetUnicodeString::<Identity, Impl, OFFSET>,
             SetUnicodeString: SetUnicodeString::<Identity, Impl, OFFSET>,
@@ -2380,7 +2380,7 @@ impl IXpsOMGradientStop_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetOwner: GetOwner::<Identity, Impl, OFFSET>,
             GetOffset: GetOffset::<Identity, Impl, OFFSET>,
             SetOffset: SetOffset::<Identity, Impl, OFFSET>,
@@ -2447,7 +2447,7 @@ impl IXpsOMGradientStopCollection_Vtbl {
             this.Append(::core::mem::transmute(&stop)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCount: GetCount::<Identity, Impl, OFFSET>,
             GetAt: GetAt::<Identity, Impl, OFFSET>,
             InsertAt: InsertAt::<Identity, Impl, OFFSET>,
@@ -2644,7 +2644,7 @@ impl IXpsOMImageResourceCollection_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCount: GetCount::<Identity, Impl, OFFSET>,
             GetAt: GetAt::<Identity, Impl, OFFSET>,
             InsertAt: InsertAt::<Identity, Impl, OFFSET>,
@@ -2800,7 +2800,7 @@ impl IXpsOMNameCollection_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCount: GetCount::<Identity, Impl, OFFSET>,
             GetAt: GetAt::<Identity, Impl, OFFSET>,
         }
@@ -3262,7 +3262,7 @@ impl IXpsOMObjectFactory_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreatePackage: CreatePackage::<Identity, Impl, OFFSET>,
             CreatePackageFromFile: CreatePackageFromFile::<Identity, Impl, OFFSET>,
             CreatePackageFromStream: CreatePackageFromStream::<Identity, Impl, OFFSET>,
@@ -3571,7 +3571,7 @@ impl IXpsOMPackage_Vtbl {
             this.WriteToStream(::core::mem::transmute(&stream), ::core::mem::transmute_copy(&optimizemarkupsize)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDocumentSequence: GetDocumentSequence::<Identity, Impl, OFFSET>,
             SetDocumentSequence: SetDocumentSequence::<Identity, Impl, OFFSET>,
             GetCoreProperties: GetCoreProperties::<Identity, Impl, OFFSET>,
@@ -3651,7 +3651,7 @@ impl IXpsOMPackageTarget_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CreateXpsOMPackageWriter: CreateXpsOMPackageWriter::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CreateXpsOMPackageWriter: CreateXpsOMPackageWriter::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IXpsOMPackageTarget as ::windows::core::Interface>::IID
@@ -3702,7 +3702,7 @@ impl IXpsOMPackageWriter_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             StartNewDocument: StartNewDocument::<Identity, Impl, OFFSET>,
             AddPage: AddPage::<Identity, Impl, OFFSET>,
             AddResource: AddResource::<Identity, Impl, OFFSET>,
@@ -4205,7 +4205,7 @@ impl IXpsOMPageReference_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetOwner: GetOwner::<Identity, Impl, OFFSET>,
             GetPage: GetPage::<Identity, Impl, OFFSET>,
             SetPage: SetPage::<Identity, Impl, OFFSET>,
@@ -4283,7 +4283,7 @@ impl IXpsOMPageReferenceCollection_Vtbl {
             this.Append(::core::mem::transmute(&pagereference)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCount: GetCount::<Identity, Impl, OFFSET>,
             GetAt: GetAt::<Identity, Impl, OFFSET>,
             InsertAt: InsertAt::<Identity, Impl, OFFSET>,
@@ -4323,7 +4323,7 @@ impl IXpsOMPart_Vtbl {
             this.SetPartName(::core::mem::transmute(&parturi)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetPartName: GetPartName::<Identity, Impl, OFFSET>,
             SetPartName: SetPartName::<Identity, Impl, OFFSET>,
         }
@@ -4386,7 +4386,7 @@ impl IXpsOMPartResources_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetFontResources: GetFontResources::<Identity, Impl, OFFSET>,
             GetImageResources: GetImageResources::<Identity, Impl, OFFSET>,
             GetColorProfileResources: GetColorProfileResources::<Identity, Impl, OFFSET>,
@@ -4454,7 +4454,7 @@ impl IXpsOMPartUriCollection_Vtbl {
             this.Append(::core::mem::transmute(&parturi)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCount: GetCount::<Identity, Impl, OFFSET>,
             GetAt: GetAt::<Identity, Impl, OFFSET>,
             InsertAt: InsertAt::<Identity, Impl, OFFSET>,
@@ -5131,7 +5131,7 @@ impl IXpsOMRemoteDictionaryResourceCollection_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCount: GetCount::<Identity, Impl, OFFSET>,
             GetAt: GetAt::<Identity, Impl, OFFSET>,
             InsertAt: InsertAt::<Identity, Impl, OFFSET>,
@@ -5188,7 +5188,7 @@ impl IXpsOMShareable_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetOwner: GetOwner::<Identity, Impl, OFFSET>,
             GetType: GetType::<Identity, Impl, OFFSET>,
         }
@@ -5315,7 +5315,7 @@ impl IXpsOMSignatureBlockResourceCollection_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCount: GetCount::<Identity, Impl, OFFSET>,
             GetAt: GetAt::<Identity, Impl, OFFSET>,
             InsertAt: InsertAt::<Identity, Impl, OFFSET>,
@@ -5438,7 +5438,7 @@ impl IXpsOMThumbnailGenerator_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GenerateThumbnail: GenerateThumbnail::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GenerateThumbnail: GenerateThumbnail::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IXpsOMThumbnailGenerator as ::windows::core::Interface>::IID
@@ -5978,7 +5978,7 @@ impl IXpsOMVisualCollection_Vtbl {
             this.Append(::core::mem::transmute(&object)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCount: GetCount::<Identity, Impl, OFFSET>,
             GetAt: GetAt::<Identity, Impl, OFFSET>,
             InsertAt: InsertAt::<Identity, Impl, OFFSET>,
@@ -6126,7 +6126,7 @@ impl IXpsSignature_Vtbl {
             this.SetSignatureXml(::core::mem::transmute_copy(&signaturexml), ::core::mem::transmute_copy(&count)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSignatureId: GetSignatureId::<Identity, Impl, OFFSET>,
             GetSignatureValue: GetSignatureValue::<Identity, Impl, OFFSET>,
             GetCertificateEnumerator: GetCertificateEnumerator::<Identity, Impl, OFFSET>,
@@ -6214,7 +6214,7 @@ impl IXpsSignatureBlock_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetRequests: GetRequests::<Identity, Impl, OFFSET>,
             GetPartName: GetPartName::<Identity, Impl, OFFSET>,
             GetDocumentIndex: GetDocumentIndex::<Identity, Impl, OFFSET>,
@@ -6262,7 +6262,7 @@ impl IXpsSignatureBlockCollection_Vtbl {
             this.RemoveAt(::core::mem::transmute_copy(&index)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCount: GetCount::<Identity, Impl, OFFSET>,
             GetAt: GetAt::<Identity, Impl, OFFSET>,
             RemoveAt: RemoveAt::<Identity, Impl, OFFSET>,
@@ -6308,7 +6308,7 @@ impl IXpsSignatureCollection_Vtbl {
             this.RemoveAt(::core::mem::transmute_copy(&index)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCount: GetCount::<Identity, Impl, OFFSET>,
             GetAt: GetAt::<Identity, Impl, OFFSET>,
             RemoveAt: RemoveAt::<Identity, Impl, OFFSET>,
@@ -6429,7 +6429,7 @@ impl IXpsSignatureManager_Vtbl {
             this.SavePackageToStream(::core::mem::transmute(&stream)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             LoadPackageFile: LoadPackageFile::<Identity, Impl, OFFSET>,
             LoadPackageStream: LoadPackageStream::<Identity, Impl, OFFSET>,
             Sign: Sign::<Identity, Impl, OFFSET>,
@@ -6564,7 +6564,7 @@ impl IXpsSignatureRequest_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetIntent: GetIntent::<Identity, Impl, OFFSET>,
             SetIntent: SetIntent::<Identity, Impl, OFFSET>,
             GetRequestedSigner: GetRequestedSigner::<Identity, Impl, OFFSET>,
@@ -6619,7 +6619,7 @@ impl IXpsSignatureRequestCollection_Vtbl {
             this.RemoveAt(::core::mem::transmute_copy(&index)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCount: GetCount::<Identity, Impl, OFFSET>,
             GetAt: GetAt::<Identity, Impl, OFFSET>,
             RemoveAt: RemoveAt::<Identity, Impl, OFFSET>,
@@ -6800,7 +6800,7 @@ impl IXpsSigningOptions_Vtbl {
             this.SetFlags(::core::mem::transmute_copy(&flags)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSignatureId: GetSignatureId::<Identity, Impl, OFFSET>,
             SetSignatureId: SetSignatureId::<Identity, Impl, OFFSET>,
             GetSignatureMethod: GetSignatureMethod::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/Storage/Xps/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Xps/mod.rs
@@ -220,7 +220,7 @@ unsafe impl ::windows::core::Interface for IXpsDocumentPackageTarget {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXpsDocumentPackageTarget_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
     pub GetXpsOMPackageWriter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, documentsequencepartname: *mut ::core::ffi::c_void, discardcontrolpartname: *mut ::core::ffi::c_void, packagewriter: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com")))]
@@ -287,7 +287,7 @@ unsafe impl ::windows::core::Interface for IXpsDocumentPackageTarget3D {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXpsDocumentPackageTarget3D_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
     pub GetXpsOMPackageWriter3D: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, documentsequencepartname: *mut ::core::ffi::c_void, discardcontrolpartname: *mut ::core::ffi::c_void, modelpartname: *mut ::core::ffi::c_void, modeldata: *mut ::core::ffi::c_void, packagewriter: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com")))]
@@ -859,7 +859,7 @@ unsafe impl ::windows::core::Interface for IXpsOMColorProfileResourceCollection 
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXpsOMColorProfileResourceCollection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, count: *mut u32) -> ::windows::core::HRESULT,
     pub GetAt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: u32, object: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub InsertAt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: u32, object: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1231,7 +1231,7 @@ unsafe impl ::windows::core::Interface for IXpsOMDashCollection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXpsOMDashCollection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, count: *mut u32) -> ::windows::core::HRESULT,
     pub GetAt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: u32, dash: *mut XPS_DASH) -> ::windows::core::HRESULT,
     pub InsertAt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: u32, dash: *const XPS_DASH) -> ::windows::core::HRESULT,
@@ -1336,7 +1336,7 @@ unsafe impl ::windows::core::Interface for IXpsOMDictionary {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXpsOMDictionary_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetOwner: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, owner: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, count: *mut u32) -> ::windows::core::HRESULT,
     pub GetAt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: u32, key: *mut ::windows::core::PWSTR, entry: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1538,7 +1538,7 @@ unsafe impl ::windows::core::Interface for IXpsOMDocumentCollection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXpsOMDocumentCollection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, count: *mut u32) -> ::windows::core::HRESULT,
     pub GetAt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: u32, document: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub InsertAt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: u32, document: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1957,7 +1957,7 @@ unsafe impl ::windows::core::Interface for IXpsOMFontResourceCollection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXpsOMFontResourceCollection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, count: *mut u32) -> ::windows::core::HRESULT,
     pub GetAt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: u32, value: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetAt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: u32, value: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -2199,7 +2199,7 @@ unsafe impl ::windows::core::Interface for IXpsOMGeometryFigure {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXpsOMGeometryFigure_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetOwner: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, owner: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetSegmentData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, datacount: *mut u32, segmentdata: *mut f32) -> ::windows::core::HRESULT,
     pub GetSegmentTypes: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, segmentcount: *mut u32, segmenttypes: *mut XPS_SEGMENT_TYPE) -> ::windows::core::HRESULT,
@@ -2306,7 +2306,7 @@ unsafe impl ::windows::core::Interface for IXpsOMGeometryFigureCollection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXpsOMGeometryFigureCollection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, count: *mut u32) -> ::windows::core::HRESULT,
     pub GetAt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: u32, geometryfigure: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub InsertAt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: u32, geometryfigure: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -2780,7 +2780,7 @@ unsafe impl ::windows::core::Interface for IXpsOMGlyphsEditor {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXpsOMGlyphsEditor_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ApplyEdits: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetUnicodeString: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, unicodestring: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub SetUnicodeString: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, unicodestring: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
@@ -3015,7 +3015,7 @@ unsafe impl ::windows::core::Interface for IXpsOMGradientStop {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXpsOMGradientStop_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetOwner: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, owner: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetOffset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, offset: *mut f32) -> ::windows::core::HRESULT,
     pub SetOffset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, offset: f32) -> ::windows::core::HRESULT,
@@ -3095,7 +3095,7 @@ unsafe impl ::windows::core::Interface for IXpsOMGradientStopCollection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXpsOMGradientStopCollection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, count: *mut u32) -> ::windows::core::HRESULT,
     pub GetAt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: u32, stop: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub InsertAt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: u32, stop: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -3480,7 +3480,7 @@ unsafe impl ::windows::core::Interface for IXpsOMImageResourceCollection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXpsOMImageResourceCollection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, count: *mut u32) -> ::windows::core::HRESULT,
     pub GetAt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: u32, object: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub InsertAt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: u32, object: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -3795,7 +3795,7 @@ unsafe impl ::windows::core::Interface for IXpsOMNameCollection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXpsOMNameCollection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, count: *mut u32) -> ::windows::core::HRESULT,
     pub GetAt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: u32, name: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
 }
@@ -4139,7 +4139,7 @@ unsafe impl ::windows::core::Interface for IXpsOMObjectFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXpsOMObjectFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreatePackage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, package: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub CreatePackageFromFile: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, filename: ::windows::core::PCWSTR, reuseobjects: super::super::Foundation::BOOL, package: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -4851,7 +4851,7 @@ unsafe impl ::windows::core::Interface for IXpsOMPackage {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXpsOMPackage_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDocumentSequence: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, documentsequence: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetDocumentSequence: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, documentsequence: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetCoreProperties: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, coreproperties: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -5082,7 +5082,7 @@ unsafe impl ::windows::core::Interface for IXpsOMPackageTarget {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXpsOMPackageTarget_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
     pub CreateXpsOMPackageWriter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, documentsequencepartname: *mut ::core::ffi::c_void, documentsequenceprintticket: *mut ::core::ffi::c_void, discardcontrolpartname: *mut ::core::ffi::c_void, packagewriter: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com")))]
@@ -5168,7 +5168,7 @@ unsafe impl ::windows::core::Interface for IXpsOMPackageWriter {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXpsOMPackageWriter_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
     pub StartNewDocument: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, documentpartname: *mut ::core::ffi::c_void, documentprintticket: *mut ::core::ffi::c_void, documentstructure: *mut ::core::ffi::c_void, signatureblockresources: *mut ::core::ffi::c_void, restrictedfonts: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com")))]
@@ -5845,7 +5845,7 @@ unsafe impl ::windows::core::Interface for IXpsOMPageReference {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXpsOMPageReference_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetOwner: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, document: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetPage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, page: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetPage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, page: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -5942,7 +5942,7 @@ unsafe impl ::windows::core::Interface for IXpsOMPageReferenceCollection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXpsOMPageReferenceCollection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, count: *mut u32) -> ::windows::core::HRESULT,
     pub GetAt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: u32, pagereference: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub InsertAt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: u32, pagereference: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -6007,7 +6007,7 @@ unsafe impl ::windows::core::Interface for IXpsOMPart {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXpsOMPart_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
     pub GetPartName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, parturi: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com")))]
@@ -6076,7 +6076,7 @@ unsafe impl ::windows::core::Interface for IXpsOMPartResources {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXpsOMPartResources_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetFontResources: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fontresources: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetImageResources: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, imageresources: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetColorProfileResources: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, colorprofileresources: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -6162,7 +6162,7 @@ unsafe impl ::windows::core::Interface for IXpsOMPartUriCollection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXpsOMPartUriCollection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, count: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
     pub GetAt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: u32, parturi: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -7202,7 +7202,7 @@ unsafe impl ::windows::core::Interface for IXpsOMRemoteDictionaryResourceCollect
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXpsOMRemoteDictionaryResourceCollection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, count: *mut u32) -> ::windows::core::HRESULT,
     pub GetAt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: u32, object: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub InsertAt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: u32, object: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -7339,7 +7339,7 @@ unsafe impl ::windows::core::Interface for IXpsOMShareable {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXpsOMShareable_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetOwner: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, owner: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, r#type: *mut XPS_OBJECT_TYPE) -> ::windows::core::HRESULT,
 }
@@ -7541,7 +7541,7 @@ unsafe impl ::windows::core::Interface for IXpsOMSignatureBlockResourceCollectio
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXpsOMSignatureBlockResourceCollection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, count: *mut u32) -> ::windows::core::HRESULT,
     pub GetAt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: u32, signatureblockresource: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub InsertAt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: u32, signatureblockresource: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -7829,7 +7829,7 @@ unsafe impl ::windows::core::Interface for IXpsOMThumbnailGenerator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXpsOMThumbnailGenerator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
     pub GenerateThumbnail: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, page: *mut ::core::ffi::c_void, thumbnailtype: XPS_IMAGE_TYPE, thumbnailsize: XPS_THUMBNAIL_SIZE, imageresourcepartname: *mut ::core::ffi::c_void, imageresource: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com")))]
@@ -8469,7 +8469,7 @@ unsafe impl ::windows::core::Interface for IXpsOMVisualCollection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXpsOMVisualCollection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, count: *mut u32) -> ::windows::core::HRESULT,
     pub GetAt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: u32, object: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub InsertAt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: u32, object: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -8577,7 +8577,7 @@ unsafe impl ::windows::core::Interface for IXpsSignature {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXpsSignature_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetSignatureId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sigid: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetSignatureValue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, signaturehashvalue: *mut *mut u8, count: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Storage_Packaging_Opc")]
@@ -8679,7 +8679,7 @@ unsafe impl ::windows::core::Interface for IXpsSignatureBlock {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXpsSignatureBlock_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetRequests: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, requests: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
     pub GetPartName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, partname: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -8746,7 +8746,7 @@ unsafe impl ::windows::core::Interface for IXpsSignatureBlockCollection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXpsSignatureBlockCollection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, count: *mut u32) -> ::windows::core::HRESULT,
     pub GetAt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: u32, signatureblock: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub RemoveAt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: u32) -> ::windows::core::HRESULT,
@@ -8805,7 +8805,7 @@ unsafe impl ::windows::core::Interface for IXpsSignatureCollection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXpsSignatureCollection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, count: *mut u32) -> ::windows::core::HRESULT,
     pub GetAt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: u32, signature: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub RemoveAt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: u32) -> ::windows::core::HRESULT,
@@ -8927,7 +8927,7 @@ unsafe impl ::windows::core::Interface for IXpsSignatureManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXpsSignatureManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub LoadPackageFile: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, filename: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
     pub LoadPackageStream: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, stream: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -9060,7 +9060,7 @@ unsafe impl ::windows::core::Interface for IXpsSignatureRequest {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXpsSignatureRequest_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetIntent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, intent: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub SetIntent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, intent: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub GetRequestedSigner: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, signername: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
@@ -9131,7 +9131,7 @@ unsafe impl ::windows::core::Interface for IXpsSignatureRequestCollection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXpsSignatureRequestCollection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, count: *mut u32) -> ::windows::core::HRESULT,
     pub GetAt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: u32, signaturerequest: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub RemoveAt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: u32) -> ::windows::core::HRESULT,
@@ -9266,7 +9266,7 @@ unsafe impl ::windows::core::Interface for IXpsSigningOptions {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXpsSigningOptions_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetSignatureId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, signatureid: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub SetSignatureId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, signatureid: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub GetSignatureMethod: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, signaturemethod: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/System/AddressBook/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/AddressBook/impl.rs
@@ -279,7 +279,7 @@ impl IMAPIAdviseSink_Vtbl {
             let this = (*this).get_impl();
             this.OnNotify(::core::mem::transmute_copy(&cnotif), ::core::mem::transmute_copy(&lpnotifications))
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnNotify: OnNotify::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnNotify: OnNotify::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMAPIAdviseSink as ::windows::core::Interface>::IID
@@ -378,7 +378,7 @@ impl IMAPIControl_Vtbl {
             this.GetState(::core::mem::transmute_copy(&ulflags), ::core::mem::transmute_copy(&lpulstate)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetLastError: GetLastError::<Identity, Impl, OFFSET>,
             Activate: Activate::<Identity, Impl, OFFSET>,
             GetState: GetState::<Identity, Impl, OFFSET>,
@@ -535,7 +535,7 @@ impl IMAPIProgress_Vtbl {
             this.SetLimits(::core::mem::transmute_copy(&lpulmin), ::core::mem::transmute_copy(&lpulmax), ::core::mem::transmute_copy(&lpulflags)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Progress: Progress::<Identity, Impl, OFFSET>,
             GetFlags: GetFlags::<Identity, Impl, OFFSET>,
             GetMax: GetMax::<Identity, Impl, OFFSET>,
@@ -622,7 +622,7 @@ impl IMAPIProp_Vtbl {
             this.GetIDsFromNames(::core::mem::transmute_copy(&cpropnames), ::core::mem::transmute_copy(&lpppropnames), ::core::mem::transmute_copy(&ulflags), ::core::mem::transmute_copy(&lppproptags)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetLastError: GetLastError::<Identity, Impl, OFFSET>,
             SaveChanges: SaveChanges::<Identity, Impl, OFFSET>,
             GetProps: GetProps::<Identity, Impl, OFFSET>,
@@ -831,7 +831,7 @@ impl IMAPITable_Vtbl {
             this.SetCollapseState(::core::mem::transmute_copy(&ulflags), ::core::mem::transmute_copy(&cbcollapsestate), ::core::mem::transmute_copy(&pbcollapsestate), ::core::mem::transmute_copy(&lpbklocation)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetLastError: GetLastError::<Identity, Impl, OFFSET>,
             Advise: Advise::<Identity, Impl, OFFSET>,
             Unadvise: Unadvise::<Identity, Impl, OFFSET>,
@@ -1215,7 +1215,7 @@ impl IProviderAdmin_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetLastError: GetLastError::<Identity, Impl, OFFSET>,
             GetProviderTable: GetProviderTable::<Identity, Impl, OFFSET>,
             CreateProvider: CreateProvider::<Identity, Impl, OFFSET>,
@@ -1290,7 +1290,7 @@ impl ITableData_Vtbl {
             this.HrDeleteRows(::core::mem::transmute_copy(&ulflags), ::core::mem::transmute_copy(&lprowsettodelete), ::core::mem::transmute_copy(&crowsdeleted)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             HrGetView: HrGetView::<Identity, Impl, OFFSET>,
             HrModifyRow: HrModifyRow::<Identity, Impl, OFFSET>,
             HrDeleteRow: HrDeleteRow::<Identity, Impl, OFFSET>,
@@ -1320,7 +1320,7 @@ impl IWABExtInit_Vtbl {
             let this = (*this).get_impl();
             this.Initialize(::core::mem::transmute_copy(&lpwabextdisplay)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Initialize: Initialize::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Initialize: Initialize::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWABExtInit as ::windows::core::Interface>::IID
@@ -1564,7 +1564,7 @@ impl IWABObject_Vtbl {
             this.SetMe(::core::mem::transmute(&lpiab), ::core::mem::transmute_copy(&ulflags), ::core::mem::transmute(&sbeid), ::core::mem::transmute_copy(&hwnd)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetLastError: GetLastError::<Identity, Impl, OFFSET>,
             AllocateBuffer: AllocateBuffer::<Identity, Impl, OFFSET>,
             AllocateMore: AllocateMore::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/System/AddressBook/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/AddressBook/mod.rs
@@ -1287,7 +1287,7 @@ unsafe impl ::windows::core::Interface for IMAPIAdviseSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMAPIAdviseSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
     pub OnNotify: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cnotif: u32, lpnotifications: *mut NOTIFICATION) -> u32,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com")))]
@@ -1481,7 +1481,7 @@ unsafe impl ::windows::core::Interface for IMAPIControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMAPIControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetLastError: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hresult: ::windows::core::HRESULT, ulflags: u32, lppmapierror: *mut *mut MAPIERROR) -> ::windows::core::HRESULT,
     pub Activate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ulflags: u32, uluiparam: usize) -> ::windows::core::HRESULT,
     pub GetState: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ulflags: u32, lpulstate: *mut u32) -> ::windows::core::HRESULT,
@@ -1748,7 +1748,7 @@ unsafe impl ::windows::core::Interface for IMAPIProgress {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMAPIProgress_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Progress: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ulvalue: u32, ulcount: u32, ultotal: u32) -> ::windows::core::HRESULT,
     pub GetFlags: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lpulflags: *mut u32) -> ::windows::core::HRESULT,
     pub GetMax: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lpulmax: *mut u32) -> ::windows::core::HRESULT,
@@ -1841,7 +1841,7 @@ unsafe impl ::windows::core::Interface for IMAPIProp {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMAPIProp_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetLastError: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hresult: ::windows::core::HRESULT, ulflags: u32, lppmapierror: *mut *mut MAPIERROR) -> ::windows::core::HRESULT,
     pub SaveChanges: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ulflags: u32) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
@@ -2102,7 +2102,7 @@ unsafe impl ::windows::core::Interface for IMAPITable {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMAPITable_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetLastError: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hresult: ::windows::core::HRESULT, ulflags: u32, lppmapierror: *mut *mut MAPIERROR) -> ::windows::core::HRESULT,
     pub Advise: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, uleventmask: u32, lpadvisesink: *mut ::core::ffi::c_void, lpulconnection: *mut u32) -> ::windows::core::HRESULT,
     pub Unadvise: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ulconnection: u32) -> ::windows::core::HRESULT,
@@ -2844,7 +2844,7 @@ unsafe impl ::windows::core::Interface for IProviderAdmin {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IProviderAdmin_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetLastError: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hresult: ::windows::core::HRESULT, ulflags: u32, lppmapierror: *mut *mut MAPIERROR) -> ::windows::core::HRESULT,
     pub GetProviderTable: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ulflags: u32, lpptable: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
@@ -2940,7 +2940,7 @@ unsafe impl ::windows::core::Interface for ITableData {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITableData_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub HrGetView: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lpssortorderset: *mut SSortOrderSet, lpfcallerrelease: *mut *mut ::core::ffi::c_void, ulcallerdata: u32, lppmapitable: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
     pub HrModifyRow: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, param0: *mut SRow) -> ::windows::core::HRESULT,
@@ -3023,7 +3023,7 @@ unsafe impl ::windows::core::Interface for IWABExtInit {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWABExtInit_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lpwabextdisplay: *mut WABEXTDISPLAY) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -3317,7 +3317,7 @@ unsafe impl ::windows::core::Interface for IWABObject {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWABObject_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetLastError: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hresult: ::windows::core::HRESULT, ulflags: u32, lppmapierror: *mut *mut MAPIERROR) -> ::windows::core::HRESULT,
     pub AllocateBuffer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cbsize: u32, lppbuffer: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub AllocateMore: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cbsize: u32, lpobject: *const ::core::ffi::c_void, lppbuffer: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/System/Antimalware/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Antimalware/impl.rs
@@ -16,7 +16,7 @@ impl IAmsiStream_Vtbl {
             this.Read(::core::mem::transmute_copy(&position), ::core::mem::transmute_copy(&size), ::core::mem::transmute_copy(&buffer), ::core::mem::transmute_copy(&readsize)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetAttribute: GetAttribute::<Identity, Impl, OFFSET>,
             Read: Read::<Identity, Impl, OFFSET>,
         }
@@ -43,7 +43,7 @@ impl IAntimalware_Vtbl {
             this.CloseSession(::core::mem::transmute_copy(&session))
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Scan: Scan::<Identity, Impl, OFFSET>,
             CloseSession: CloseSession::<Identity, Impl, OFFSET>,
         }
@@ -111,7 +111,7 @@ impl IAntimalwareProvider_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Scan: Scan::<Identity, Impl, OFFSET>,
             CloseSession: CloseSession::<Identity, Impl, OFFSET>,
             DisplayName: DisplayName::<Identity, Impl, OFFSET>,
@@ -177,7 +177,7 @@ impl IAntimalwareUacProvider_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             UacScan: UacScan::<Identity, Impl, OFFSET>,
             DisplayName: DisplayName::<Identity, Impl, OFFSET>,
         }

--- a/crates/libs/windows/src/Windows/Win32/System/Antimalware/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Antimalware/mod.rs
@@ -156,7 +156,7 @@ unsafe impl ::windows::core::Interface for IAmsiStream {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAmsiStream_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetAttribute: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, attribute: AMSI_ATTRIBUTE, datasize: u32, data: *mut u8, retdata: *mut u32) -> ::windows::core::HRESULT,
     pub Read: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, position: u64, size: u32, buffer: *mut u8, readsize: *mut u32) -> ::windows::core::HRESULT,
 }
@@ -212,7 +212,7 @@ unsafe impl ::windows::core::Interface for IAntimalware {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAntimalware_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Scan: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, stream: *mut ::core::ffi::c_void, result: *mut AMSI_RESULT, provider: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CloseSession: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, session: u64),
 }
@@ -351,7 +351,7 @@ unsafe impl ::windows::core::Interface for IAntimalwareProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAntimalwareProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Scan: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, stream: *mut ::core::ffi::c_void, result: *mut AMSI_RESULT) -> ::windows::core::HRESULT,
     pub CloseSession: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, session: u64),
     pub DisplayName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, displayname: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
@@ -492,7 +492,7 @@ unsafe impl ::windows::core::Interface for IAntimalwareUacProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAntimalwareUacProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub UacScan: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, context: *const AMSI_UAC_REQUEST_CONTEXT, result: *mut AMSI_RESULT) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]

--- a/crates/libs/windows/src/Windows/Win32/System/ApplicationInstallationAndServicing/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/ApplicationInstallationAndServicing/impl.rs
@@ -40,7 +40,7 @@ impl IAssemblyCache_Vtbl {
             this.InstallAssembly(::core::mem::transmute_copy(&dwflags), ::core::mem::transmute(&pszmanifestfilepath), ::core::mem::transmute_copy(&prefdata)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             UninstallAssembly: UninstallAssembly::<Identity, Impl, OFFSET>,
             QueryAssemblyInfo: QueryAssemblyInfo::<Identity, Impl, OFFSET>,
             CreateAssemblyCacheItem: CreateAssemblyCacheItem::<Identity, Impl, OFFSET>,
@@ -79,7 +79,7 @@ impl IAssemblyCacheItem_Vtbl {
             this.AbortItem().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateStream: CreateStream::<Identity, Impl, OFFSET>,
             Commit: Commit::<Identity, Impl, OFFSET>,
             AbortItem: AbortItem::<Identity, Impl, OFFSET>,
@@ -155,7 +155,7 @@ impl IAssemblyName_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetProperty: SetProperty::<Identity, Impl, OFFSET>,
             GetProperty: GetProperty::<Identity, Impl, OFFSET>,
             Finalize: Finalize::<Identity, Impl, OFFSET>,
@@ -210,7 +210,7 @@ impl IEnumMsmDependency_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -260,7 +260,7 @@ impl IEnumMsmError_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -307,7 +307,7 @@ impl IEnumMsmString_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -1267,7 +1267,7 @@ impl IPMApplicationInfo_Vtbl {
             this.set_Title(::core::mem::transmute(&apptitle)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ProductID: ProductID::<Identity, Impl, OFFSET>,
             InstanceID: InstanceID::<Identity, Impl, OFFSET>,
             OfferID: OfferID::<Identity, Impl, OFFSET>,
@@ -1346,7 +1346,7 @@ impl IPMApplicationInfoEnumerator_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Next: Next::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Next: Next::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IPMApplicationInfoEnumerator as ::windows::core::Interface>::IID
@@ -1481,7 +1481,7 @@ impl IPMBackgroundServiceAgentInfo_Vtbl {
             this.set_IsScheduleAllowed(::core::mem::transmute_copy(&isscheduleallowed)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ProductID: ProductID::<Identity, Impl, OFFSET>,
             TaskID: TaskID::<Identity, Impl, OFFSET>,
             BSAID: BSAID::<Identity, Impl, OFFSET>,
@@ -1519,7 +1519,7 @@ impl IPMBackgroundServiceAgentInfoEnumerator_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Next: Next::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Next: Next::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IPMBackgroundServiceAgentInfoEnumerator as ::windows::core::Interface>::IID
@@ -1594,7 +1594,7 @@ impl IPMBackgroundWorkerInfo_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ProductID: ProductID::<Identity, Impl, OFFSET>,
             TaskID: TaskID::<Identity, Impl, OFFSET>,
             BGName: BGName::<Identity, Impl, OFFSET>,
@@ -1624,7 +1624,7 @@ impl IPMBackgroundWorkerInfoEnumerator_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Next: Next::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Next: Next::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IPMBackgroundWorkerInfoEnumerator as ::windows::core::Interface>::IID
@@ -1863,7 +1863,7 @@ impl IPMDeploymentManager_Vtbl {
             this.FixJunctionsForAppsOnSDCard().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ReportDownloadBegin: ReportDownloadBegin::<Identity, Impl, OFFSET>,
             ReportDownloadProgress: ReportDownloadProgress::<Identity, Impl, OFFSET>,
             ReportDownloadComplete: ReportDownloadComplete::<Identity, Impl, OFFSET>,
@@ -2076,7 +2076,7 @@ impl IPMEnumerationManager_Vtbl {
             this.get_StartAppEnumeratorBlob(::core::mem::transmute(&filter), ::core::mem::transmute_copy(&pcapps), ::core::mem::transmute_copy(&ppappblobs)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             get_AllApplications: get_AllApplications::<Identity, Impl, OFFSET>,
             get_AllTiles: get_AllTiles::<Identity, Impl, OFFSET>,
             get_AllTasks: get_AllTasks::<Identity, Impl, OFFSET>,
@@ -2121,7 +2121,7 @@ impl IPMExtensionCachedFileUpdaterInfo_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SupportsUpdates: SupportsUpdates::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SupportsUpdates: SupportsUpdates::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IPMExtensionCachedFileUpdaterInfo as ::windows::core::Interface>::IID
@@ -2138,7 +2138,7 @@ impl IPMExtensionContractInfo_Vtbl {
             let this = (*this).get_impl();
             this.get_InvocationInfo(::core::mem::transmute_copy(&paumid), ::core::mem::transmute_copy(&pargs)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), get_InvocationInfo: get_InvocationInfo::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), get_InvocationInfo: get_InvocationInfo::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IPMExtensionContractInfo as ::windows::core::Interface>::IID
@@ -2192,7 +2192,7 @@ impl IPMExtensionFileExtensionInfo_Vtbl {
             this.get_AllFileTypes(::core::mem::transmute_copy(&pcbtypes), ::core::mem::transmute_copy(&pptypes)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Name: Name::<Identity, Impl, OFFSET>,
             DisplayName: DisplayName::<Identity, Impl, OFFSET>,
             get_Logo: get_Logo::<Identity, Impl, OFFSET>,
@@ -2233,7 +2233,7 @@ impl IPMExtensionFileOpenPickerInfo_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             get_AllFileTypes: get_AllFileTypes::<Identity, Impl, OFFSET>,
             SupportsAllFileTypes: SupportsAllFileTypes::<Identity, Impl, OFFSET>,
         }
@@ -2269,7 +2269,7 @@ impl IPMExtensionFileSavePickerInfo_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             get_AllFileTypes: get_AllFileTypes::<Identity, Impl, OFFSET>,
             SupportsAllFileTypes: SupportsAllFileTypes::<Identity, Impl, OFFSET>,
         }
@@ -2326,7 +2326,7 @@ impl IPMExtensionInfo_Vtbl {
             this.get_InvocationInfo(::core::mem::transmute_copy(&pimageurn), ::core::mem::transmute_copy(&pparameters)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SupplierPID: SupplierPID::<Identity, Impl, OFFSET>,
             SupplierTaskID: SupplierTaskID::<Identity, Impl, OFFSET>,
             Title: Title::<Identity, Impl, OFFSET>,
@@ -2356,7 +2356,7 @@ impl IPMExtensionInfoEnumerator_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Next: Next::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Next: Next::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IPMExtensionInfoEnumerator as ::windows::core::Interface>::IID
@@ -2380,7 +2380,7 @@ impl IPMExtensionProtocolInfo_Vtbl {
             this.get_InvocationInfo(::core::mem::transmute_copy(&pimageurn), ::core::mem::transmute_copy(&pparameters)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Protocol: Protocol::<Identity, Impl, OFFSET>,
             get_InvocationInfo: get_InvocationInfo::<Identity, Impl, OFFSET>,
         }
@@ -2422,7 +2422,7 @@ impl IPMExtensionShareTargetInfo_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             get_AllFileTypes: get_AllFileTypes::<Identity, Impl, OFFSET>,
             get_AllDataFormats: get_AllDataFormats::<Identity, Impl, OFFSET>,
             SupportsAllFileTypes: SupportsAllFileTypes::<Identity, Impl, OFFSET>,
@@ -2645,7 +2645,7 @@ impl IPMLiveTileJobInfo_Vtbl {
             this.set_DownloadState(::core::mem::transmute_copy(&uldownloadstate)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ProductID: ProductID::<Identity, Impl, OFFSET>,
             TileID: TileID::<Identity, Impl, OFFSET>,
             NextSchedule: NextSchedule::<Identity, Impl, OFFSET>,
@@ -2693,7 +2693,7 @@ impl IPMLiveTileJobInfoEnumerator_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Next: Next::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Next: Next::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IPMLiveTileJobInfoEnumerator as ::windows::core::Interface>::IID
@@ -2906,7 +2906,7 @@ impl IPMTaskInfo_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ProductID: ProductID::<Identity, Impl, OFFSET>,
             TaskID: TaskID::<Identity, Impl, OFFSET>,
             NavigationPage: NavigationPage::<Identity, Impl, OFFSET>,
@@ -2951,7 +2951,7 @@ impl IPMTaskInfoEnumerator_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Next: Next::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Next: Next::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IPMTaskInfoEnumerator as ::windows::core::Interface>::IID
@@ -3188,7 +3188,7 @@ impl IPMTileInfo_Vtbl {
             this.set_IsAutoRestoreDisabled(::core::mem::transmute_copy(&autorestoredisabled)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ProductID: ProductID::<Identity, Impl, OFFSET>,
             TileID: TileID::<Identity, Impl, OFFSET>,
             TemplateType: TemplateType::<Identity, Impl, OFFSET>,
@@ -3236,7 +3236,7 @@ impl IPMTileInfoEnumerator_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Next: Next::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Next: Next::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IPMTileInfoEnumerator as ::windows::core::Interface>::IID
@@ -3259,7 +3259,7 @@ impl IPMTilePropertyEnumerator_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Next: Next::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Next: Next::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IPMTilePropertyEnumerator as ::windows::core::Interface>::IID
@@ -3295,7 +3295,7 @@ impl IPMTilePropertyInfo_Vtbl {
             this.set_Property(::core::mem::transmute(&propvalue)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             PropertyID: PropertyID::<Identity, Impl, OFFSET>,
             PropertyValue: PropertyValue::<Identity, Impl, OFFSET>,
             set_Property: set_Property::<Identity, Impl, OFFSET>,
@@ -3356,7 +3356,7 @@ impl IValidate_Vtbl {
             this.Validate(::core::mem::transmute(&wzices)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OpenDatabase: OpenDatabase::<Identity, Impl, OFFSET>,
             OpenCUB: OpenCUB::<Identity, Impl, OFFSET>,
             CloseDatabase: CloseDatabase::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/System/ApplicationInstallationAndServicing/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/ApplicationInstallationAndServicing/mod.rs
@@ -4268,7 +4268,7 @@ unsafe impl ::windows::core::Interface for IAssemblyCache {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAssemblyCache_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub UninstallAssembly: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwflags: u32, pszassemblyname: ::windows::core::PCWSTR, prefdata: *mut FUSION_INSTALL_REFERENCE, puldisposition: *mut IASSEMBLYCACHE_UNINSTALL_DISPOSITION) -> ::windows::core::HRESULT,
     pub QueryAssemblyInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwflags: QUERYASMINFO_FLAGS, pszassemblyname: ::windows::core::PCWSTR, pasminfo: *mut ASSEMBLY_INFO) -> ::windows::core::HRESULT,
     pub CreateAssemblyCacheItem: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwflags: u32, pvreserved: *mut ::core::ffi::c_void, ppasmitem: *mut *mut ::core::ffi::c_void, pszassemblyname: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
@@ -4332,7 +4332,7 @@ unsafe impl ::windows::core::Interface for IAssemblyCacheItem {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAssemblyCacheItem_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub CreateStream: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwflags: u32, pszstreamname: ::windows::core::PCWSTR, dwformat: u32, dwformatflags: u32, ppistream: *mut *mut ::core::ffi::c_void, pulimaxsize: *mut u64) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -4419,7 +4419,7 @@ unsafe impl ::windows::core::Interface for IAssemblyName {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAssemblyName_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetProperty: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, propertyid: u32, pvproperty: *mut ::core::ffi::c_void, cbproperty: u32) -> ::windows::core::HRESULT,
     pub GetProperty: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, propertyid: u32, pvproperty: *mut ::core::ffi::c_void, pcbproperty: *mut u32) -> ::windows::core::HRESULT,
     pub Finalize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -4488,7 +4488,7 @@ unsafe impl ::windows::core::Interface for IEnumMsmDependency {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumMsmDependency_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cfetch: u32, rgmsmdependencies: *mut *mut ::core::ffi::c_void, pcfetched: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -4555,7 +4555,7 @@ unsafe impl ::windows::core::Interface for IEnumMsmError {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumMsmError_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cfetch: u32, rgmsmerrors: *mut *mut ::core::ffi::c_void, pcfetched: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -4620,7 +4620,7 @@ unsafe impl ::windows::core::Interface for IEnumMsmString {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumMsmString_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cfetch: u32, rgbstrstrings: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>, pcfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cskip: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -5640,7 +5640,7 @@ unsafe impl ::windows::core::Interface for IPMApplicationInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPMApplicationInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ProductID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pproductid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub InstanceID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinstanceid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub OfferID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pofferid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
@@ -5831,7 +5831,7 @@ unsafe impl ::windows::core::Interface for IPMApplicationInfoEnumerator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPMApplicationInfoEnumerator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppappinfo: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_ApplicationInstallationAndServicing\"`*"]
@@ -5943,7 +5943,7 @@ unsafe impl ::windows::core::Interface for IPMBackgroundServiceAgentInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPMBackgroundServiceAgentInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ProductID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pproductid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub TaskID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptaskid: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub BSAID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbsaid: *mut u32) -> ::windows::core::HRESULT,
@@ -6024,7 +6024,7 @@ unsafe impl ::windows::core::Interface for IPMBackgroundServiceAgentInfoEnumerat
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPMBackgroundServiceAgentInfoEnumerator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppbsainfo: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_ApplicationInstallationAndServicing\"`*"]
@@ -6094,7 +6094,7 @@ unsafe impl ::windows::core::Interface for IPMBackgroundWorkerInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPMBackgroundWorkerInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ProductID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pproductid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub TaskID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptaskid: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub BGName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbgname: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
@@ -6152,7 +6152,7 @@ unsafe impl ::windows::core::Interface for IPMBackgroundWorkerInfoEnumerator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPMBackgroundWorkerInfoEnumerator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppbwinfo: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_ApplicationInstallationAndServicing\"`*"]
@@ -6351,7 +6351,7 @@ unsafe impl ::windows::core::Interface for IPMDeploymentManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPMDeploymentManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ReportDownloadBegin: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, productid: ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub ReportDownloadProgress: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, productid: ::windows::core::GUID, usprogress: u16) -> ::windows::core::HRESULT,
     pub ReportDownloadComplete: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, productid: ::windows::core::GUID, hrresult: ::windows::core::HRESULT) -> ::windows::core::HRESULT,
@@ -6543,7 +6543,7 @@ unsafe impl ::windows::core::Interface for IPMEnumerationManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPMEnumerationManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub get_AllApplications: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppappenum: *mut *mut ::core::ffi::c_void, filter: ::core::mem::ManuallyDrop<PM_ENUM_FILTER>) -> ::windows::core::HRESULT,
     pub get_AllTiles: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pptileenum: *mut *mut ::core::ffi::c_void, filter: ::core::mem::ManuallyDrop<PM_ENUM_FILTER>) -> ::windows::core::HRESULT,
     pub get_AllTasks: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pptaskenum: *mut *mut ::core::ffi::c_void, filter: ::core::mem::ManuallyDrop<PM_ENUM_FILTER>) -> ::windows::core::HRESULT,
@@ -6618,7 +6618,7 @@ unsafe impl ::windows::core::Interface for IPMExtensionCachedFileUpdaterInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPMExtensionCachedFileUpdaterInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub SupportsUpdates: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psupportsupdates: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -6670,7 +6670,7 @@ unsafe impl ::windows::core::Interface for IPMExtensionContractInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPMExtensionContractInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub get_InvocationInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, paumid: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>, pargs: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_ApplicationInstallationAndServicing\"`*"]
@@ -6737,7 +6737,7 @@ unsafe impl ::windows::core::Interface for IPMExtensionFileExtensionInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPMExtensionFileExtensionInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Name: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pname: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub DisplayName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdisplayname: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub get_Logo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, logosize: PM_LOGO_SIZE, plogo: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
@@ -6798,7 +6798,7 @@ unsafe impl ::windows::core::Interface for IPMExtensionFileOpenPickerInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPMExtensionFileOpenPickerInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub get_AllFileTypes: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pctypes: *mut u32, pptypes: *mut *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub SupportsAllFileTypes: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psupportsalltypes: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -6857,7 +6857,7 @@ unsafe impl ::windows::core::Interface for IPMExtensionFileSavePickerInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPMExtensionFileSavePickerInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub get_AllFileTypes: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pctypes: *mut u32, pptypes: *mut *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub SupportsAllFileTypes: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psupportsalltypes: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -6926,7 +6926,7 @@ unsafe impl ::windows::core::Interface for IPMExtensionInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPMExtensionInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SupplierPID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psupplierpid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub SupplierTaskID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psuppliertid: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub Title: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptitle: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
@@ -6981,7 +6981,7 @@ unsafe impl ::windows::core::Interface for IPMExtensionInfoEnumerator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPMExtensionInfoEnumerator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppextensioninfo: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_ApplicationInstallationAndServicing\"`*"]
@@ -7033,7 +7033,7 @@ unsafe impl ::windows::core::Interface for IPMExtensionProtocolInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPMExtensionProtocolInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Protocol: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pprotocol: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub get_InvocationInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pimageurn: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>, pparameters: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
 }
@@ -7092,7 +7092,7 @@ unsafe impl ::windows::core::Interface for IPMExtensionShareTargetInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPMExtensionShareTargetInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub get_AllFileTypes: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pctypes: *mut u32, pptypes: *mut *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub get_AllDataFormats: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcdataformats: *mut u32, ppdataformats: *mut *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -7240,7 +7240,7 @@ unsafe impl ::windows::core::Interface for IPMLiveTileJobInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPMLiveTileJobInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ProductID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pproductid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub TileID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptileid: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -7331,7 +7331,7 @@ unsafe impl ::windows::core::Interface for IPMLiveTileJobInfoEnumerator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPMLiveTileJobInfoEnumerator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pplivetilejobinfo: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_ApplicationInstallationAndServicing\"`*"]
@@ -7460,7 +7460,7 @@ unsafe impl ::windows::core::Interface for IPMTaskInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPMTaskInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ProductID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pproductid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub TaskID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptaskid: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub NavigationPage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pnavigationpage: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
@@ -7542,7 +7542,7 @@ unsafe impl ::windows::core::Interface for IPMTaskInfoEnumerator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPMTaskInfoEnumerator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pptaskinfo: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_ApplicationInstallationAndServicing\"`*"]
@@ -7707,7 +7707,7 @@ unsafe impl ::windows::core::Interface for IPMTileInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPMTileInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ProductID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pproductid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub TileID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptileid: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub TemplateType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptemplatetype: *mut TILE_TEMPLATE_TYPE) -> ::windows::core::HRESULT,
@@ -7813,7 +7813,7 @@ unsafe impl ::windows::core::Interface for IPMTileInfoEnumerator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPMTileInfoEnumerator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pptileinfo: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_ApplicationInstallationAndServicing\"`*"]
@@ -7863,7 +7863,7 @@ unsafe impl ::windows::core::Interface for IPMTilePropertyEnumerator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPMTilePropertyEnumerator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pppropinfo: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_ApplicationInstallationAndServicing\"`*"]
@@ -7919,7 +7919,7 @@ unsafe impl ::windows::core::Interface for IPMTilePropertyInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPMTilePropertyInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub PropertyID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppropid: *mut u32) -> ::windows::core::HRESULT,
     pub PropertyValue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppropvalue: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub set_Property: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, propvalue: ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
@@ -8001,7 +8001,7 @@ unsafe impl ::windows::core::Interface for IValidate {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IValidate_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OpenDatabase: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, szdatabase: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub OpenCUB: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, szcubfile: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub CloseDatabase: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/System/AssessmentTool/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/AssessmentTool/impl.rs
@@ -48,7 +48,7 @@ impl IInitiateWinSATAssessment_Vtbl {
             this.CancelAssessment().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             InitiateAssessment: InitiateAssessment::<Identity, Impl, OFFSET>,
             InitiateFormalAssessment: InitiateFormalAssessment::<Identity, Impl, OFFSET>,
             CancelAssessment: CancelAssessment::<Identity, Impl, OFFSET>,
@@ -214,7 +214,7 @@ impl IProvideWinSATVisuals_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), get_Bitmap: get_Bitmap::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), get_Bitmap: get_Bitmap::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IProvideWinSATVisuals as ::windows::core::Interface>::IID
@@ -263,7 +263,7 @@ impl IQueryOEMWinSATCustomization_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetOEMPrePopulationInfo: GetOEMPrePopulationInfo::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetOEMPrePopulationInfo: GetOEMPrePopulationInfo::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IQueryOEMWinSATCustomization as ::windows::core::Interface>::IID
@@ -329,7 +329,7 @@ impl IWinSATInitiateEvents_Vtbl {
             this.WinSATUpdate(::core::mem::transmute_copy(&ucurrenttick), ::core::mem::transmute_copy(&uticktotal), ::core::mem::transmute(&strcurrentstate)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             WinSATComplete: WinSATComplete::<Identity, Impl, OFFSET>,
             WinSATUpdate: WinSATUpdate::<Identity, Impl, OFFSET>,
         }

--- a/crates/libs/windows/src/Windows/Win32/System/AssessmentTool/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/AssessmentTool/mod.rs
@@ -332,7 +332,7 @@ unsafe impl ::windows::core::Interface for IInitiateWinSATAssessment {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IInitiateWinSATAssessment_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub InitiateAssessment: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cmdline: ::windows::core::PCWSTR, pcallbacks: *mut ::core::ffi::c_void, callerhwnd: super::super::Foundation::HWND) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -590,7 +590,7 @@ unsafe impl ::windows::core::Interface for IProvideWinSATVisuals {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IProvideWinSATVisuals_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Graphics_Gdi")]
     pub get_Bitmap: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bitmapsize: WINSAT_BITMAP_SIZE, state: WINSAT_ASSESSMENT_STATE, rating: f32, pbitmap: *mut super::super::Graphics::Gdi::HBITMAP) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Graphics_Gdi"))]
@@ -727,7 +727,7 @@ unsafe impl ::windows::core::Interface for IQueryOEMWinSATCustomization {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IQueryOEMWinSATCustomization_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetOEMPrePopulationInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, state: *mut WINSAT_OEM_CUSTOMIZATION_STATE) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_AssessmentTool\"`, `\"Win32_System_Com\"`*"]
@@ -879,7 +879,7 @@ unsafe impl ::windows::core::Interface for IWinSATInitiateEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWinSATInitiateEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub WinSATComplete: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hresult: ::windows::core::HRESULT, strdescription: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub WinSATUpdate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ucurrenttick: u32, uticktotal: u32, strcurrentstate: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
 }

--- a/crates/libs/windows/src/Windows/Win32/System/Com/CallObj/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/CallObj/impl.rs
@@ -157,7 +157,7 @@ impl ICallFrame_Vtbl {
             this.Invoke(::core::mem::transmute_copy(&pvreceiver)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetInfo: GetInfo::<Identity, Impl, OFFSET>,
             GetIIDAndMethod: GetIIDAndMethod::<Identity, Impl, OFFSET>,
             GetNames: GetNames::<Identity, Impl, OFFSET>,
@@ -194,7 +194,7 @@ impl ICallFrameEvents_Vtbl {
             let this = (*this).get_impl();
             this.OnCall(::core::mem::transmute(&pframe)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnCall: OnCall::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnCall: OnCall::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ICallFrameEvents as ::windows::core::Interface>::IID
@@ -214,7 +214,7 @@ impl ICallFrameWalker_Vtbl {
             let this = (*this).get_impl();
             this.OnWalkInterface(::core::mem::transmute_copy(&iid), ::core::mem::transmute_copy(&ppvinterface), ::core::mem::transmute_copy(&fin), ::core::mem::transmute_copy(&fout)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnWalkInterface: OnWalkInterface::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnWalkInterface: OnWalkInterface::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ICallFrameWalker as ::windows::core::Interface>::IID
@@ -259,7 +259,7 @@ impl ICallIndirect_Vtbl {
             this.GetIID(::core::mem::transmute_copy(&piid), ::core::mem::transmute_copy(&pfderivesfromidispatch), ::core::mem::transmute_copy(&pcmethod), ::core::mem::transmute_copy(&pwszinterface)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CallIndirect: CallIndirect::<Identity, Impl, OFFSET>,
             GetMethodInfo: GetMethodInfo::<Identity, Impl, OFFSET>,
             GetStackSize: GetStackSize::<Identity, Impl, OFFSET>,
@@ -327,7 +327,7 @@ impl ICallUnmarshal_Vtbl {
             this.ReleaseMarshalData(::core::mem::transmute_copy(&imethod), ::core::mem::transmute_copy(&pbuffer), ::core::mem::transmute_copy(&cbbuffer), ::core::mem::transmute_copy(&ibfirstrelease), ::core::mem::transmute_copy(&datarep), ::core::mem::transmute_copy(&pcontext)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Unmarshal: Unmarshal::<Identity, Impl, OFFSET>,
             ReleaseMarshalData: ReleaseMarshalData::<Identity, Impl, OFFSET>,
         }
@@ -360,7 +360,7 @@ impl IInterfaceRelated_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetIID: SetIID::<Identity, Impl, OFFSET>,
             GetIID: GetIID::<Identity, Impl, OFFSET>,
         }

--- a/crates/libs/windows/src/Windows/Win32/System/Com/CallObj/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/CallObj/mod.rs
@@ -160,7 +160,7 @@ unsafe impl ::windows::core::Interface for ICallFrame {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICallFrame_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *mut CALLFRAMEINFO) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -254,7 +254,7 @@ unsafe impl ::windows::core::Interface for ICallFrameEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICallFrameEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnCall: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pframe: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Com_CallObj\"`*"]
@@ -309,7 +309,7 @@ unsafe impl ::windows::core::Interface for ICallFrameWalker {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICallFrameWalker_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub OnWalkInterface: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, iid: *const ::windows::core::GUID, ppvinterface: *const *const ::core::ffi::c_void, fin: super::super::super::Foundation::BOOL, fout: super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -375,7 +375,7 @@ unsafe impl ::windows::core::Interface for ICallIndirect {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICallIndirect_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CallIndirect: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, phrreturn: *mut ::windows::core::HRESULT, imethod: u32, pvargs: *const ::core::ffi::c_void, cbargs: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub GetMethodInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, imethod: u32, pinfo: *mut CALLFRAMEINFO, pwszmethod: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
@@ -532,7 +532,7 @@ unsafe impl ::windows::core::Interface for ICallUnmarshal {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICallUnmarshal_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Unmarshal: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, imethod: u32, pbuffer: *const ::core::ffi::c_void, cbbuffer: u32, fforcebuffercopy: super::super::super::Foundation::BOOL, datarep: u32, pcontext: *const CALLFRAME_MARSHALCONTEXT, pcbunmarshalled: *mut u32, ppframe: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -592,7 +592,7 @@ unsafe impl ::windows::core::Interface for IInterfaceRelated {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IInterfaceRelated_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetIID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, iid: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub GetIID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, piid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
 }

--- a/crates/libs/windows/src/Windows/Win32/System/Com/Events/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/Events/impl.rs
@@ -2,7 +2,7 @@ pub trait IDontSupportEventSubscription_Impl: Sized {}
 impl ::windows::core::RuntimeName for IDontSupportEventSubscription {}
 impl IDontSupportEventSubscription_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IDontSupportEventSubscription_Impl, const OFFSET: isize>() -> IDontSupportEventSubscription_Vtbl {
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>() }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>() }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDontSupportEventSubscription as ::windows::core::Interface>::IID
@@ -44,7 +44,7 @@ impl IEnumEventObject_Vtbl {
             this.Skip(::core::mem::transmute_copy(&cskipelem)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Clone: Clone::<Identity, Impl, OFFSET>,
             Next: Next::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -400,7 +400,7 @@ impl IEventObjectChange_Vtbl {
             this.ChangedPublisher(::core::mem::transmute_copy(&changetype), ::core::mem::transmute(&bstrpublisherid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ChangedSubscription: ChangedSubscription::<Identity, Impl, OFFSET>,
             ChangedEventClass: ChangedEventClass::<Identity, Impl, OFFSET>,
             ChangedPublisher: ChangedPublisher::<Identity, Impl, OFFSET>,
@@ -428,7 +428,7 @@ impl IEventObjectChange2_Vtbl {
             this.ChangedEventClass(::core::mem::transmute_copy(&pinfo)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ChangedSubscription: ChangedSubscription::<Identity, Impl, OFFSET>,
             ChangedEventClass: ChangedEventClass::<Identity, Impl, OFFSET>,
         }
@@ -1258,7 +1258,7 @@ impl IMultiInterfaceEventControl_Vtbl {
             this.SetFireInParallel(::core::mem::transmute_copy(&ffireinparallel)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetMultiInterfacePublisherFilter: SetMultiInterfacePublisherFilter::<Identity, Impl, OFFSET>,
             GetSubscriptions: GetSubscriptions::<Identity, Impl, OFFSET>,
             SetDefaultQuery: SetDefaultQuery::<Identity, Impl, OFFSET>,
@@ -1290,7 +1290,7 @@ impl IMultiInterfacePublisherFilter_Vtbl {
             this.PrepareToFire(::core::mem::transmute_copy(&iid), ::core::mem::transmute(&methodname), ::core::mem::transmute(&firingcontrol)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             PrepareToFire: PrepareToFire::<Identity, Impl, OFFSET>,
         }
@@ -1317,7 +1317,7 @@ impl IPublisherFilter_Vtbl {
             this.PrepareToFire(::core::mem::transmute(&methodname), ::core::mem::transmute(&firingcontrol)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             PrepareToFire: PrepareToFire::<Identity, Impl, OFFSET>,
         }

--- a/crates/libs/windows/src/Windows/Win32/System/Com/Events/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/Events/mod.rs
@@ -40,7 +40,7 @@ unsafe impl ::windows::core::Interface for IDontSupportEventSubscription {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDontSupportEventSubscription_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
 }
 #[doc = "*Required features: `\"Win32_System_Com_Events\"`*"]
 #[repr(transparent)]
@@ -98,7 +98,7 @@ unsafe impl ::windows::core::Interface for IEnumEventObject {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumEventObject_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Clone: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppinterface: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, creqelem: u32, ppinterface: *mut *mut ::core::ffi::c_void, cretelem: *mut u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -564,7 +564,7 @@ unsafe impl ::windows::core::Interface for IEventObjectChange {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEventObjectChange_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ChangedSubscription: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, changetype: EOC_ChangeType, bstrsubscriptionid: ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub ChangedEventClass: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, changetype: EOC_ChangeType, bstreventclassid: ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub ChangedPublisher: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, changetype: EOC_ChangeType, bstrpublisherid: ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
@@ -618,7 +618,7 @@ unsafe impl ::windows::core::Interface for IEventObjectChange2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEventObjectChange2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ChangedSubscription: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *const COMEVENTSYSCHANGEINFO) -> ::windows::core::HRESULT,
     pub ChangedEventClass: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *const COMEVENTSYSCHANGEINFO) -> ::windows::core::HRESULT,
 }
@@ -1445,7 +1445,7 @@ unsafe impl ::windows::core::Interface for IMultiInterfaceEventControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMultiInterfaceEventControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetMultiInterfacePublisherFilter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, classfilter: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetSubscriptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, eventiid: *const ::windows::core::GUID, bstrmethodname: ::core::mem::ManuallyDrop<::windows::core::BSTR>, optionalcriteria: ::core::mem::ManuallyDrop<::windows::core::BSTR>, optionalerrorindex: *const i32, ppcollection: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetDefaultQuery: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, eventiid: *const ::windows::core::GUID, bstrmethodname: ::core::mem::ManuallyDrop<::windows::core::BSTR>, bstrcriteria: ::core::mem::ManuallyDrop<::windows::core::BSTR>, errorindex: *mut i32) -> ::windows::core::HRESULT,
@@ -1521,7 +1521,7 @@ unsafe impl ::windows::core::Interface for IMultiInterfacePublisherFilter {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMultiInterfacePublisherFilter_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, peic: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub PrepareToFire: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, iid: *const ::windows::core::GUID, methodname: ::core::mem::ManuallyDrop<::windows::core::BSTR>, firingcontrol: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -1580,7 +1580,7 @@ unsafe impl ::windows::core::Interface for IPublisherFilter {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPublisherFilter_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, methodname: ::core::mem::ManuallyDrop<::windows::core::BSTR>, dispuserdefined: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub PrepareToFire: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, methodname: ::core::mem::ManuallyDrop<::windows::core::BSTR>, firingcontrol: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }

--- a/crates/libs/windows/src/Windows/Win32/System/Com/Marshal/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/Marshal/impl.rs
@@ -40,7 +40,7 @@ impl IMarshal_Vtbl {
             this.DisconnectObject(::core::mem::transmute_copy(&dwreserved)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetUnmarshalClass: GetUnmarshalClass::<Identity, Impl, OFFSET>,
             GetMarshalSizeMax: GetMarshalSizeMax::<Identity, Impl, OFFSET>,
             MarshalInterface: MarshalInterface::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/System/Com/Marshal/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/Marshal/mod.rs
@@ -1263,7 +1263,7 @@ unsafe impl ::windows::core::Interface for IMarshal {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMarshal_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetUnmarshalClass: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, pv: *const ::core::ffi::c_void, dwdestcontext: u32, pvdestcontext: *mut ::core::ffi::c_void, mshlflags: u32, pcid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub GetMarshalSizeMax: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, pv: *const ::core::ffi::c_void, dwdestcontext: u32, pvdestcontext: *mut ::core::ffi::c_void, mshlflags: u32, psize: *mut u32) -> ::windows::core::HRESULT,
     pub MarshalInterface: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pstm: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, pv: *const ::core::ffi::c_void, dwdestcontext: u32, pvdestcontext: *mut ::core::ffi::c_void, mshlflags: u32) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/System/Com/StructuredStorage/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/StructuredStorage/impl.rs
@@ -22,7 +22,7 @@ impl IDirectWriterLock_Vtbl {
             this.HaveWriteAccess().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             WaitForWriteAccess: WaitForWriteAccess::<Identity, Impl, OFFSET>,
             ReleaseWriteAccess: ReleaseWriteAccess::<Identity, Impl, OFFSET>,
             HaveWriteAccess: HaveWriteAccess::<Identity, Impl, OFFSET>,
@@ -71,7 +71,7 @@ impl IEnumSTATPROPSETSTG_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -118,7 +118,7 @@ impl IEnumSTATPROPSTG_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -168,7 +168,7 @@ impl IEnumSTATSTG_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -224,7 +224,7 @@ impl IFillLockBytes_Vtbl {
             this.Terminate(::core::mem::transmute_copy(&bcanceled)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             FillAppend: FillAppend::<Identity, Impl, OFFSET>,
             FillAt: FillAt::<Identity, Impl, OFFSET>,
             SetFillSize: SetFillSize::<Identity, Impl, OFFSET>,
@@ -271,7 +271,7 @@ impl ILayoutStorage_Vtbl {
             this.ReLayoutDocfileOnILockBytes(::core::mem::transmute(&pilockbytes)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             LayoutScript: LayoutScript::<Identity, Impl, OFFSET>,
             BeginMonitor: BeginMonitor::<Identity, Impl, OFFSET>,
             EndMonitor: EndMonitor::<Identity, Impl, OFFSET>,
@@ -340,7 +340,7 @@ impl ILockBytes_Vtbl {
             this.Stat(::core::mem::transmute_copy(&pstatstg), ::core::mem::transmute_copy(&grfstatflag)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ReadAt: ReadAt::<Identity, Impl, OFFSET>,
             WriteAt: WriteAt::<Identity, Impl, OFFSET>,
             Flush: Flush::<Identity, Impl, OFFSET>,
@@ -432,7 +432,7 @@ impl IPropertyBag_Vtbl {
             let this = (*this).get_impl();
             this.Write(::core::mem::transmute(&pszpropname), ::core::mem::transmute_copy(&pvar)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Read: Read::<Identity, Impl, OFFSET>, Write: Write::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Read: Read::<Identity, Impl, OFFSET>, Write: Write::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IPropertyBag as ::windows::core::Interface>::IID
@@ -483,7 +483,7 @@ impl IPropertyBag2_Vtbl {
             this.LoadObject(::core::mem::transmute(&pstrname), ::core::mem::transmute_copy(&dwhint), ::core::mem::transmute(&punkobject), ::core::mem::transmute(&perrlog)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Read: Read::<Identity, Impl, OFFSET>,
             Write: Write::<Identity, Impl, OFFSET>,
             CountProperties: CountProperties::<Identity, Impl, OFFSET>,
@@ -543,7 +543,7 @@ impl IPropertySetStorage_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Create: Create::<Identity, Impl, OFFSET>,
             Open: Open::<Identity, Impl, OFFSET>,
             Delete: Delete::<Identity, Impl, OFFSET>,
@@ -659,7 +659,7 @@ impl IPropertyStorage_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ReadMultiple: ReadMultiple::<Identity, Impl, OFFSET>,
             WriteMultiple: WriteMultiple::<Identity, Impl, OFFSET>,
             DeleteMultiple: DeleteMultiple::<Identity, Impl, OFFSET>,
@@ -689,7 +689,7 @@ impl IRootStorage_Vtbl {
             let this = (*this).get_impl();
             this.SwitchToFile(::core::mem::transmute(&pszfile)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SwitchToFile: SwitchToFile::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SwitchToFile: SwitchToFile::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IRootStorage as ::windows::core::Interface>::IID
@@ -812,7 +812,7 @@ impl IStorage_Vtbl {
             this.Stat(::core::mem::transmute_copy(&pstatstg), ::core::mem::transmute_copy(&grfstatflag)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateStream: CreateStream::<Identity, Impl, OFFSET>,
             OpenStream: OpenStream::<Identity, Impl, OFFSET>,
             CreateStorage: CreateStorage::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/System/Com/StructuredStorage/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/StructuredStorage/mod.rs
@@ -612,7 +612,7 @@ unsafe impl ::windows::core::Interface for IDirectWriterLock {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirectWriterLock_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub WaitForWriteAccess: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwtimeout: u32) -> ::windows::core::HRESULT,
     pub ReleaseWriteAccess: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub HaveWriteAccess: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -675,7 +675,7 @@ unsafe impl ::windows::core::Interface for IEnumSTATPROPSETSTG {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumSTATPROPSETSTG_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut STATPROPSETSTG, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -740,7 +740,7 @@ unsafe impl ::windows::core::Interface for IEnumSTATPROPSTG {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumSTATPROPSTG_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut STATPROPSTG, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -804,7 +804,7 @@ unsafe impl ::windows::core::Interface for IEnumSTATSTG {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumSTATSTG_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut super::STATSTG, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -875,7 +875,7 @@ unsafe impl ::windows::core::Interface for IFillLockBytes {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IFillLockBytes_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub FillAppend: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pv: *const ::core::ffi::c_void, cb: u32, pcbwritten: *mut u32) -> ::windows::core::HRESULT,
     pub FillAt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, uloffset: u64, pv: *const ::core::ffi::c_void, cb: u32, pcbwritten: *mut u32) -> ::windows::core::HRESULT,
     pub SetFillSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ulsize: u64) -> ::windows::core::HRESULT,
@@ -948,7 +948,7 @@ unsafe impl ::windows::core::Interface for ILayoutStorage {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ILayoutStorage_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub LayoutScript: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pstoragelayout: *const super::StorageLayout, nentries: u32, glfinterleavedflag: u32) -> ::windows::core::HRESULT,
     pub BeginMonitor: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub EndMonitor: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1022,7 +1022,7 @@ unsafe impl ::windows::core::Interface for ILockBytes {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ILockBytes_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ReadAt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, uloffset: u64, pv: *mut ::core::ffi::c_void, cb: u32, pcbread: *mut u32) -> ::windows::core::HRESULT,
     pub WriteAt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, uloffset: u64, pv: *const ::core::ffi::c_void, cb: u32, pcbwritten: *mut u32) -> ::windows::core::HRESULT,
     pub Flush: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1200,7 +1200,7 @@ unsafe impl ::windows::core::Interface for IPropertyBag {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPropertyBag_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
     pub Read: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszpropname: ::windows::core::PCWSTR, pvar: *mut super::VARIANT, perrorlog: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Ole")))]
@@ -1281,7 +1281,7 @@ unsafe impl ::windows::core::Interface for IPropertyBag2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPropertyBag2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
     pub Read: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cproperties: u32, ppropbag: *const PROPBAG2, perrlog: *mut ::core::ffi::c_void, pvarvalue: *mut super::VARIANT, phrerror: *mut ::windows::core::HRESULT) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Ole")))]
@@ -1352,7 +1352,7 @@ unsafe impl ::windows::core::Interface for IPropertySetStorage {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPropertySetStorage_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Create: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, rfmtid: *const ::windows::core::GUID, pclsid: *const ::windows::core::GUID, grfflags: u32, grfmode: u32, ppprstg: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Open: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, rfmtid: *const ::windows::core::GUID, grfmode: u32, ppprstg: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Delete: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, rfmtid: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
@@ -1449,7 +1449,7 @@ unsafe impl ::windows::core::Interface for IPropertyStorage {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPropertyStorage_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub ReadMultiple: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cpspec: u32, rgpspec: *const PROPSPEC, rgpropvar: *mut PROPVARIANT) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -1524,7 +1524,7 @@ unsafe impl ::windows::core::Interface for IRootStorage {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRootStorage_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SwitchToFile: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszfile: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Com_StructuredStorage\"`*"]
@@ -1653,7 +1653,7 @@ unsafe impl ::windows::core::Interface for IStorage {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IStorage_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateStream: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwcsname: ::windows::core::PCWSTR, grfmode: super::STGM, reserved1: u32, reserved2: u32, ppstm: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub OpenStream: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwcsname: ::windows::core::PCWSTR, reserved1: *mut ::core::ffi::c_void, grfmode: super::STGM, reserved2: u32, ppstm: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CreateStorage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwcsname: ::windows::core::PCWSTR, grfmode: super::STGM, reserved1: u32, reserved2: u32, ppstg: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/System/Com/UI/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/UI/impl.rs
@@ -12,7 +12,7 @@ impl IDummyHICONIncluder_Vtbl {
             let this = (*this).get_impl();
             this.Dummy(::core::mem::transmute_copy(&h1), ::core::mem::transmute_copy(&h2)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Dummy: Dummy::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Dummy: Dummy::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDummyHICONIncluder as ::windows::core::Interface>::IID
@@ -39,7 +39,7 @@ impl IThumbnailExtractor_Vtbl {
             this.OnFileUpdated(::core::mem::transmute(&pstg)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ExtractThumbnail: ExtractThumbnail::<Identity, Impl, OFFSET>,
             OnFileUpdated: OnFileUpdated::<Identity, Impl, OFFSET>,
         }

--- a/crates/libs/windows/src/Windows/Win32/System/Com/UI/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/UI/mod.rs
@@ -50,7 +50,7 @@ unsafe impl ::windows::core::Interface for IDummyHICONIncluder {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDummyHICONIncluder_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
     pub Dummy: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, h1: super::super::super::UI::WindowsAndMessaging::HICON, h2: super::super::super::Graphics::Gdi::HDC) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging")))]
@@ -115,7 +115,7 @@ unsafe impl ::windows::core::Interface for IThumbnailExtractor {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IThumbnailExtractor_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
     pub ExtractThumbnail: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pstg: *mut ::core::ffi::c_void, ullength: u32, ulheight: u32, puloutputlength: *mut u32, puloutputheight: *mut u32, phoutputbitmap: *mut super::super::super::Graphics::Gdi::HBITMAP) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage")))]

--- a/crates/libs/windows/src/Windows/Win32/System/Com/Urlmon/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/Urlmon/impl.rs
@@ -15,7 +15,7 @@ impl IBindCallbackRedirect_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Redirect: Redirect::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Redirect: Redirect::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IBindCallbackRedirect as ::windows::core::Interface>::IID
@@ -38,7 +38,7 @@ impl IBindHttpSecurity_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetIgnoreCertMask: GetIgnoreCertMask::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetIgnoreCertMask: GetIgnoreCertMask::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IBindHttpSecurity as ::windows::core::Interface>::IID
@@ -61,7 +61,7 @@ impl IBindProtocol_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CreateBinding: CreateBinding::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CreateBinding: CreateBinding::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IBindProtocol as ::windows::core::Interface>::IID
@@ -91,7 +91,7 @@ impl ICatalogFileInfo_Vtbl {
             this.GetJavaTrust(::core::mem::transmute_copy(&ppjavatrust)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCatalogFile: GetCatalogFile::<Identity, Impl, OFFSET>,
             GetJavaTrust: GetJavaTrust::<Identity, Impl, OFFSET>,
         }
@@ -144,7 +144,7 @@ impl IDataFilter_Vtbl {
             this.SetEncodingLevel(::core::mem::transmute_copy(&dwenclevel)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             DoEncode: DoEncode::<Identity, Impl, OFFSET>,
             DoDecode: DoDecode::<Identity, Impl, OFFSET>,
             SetEncodingLevel: SetEncodingLevel::<Identity, Impl, OFFSET>,
@@ -184,7 +184,7 @@ impl IEncodingFilterFactory_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             FindBestFilter: FindBestFilter::<Identity, Impl, OFFSET>,
             GetDefaultFilter: GetDefaultFilter::<Identity, Impl, OFFSET>,
         }
@@ -213,7 +213,7 @@ impl IGetBindHandle_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetBindHandle: GetBindHandle::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetBindHandle: GetBindHandle::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IGetBindHandle as ::windows::core::Interface>::IID
@@ -249,7 +249,7 @@ impl IHttpNegotiate_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             BeginningTransaction: BeginningTransaction::<Identity, Impl, OFFSET>,
             OnResponse: OnResponse::<Identity, Impl, OFFSET>,
         }
@@ -319,7 +319,7 @@ pub trait IInternet_Impl: Sized {}
 impl ::windows::core::RuntimeName for IInternet {}
 impl IInternet_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IInternet_Impl, const OFFSET: isize>() -> IInternet_Vtbl {
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>() }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>() }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IInternet as ::windows::core::Interface>::IID
@@ -346,7 +346,7 @@ impl IInternetBindInfo_Vtbl {
             this.GetBindString(::core::mem::transmute_copy(&ulstringtype), ::core::mem::transmute_copy(&ppwzstr), ::core::mem::transmute_copy(&cel), ::core::mem::transmute_copy(&pcelfetched)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetBindInfo: GetBindInfo::<Identity, Impl, OFFSET>,
             GetBindString: GetBindString::<Identity, Impl, OFFSET>,
         }
@@ -399,7 +399,7 @@ impl IInternetHostSecurityManager_Vtbl {
             this.QueryCustomPolicy(::core::mem::transmute_copy(&guidkey), ::core::mem::transmute_copy(&pppolicy), ::core::mem::transmute_copy(&pcbpolicy), ::core::mem::transmute_copy(&pcontext), ::core::mem::transmute_copy(&cbcontext), ::core::mem::transmute_copy(&dwreserved)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSecurityId: GetSecurityId::<Identity, Impl, OFFSET>,
             ProcessUrlAction: ProcessUrlAction::<Identity, Impl, OFFSET>,
             QueryCustomPolicy: QueryCustomPolicy::<Identity, Impl, OFFSET>,
@@ -433,7 +433,7 @@ impl IInternetPriority_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetPriority: SetPriority::<Identity, Impl, OFFSET>,
             GetPriority: GetPriority::<Identity, Impl, OFFSET>,
         }
@@ -542,7 +542,7 @@ impl IInternetProtocolInfo_Vtbl {
             this.QueryInfo(::core::mem::transmute(&pwzurl), ::core::mem::transmute_copy(&oueryoption), ::core::mem::transmute_copy(&dwqueryflags), ::core::mem::transmute_copy(&pbuffer), ::core::mem::transmute_copy(&cbbuffer), ::core::mem::transmute_copy(&pcbbuf), ::core::mem::transmute_copy(&dwreserved)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ParseUrl: ParseUrl::<Identity, Impl, OFFSET>,
             CombineUrl: CombineUrl::<Identity, Impl, OFFSET>,
             CompareUrl: CompareUrl::<Identity, Impl, OFFSET>,
@@ -598,7 +598,7 @@ impl IInternetProtocolRoot_Vtbl {
             this.Resume().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Start: Start::<Identity, Impl, OFFSET>,
             Continue: Continue::<Identity, Impl, OFFSET>,
             Abort: Abort::<Identity, Impl, OFFSET>,
@@ -641,7 +641,7 @@ impl IInternetProtocolSink_Vtbl {
             this.ReportResult(::core::mem::transmute_copy(&hrresult), ::core::mem::transmute_copy(&dwerror), ::core::mem::transmute(&szresult)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Switch: Switch::<Identity, Impl, OFFSET>,
             ReportProgress: ReportProgress::<Identity, Impl, OFFSET>,
             ReportData: ReportData::<Identity, Impl, OFFSET>,
@@ -676,7 +676,7 @@ impl IInternetProtocolSinkStackable_Vtbl {
             this.RollbackSwitch().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SwitchSink: SwitchSink::<Identity, Impl, OFFSET>,
             CommitSwitch: CommitSwitch::<Identity, Impl, OFFSET>,
             RollbackSwitch: RollbackSwitch::<Identity, Impl, OFFSET>,
@@ -746,7 +746,7 @@ impl IInternetSecurityManager_Vtbl {
             this.GetZoneMappings(::core::mem::transmute_copy(&dwzone), ::core::mem::transmute_copy(&ppenumstring), ::core::mem::transmute_copy(&dwflags)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetSecuritySite: SetSecuritySite::<Identity, Impl, OFFSET>,
             GetSecuritySite: GetSecuritySite::<Identity, Impl, OFFSET>,
             MapUrlToZone: MapUrlToZone::<Identity, Impl, OFFSET>,
@@ -846,7 +846,7 @@ impl IInternetSecurityMgrSite_Vtbl {
             this.EnableModeless(::core::mem::transmute_copy(&fenable)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetWindow: GetWindow::<Identity, Impl, OFFSET>,
             EnableModeless: EnableModeless::<Identity, Impl, OFFSET>,
         }
@@ -903,7 +903,7 @@ impl IInternetSession_Vtbl {
             this.GetSessionOption(::core::mem::transmute_copy(&dwoption), ::core::mem::transmute_copy(&pbuffer), ::core::mem::transmute_copy(&pdwbufferlength), ::core::mem::transmute_copy(&dwreserved)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RegisterNameSpace: RegisterNameSpace::<Identity, Impl, OFFSET>,
             UnregisterNameSpace: UnregisterNameSpace::<Identity, Impl, OFFSET>,
             RegisterMimeFilter: RegisterMimeFilter::<Identity, Impl, OFFSET>,
@@ -935,7 +935,7 @@ impl IInternetThreadSwitch_Vtbl {
             this.Continue().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Prepare: Prepare::<Identity, Impl, OFFSET>,
             Continue: Continue::<Identity, Impl, OFFSET>,
         }
@@ -1031,7 +1031,7 @@ impl IInternetZoneManager_Vtbl {
             this.CopyTemplatePoliciesToZone(::core::mem::transmute_copy(&dwtemplate), ::core::mem::transmute_copy(&dwzone), ::core::mem::transmute_copy(&dwreserved)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetZoneAttributes: GetZoneAttributes::<Identity, Impl, OFFSET>,
             SetZoneAttributes: SetZoneAttributes::<Identity, Impl, OFFSET>,
             GetZoneCustomPolicy: GetZoneCustomPolicy::<Identity, Impl, OFFSET>,
@@ -1135,7 +1135,7 @@ impl IMonikerProp_Vtbl {
             let this = (*this).get_impl();
             this.PutProperty(::core::mem::transmute_copy(&mkp), ::core::mem::transmute(&val)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), PutProperty: PutProperty::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), PutProperty: PutProperty::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMonikerProp as ::windows::core::Interface>::IID
@@ -1198,7 +1198,7 @@ impl IPersistMoniker_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetClassID: GetClassID::<Identity, Impl, OFFSET>,
             IsDirty: IsDirty::<Identity, Impl, OFFSET>,
             Load: Load::<Identity, Impl, OFFSET>,
@@ -1244,7 +1244,7 @@ impl ISoftDistExt_Vtbl {
             this.AsyncInstallDistributionUnit(::core::mem::transmute(&pbc), ::core::mem::transmute_copy(&pvreserved), ::core::mem::transmute_copy(&flags), ::core::mem::transmute_copy(&lpcbh)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ProcessSoftDist: ProcessSoftDist::<Identity, Impl, OFFSET>,
             GetFirstCodeBase: GetFirstCodeBase::<Identity, Impl, OFFSET>,
             GetNextCodeBase: GetNextCodeBase::<Identity, Impl, OFFSET>,
@@ -1285,7 +1285,7 @@ impl IUriBuilderFactory_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateIUriBuilder: CreateIUriBuilder::<Identity, Impl, OFFSET>,
             CreateInitializedIUriBuilder: CreateInitializedIUriBuilder::<Identity, Impl, OFFSET>,
         }
@@ -1311,7 +1311,7 @@ impl IUriContainer_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetIUri: GetIUri::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetIUri: GetIUri::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IUriContainer as ::windows::core::Interface>::IID
@@ -1328,7 +1328,7 @@ impl IWinInetCacheHints_Vtbl {
             let this = (*this).get_impl();
             this.SetCacheExtension(::core::mem::transmute(&pwzext), ::core::mem::transmute_copy(&pszcachefile), ::core::mem::transmute_copy(&pcbcachefile), ::core::mem::transmute_copy(&pdwwinineterror), ::core::mem::transmute_copy(&pdwreserved)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SetCacheExtension: SetCacheExtension::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SetCacheExtension: SetCacheExtension::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWinInetCacheHints as ::windows::core::Interface>::IID
@@ -1369,7 +1369,7 @@ impl IWinInetFileStream_Vtbl {
             this.SetDeleteFile(::core::mem::transmute_copy(&dwreserved)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetHandleForUnlock: SetHandleForUnlock::<Identity, Impl, OFFSET>,
             SetDeleteFile: SetDeleteFile::<Identity, Impl, OFFSET>,
         }
@@ -1406,7 +1406,7 @@ impl IWinInetHttpTimeouts_Vtbl {
             let this = (*this).get_impl();
             this.GetRequestTimeouts(::core::mem::transmute_copy(&pdwconnecttimeout), ::core::mem::transmute_copy(&pdwsendtimeout), ::core::mem::transmute_copy(&pdwreceivetimeout)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetRequestTimeouts: GetRequestTimeouts::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetRequestTimeouts: GetRequestTimeouts::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWinInetHttpTimeouts as ::windows::core::Interface>::IID
@@ -1423,7 +1423,7 @@ impl IWinInetInfo_Vtbl {
             let this = (*this).get_impl();
             this.QueryOption(::core::mem::transmute_copy(&dwoption), ::core::mem::transmute_copy(&pbuffer), ::core::mem::transmute_copy(&pcbbuf)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), QueryOption: QueryOption::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), QueryOption: QueryOption::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWinInetInfo as ::windows::core::Interface>::IID
@@ -1449,7 +1449,7 @@ impl IWindowForBindingUI_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetWindow: GetWindow::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetWindow: GetWindow::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWindowForBindingUI as ::windows::core::Interface>::IID
@@ -1466,7 +1466,7 @@ impl IWrappedProtocol_Vtbl {
             let this = (*this).get_impl();
             this.GetWrapperCode(::core::mem::transmute_copy(&pncode), ::core::mem::transmute_copy(&dwreserved)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetWrapperCode: GetWrapperCode::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetWrapperCode: GetWrapperCode::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWrappedProtocol as ::windows::core::Interface>::IID
@@ -1502,7 +1502,7 @@ impl IZoneIdentifier_Vtbl {
             this.Remove().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetId: GetId::<Identity, Impl, OFFSET>,
             SetId: SetId::<Identity, Impl, OFFSET>,
             Remove: Remove::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/System/Com/Urlmon/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/Urlmon/mod.rs
@@ -958,7 +958,7 @@ unsafe impl ::windows::core::Interface for IBindCallbackRedirect {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IBindCallbackRedirect_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Redirect: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lpcurl: ::windows::core::PCWSTR, vbcancel: *mut i16) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`*"]
@@ -1008,7 +1008,7 @@ unsafe impl ::windows::core::Interface for IBindHttpSecurity {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IBindHttpSecurity_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetIgnoreCertMask: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwignorecertmask: *mut u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`*"]
@@ -1062,7 +1062,7 @@ unsafe impl ::windows::core::Interface for IBindProtocol {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IBindProtocol_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateBinding: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, szurl: ::windows::core::PCWSTR, pbc: *mut ::core::ffi::c_void, ppb: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`*"]
@@ -1115,7 +1115,7 @@ unsafe impl ::windows::core::Interface for ICatalogFileInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICatalogFileInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCatalogFile: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppszcatalogfile: *mut ::windows::core::PSTR) -> ::windows::core::HRESULT,
     pub GetJavaTrust: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppjavatrust: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -1245,7 +1245,7 @@ unsafe impl ::windows::core::Interface for IDataFilter {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDataFilter_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub DoEncode: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwflags: u32, linbuffersize: i32, pbinbuffer: *const u8, loutbuffersize: i32, pboutbuffer: *mut u8, linbytesavailable: i32, plinbytesread: *mut i32, ploutbyteswritten: *mut i32, dwreserved: u32) -> ::windows::core::HRESULT,
     pub DoDecode: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwflags: u32, linbuffersize: i32, pbinbuffer: *const u8, loutbuffersize: i32, pboutbuffer: *mut u8, linbytesavailable: i32, plinbytesread: *mut i32, ploutbyteswritten: *mut i32, dwreserved: u32) -> ::windows::core::HRESULT,
     pub SetEncodingLevel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwenclevel: u32) -> ::windows::core::HRESULT,
@@ -1309,7 +1309,7 @@ unsafe impl ::windows::core::Interface for IEncodingFilterFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEncodingFilterFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub FindBestFilter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwzcodein: ::windows::core::PCWSTR, pwzcodeout: ::windows::core::PCWSTR, info: DATAINFO, ppdf: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetDefaultFilter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwzcodein: ::windows::core::PCWSTR, pwzcodeout: ::windows::core::PCWSTR, ppdf: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -1362,7 +1362,7 @@ unsafe impl ::windows::core::Interface for IGetBindHandle {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IGetBindHandle_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetBindHandle: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, enumrequestedhandle: BINDHANDLETYPES, prethandle: *mut super::super::super::Foundation::HANDLE) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -1427,7 +1427,7 @@ unsafe impl ::windows::core::Interface for IHttpNegotiate {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IHttpNegotiate_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub BeginningTransaction: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, szurl: ::windows::core::PCWSTR, szheaders: ::windows::core::PCWSTR, dwreserved: u32, pszadditionalheaders: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub OnResponse: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwresponsecode: u32, szresponseheaders: ::windows::core::PCWSTR, szrequestheaders: ::windows::core::PCWSTR, pszadditionalrequestheaders: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
 }
@@ -1721,7 +1721,7 @@ unsafe impl ::windows::core::Interface for IInternet {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IInternet_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
 }
 #[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`*"]
 #[repr(transparent)]
@@ -1774,7 +1774,7 @@ unsafe impl ::windows::core::Interface for IInternetBindInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IInternetBindInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_Security", feature = "Win32_System_Com_StructuredStorage"))]
     pub GetBindInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, grfbindf: *mut u32, pbindinfo: *mut super::BINDINFO) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_Security", feature = "Win32_System_Com_StructuredStorage")))]
@@ -1910,7 +1910,7 @@ unsafe impl ::windows::core::Interface for IInternetHostSecurityManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IInternetHostSecurityManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetSecurityId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbsecurityid: *mut u8, pcbsecurityid: *mut u32, dwreserved: usize) -> ::windows::core::HRESULT,
     pub ProcessUrlAction: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwaction: u32, ppolicy: *mut u8, cbpolicy: u32, pcontext: *const u8, cbcontext: u32, dwflags: u32, dwreserved: u32) -> ::windows::core::HRESULT,
     pub QueryCustomPolicy: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, guidkey: *const ::windows::core::GUID, pppolicy: *mut *mut u8, pcbpolicy: *mut u32, pcontext: *const u8, cbcontext: u32, dwreserved: u32) -> ::windows::core::HRESULT,
@@ -1965,7 +1965,7 @@ unsafe impl ::windows::core::Interface for IInternetPriority {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IInternetPriority_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetPriority: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, npriority: i32) -> ::windows::core::HRESULT,
     pub GetPriority: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pnpriority: *mut i32) -> ::windows::core::HRESULT,
 }
@@ -2271,7 +2271,7 @@ unsafe impl ::windows::core::Interface for IInternetProtocolInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IInternetProtocolInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ParseUrl: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwzurl: ::windows::core::PCWSTR, parseaction: PARSEACTION, dwparseflags: u32, pwzresult: ::windows::core::PWSTR, cchresult: u32, pcchresult: *mut u32, dwreserved: u32) -> ::windows::core::HRESULT,
     pub CombineUrl: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwzbaseurl: ::windows::core::PCWSTR, pwzrelativeurl: ::windows::core::PCWSTR, dwcombineflags: u32, pwzresult: ::windows::core::PCWSTR, cchresult: u32, pcchresult: *mut u32, dwreserved: u32) -> ::windows::core::HRESULT,
     pub CompareUrl: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwzurl1: ::windows::core::PCWSTR, pwzurl2: ::windows::core::PCWSTR, dwcompareflags: u32) -> ::windows::core::HRESULT,
@@ -2346,7 +2346,7 @@ unsafe impl ::windows::core::Interface for IInternetProtocolRoot {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IInternetProtocolRoot_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Start: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, szurl: ::windows::core::PCWSTR, poiprotsink: *mut ::core::ffi::c_void, poibindinfo: *mut ::core::ffi::c_void, grfpi: u32, dwreserved: super::super::super::Foundation::HANDLE_PTR) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -2418,7 +2418,7 @@ unsafe impl ::windows::core::Interface for IInternetProtocolSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IInternetProtocolSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Switch: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pprotocoldata: *const PROTOCOLDATA) -> ::windows::core::HRESULT,
     pub ReportProgress: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ulstatuscode: u32, szstatustext: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub ReportData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, grfbscf: u32, ulprogress: u32, ulprogressmax: u32) -> ::windows::core::HRESULT,
@@ -2479,7 +2479,7 @@ unsafe impl ::windows::core::Interface for IInternetProtocolSinkStackable {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IInternetProtocolSinkStackable_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SwitchSink: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, poiprotsink: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CommitSwitch: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub RollbackSwitch: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -2570,7 +2570,7 @@ unsafe impl ::windows::core::Interface for IInternetSecurityManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IInternetSecurityManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetSecuritySite: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psite: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetSecuritySite: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppsite: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub MapUrlToZone: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszurl: ::windows::core::PCWSTR, pdwzone: *mut u32, dwflags: u32) -> ::windows::core::HRESULT,
@@ -2899,7 +2899,7 @@ unsafe impl ::windows::core::Interface for IInternetSecurityMgrSite {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IInternetSecurityMgrSite_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetWindow: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, phwnd: *mut super::super::super::Foundation::HWND) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -2994,7 +2994,7 @@ unsafe impl ::windows::core::Interface for IInternetSession {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IInternetSession_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub RegisterNameSpace: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcf: *mut ::core::ffi::c_void, rclsid: *const ::windows::core::GUID, pwzprotocol: ::windows::core::PCWSTR, cpatterns: u32, ppwzpatterns: *const ::windows::core::PWSTR, dwreserved: u32) -> ::windows::core::HRESULT,
     pub UnregisterNameSpace: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcf: *mut ::core::ffi::c_void, pszprotocol: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub RegisterMimeFilter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcf: *mut ::core::ffi::c_void, rclsid: *const ::windows::core::GUID, pwztype: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
@@ -3052,7 +3052,7 @@ unsafe impl ::windows::core::Interface for IInternetThreadSwitch {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IInternetThreadSwitch_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Prepare: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Continue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -3147,7 +3147,7 @@ unsafe impl ::windows::core::Interface for IInternetZoneManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IInternetZoneManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetZoneAttributes: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwzone: u32, pzoneattributes: *mut ZONEATTRIBUTES) -> ::windows::core::HRESULT,
     pub SetZoneAttributes: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwzone: u32, pzoneattributes: *const ZONEATTRIBUTES) -> ::windows::core::HRESULT,
     pub GetZoneCustomPolicy: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwzone: u32, guidkey: *const ::windows::core::GUID, pppolicy: *mut *mut u8, pcbpolicy: *mut u32, urlzonereg: URLZONEREG) -> ::windows::core::HRESULT,
@@ -3491,7 +3491,7 @@ unsafe impl ::windows::core::Interface for IMonikerProp {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMonikerProp_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub PutProperty: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, mkp: MONIKERPROPERTY, val: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`*"]
@@ -3575,7 +3575,7 @@ unsafe impl ::windows::core::Interface for IPersistMoniker {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPersistMoniker_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetClassID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pclassid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub IsDirty: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -3653,7 +3653,7 @@ unsafe impl ::windows::core::Interface for ISoftDistExt {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISoftDistExt_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Data_Xml_MsXml")]
     pub ProcessSoftDist: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, szcdfurl: ::windows::core::PCWSTR, psoftdistelement: *mut ::core::ffi::c_void, lpsdi: *mut SOFTDISTINFO) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Data_Xml_MsXml"))]
@@ -3713,7 +3713,7 @@ unsafe impl ::windows::core::Interface for IUriBuilderFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUriBuilderFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateIUriBuilder: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwflags: u32, dwreserved: usize, ppiuribuilder: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CreateInitializedIUriBuilder: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwflags: u32, dwreserved: usize, ppiuribuilder: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -3764,7 +3764,7 @@ unsafe impl ::windows::core::Interface for IUriContainer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUriContainer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetIUri: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppiuri: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`*"]
@@ -3816,7 +3816,7 @@ unsafe impl ::windows::core::Interface for IWinInetCacheHints {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWinInetCacheHints_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetCacheExtension: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwzext: ::windows::core::PCWSTR, pszcachefile: *mut ::core::ffi::c_void, pcbcachefile: *mut u32, pdwwinineterror: *mut u32, pdwreserved: *mut u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`*"]
@@ -3941,7 +3941,7 @@ unsafe impl ::windows::core::Interface for IWinInetFileStream {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWinInetFileStream_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetHandleForUnlock: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hwininetlockhandle: usize, dwreserved: usize) -> ::windows::core::HRESULT,
     pub SetDeleteFile: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwreserved: usize) -> ::windows::core::HRESULT,
 }
@@ -4058,7 +4058,7 @@ unsafe impl ::windows::core::Interface for IWinInetHttpTimeouts {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWinInetHttpTimeouts_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetRequestTimeouts: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwconnecttimeout: *mut u32, pdwsendtimeout: *mut u32, pdwreceivetimeout: *mut u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`*"]
@@ -4107,7 +4107,7 @@ unsafe impl ::windows::core::Interface for IWinInetInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWinInetInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub QueryOption: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwoption: u32, pbuffer: *mut ::core::ffi::c_void, pcbbuf: *mut u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`*"]
@@ -4159,7 +4159,7 @@ unsafe impl ::windows::core::Interface for IWindowForBindingUI {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWindowForBindingUI_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetWindow: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, rguidreason: *const ::windows::core::GUID, phwnd: *mut super::super::super::Foundation::HWND) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -4211,7 +4211,7 @@ unsafe impl ::windows::core::Interface for IWrappedProtocol {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWrappedProtocol_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetWrapperCode: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pncode: *mut i32, dwreserved: usize) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`*"]
@@ -4267,7 +4267,7 @@ unsafe impl ::windows::core::Interface for IZoneIdentifier {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IZoneIdentifier_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwzone: *mut u32) -> ::windows::core::HRESULT,
     pub SetId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwzone: u32) -> ::windows::core::HRESULT,
     pub Remove: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/System/Com/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/impl.rs
@@ -67,7 +67,7 @@ impl AsyncIAdviseSink_Vtbl {
             this.Finish_OnClose()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Begin_OnDataChange: Begin_OnDataChange::<Identity, Impl, OFFSET>,
             Finish_OnDataChange: Finish_OnDataChange::<Identity, Impl, OFFSET>,
             Begin_OnViewChange: Begin_OnViewChange::<Identity, Impl, OFFSET>,
@@ -132,7 +132,7 @@ impl AsyncIMultiQI_Vtbl {
             this.Finish_QueryMultipleInterfaces(::core::mem::transmute_copy(&pmqis)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Begin_QueryMultipleInterfaces: Begin_QueryMultipleInterfaces::<Identity, Impl, OFFSET>,
             Finish_QueryMultipleInterfaces: Finish_QueryMultipleInterfaces::<Identity, Impl, OFFSET>,
         }
@@ -171,7 +171,7 @@ impl AsyncIPipeByte_Vtbl {
             this.Finish_Push().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Begin_Pull: Begin_Pull::<Identity, Impl, OFFSET>,
             Finish_Pull: Finish_Pull::<Identity, Impl, OFFSET>,
             Begin_Push: Begin_Push::<Identity, Impl, OFFSET>,
@@ -212,7 +212,7 @@ impl AsyncIPipeDouble_Vtbl {
             this.Finish_Push().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Begin_Pull: Begin_Pull::<Identity, Impl, OFFSET>,
             Finish_Pull: Finish_Pull::<Identity, Impl, OFFSET>,
             Begin_Push: Begin_Push::<Identity, Impl, OFFSET>,
@@ -253,7 +253,7 @@ impl AsyncIPipeLong_Vtbl {
             this.Finish_Push().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Begin_Pull: Begin_Pull::<Identity, Impl, OFFSET>,
             Finish_Pull: Finish_Pull::<Identity, Impl, OFFSET>,
             Begin_Push: Begin_Push::<Identity, Impl, OFFSET>,
@@ -306,7 +306,7 @@ impl AsyncIUnknown_Vtbl {
             this.Finish_Release()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Begin_QueryInterface: Begin_QueryInterface::<Identity, Impl, OFFSET>,
             Finish_QueryInterface: Finish_QueryInterface::<Identity, Impl, OFFSET>,
             Begin_AddRef: Begin_AddRef::<Identity, Impl, OFFSET>,
@@ -336,7 +336,7 @@ impl IActivationFilter_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), HandleActivation: HandleActivation::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), HandleActivation: HandleActivation::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IActivationFilter as ::windows::core::Interface>::IID
@@ -360,7 +360,7 @@ impl IAddrExclusionControl_Vtbl {
             this.UpdateAddrExclusionList(::core::mem::transmute(&penumerator)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCurrentAddrExclusionList: GetCurrentAddrExclusionList::<Identity, Impl, OFFSET>,
             UpdateAddrExclusionList: UpdateAddrExclusionList::<Identity, Impl, OFFSET>,
         }
@@ -387,7 +387,7 @@ impl IAddrTrackingControl_Vtbl {
             this.DisableCOMDynamicAddrTracking().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             EnableCOMDynamicAddrTracking: EnableCOMDynamicAddrTracking::<Identity, Impl, OFFSET>,
             DisableCOMDynamicAddrTracking: DisableCOMDynamicAddrTracking::<Identity, Impl, OFFSET>,
         }
@@ -435,7 +435,7 @@ impl IAdviseSink_Vtbl {
             this.OnClose()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnDataChange: OnDataChange::<Identity, Impl, OFFSET>,
             OnViewChange: OnViewChange::<Identity, Impl, OFFSET>,
             OnRename: OnRename::<Identity, Impl, OFFSET>,
@@ -471,7 +471,7 @@ pub trait IAgileObject_Impl: Sized {}
 impl ::windows::core::RuntimeName for IAgileObject {}
 impl IAgileObject_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IAgileObject_Impl, const OFFSET: isize>() -> IAgileObject_Vtbl {
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>() }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>() }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IAgileObject as ::windows::core::Interface>::IID
@@ -507,7 +507,7 @@ impl IAsyncManager_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CompleteCall: CompleteCall::<Identity, Impl, OFFSET>,
             GetCallContext: GetCallContext::<Identity, Impl, OFFSET>,
             GetState: GetState::<Identity, Impl, OFFSET>,
@@ -565,7 +565,7 @@ impl IAuthenticate_Vtbl {
             let this = (*this).get_impl();
             this.Authenticate(::core::mem::transmute_copy(&phwnd), ::core::mem::transmute_copy(&pszusername), ::core::mem::transmute_copy(&pszpassword)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Authenticate: Authenticate::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Authenticate: Authenticate::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IAuthenticate as ::windows::core::Interface>::IID
@@ -675,7 +675,7 @@ impl IBindCtx_Vtbl {
             this.RevokeObjectParam(::core::mem::transmute(&pszkey)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RegisterObjectBound: RegisterObjectBound::<Identity, Impl, OFFSET>,
             RevokeObjectBound: RevokeObjectBound::<Identity, Impl, OFFSET>,
             ReleaseBoundObjects: ReleaseBoundObjects::<Identity, Impl, OFFSET>,
@@ -716,7 +716,7 @@ impl IBindHost_Vtbl {
             this.MonikerBindToObject(::core::mem::transmute(&pmk), ::core::mem::transmute(&pbc), ::core::mem::transmute(&pbsc), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppvobj)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateMoniker: CreateMoniker::<Identity, Impl, OFFSET>,
             MonikerBindToStorage: MonikerBindToStorage::<Identity, Impl, OFFSET>,
             MonikerBindToObject: MonikerBindToObject::<Identity, Impl, OFFSET>,
@@ -789,7 +789,7 @@ impl IBindStatusCallback_Vtbl {
             this.OnObjectAvailable(::core::mem::transmute_copy(&riid), ::core::mem::transmute(&punk)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnStartBinding: OnStartBinding::<Identity, Impl, OFFSET>,
             GetPriority: GetPriority::<Identity, Impl, OFFSET>,
             OnLowResource: OnLowResource::<Identity, Impl, OFFSET>,
@@ -872,7 +872,7 @@ impl IBinding_Vtbl {
             this.GetBindResult(::core::mem::transmute_copy(&pclsidprotocol), ::core::mem::transmute_copy(&pdwresult), ::core::mem::transmute_copy(&pszresult), ::core::mem::transmute_copy(&pdwreserved)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Abort: Abort::<Identity, Impl, OFFSET>,
             Suspend: Suspend::<Identity, Impl, OFFSET>,
             Resume: Resume::<Identity, Impl, OFFSET>,
@@ -902,7 +902,11 @@ impl IBlockingLock_Vtbl {
             let this = (*this).get_impl();
             this.Unlock().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Lock: Lock::<Identity, Impl, OFFSET>, Unlock: Unlock::<Identity, Impl, OFFSET> }
+        Self {
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
+            Lock: Lock::<Identity, Impl, OFFSET>,
+            Unlock: Unlock::<Identity, Impl, OFFSET>,
+        }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IBlockingLock as ::windows::core::Interface>::IID
@@ -925,7 +929,7 @@ impl ICallFactory_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CreateCall: CreateCall::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CreateCall: CreateCall::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ICallFactory as ::windows::core::Interface>::IID
@@ -949,7 +953,7 @@ impl ICancelMethodCalls_Vtbl {
             this.TestCancel().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Cancel: Cancel::<Identity, Impl, OFFSET>,
             TestCancel: TestCancel::<Identity, Impl, OFFSET>,
         }
@@ -1030,7 +1034,7 @@ impl ICatInformation_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             EnumCategories: EnumCategories::<Identity, Impl, OFFSET>,
             GetCategoryDesc: GetCategoryDesc::<Identity, Impl, OFFSET>,
             EnumClassesOfCategories: EnumClassesOfCategories::<Identity, Impl, OFFSET>,
@@ -1085,7 +1089,7 @@ impl ICatRegister_Vtbl {
             this.UnRegisterClassReqCategories(::core::mem::transmute_copy(&rclsid), ::core::mem::transmute_copy(&ccategories), ::core::mem::transmute_copy(&rgcatid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RegisterCategories: RegisterCategories::<Identity, Impl, OFFSET>,
             UnRegisterCategories: UnRegisterCategories::<Identity, Impl, OFFSET>,
             RegisterClassImplCategories: RegisterClassImplCategories::<Identity, Impl, OFFSET>,
@@ -1140,7 +1144,7 @@ impl IChannelHook_Vtbl {
             this.ServerFillBuffer(::core::mem::transmute_copy(&uextent), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&pdatasize), ::core::mem::transmute_copy(&pdatabuffer), ::core::mem::transmute_copy(&hrfault))
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ClientGetSize: ClientGetSize::<Identity, Impl, OFFSET>,
             ClientFillBuffer: ClientFillBuffer::<Identity, Impl, OFFSET>,
             ClientNotify: ClientNotify::<Identity, Impl, OFFSET>,
@@ -1164,7 +1168,7 @@ impl IClassActivator_Vtbl {
             let this = (*this).get_impl();
             this.GetClassObject(::core::mem::transmute_copy(&rclsid), ::core::mem::transmute_copy(&dwclasscontext), ::core::mem::transmute_copy(&locale), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppv)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetClassObject: GetClassObject::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetClassObject: GetClassObject::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IClassActivator as ::windows::core::Interface>::IID
@@ -1191,7 +1195,7 @@ impl IClassFactory_Vtbl {
             this.LockServer(::core::mem::transmute_copy(&flock)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateInstance: CreateInstance::<Identity, Impl, OFFSET>,
             LockServer: LockServer::<Identity, Impl, OFFSET>,
         }
@@ -1230,7 +1234,7 @@ impl IClientSecurity_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             QueryBlanket: QueryBlanket::<Identity, Impl, OFFSET>,
             SetBlanket: SetBlanket::<Identity, Impl, OFFSET>,
             CopyProxy: CopyProxy::<Identity, Impl, OFFSET>,
@@ -1288,7 +1292,7 @@ impl IComThreadingInfo_Vtbl {
             this.SetCurrentLogicalThreadId(::core::mem::transmute_copy(&rguid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCurrentApartmentType: GetCurrentApartmentType::<Identity, Impl, OFFSET>,
             GetCurrentThreadType: GetCurrentThreadType::<Identity, Impl, OFFSET>,
             GetCurrentLogicalThreadId: GetCurrentLogicalThreadId::<Identity, Impl, OFFSET>,
@@ -1359,7 +1363,7 @@ impl IConnectionPoint_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetConnectionInterface: GetConnectionInterface::<Identity, Impl, OFFSET>,
             GetConnectionPointContainer: GetConnectionPointContainer::<Identity, Impl, OFFSET>,
             Advise: Advise::<Identity, Impl, OFFSET>,
@@ -1401,7 +1405,7 @@ impl IConnectionPointContainer_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             EnumConnectionPoints: EnumConnectionPoints::<Identity, Impl, OFFSET>,
             FindConnectionPoint: FindConnectionPoint::<Identity, Impl, OFFSET>,
         }
@@ -1421,7 +1425,7 @@ impl IContextCallback_Vtbl {
             let this = (*this).get_impl();
             this.ContextCallback(::core::mem::transmute(&pfncallback), ::core::mem::transmute_copy(&pparam), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&imethod), ::core::mem::transmute(&punk)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), ContextCallback: ContextCallback::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), ContextCallback: ContextCallback::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IContextCallback as ::windows::core::Interface>::IID
@@ -1469,7 +1473,7 @@ impl IDataAdviseHolder_Vtbl {
             this.SendOnDataChange(::core::mem::transmute(&pdataobject), ::core::mem::transmute_copy(&dwreserved), ::core::mem::transmute_copy(&advf)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Advise: Advise::<Identity, Impl, OFFSET>,
             Unadvise: Unadvise::<Identity, Impl, OFFSET>,
             EnumAdvise: EnumAdvise::<Identity, Impl, OFFSET>,
@@ -1567,7 +1571,7 @@ impl IDataObject_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetData: GetData::<Identity, Impl, OFFSET>,
             GetDataHere: GetDataHere::<Identity, Impl, OFFSET>,
             QueryGetData: QueryGetData::<Identity, Impl, OFFSET>,
@@ -1634,7 +1638,7 @@ impl IDispatch_Vtbl {
             this.Invoke(::core::mem::transmute_copy(&dispidmember), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&lcid), ::core::mem::transmute_copy(&wflags), ::core::mem::transmute_copy(&pdispparams), ::core::mem::transmute_copy(&pvarresult), ::core::mem::transmute_copy(&pexcepinfo), ::core::mem::transmute_copy(&puargerr)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTypeInfoCount: GetTypeInfoCount::<Identity, Impl, OFFSET>,
             GetTypeInfo: GetTypeInfo::<Identity, Impl, OFFSET>,
             GetIDsOfNames: GetIDsOfNames::<Identity, Impl, OFFSET>,
@@ -1681,7 +1685,7 @@ impl IEnumCATEGORYINFO_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -1728,7 +1732,7 @@ impl IEnumConnectionPoints_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -1775,7 +1779,7 @@ impl IEnumConnections_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -1822,7 +1826,7 @@ impl IEnumFORMATETC_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -1869,7 +1873,7 @@ impl IEnumGUID_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -1916,7 +1920,7 @@ impl IEnumMoniker_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -1963,7 +1967,7 @@ impl IEnumSTATDATA_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -2010,7 +2014,7 @@ impl IEnumString_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -2057,7 +2061,7 @@ impl IEnumUnknown_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -2134,7 +2138,7 @@ impl IErrorInfo_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetGUID: GetGUID::<Identity, Impl, OFFSET>,
             GetSource: GetSource::<Identity, Impl, OFFSET>,
             GetDescription: GetDescription::<Identity, Impl, OFFSET>,
@@ -2157,7 +2161,7 @@ impl IErrorLog_Vtbl {
             let this = (*this).get_impl();
             this.AddError(::core::mem::transmute(&pszpropname), ::core::mem::transmute_copy(&pexcepinfo)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), AddError: AddError::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), AddError: AddError::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IErrorLog as ::windows::core::Interface>::IID
@@ -2184,7 +2188,7 @@ impl IExternalConnection_Vtbl {
             this.ReleaseConnection(::core::mem::transmute_copy(&extconn), ::core::mem::transmute_copy(&reserved), ::core::mem::transmute_copy(&flastreleasecloses))
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddConnection: AddConnection::<Identity, Impl, OFFSET>,
             ReleaseConnection: ReleaseConnection::<Identity, Impl, OFFSET>,
         }
@@ -2197,7 +2201,7 @@ pub trait IFastRundown_Impl: Sized {}
 impl ::windows::core::RuntimeName for IFastRundown {}
 impl IFastRundown_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IFastRundown_Impl, const OFFSET: isize>() -> IFastRundown_Vtbl {
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>() }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>() }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IFastRundown as ::windows::core::Interface>::IID
@@ -2214,7 +2218,7 @@ impl IForegroundTransfer_Vtbl {
             let this = (*this).get_impl();
             this.AllowForegroundTransfer(::core::mem::transmute_copy(&lpvreserved)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), AllowForegroundTransfer: AllowForegroundTransfer::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), AllowForegroundTransfer: AllowForegroundTransfer::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IForegroundTransfer as ::windows::core::Interface>::IID
@@ -2250,7 +2254,7 @@ impl IGlobalInterfaceTable_Vtbl {
             this.GetInterfaceFromGlobal(::core::mem::transmute_copy(&dwcookie), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppv)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RegisterInterfaceInGlobal: RegisterInterfaceInGlobal::<Identity, Impl, OFFSET>,
             RevokeInterfaceFromGlobal: RevokeInterfaceFromGlobal::<Identity, Impl, OFFSET>,
             GetInterfaceFromGlobal: GetInterfaceFromGlobal::<Identity, Impl, OFFSET>,
@@ -2283,7 +2287,7 @@ impl IGlobalOptions_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Set: Set::<Identity, Impl, OFFSET>, Query: Query::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Set: Set::<Identity, Impl, OFFSET>, Query: Query::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IGlobalOptions as ::windows::core::Interface>::IID
@@ -2319,7 +2323,7 @@ impl IInitializeSpy_Vtbl {
             this.PostUninitialize(::core::mem::transmute_copy(&dwnewthreadaptrefs)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             PreInitialize: PreInitialize::<Identity, Impl, OFFSET>,
             PostInitialize: PostInitialize::<Identity, Impl, OFFSET>,
             PreUninitialize: PreUninitialize::<Identity, Impl, OFFSET>,
@@ -2341,7 +2345,7 @@ impl IInternalUnknown_Vtbl {
             let this = (*this).get_impl();
             this.QueryInternalInterface(::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppv)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), QueryInternalInterface: QueryInternalInterface::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), QueryInternalInterface: QueryInternalInterface::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IInternalUnknown as ::windows::core::Interface>::IID
@@ -2377,7 +2381,7 @@ impl IMachineGlobalObjectTable_Vtbl {
             this.RevokeObject(::core::mem::transmute_copy(&token)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RegisterObject: RegisterObject::<Identity, Impl, OFFSET>,
             GetObject: GetObject::<Identity, Impl, OFFSET>,
             RevokeObject: RevokeObject::<Identity, Impl, OFFSET>,
@@ -2429,7 +2433,7 @@ impl IMalloc_Vtbl {
             this.HeapMinimize()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Alloc: Alloc::<Identity, Impl, OFFSET>,
             Realloc: Realloc::<Identity, Impl, OFFSET>,
             Free: Free::<Identity, Impl, OFFSET>,
@@ -2523,7 +2527,7 @@ impl IMallocSpy_Vtbl {
             this.PostHeapMinimize()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             PreAlloc: PreAlloc::<Identity, Impl, OFFSET>,
             PostAlloc: PostAlloc::<Identity, Impl, OFFSET>,
             PreFree: PreFree::<Identity, Impl, OFFSET>,
@@ -2728,7 +2732,7 @@ impl IMultiQI_Vtbl {
             let this = (*this).get_impl();
             this.QueryMultipleInterfaces(::core::mem::transmute_copy(&cmqis), ::core::mem::transmute_copy(&pmqis)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), QueryMultipleInterfaces: QueryMultipleInterfaces::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), QueryMultipleInterfaces: QueryMultipleInterfaces::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMultiQI as ::windows::core::Interface>::IID
@@ -2738,7 +2742,7 @@ pub trait INoMarshal_Impl: Sized {}
 impl ::windows::core::RuntimeName for INoMarshal {}
 impl INoMarshal_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: INoMarshal_Impl, const OFFSET: isize>() -> INoMarshal_Vtbl {
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>() }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>() }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<INoMarshal as ::windows::core::Interface>::IID
@@ -2762,7 +2766,7 @@ impl IOplockStorage_Vtbl {
             this.OpenStorageEx(::core::mem::transmute(&pwcsname), ::core::mem::transmute_copy(&grfmode), ::core::mem::transmute_copy(&stgfmt), ::core::mem::transmute_copy(&grfattrs), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppstgopen)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateStorageEx: CreateStorageEx::<Identity, Impl, OFFSET>,
             OpenStorageEx: OpenStorageEx::<Identity, Impl, OFFSET>,
         }
@@ -2795,7 +2799,7 @@ impl IPSFactoryBuffer_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateProxy: CreateProxy::<Identity, Impl, OFFSET>,
             CreateStub: CreateStub::<Identity, Impl, OFFSET>,
         }
@@ -2821,7 +2825,7 @@ impl IPersist_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetClassID: GetClassID::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetClassID: GetClassID::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IPersist as ::windows::core::Interface>::IID
@@ -3065,7 +3069,7 @@ impl IPipeByte_Vtbl {
             let this = (*this).get_impl();
             this.Push(::core::mem::transmute_copy(&buf), ::core::mem::transmute_copy(&csent)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Pull: Pull::<Identity, Impl, OFFSET>, Push: Push::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Pull: Pull::<Identity, Impl, OFFSET>, Push: Push::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IPipeByte as ::windows::core::Interface>::IID
@@ -3088,7 +3092,7 @@ impl IPipeDouble_Vtbl {
             let this = (*this).get_impl();
             this.Push(::core::mem::transmute_copy(&buf), ::core::mem::transmute_copy(&csent)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Pull: Pull::<Identity, Impl, OFFSET>, Push: Push::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Pull: Pull::<Identity, Impl, OFFSET>, Push: Push::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IPipeDouble as ::windows::core::Interface>::IID
@@ -3111,7 +3115,7 @@ impl IPipeLong_Vtbl {
             let this = (*this).get_impl();
             this.Push(::core::mem::transmute_copy(&buf), ::core::mem::transmute_copy(&csent)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Pull: Pull::<Identity, Impl, OFFSET>, Push: Push::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Pull: Pull::<Identity, Impl, OFFSET>, Push: Push::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IPipeLong as ::windows::core::Interface>::IID
@@ -3128,7 +3132,7 @@ impl IProcessInitControl_Vtbl {
             let this = (*this).get_impl();
             this.ResetInitializerTimeout(::core::mem::transmute_copy(&dwsecondsremaining)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), ResetInitializerTimeout: ResetInitializerTimeout::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), ResetInitializerTimeout: ResetInitializerTimeout::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IProcessInitControl as ::windows::core::Interface>::IID
@@ -3152,7 +3156,7 @@ impl IProcessLock_Vtbl {
             this.ReleaseRefOnProcess()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddRefOnProcess: AddRefOnProcess::<Identity, Impl, OFFSET>,
             ReleaseRefOnProcess: ReleaseRefOnProcess::<Identity, Impl, OFFSET>,
         }
@@ -3175,7 +3179,7 @@ impl IProgressNotify_Vtbl {
             let this = (*this).get_impl();
             this.OnProgress(::core::mem::transmute_copy(&dwprogresscurrent), ::core::mem::transmute_copy(&dwprogressmaximum), ::core::mem::transmute_copy(&faccurate), ::core::mem::transmute_copy(&fowner)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnProgress: OnProgress::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnProgress: OnProgress::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IProgressNotify as ::windows::core::Interface>::IID
@@ -3192,7 +3196,7 @@ impl IROTData_Vtbl {
             let this = (*this).get_impl();
             this.GetComparisonData(::core::mem::transmute_copy(&pbdata), ::core::mem::transmute_copy(&cbmax), ::core::mem::transmute_copy(&pcbdata)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetComparisonData: GetComparisonData::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetComparisonData: GetComparisonData::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IROTData as ::windows::core::Interface>::IID
@@ -3209,7 +3213,7 @@ impl IReleaseMarshalBuffers_Vtbl {
             let this = (*this).get_impl();
             this.ReleaseMarshalBuffer(::core::mem::transmute_copy(&pmsg), ::core::mem::transmute_copy(&dwflags), ::core::mem::transmute(&pchnl)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), ReleaseMarshalBuffer: ReleaseMarshalBuffer::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), ReleaseMarshalBuffer: ReleaseMarshalBuffer::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IReleaseMarshalBuffers as ::windows::core::Interface>::IID
@@ -3251,7 +3255,7 @@ impl IRpcChannelBuffer_Vtbl {
             this.IsConnected().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetBuffer: GetBuffer::<Identity, Impl, OFFSET>,
             SendReceive: SendReceive::<Identity, Impl, OFFSET>,
             FreeBuffer: FreeBuffer::<Identity, Impl, OFFSET>,
@@ -3384,7 +3388,7 @@ impl IRpcHelper_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDCOMProtocolVersion: GetDCOMProtocolVersion::<Identity, Impl, OFFSET>,
             GetIIDFromOBJREF: GetIIDFromOBJREF::<Identity, Impl, OFFSET>,
         }
@@ -3416,7 +3420,7 @@ impl IRpcOptions_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Set: Set::<Identity, Impl, OFFSET>, Query: Query::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Set: Set::<Identity, Impl, OFFSET>, Query: Query::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IRpcOptions as ::windows::core::Interface>::IID
@@ -3440,7 +3444,7 @@ impl IRpcProxyBuffer_Vtbl {
             this.Disconnect()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Connect: Connect::<Identity, Impl, OFFSET>,
             Disconnect: Disconnect::<Identity, Impl, OFFSET>,
         }
@@ -3497,7 +3501,7 @@ impl IRpcStubBuffer_Vtbl {
             this.DebugServerRelease(::core::mem::transmute_copy(&pv))
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Connect: Connect::<Identity, Impl, OFFSET>,
             Disconnect: Disconnect::<Identity, Impl, OFFSET>,
             Invoke: Invoke::<Identity, Impl, OFFSET>,
@@ -3522,7 +3526,7 @@ impl IRpcSyntaxNegotiate_Vtbl {
             let this = (*this).get_impl();
             this.NegotiateSyntax(::core::mem::transmute_copy(&pmsg)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), NegotiateSyntax: NegotiateSyntax::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), NegotiateSyntax: NegotiateSyntax::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IRpcSyntaxNegotiate as ::windows::core::Interface>::IID
@@ -3573,7 +3577,7 @@ impl IRunnableObject_Vtbl {
             this.SetContainedObject(::core::mem::transmute_copy(&fcontained)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetRunningClass: GetRunningClass::<Identity, Impl, OFFSET>,
             Run: Run::<Identity, Impl, OFFSET>,
             IsRunning: IsRunning::<Identity, Impl, OFFSET>,
@@ -3660,7 +3664,7 @@ impl IRunningObjectTable_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Register: Register::<Identity, Impl, OFFSET>,
             Revoke: Revoke::<Identity, Impl, OFFSET>,
             IsRunning: IsRunning::<Identity, Impl, OFFSET>,
@@ -3691,7 +3695,7 @@ impl ISequentialStream_Vtbl {
             let this = (*this).get_impl();
             this.Write(::core::mem::transmute_copy(&pv), ::core::mem::transmute_copy(&cb), ::core::mem::transmute_copy(&pcbwritten))
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Read: Read::<Identity, Impl, OFFSET>, Write: Write::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Read: Read::<Identity, Impl, OFFSET>, Write: Write::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ISequentialStream as ::windows::core::Interface>::IID
@@ -3730,7 +3734,7 @@ impl IServerSecurity_Vtbl {
             this.IsImpersonating()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             QueryBlanket: QueryBlanket::<Identity, Impl, OFFSET>,
             ImpersonateClient: ImpersonateClient::<Identity, Impl, OFFSET>,
             RevertToSelf: RevertToSelf::<Identity, Impl, OFFSET>,
@@ -3752,7 +3756,7 @@ impl IServiceProvider_Vtbl {
             let this = (*this).get_impl();
             this.QueryService(::core::mem::transmute_copy(&guidservice), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppvobject)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), QueryService: QueryService::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), QueryService: QueryService::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IServiceProvider as ::windows::core::Interface>::IID
@@ -3769,7 +3773,7 @@ impl IStdMarshalInfo_Vtbl {
             let this = (*this).get_impl();
             this.GetClassForHandler(::core::mem::transmute_copy(&dwdestcontext), ::core::mem::transmute_copy(&pvdestcontext), ::core::mem::transmute_copy(&pclsid)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetClassForHandler: GetClassForHandler::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetClassForHandler: GetClassForHandler::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IStdMarshalInfo as ::windows::core::Interface>::IID
@@ -3878,7 +3882,7 @@ impl ISupportErrorInfo_Vtbl {
             this.InterfaceSupportsErrorInfo(::core::mem::transmute_copy(&riid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             InterfaceSupportsErrorInfo: InterfaceSupportsErrorInfo::<Identity, Impl, OFFSET>,
         }
     }
@@ -3904,7 +3908,7 @@ impl ISurrogate_Vtbl {
             this.FreeSurrogate().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             LoadDllServer: LoadDllServer::<Identity, Impl, OFFSET>,
             FreeSurrogate: FreeSurrogate::<Identity, Impl, OFFSET>,
         }
@@ -3958,7 +3962,7 @@ impl ISurrogateService_Vtbl {
             this.ProcessShutdown(::core::mem::transmute_copy(&shutdowntype)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Init: Init::<Identity, Impl, OFFSET>,
             ApplicationLaunch: ApplicationLaunch::<Identity, Impl, OFFSET>,
             ApplicationFree: ApplicationFree::<Identity, Impl, OFFSET>,
@@ -3994,7 +3998,7 @@ impl ISynchronize_Vtbl {
             this.Reset().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Wait: Wait::<Identity, Impl, OFFSET>,
             Signal: Signal::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -4028,7 +4032,7 @@ impl ISynchronizeContainer_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddSynchronize: AddSynchronize::<Identity, Impl, OFFSET>,
             WaitMultiple: WaitMultiple::<Identity, Impl, OFFSET>,
         }
@@ -4077,7 +4081,7 @@ impl ISynchronizeHandle_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetHandle: GetHandle::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetHandle: GetHandle::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ISynchronizeHandle as ::windows::core::Interface>::IID
@@ -4111,7 +4115,7 @@ impl ITimeAndNoticeControl_Vtbl {
             let this = (*this).get_impl();
             this.SuppressChanges(::core::mem::transmute_copy(&res1), ::core::mem::transmute_copy(&res2)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SuppressChanges: SuppressChanges::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SuppressChanges: SuppressChanges::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ITimeAndNoticeControl as ::windows::core::Interface>::IID
@@ -4138,7 +4142,7 @@ impl ITypeComp_Vtbl {
             this.BindType(::core::mem::transmute(&szname), ::core::mem::transmute_copy(&lhashval), ::core::mem::transmute_copy(&pptinfo), ::core::mem::transmute_copy(&pptcomp)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Bind: Bind::<Identity, Impl, OFFSET>,
             BindType: BindType::<Identity, Impl, OFFSET>,
         }
@@ -4324,7 +4328,7 @@ impl ITypeInfo_Vtbl {
             this.ReleaseVarDesc(::core::mem::transmute_copy(&pvardesc))
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTypeAttr: GetTypeAttr::<Identity, Impl, OFFSET>,
             GetTypeComp: GetTypeComp::<Identity, Impl, OFFSET>,
             GetFuncDesc: GetFuncDesc::<Identity, Impl, OFFSET>,
@@ -4654,7 +4658,7 @@ impl ITypeLib_Vtbl {
             this.ReleaseTLibAttr(::core::mem::transmute_copy(&ptlibattr))
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTypeInfoCount: GetTypeInfoCount::<Identity, Impl, OFFSET>,
             GetTypeInfo: GetTypeInfo::<Identity, Impl, OFFSET>,
             GetTypeInfoType: GetTypeInfoType::<Identity, Impl, OFFSET>,
@@ -4829,7 +4833,7 @@ impl ITypeLibRegistration_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetGuid: GetGuid::<Identity, Impl, OFFSET>,
             GetVersion: GetVersion::<Identity, Impl, OFFSET>,
             GetLcid: GetLcid::<Identity, Impl, OFFSET>,
@@ -4861,7 +4865,7 @@ impl ITypeLibRegistrationReader_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), EnumTypeLibRegistrations: EnumTypeLibRegistrations::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), EnumTypeLibRegistrations: EnumTypeLibRegistrations::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ITypeLibRegistrationReader as ::windows::core::Interface>::IID
@@ -5158,7 +5162,7 @@ impl IUri_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetPropertyBSTR: GetPropertyBSTR::<Identity, Impl, OFFSET>,
             GetPropertyLength: GetPropertyLength::<Identity, Impl, OFFSET>,
             GetPropertyDWORD: GetPropertyDWORD::<Identity, Impl, OFFSET>,
@@ -5367,7 +5371,7 @@ impl IUriBuilder_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateUriSimple: CreateUriSimple::<Identity, Impl, OFFSET>,
             CreateUri: CreateUri::<Identity, Impl, OFFSET>,
             CreateUriWithFlags: CreateUriWithFlags::<Identity, Impl, OFFSET>,
@@ -5408,7 +5412,7 @@ impl IUrlMon_Vtbl {
             let this = (*this).get_impl();
             this.AsyncGetClassBits(::core::mem::transmute_copy(&rclsid), ::core::mem::transmute(&psztype), ::core::mem::transmute(&pszext), ::core::mem::transmute_copy(&dwfileversionms), ::core::mem::transmute_copy(&dwfileversionls), ::core::mem::transmute(&pszcodebase), ::core::mem::transmute(&pbc), ::core::mem::transmute_copy(&dwclasscontext), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&flags)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), AsyncGetClassBits: AsyncGetClassBits::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), AsyncGetClassBits: AsyncGetClassBits::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IUrlMon as ::windows::core::Interface>::IID
@@ -5438,7 +5442,7 @@ impl IWaitMultiple_Vtbl {
             this.AddSynchronize(::core::mem::transmute(&psync)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             WaitMultiple: WaitMultiple::<Identity, Impl, OFFSET>,
             AddSynchronize: AddSynchronize::<Identity, Impl, OFFSET>,
         }

--- a/crates/libs/windows/src/Windows/Win32/System/Com/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/mod.rs
@@ -1318,7 +1318,7 @@ unsafe impl ::windows::core::Interface for AsyncIAdviseSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct AsyncIAdviseSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
     pub Begin_OnDataChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pformatetc: *const FORMATETC, pstgmed: *const STGMEDIUM),
     #[cfg(not(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage")))]
@@ -1488,7 +1488,7 @@ unsafe impl ::windows::core::Interface for AsyncIMultiQI {
 #[repr(C)]
 #[doc(hidden)]
 pub struct AsyncIMultiQI_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Begin_QueryMultipleInterfaces: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cmqis: u32, pmqis: *mut MULTI_QI) -> ::windows::core::HRESULT,
     pub Finish_QueryMultipleInterfaces: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pmqis: *mut MULTI_QI) -> ::windows::core::HRESULT,
 }
@@ -1547,7 +1547,7 @@ unsafe impl ::windows::core::Interface for AsyncIPipeByte {
 #[repr(C)]
 #[doc(hidden)]
 pub struct AsyncIPipeByte_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Begin_Pull: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, crequest: u32) -> ::windows::core::HRESULT,
     pub Finish_Pull: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, buf: *mut u8, pcreturned: *mut u32) -> ::windows::core::HRESULT,
     pub Begin_Push: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, buf: *const u8, csent: u32) -> ::windows::core::HRESULT,
@@ -1608,7 +1608,7 @@ unsafe impl ::windows::core::Interface for AsyncIPipeDouble {
 #[repr(C)]
 #[doc(hidden)]
 pub struct AsyncIPipeDouble_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Begin_Pull: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, crequest: u32) -> ::windows::core::HRESULT,
     pub Finish_Pull: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, buf: *mut f64, pcreturned: *mut u32) -> ::windows::core::HRESULT,
     pub Begin_Push: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, buf: *const f64, csent: u32) -> ::windows::core::HRESULT,
@@ -1669,7 +1669,7 @@ unsafe impl ::windows::core::Interface for AsyncIPipeLong {
 #[repr(C)]
 #[doc(hidden)]
 pub struct AsyncIPipeLong_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Begin_Pull: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, crequest: u32) -> ::windows::core::HRESULT,
     pub Finish_Pull: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, buf: *mut i32, pcreturned: *mut u32) -> ::windows::core::HRESULT,
     pub Begin_Push: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, buf: *const i32, csent: u32) -> ::windows::core::HRESULT,
@@ -1736,7 +1736,7 @@ unsafe impl ::windows::core::Interface for AsyncIUnknown {
 #[repr(C)]
 #[doc(hidden)]
 pub struct AsyncIUnknown_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Begin_QueryInterface: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub Finish_QueryInterface: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Begin_AddRef: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1791,7 +1791,7 @@ unsafe impl ::windows::core::Interface for IActivationFilter {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IActivationFilter_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub HandleActivation: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwactivationtype: u32, rclsid: *const ::windows::core::GUID, preplacementclsid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Com\"`*"]
@@ -1846,7 +1846,7 @@ unsafe impl ::windows::core::Interface for IAddrExclusionControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAddrExclusionControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCurrentAddrExclusionList: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppenumerator: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub UpdateAddrExclusionList: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, penumerator: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -1899,7 +1899,7 @@ unsafe impl ::windows::core::Interface for IAddrTrackingControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAddrTrackingControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub EnableCOMDynamicAddrTracking: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub DisableCOMDynamicAddrTracking: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -1966,7 +1966,7 @@ unsafe impl ::windows::core::Interface for IAdviseSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAdviseSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
     pub OnDataChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pformatetc: *const FORMATETC, pstgmed: *const STGMEDIUM),
     #[cfg(not(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage")))]
@@ -2105,7 +2105,7 @@ unsafe impl ::windows::core::Interface for IAgileObject {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAgileObject_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
 }
 #[doc = "*Required features: `\"Win32_System_Com\"`*"]
 #[repr(transparent)]
@@ -2160,7 +2160,7 @@ unsafe impl ::windows::core::Interface for IAsyncManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAsyncManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CompleteCall: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, result: ::windows::core::HRESULT) -> ::windows::core::HRESULT,
     pub GetCallContext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, pinterface: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetState: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pulstateflags: *mut u32) -> ::windows::core::HRESULT,
@@ -2322,7 +2322,7 @@ unsafe impl ::windows::core::Interface for IAuthenticate {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAuthenticate_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Authenticate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, phwnd: *mut super::super::Foundation::HWND, pszusername: *mut ::windows::core::PWSTR, pszpassword: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -2494,7 +2494,7 @@ unsafe impl ::windows::core::Interface for IBindCtx {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IBindCtx_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub RegisterObjectBound: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punk: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub RevokeObjectBound: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punk: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub ReleaseBoundObjects: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -2572,7 +2572,7 @@ unsafe impl ::windows::core::Interface for IBindHost {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IBindHost_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateMoniker: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, szname: ::windows::core::PCWSTR, pbc: *mut ::core::ffi::c_void, ppmk: *mut *mut ::core::ffi::c_void, dwreserved: u32) -> ::windows::core::HRESULT,
     pub MonikerBindToStorage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pmk: *mut ::core::ffi::c_void, pbc: *mut ::core::ffi::c_void, pbsc: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppvobj: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub MonikerBindToObject: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pmk: *mut ::core::ffi::c_void, pbc: *mut ::core::ffi::c_void, pbsc: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppvobj: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -2661,7 +2661,7 @@ unsafe impl ::windows::core::Interface for IBindStatusCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IBindStatusCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnStartBinding: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwreserved: u32, pib: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetPriority: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pnpriority: *mut i32) -> ::windows::core::HRESULT,
     pub OnLowResource: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, reserved: u32) -> ::windows::core::HRESULT,
@@ -2849,7 +2849,7 @@ unsafe impl ::windows::core::Interface for IBinding {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IBinding_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Abort: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Suspend: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Resume: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -2906,7 +2906,7 @@ unsafe impl ::windows::core::Interface for IBlockingLock {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IBlockingLock_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Lock: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwtimeout: u32) -> ::windows::core::HRESULT,
     pub Unlock: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -2960,7 +2960,7 @@ unsafe impl ::windows::core::Interface for ICallFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICallFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateCall: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, pctrlunk: *mut ::core::ffi::c_void, riid2: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Com\"`*"]
@@ -3012,7 +3012,7 @@ unsafe impl ::windows::core::Interface for ICancelMethodCalls {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICancelMethodCalls_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Cancel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ulseconds: u32) -> ::windows::core::HRESULT,
     pub TestCancel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -3082,7 +3082,7 @@ unsafe impl ::windows::core::Interface for ICatInformation {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICatInformation_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub EnumCategories: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lcid: u32, ppenumcategoryinfo: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetCategoryDesc: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, rcatid: *const ::windows::core::GUID, lcid: u32, pszdesc: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub EnumClassesOfCategories: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cimplemented: u32, rgcatidimpl: *const ::windows::core::GUID, crequired: u32, rgcatidreq: *const ::windows::core::GUID, ppenumclsid: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -3151,7 +3151,7 @@ unsafe impl ::windows::core::Interface for ICatRegister {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICatRegister_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub RegisterCategories: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ccategories: u32, rgcategoryinfo: *const CATEGORYINFO) -> ::windows::core::HRESULT,
     pub UnRegisterCategories: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ccategories: u32, rgcatid: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub RegisterClassImplCategories: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, rclsid: *const ::windows::core::GUID, ccategories: u32, rgcatid: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
@@ -3220,7 +3220,7 @@ unsafe impl ::windows::core::Interface for IChannelHook {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IChannelHook_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ClientGetSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, uextent: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, pdatasize: *mut u32),
     pub ClientFillBuffer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, uextent: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, pdatasize: *mut u32, pdatabuffer: *const ::core::ffi::c_void),
     pub ClientNotify: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, uextent: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, cbdatasize: u32, pdatabuffer: *const ::core::ffi::c_void, ldatarep: u32, hrfault: ::windows::core::HRESULT),
@@ -3278,7 +3278,7 @@ unsafe impl ::windows::core::Interface for IClassActivator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IClassActivator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetClassObject: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, rclsid: *const ::windows::core::GUID, dwclasscontext: u32, locale: u32, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Com\"`*"]
@@ -3340,7 +3340,7 @@ unsafe impl ::windows::core::Interface for IClassFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IClassFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateInstance: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punkouter: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub LockServer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, flock: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -3421,7 +3421,7 @@ unsafe impl ::windows::core::Interface for IClientSecurity {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IClientSecurity_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub QueryBlanket: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pproxy: *mut ::core::ffi::c_void, pauthnsvc: *mut u32, pauthzsvc: *mut u32, pserverprincname: *mut *mut u16, pauthnlevel: *mut RPC_C_AUTHN_LEVEL, pimplevel: *mut RPC_C_IMP_LEVEL, pauthinfo: *mut *mut ::core::ffi::c_void, pcapabilites: *mut EOLE_AUTHENTICATION_CAPABILITIES) -> ::windows::core::HRESULT,
     pub SetBlanket: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pproxy: *mut ::core::ffi::c_void, dwauthnsvc: u32, dwauthzsvc: u32, pserverprincname: ::windows::core::PCWSTR, dwauthnlevel: RPC_C_AUTHN_LEVEL, dwimplevel: RPC_C_IMP_LEVEL, pauthinfo: *const ::core::ffi::c_void, dwcapabilities: EOLE_AUTHENTICATION_CAPABILITIES) -> ::windows::core::HRESULT,
     pub CopyProxy: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pproxy: *mut ::core::ffi::c_void, ppcopy: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -3484,7 +3484,7 @@ unsafe impl ::windows::core::Interface for IComThreadingInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IComThreadingInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCurrentApartmentType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, papttype: *mut APTTYPE) -> ::windows::core::HRESULT,
     pub GetCurrentThreadType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pthreadtype: *mut THDTYPE) -> ::windows::core::HRESULT,
     pub GetCurrentLogicalThreadId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pguidlogicalthreadid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
@@ -3555,7 +3555,7 @@ unsafe impl ::windows::core::Interface for IConnectionPoint {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IConnectionPoint_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetConnectionInterface: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, piid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub GetConnectionPointContainer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppcpc: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Advise: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punksink: *mut ::core::ffi::c_void, pdwcookie: *mut u32) -> ::windows::core::HRESULT,
@@ -3613,7 +3613,7 @@ unsafe impl ::windows::core::Interface for IConnectionPointContainer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IConnectionPointContainer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub EnumConnectionPoints: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub FindConnectionPoint: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppcp: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -3666,7 +3666,7 @@ unsafe impl ::windows::core::Interface for IContextCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IContextCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ContextCallback: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfncallback: *mut ::core::ffi::c_void, pparam: *const ComCallData, riid: *const ::windows::core::GUID, imethod: i32, punk: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Com\"`*"]
@@ -3733,7 +3733,7 @@ unsafe impl ::windows::core::Interface for IDataAdviseHolder {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDataAdviseHolder_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Advise: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdataobject: *mut ::core::ffi::c_void, pfetc: *const FORMATETC, advf: u32, padvise: *mut ::core::ffi::c_void, pdwconnection: *mut u32) -> ::windows::core::HRESULT,
     pub Unadvise: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwconnection: u32) -> ::windows::core::HRESULT,
     pub EnumAdvise: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppenumadvise: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -3825,7 +3825,7 @@ unsafe impl ::windows::core::Interface for IDataObject {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDataObject_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
     pub GetData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pformatetcin: *const FORMATETC, pmedium: *mut STGMEDIUM) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage")))]
@@ -3905,7 +3905,7 @@ unsafe impl ::windows::core::Interface for IDispatch {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDispatch_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetTypeInfoCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pctinfo: *mut u32) -> ::windows::core::HRESULT,
     pub GetTypeInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, itinfo: u32, lcid: u32, pptinfo: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetIDsOfNames: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, rgsznames: *const ::windows::core::PWSTR, cnames: u32, lcid: u32, rgdispid: *mut i32) -> ::windows::core::HRESULT,
@@ -3970,7 +3970,7 @@ unsafe impl ::windows::core::Interface for IEnumCATEGORYINFO {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumCATEGORYINFO_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut CATEGORYINFO, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -4032,7 +4032,7 @@ unsafe impl ::windows::core::Interface for IEnumConnectionPoints {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumConnectionPoints_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cconnections: u32, ppcp: *mut *mut ::core::ffi::c_void, pcfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cconnections: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -4094,7 +4094,7 @@ unsafe impl ::windows::core::Interface for IEnumConnections {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumConnections_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cconnections: u32, rgcd: *mut CONNECTDATA, pcfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cconnections: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -4156,7 +4156,7 @@ unsafe impl ::windows::core::Interface for IEnumFORMATETC {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumFORMATETC_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut FORMATETC, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -4218,7 +4218,7 @@ unsafe impl ::windows::core::Interface for IEnumGUID {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumGUID_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut ::windows::core::GUID, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -4280,7 +4280,7 @@ unsafe impl ::windows::core::Interface for IEnumMoniker {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumMoniker_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -4342,7 +4342,7 @@ unsafe impl ::windows::core::Interface for IEnumSTATDATA {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumSTATDATA_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut STATDATA, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -4404,7 +4404,7 @@ unsafe impl ::windows::core::Interface for IEnumString {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumString_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut ::windows::core::PWSTR, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -4466,7 +4466,7 @@ unsafe impl ::windows::core::Interface for IEnumUnknown {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumUnknown_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -4535,7 +4535,7 @@ unsafe impl ::windows::core::Interface for IErrorInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IErrorInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetGUID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pguid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub GetSource: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstrsource: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub GetDescription: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstrdescription: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
@@ -4591,7 +4591,7 @@ unsafe impl ::windows::core::Interface for IErrorLog {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IErrorLog_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddError: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszpropname: ::windows::core::PCWSTR, pexcepinfo: *const EXCEPINFO) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Com\"`*"]
@@ -4648,7 +4648,7 @@ unsafe impl ::windows::core::Interface for IExternalConnection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IExternalConnection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddConnection: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, extconn: u32, reserved: u32) -> u32,
     #[cfg(feature = "Win32_Foundation")]
     pub ReleaseConnection: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, extconn: u32, reserved: u32, flastreleasecloses: super::super::Foundation::BOOL) -> u32,
@@ -4697,7 +4697,7 @@ unsafe impl ::windows::core::Interface for IFastRundown {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IFastRundown_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
 }
 #[doc = "*Required features: `\"Win32_System_Com\"`*"]
 #[repr(transparent)]
@@ -4745,7 +4745,7 @@ unsafe impl ::windows::core::Interface for IForegroundTransfer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IForegroundTransfer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AllowForegroundTransfer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lpvreserved: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Com\"`*"]
@@ -4804,7 +4804,7 @@ unsafe impl ::windows::core::Interface for IGlobalInterfaceTable {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IGlobalInterfaceTable_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub RegisterInterfaceInGlobal: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punk: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, pdwcookie: *mut u32) -> ::windows::core::HRESULT,
     pub RevokeInterfaceFromGlobal: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwcookie: u32) -> ::windows::core::HRESULT,
     pub GetInterfaceFromGlobal: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwcookie: u32, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -4859,7 +4859,7 @@ unsafe impl ::windows::core::Interface for IGlobalOptions {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IGlobalOptions_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Set: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwproperty: GLOBALOPT_PROPERTIES, dwvalue: usize) -> ::windows::core::HRESULT,
     pub Query: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwproperty: GLOBALOPT_PROPERTIES, pdwvalue: *mut usize) -> ::windows::core::HRESULT,
 }
@@ -4918,7 +4918,7 @@ unsafe impl ::windows::core::Interface for IInitializeSpy {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IInitializeSpy_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub PreInitialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwcoinit: u32, dwcurthreadaptrefs: u32) -> ::windows::core::HRESULT,
     pub PostInitialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hrcoinit: ::windows::core::HRESULT, dwcoinit: u32, dwnewthreadaptrefs: u32) -> ::windows::core::HRESULT,
     pub PreUninitialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwcurthreadaptrefs: u32) -> ::windows::core::HRESULT,
@@ -4970,7 +4970,7 @@ unsafe impl ::windows::core::Interface for IInternalUnknown {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IInternalUnknown_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub QueryInternalInterface: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Com\"`*"]
@@ -5035,7 +5035,7 @@ unsafe impl ::windows::core::Interface for IMachineGlobalObjectTable {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMachineGlobalObjectTable_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub RegisterObject: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, clsid: *const ::windows::core::GUID, identifier: ::windows::core::PCWSTR, object: *mut ::core::ffi::c_void, token: *mut *mut MachineGlobalObjectTableRegistrationToken__) -> ::windows::core::HRESULT,
     pub GetObject: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, clsid: *const ::windows::core::GUID, identifier: ::windows::core::PCWSTR, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub RevokeObject: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, token: *const MachineGlobalObjectTableRegistrationToken__) -> ::windows::core::HRESULT,
@@ -5101,7 +5101,7 @@ unsafe impl ::windows::core::Interface for IMalloc {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMalloc_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Alloc: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cb: usize) -> *mut ::core::ffi::c_void,
     pub Realloc: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pv: *const ::core::ffi::c_void, cb: usize) -> *mut ::core::ffi::c_void,
     pub Free: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pv: *const ::core::ffi::c_void),
@@ -5228,7 +5228,7 @@ unsafe impl ::windows::core::Interface for IMallocSpy {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMallocSpy_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub PreAlloc: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cbrequest: usize) -> usize,
     pub PostAlloc: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pactual: *const ::core::ffi::c_void) -> *mut ::core::ffi::c_void,
     #[cfg(feature = "Win32_Foundation")]
@@ -5542,7 +5542,7 @@ unsafe impl ::windows::core::Interface for IMultiQI {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMultiQI_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub QueryMultipleInterfaces: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cmqis: u32, pmqis: *mut MULTI_QI) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Com\"`*"]
@@ -5587,7 +5587,7 @@ unsafe impl ::windows::core::Interface for INoMarshal {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INoMarshal_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
 }
 #[doc = "*Required features: `\"Win32_System_Com\"`*"]
 #[repr(transparent)]
@@ -5648,7 +5648,7 @@ unsafe impl ::windows::core::Interface for IOplockStorage {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOplockStorage_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateStorageEx: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwcsname: ::windows::core::PCWSTR, grfmode: u32, stgfmt: u32, grfattrs: u32, riid: *const ::windows::core::GUID, ppstgopen: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub OpenStorageEx: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwcsname: ::windows::core::PCWSTR, grfmode: u32, stgfmt: u32, grfattrs: u32, riid: *const ::windows::core::GUID, ppstgopen: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -5708,7 +5708,7 @@ unsafe impl ::windows::core::Interface for IPSFactoryBuffer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPSFactoryBuffer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateProxy: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punkouter: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppproxy: *mut *mut ::core::ffi::c_void, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CreateStub: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, punkserver: *mut ::core::ffi::c_void, ppstub: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -5759,7 +5759,7 @@ unsafe impl ::windows::core::Interface for IPersist {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPersist_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetClassID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pclassid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Com\"`*"]
@@ -6194,7 +6194,7 @@ unsafe impl ::windows::core::Interface for IPipeByte {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPipeByte_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Pull: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, buf: *mut u8, crequest: u32, pcreturned: *mut u32) -> ::windows::core::HRESULT,
     pub Push: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, buf: *const u8, csent: u32) -> ::windows::core::HRESULT,
 }
@@ -6247,7 +6247,7 @@ unsafe impl ::windows::core::Interface for IPipeDouble {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPipeDouble_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Pull: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, buf: *mut f64, crequest: u32, pcreturned: *mut u32) -> ::windows::core::HRESULT,
     pub Push: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, buf: *const f64, csent: u32) -> ::windows::core::HRESULT,
 }
@@ -6300,7 +6300,7 @@ unsafe impl ::windows::core::Interface for IPipeLong {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPipeLong_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Pull: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, buf: *mut i32, crequest: u32, pcreturned: *mut u32) -> ::windows::core::HRESULT,
     pub Push: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, buf: *const i32, csent: u32) -> ::windows::core::HRESULT,
 }
@@ -6350,7 +6350,7 @@ unsafe impl ::windows::core::Interface for IProcessInitControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IProcessInitControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ResetInitializerTimeout: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwsecondsremaining: u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Com\"`*"]
@@ -6402,7 +6402,7 @@ unsafe impl ::windows::core::Interface for IProcessLock {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IProcessLock_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddRefOnProcess: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32,
     pub ReleaseRefOnProcess: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32,
 }
@@ -6458,7 +6458,7 @@ unsafe impl ::windows::core::Interface for IProgressNotify {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IProgressNotify_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub OnProgress: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwprogresscurrent: u32, dwprogressmaximum: u32, faccurate: super::super::Foundation::BOOL, fowner: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -6510,7 +6510,7 @@ unsafe impl ::windows::core::Interface for IROTData {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IROTData_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetComparisonData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbdata: *mut u8, cbmax: u32, pcbdata: *mut u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Com\"`*"]
@@ -6562,7 +6562,7 @@ unsafe impl ::windows::core::Interface for IReleaseMarshalBuffers {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IReleaseMarshalBuffers_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ReleaseMarshalBuffer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pmsg: *mut RPCOLEMESSAGE, dwflags: u32, pchnl: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Com\"`*"]
@@ -6623,7 +6623,7 @@ unsafe impl ::windows::core::Interface for IRpcChannelBuffer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRpcChannelBuffer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetBuffer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pmessage: *mut RPCOLEMESSAGE, riid: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub SendReceive: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pmessage: *mut RPCOLEMESSAGE, pstatus: *mut u32) -> ::windows::core::HRESULT,
     pub FreeBuffer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pmessage: *mut RPCOLEMESSAGE) -> ::windows::core::HRESULT,
@@ -6887,7 +6887,7 @@ unsafe impl ::windows::core::Interface for IRpcHelper {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRpcHelper_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDCOMProtocolVersion: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcomversion: *mut u32) -> ::windows::core::HRESULT,
     pub GetIIDFromOBJREF: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pobjref: *const ::core::ffi::c_void, piid: *mut *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
 }
@@ -6947,7 +6947,7 @@ unsafe impl ::windows::core::Interface for IRpcOptions {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRpcOptions_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Set: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pprx: *mut ::core::ffi::c_void, dwproperty: RPCOPT_PROPERTIES, dwvalue: usize) -> ::windows::core::HRESULT,
     pub Query: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pprx: *mut ::core::ffi::c_void, dwproperty: RPCOPT_PROPERTIES, pdwvalue: *mut usize) -> ::windows::core::HRESULT,
 }
@@ -7003,7 +7003,7 @@ unsafe impl ::windows::core::Interface for IRpcProxyBuffer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRpcProxyBuffer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Connect: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, prpcchannelbuffer: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Disconnect: unsafe extern "system" fn(this: *mut ::core::ffi::c_void),
 }
@@ -7077,7 +7077,7 @@ unsafe impl ::windows::core::Interface for IRpcStubBuffer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRpcStubBuffer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Connect: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punkserver: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Disconnect: unsafe extern "system" fn(this: *mut ::core::ffi::c_void),
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, _prpcmsg: *mut RPCOLEMESSAGE, _prpcchannelbuffer: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -7132,7 +7132,7 @@ unsafe impl ::windows::core::Interface for IRpcSyntaxNegotiate {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRpcSyntaxNegotiate_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub NegotiateSyntax: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pmsg: *mut RPCOLEMESSAGE) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Com\"`*"]
@@ -7210,7 +7210,7 @@ unsafe impl ::windows::core::Interface for IRunnableObject {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRunnableObject_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetRunningClass: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lpclsid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub Run: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbc: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -7311,7 +7311,7 @@ unsafe impl ::windows::core::Interface for IRunningObjectTable {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRunningObjectTable_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Register: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, grfflags: ROT_FLAGS, punkobject: *mut ::core::ffi::c_void, pmkobjectname: *mut ::core::ffi::c_void, pdwregister: *mut u32) -> ::windows::core::HRESULT,
     pub Revoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwregister: u32) -> ::windows::core::HRESULT,
     pub IsRunning: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pmkobjectname: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -7375,7 +7375,7 @@ unsafe impl ::windows::core::Interface for ISequentialStream {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISequentialStream_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Read: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pv: *mut ::core::ffi::c_void, cb: u32, pcbread: *mut u32) -> ::windows::core::HRESULT,
     pub Write: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pv: *const ::core::ffi::c_void, cb: u32, pcbwritten: *mut u32) -> ::windows::core::HRESULT,
 }
@@ -7446,7 +7446,7 @@ unsafe impl ::windows::core::Interface for IServerSecurity {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IServerSecurity_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub QueryBlanket: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pauthnsvc: *mut u32, pauthzsvc: *mut u32, pserverprincname: *mut *mut u16, pauthnlevel: *mut u32, pimplevel: *mut u32, pprivs: *mut *mut ::core::ffi::c_void, pcapabilities: *mut u32) -> ::windows::core::HRESULT,
     pub ImpersonateClient: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub RevertToSelf: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -7501,7 +7501,7 @@ unsafe impl ::windows::core::Interface for IServiceProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IServiceProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub QueryService: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, guidservice: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Com\"`*"]
@@ -7550,7 +7550,7 @@ unsafe impl ::windows::core::Interface for IStdMarshalInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IStdMarshalInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetClassForHandler: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwdestcontext: u32, pvdestcontext: *mut ::core::ffi::c_void, pclsid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Com\"`*"]
@@ -7711,7 +7711,7 @@ unsafe impl ::windows::core::Interface for ISupportErrorInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISupportErrorInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub InterfaceSupportsErrorInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Com\"`*"]
@@ -7763,7 +7763,7 @@ unsafe impl ::windows::core::Interface for ISurrogate {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISurrogate_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub LoadDllServer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, clsid: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub FreeSurrogate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -7831,7 +7831,7 @@ unsafe impl ::windows::core::Interface for ISurrogateService {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISurrogateService_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Init: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, rguidprocessid: *const ::windows::core::GUID, pprocesslock: *mut ::core::ffi::c_void, pfapplicationaware: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -7893,7 +7893,7 @@ unsafe impl ::windows::core::Interface for ISynchronize {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISynchronize_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Wait: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwflags: u32, dwmilliseconds: u32) -> ::windows::core::HRESULT,
     pub Signal: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -7951,7 +7951,7 @@ unsafe impl ::windows::core::Interface for ISynchronizeContainer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISynchronizeContainer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddSynchronize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psync: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub WaitMultiple: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwflags: u32, dwtimeout: u32, ppsync: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -8079,7 +8079,7 @@ unsafe impl ::windows::core::Interface for ISynchronizeHandle {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISynchronizeHandle_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetHandle: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ph: *mut super::super::Foundation::HANDLE) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -8204,7 +8204,7 @@ unsafe impl ::windows::core::Interface for ITimeAndNoticeControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITimeAndNoticeControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SuppressChanges: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, res1: u32, res2: u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Com\"`*"]
@@ -8264,7 +8264,7 @@ unsafe impl ::windows::core::Interface for ITypeComp {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITypeComp_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
     pub Bind: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, szname: ::windows::core::PCWSTR, lhashval: u32, wflags: u16, pptinfo: *mut *mut ::core::ffi::c_void, pdesckind: *mut DESCKIND, pbindptr: *mut BINDPTR) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Ole")))]
@@ -8399,7 +8399,7 @@ unsafe impl ::windows::core::Interface for ITypeInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITypeInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Ole")]
     pub GetTypeAttr: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pptypeattr: *mut *mut TYPEATTR) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Ole"))]
@@ -8790,7 +8790,7 @@ unsafe impl ::windows::core::Interface for ITypeLib {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITypeLib_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetTypeInfoCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32,
     pub GetTypeInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: u32, pptinfo: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetTypeInfoType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: u32, ptkind: *mut TYPEKIND) -> ::windows::core::HRESULT,
@@ -9005,7 +9005,7 @@ unsafe impl ::windows::core::Interface for ITypeLibRegistration {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITypeLibRegistration_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetGuid: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pguid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub GetVersion: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pversion: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub GetLcid: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, plcid: *mut u32) -> ::windows::core::HRESULT,
@@ -9062,7 +9062,7 @@ unsafe impl ::windows::core::Interface for ITypeLibRegistrationReader {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITypeLibRegistrationReader_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub EnumTypeLibRegistrations: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppenumunknown: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Com\"`*"]
@@ -9212,7 +9212,7 @@ unsafe impl ::windows::core::Interface for IUri {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUri_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetPropertyBSTR: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, uriprop: Uri_PROPERTY, pbstrproperty: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>, dwflags: u32) -> ::windows::core::HRESULT,
     pub GetPropertyLength: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, uriprop: Uri_PROPERTY, pcchproperty: *mut u32, dwflags: u32) -> ::windows::core::HRESULT,
     pub GetPropertyDWORD: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, uriprop: Uri_PROPERTY, pdwproperty: *mut u32, dwflags: u32) -> ::windows::core::HRESULT,
@@ -9395,7 +9395,7 @@ unsafe impl ::windows::core::Interface for IUriBuilder {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUriBuilder_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateUriSimple: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwallowencodingpropertymask: u32, dwreserved: usize, ppiuri: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CreateUri: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwcreateflags: u32, dwallowencodingpropertymask: u32, dwreserved: usize, ppiuri: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CreateUriWithFlags: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwcreateflags: u32, dwuribuilderflags: u32, dwallowencodingpropertymask: u32, dwreserved: usize, ppiuri: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -9481,7 +9481,7 @@ unsafe impl ::windows::core::Interface for IUrlMon {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUrlMon_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AsyncGetClassBits: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, rclsid: *const ::windows::core::GUID, psztype: ::windows::core::PCWSTR, pszext: ::windows::core::PCWSTR, dwfileversionms: u32, dwfileversionls: u32, pszcodebase: ::windows::core::PCWSTR, pbc: *mut ::core::ffi::c_void, dwclasscontext: u32, riid: *const ::windows::core::GUID, flags: u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Com\"`*"]
@@ -9537,7 +9537,7 @@ unsafe impl ::windows::core::Interface for IWaitMultiple {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWaitMultiple_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub WaitMultiple: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, timeout: u32, psync: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub AddSynchronize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psync: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }

--- a/crates/libs/windows/src/Windows/Win32/System/ComponentServices/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/ComponentServices/impl.rs
@@ -201,7 +201,7 @@ impl IAsyncErrorNotify_Vtbl {
             let this = (*this).get_impl();
             this.OnError(::core::mem::transmute_copy(&hr)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnError: OnError::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnError: OnError::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IAsyncErrorNotify as ::windows::core::Interface>::IID
@@ -788,7 +788,7 @@ impl ICOMLBArguments_Vtbl {
             this.SetMachineName(::core::mem::transmute_copy(&cchsvr), ::core::mem::transmute(&szservername)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCLSID: GetCLSID::<Identity, Impl, OFFSET>,
             SetCLSID: SetCLSID::<Identity, Impl, OFFSET>,
             GetMachineName: GetMachineName::<Identity, Impl, OFFSET>,
@@ -1111,7 +1111,7 @@ impl ICheckSxsConfig_Vtbl {
             let this = (*this).get_impl();
             this.IsSameSxsConfig(::core::mem::transmute(&wszsxsname), ::core::mem::transmute(&wszsxsdirectory), ::core::mem::transmute(&wszsxsappname)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), IsSameSxsConfig: IsSameSxsConfig::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), IsSameSxsConfig: IsSameSxsConfig::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ICheckSxsConfig as ::windows::core::Interface>::IID
@@ -1165,7 +1165,7 @@ impl IComActivityEvents_Vtbl {
             this.OnActivityLeaveSame(::core::mem::transmute_copy(&pinfo), ::core::mem::transmute_copy(&guidcurrent), ::core::mem::transmute_copy(&dwcalldepth)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnActivityCreate: OnActivityCreate::<Identity, Impl, OFFSET>,
             OnActivityDestroy: OnActivityDestroy::<Identity, Impl, OFFSET>,
             OnActivityEnter: OnActivityEnter::<Identity, Impl, OFFSET>,
@@ -1218,7 +1218,7 @@ impl IComApp2Events_Vtbl {
             this.OnAppRecycle2(::core::mem::transmute_copy(&pinfo), ::core::mem::transmute(&guidapp), ::core::mem::transmute(&guidprocess), ::core::mem::transmute_copy(&lreason)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnAppActivation2: OnAppActivation2::<Identity, Impl, OFFSET>,
             OnAppShutdown2: OnAppShutdown2::<Identity, Impl, OFFSET>,
             OnAppForceShutdown2: OnAppForceShutdown2::<Identity, Impl, OFFSET>,
@@ -1254,7 +1254,7 @@ impl IComAppEvents_Vtbl {
             this.OnAppForceShutdown(::core::mem::transmute_copy(&pinfo), ::core::mem::transmute(&guidapp)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnAppActivation: OnAppActivation::<Identity, Impl, OFFSET>,
             OnAppShutdown: OnAppShutdown::<Identity, Impl, OFFSET>,
             OnAppForceShutdown: OnAppForceShutdown::<Identity, Impl, OFFSET>,
@@ -1363,7 +1363,7 @@ impl IComCRMEvents_Vtbl {
             this.OnCRMDeliver(::core::mem::transmute_copy(&pinfo), ::core::mem::transmute(&guidclerkclsid), ::core::mem::transmute_copy(&fvariants), ::core::mem::transmute_copy(&dwrecordsize)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnCRMRecoveryStart: OnCRMRecoveryStart::<Identity, Impl, OFFSET>,
             OnCRMRecoveryDone: OnCRMRecoveryDone::<Identity, Impl, OFFSET>,
             OnCRMCheckpoint: OnCRMCheckpoint::<Identity, Impl, OFFSET>,
@@ -1396,7 +1396,7 @@ impl IComExceptionEvents_Vtbl {
             let this = (*this).get_impl();
             this.OnExceptionUser(::core::mem::transmute_copy(&pinfo), ::core::mem::transmute_copy(&code), ::core::mem::transmute_copy(&address), ::core::mem::transmute(&pszstacktrace)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnExceptionUser: OnExceptionUser::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnExceptionUser: OnExceptionUser::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IComExceptionEvents as ::windows::core::Interface>::IID
@@ -1413,7 +1413,7 @@ impl IComIdentityEvents_Vtbl {
             let this = (*this).get_impl();
             this.OnIISRequestInfo(::core::mem::transmute_copy(&pinfo), ::core::mem::transmute_copy(&objid), ::core::mem::transmute(&pszclientip), ::core::mem::transmute(&pszserverip), ::core::mem::transmute(&pszurl)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnIISRequestInfo: OnIISRequestInfo::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnIISRequestInfo: OnIISRequestInfo::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IComIdentityEvents as ::windows::core::Interface>::IID
@@ -1437,7 +1437,7 @@ impl IComInstance2Events_Vtbl {
             this.OnObjectDestroy2(::core::mem::transmute_copy(&pinfo), ::core::mem::transmute_copy(&ctxtid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnObjectCreate2: OnObjectCreate2::<Identity, Impl, OFFSET>,
             OnObjectDestroy2: OnObjectDestroy2::<Identity, Impl, OFFSET>,
         }
@@ -1464,7 +1464,7 @@ impl IComInstanceEvents_Vtbl {
             this.OnObjectDestroy(::core::mem::transmute_copy(&pinfo), ::core::mem::transmute_copy(&ctxtid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnObjectCreate: OnObjectCreate::<Identity, Impl, OFFSET>,
             OnObjectDestroy: OnObjectDestroy::<Identity, Impl, OFFSET>,
         }
@@ -1512,7 +1512,7 @@ impl IComLTxEvents_Vtbl {
             this.OnLtxTransactionPromote(::core::mem::transmute_copy(&pinfo), ::core::mem::transmute(&guidltx), ::core::mem::transmute(&txnid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnLtxTransactionStart: OnLtxTransactionStart::<Identity, Impl, OFFSET>,
             OnLtxTransactionPrepare: OnLtxTransactionPrepare::<Identity, Impl, OFFSET>,
             OnLtxTransactionAbort: OnLtxTransactionAbort::<Identity, Impl, OFFSET>,
@@ -1548,7 +1548,7 @@ impl IComMethod2Events_Vtbl {
             this.OnMethodException2(::core::mem::transmute_copy(&pinfo), ::core::mem::transmute_copy(&oid), ::core::mem::transmute_copy(&guidcid), ::core::mem::transmute_copy(&guidrid), ::core::mem::transmute_copy(&dwthread), ::core::mem::transmute_copy(&imeth)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnMethodCall2: OnMethodCall2::<Identity, Impl, OFFSET>,
             OnMethodReturn2: OnMethodReturn2::<Identity, Impl, OFFSET>,
             OnMethodException2: OnMethodException2::<Identity, Impl, OFFSET>,
@@ -1582,7 +1582,7 @@ impl IComMethodEvents_Vtbl {
             this.OnMethodException(::core::mem::transmute_copy(&pinfo), ::core::mem::transmute_copy(&oid), ::core::mem::transmute_copy(&guidcid), ::core::mem::transmute_copy(&guidrid), ::core::mem::transmute_copy(&imeth)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnMethodCall: OnMethodCall::<Identity, Impl, OFFSET>,
             OnMethodReturn: OnMethodReturn::<Identity, Impl, OFFSET>,
             OnMethodException: OnMethodException::<Identity, Impl, OFFSET>,
@@ -1634,7 +1634,7 @@ impl IComMtaThreadPoolKnobs_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             MTASetMaxThreadCount: MTASetMaxThreadCount::<Identity, Impl, OFFSET>,
             MTAGetMaxThreadCount: MTAGetMaxThreadCount::<Identity, Impl, OFFSET>,
             MTASetThrottleValue: MTASetThrottleValue::<Identity, Impl, OFFSET>,
@@ -1656,7 +1656,7 @@ impl IComObjectConstruction2Events_Vtbl {
             let this = (*this).get_impl();
             this.OnObjectConstruct2(::core::mem::transmute_copy(&pinfo), ::core::mem::transmute_copy(&guidobject), ::core::mem::transmute(&sconstructstring), ::core::mem::transmute_copy(&oid), ::core::mem::transmute_copy(&guidpartition)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnObjectConstruct2: OnObjectConstruct2::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnObjectConstruct2: OnObjectConstruct2::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IComObjectConstruction2Events as ::windows::core::Interface>::IID
@@ -1673,7 +1673,7 @@ impl IComObjectConstructionEvents_Vtbl {
             let this = (*this).get_impl();
             this.OnObjectConstruct(::core::mem::transmute_copy(&pinfo), ::core::mem::transmute_copy(&guidobject), ::core::mem::transmute(&sconstructstring), ::core::mem::transmute_copy(&oid)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnObjectConstruct: OnObjectConstruct::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnObjectConstruct: OnObjectConstruct::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IComObjectConstructionEvents as ::windows::core::Interface>::IID
@@ -1721,7 +1721,7 @@ impl IComObjectEvents_Vtbl {
             this.OnSetAbort(::core::mem::transmute_copy(&pinfo), ::core::mem::transmute_copy(&ctxtid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnObjectActivate: OnObjectActivate::<Identity, Impl, OFFSET>,
             OnObjectDeactivate: OnObjectDeactivate::<Identity, Impl, OFFSET>,
             OnDisableCommit: OnDisableCommit::<Identity, Impl, OFFSET>,
@@ -1764,7 +1764,7 @@ impl IComObjectPool2Events_Vtbl {
             this.OnObjPoolGetFromTx2(::core::mem::transmute_copy(&pinfo), ::core::mem::transmute_copy(&guidactivity), ::core::mem::transmute_copy(&guidobject), ::core::mem::transmute_copy(&guidtx), ::core::mem::transmute_copy(&objid), ::core::mem::transmute_copy(&guidpartition)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnObjPoolPutObject2: OnObjPoolPutObject2::<Identity, Impl, OFFSET>,
             OnObjPoolGetObject2: OnObjPoolGetObject2::<Identity, Impl, OFFSET>,
             OnObjPoolRecycleToTx2: OnObjPoolRecycleToTx2::<Identity, Impl, OFFSET>,
@@ -1805,7 +1805,7 @@ impl IComObjectPoolEvents_Vtbl {
             this.OnObjPoolGetFromTx(::core::mem::transmute_copy(&pinfo), ::core::mem::transmute_copy(&guidactivity), ::core::mem::transmute_copy(&guidobject), ::core::mem::transmute_copy(&guidtx), ::core::mem::transmute_copy(&objid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnObjPoolPutObject: OnObjPoolPutObject::<Identity, Impl, OFFSET>,
             OnObjPoolGetObject: OnObjPoolGetObject::<Identity, Impl, OFFSET>,
             OnObjPoolRecycleToTx: OnObjPoolRecycleToTx::<Identity, Impl, OFFSET>,
@@ -1852,7 +1852,7 @@ impl IComObjectPoolEvents2_Vtbl {
             this.OnObjPoolCreatePool(::core::mem::transmute_copy(&pinfo), ::core::mem::transmute_copy(&guidobject), ::core::mem::transmute_copy(&dwmin), ::core::mem::transmute_copy(&dwmax), ::core::mem::transmute_copy(&dwtimeout)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnObjPoolCreateObject: OnObjPoolCreateObject::<Identity, Impl, OFFSET>,
             OnObjPoolDestroyObject: OnObjPoolDestroyObject::<Identity, Impl, OFFSET>,
             OnObjPoolCreateDecision: OnObjPoolCreateDecision::<Identity, Impl, OFFSET>,
@@ -1912,7 +1912,7 @@ impl IComQCEvents_Vtbl {
             this.OnQCPlayback(::core::mem::transmute_copy(&pinfo), ::core::mem::transmute_copy(&objid), ::core::mem::transmute_copy(&guidmsgid), ::core::mem::transmute_copy(&guidworkflowid), ::core::mem::transmute_copy(&hr)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnQCRecord: OnQCRecord::<Identity, Impl, OFFSET>,
             OnQCQueueOpen: OnQCQueueOpen::<Identity, Impl, OFFSET>,
             OnQCReceive: OnQCReceive::<Identity, Impl, OFFSET>,
@@ -1965,7 +1965,7 @@ impl IComResourceEvents_Vtbl {
             this.OnResourceTrack(::core::mem::transmute_copy(&pinfo), ::core::mem::transmute_copy(&objectid), ::core::mem::transmute(&psztype), ::core::mem::transmute_copy(&resid), ::core::mem::transmute_copy(&enlisted)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnResourceCreate: OnResourceCreate::<Identity, Impl, OFFSET>,
             OnResourceAllocate: OnResourceAllocate::<Identity, Impl, OFFSET>,
             OnResourceRecycle: OnResourceRecycle::<Identity, Impl, OFFSET>,
@@ -1998,7 +1998,7 @@ impl IComSecurityEvents_Vtbl {
             this.OnAuthenticateFail(::core::mem::transmute_copy(&pinfo), ::core::mem::transmute_copy(&guidactivity), ::core::mem::transmute_copy(&objectid), ::core::mem::transmute_copy(&guidiid), ::core::mem::transmute_copy(&imeth), ::core::mem::transmute_copy(&cbbyteorig), ::core::mem::transmute_copy(&psidoriginaluser), ::core::mem::transmute_copy(&cbbytecur), ::core::mem::transmute_copy(&psidcurrentuser), ::core::mem::transmute_copy(&bcurrentuserinpersonatinginproc)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnAuthenticate: OnAuthenticate::<Identity, Impl, OFFSET>,
             OnAuthenticateFail: OnAuthenticateFail::<Identity, Impl, OFFSET>,
         }
@@ -2115,7 +2115,7 @@ impl IComStaThreadPoolKnobs_Vtbl {
             this.SetQueueDepth(::core::mem::transmute_copy(&dwqdepth)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetMinThreadCount: SetMinThreadCount::<Identity, Impl, OFFSET>,
             GetMinThreadCount: GetMinThreadCount::<Identity, Impl, OFFSET>,
             SetMaxThreadCount: SetMaxThreadCount::<Identity, Impl, OFFSET>,
@@ -2321,7 +2321,7 @@ impl IComThreadEvents_Vtbl {
             this.OnThreadUnassignApartment(::core::mem::transmute_copy(&pinfo), ::core::mem::transmute_copy(&aptid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnThreadStart: OnThreadStart::<Identity, Impl, OFFSET>,
             OnThreadTerminate: OnThreadTerminate::<Identity, Impl, OFFSET>,
             OnThreadBindToApartment: OnThreadBindToApartment::<Identity, Impl, OFFSET>,
@@ -2375,7 +2375,7 @@ impl IComTrackingInfoCollection_Vtbl {
             this.Item(::core::mem::transmute_copy(&ulindex), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppv)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Type: Type::<Identity, Impl, OFFSET>,
             Count: Count::<Identity, Impl, OFFSET>,
             Item: Item::<Identity, Impl, OFFSET>,
@@ -2396,7 +2396,7 @@ impl IComTrackingInfoEvents_Vtbl {
             let this = (*this).get_impl();
             this.OnNewTrackingInfo(::core::mem::transmute(&ptoplevelcollection)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnNewTrackingInfo: OnNewTrackingInfo::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnNewTrackingInfo: OnNewTrackingInfo::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IComTrackingInfoEvents as ::windows::core::Interface>::IID
@@ -2422,7 +2422,7 @@ impl IComTrackingInfoObject_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetValue: GetValue::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetValue: GetValue::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IComTrackingInfoObject as ::windows::core::Interface>::IID
@@ -2458,7 +2458,7 @@ impl IComTrackingInfoProperties_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             PropCount: PropCount::<Identity, Impl, OFFSET>,
             GetPropName: GetPropName::<Identity, Impl, OFFSET>,
         }
@@ -2500,7 +2500,7 @@ impl IComTransaction2Events_Vtbl {
             this.OnTransactionCommit2(::core::mem::transmute_copy(&pinfo), ::core::mem::transmute_copy(&guidtx)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnTransactionStart2: OnTransactionStart2::<Identity, Impl, OFFSET>,
             OnTransactionPrepare2: OnTransactionPrepare2::<Identity, Impl, OFFSET>,
             OnTransactionAbort2: OnTransactionAbort2::<Identity, Impl, OFFSET>,
@@ -2544,7 +2544,7 @@ impl IComTransactionEvents_Vtbl {
             this.OnTransactionCommit(::core::mem::transmute_copy(&pinfo), ::core::mem::transmute_copy(&guidtx)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnTransactionStart: OnTransactionStart::<Identity, Impl, OFFSET>,
             OnTransactionPrepare: OnTransactionPrepare::<Identity, Impl, OFFSET>,
             OnTransactionAbort: OnTransactionAbort::<Identity, Impl, OFFSET>,
@@ -2569,7 +2569,7 @@ impl IComUserEvent_Vtbl {
             let this = (*this).get_impl();
             this.OnUserEvent(::core::mem::transmute_copy(&pinfo), ::core::mem::transmute_copy(&pvarevent)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnUserEvent: OnUserEvent::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnUserEvent: OnUserEvent::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IComUserEvent as ::windows::core::Interface>::IID
@@ -2620,7 +2620,7 @@ impl IContextProperties_Vtbl {
             this.RemoveProperty(::core::mem::transmute(&name)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Count: Count::<Identity, Impl, OFFSET>,
             GetProperty: GetProperty::<Identity, Impl, OFFSET>,
             EnumNames: EnumNames::<Identity, Impl, OFFSET>,
@@ -2653,7 +2653,7 @@ impl IContextSecurityPerimeter_Vtbl {
             this.SetPerimeterFlag(::core::mem::transmute_copy(&fflag)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetPerimeterFlag: GetPerimeterFlag::<Identity, Impl, OFFSET>,
             SetPerimeterFlag: SetPerimeterFlag::<Identity, Impl, OFFSET>,
         }
@@ -2692,7 +2692,7 @@ impl IContextState_Vtbl {
             this.GetMyTransactionVote(::core::mem::transmute_copy(&ptxvote)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetDeactivateOnReturn: SetDeactivateOnReturn::<Identity, Impl, OFFSET>,
             GetDeactivateOnReturn: GetDeactivateOnReturn::<Identity, Impl, OFFSET>,
             SetMyTransactionVote: SetMyTransactionVote::<Identity, Impl, OFFSET>,
@@ -2714,7 +2714,7 @@ impl ICreateWithLocalTransaction_Vtbl {
             let this = (*this).get_impl();
             this.CreateInstanceWithSysTx(::core::mem::transmute(&ptransaction), ::core::mem::transmute_copy(&rclsid), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&pobject)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CreateInstanceWithSysTx: CreateInstanceWithSysTx::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CreateInstanceWithSysTx: CreateInstanceWithSysTx::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ICreateWithLocalTransaction as ::windows::core::Interface>::IID
@@ -2731,7 +2731,7 @@ impl ICreateWithTipTransactionEx_Vtbl {
             let this = (*this).get_impl();
             this.CreateInstance(::core::mem::transmute(&bstrtipurl), ::core::mem::transmute_copy(&rclsid), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&pobject)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CreateInstance: CreateInstance::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CreateInstance: CreateInstance::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ICreateWithTipTransactionEx as ::windows::core::Interface>::IID
@@ -2751,7 +2751,7 @@ impl ICreateWithTransactionEx_Vtbl {
             let this = (*this).get_impl();
             this.CreateInstance(::core::mem::transmute(&ptransaction), ::core::mem::transmute_copy(&rclsid), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&pobject)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CreateInstance: CreateInstance::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CreateInstance: CreateInstance::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ICreateWithTransactionEx as ::windows::core::Interface>::IID
@@ -2850,7 +2850,7 @@ impl ICrmCompensator_Vtbl {
             this.EndAbort().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetLogControl: SetLogControl::<Identity, Impl, OFFSET>,
             BeginPrepare: BeginPrepare::<Identity, Impl, OFFSET>,
             PrepareRecord: PrepareRecord::<Identity, Impl, OFFSET>,
@@ -2960,7 +2960,7 @@ impl ICrmCompensatorVariants_Vtbl {
             this.EndAbortVariants().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetLogControlVariants: SetLogControlVariants::<Identity, Impl, OFFSET>,
             BeginPrepareVariants: BeginPrepareVariants::<Identity, Impl, OFFSET>,
             PrepareRecordVariants: PrepareRecordVariants::<Identity, Impl, OFFSET>,
@@ -3034,7 +3034,7 @@ impl ICrmFormatLogRecords_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetColumnCount: GetColumnCount::<Identity, Impl, OFFSET>,
             GetColumnHeaders: GetColumnHeaders::<Identity, Impl, OFFSET>,
             GetColumn: GetColumn::<Identity, Impl, OFFSET>,
@@ -3102,7 +3102,7 @@ impl ICrmLogControl_Vtbl {
             this.WriteLogRecord(::core::mem::transmute_copy(&rgblob), ::core::mem::transmute_copy(&cblob)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             TransactionUOW: TransactionUOW::<Identity, Impl, OFFSET>,
             RegisterCompensator: RegisterCompensator::<Identity, Impl, OFFSET>,
             WriteLogRecordVariants: WriteLogRecordVariants::<Identity, Impl, OFFSET>,
@@ -3149,7 +3149,7 @@ impl ICrmMonitor_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetClerks: GetClerks::<Identity, Impl, OFFSET>,
             HoldClerk: HoldClerk::<Identity, Impl, OFFSET>,
         }
@@ -3328,7 +3328,7 @@ impl ICrmMonitorLogRecords_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Count: Count::<Identity, Impl, OFFSET>,
             TransactionState: TransactionState::<Identity, Impl, OFFSET>,
             StructuredRecords: StructuredRecords::<Identity, Impl, OFFSET>,
@@ -3385,7 +3385,7 @@ impl IDispenserDriver_Vtbl {
             this.DestroyResourceS(::core::mem::transmute_copy(&resid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateResource: CreateResource::<Identity, Impl, OFFSET>,
             RateResource: RateResource::<Identity, Impl, OFFSET>,
             EnlistResource: EnlistResource::<Identity, Impl, OFFSET>,
@@ -3422,7 +3422,7 @@ impl IDispenserManager_Vtbl {
             this.GetContext(::core::mem::transmute_copy(&__midl__idispensermanager0002), ::core::mem::transmute_copy(&__midl__idispensermanager0003)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RegisterDispenser: RegisterDispenser::<Identity, Impl, OFFSET>,
             GetContext: GetContext::<Identity, Impl, OFFSET>,
         }
@@ -3467,7 +3467,7 @@ impl IEnumNames_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -3578,7 +3578,7 @@ impl IGetAppTrackerData_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetApplicationProcesses: GetApplicationProcesses::<Identity, Impl, OFFSET>,
             GetApplicationProcessDetails: GetApplicationProcessDetails::<Identity, Impl, OFFSET>,
             GetApplicationsInProcess: GetApplicationsInProcess::<Identity, Impl, OFFSET>,
@@ -3625,7 +3625,7 @@ impl IGetContextProperties_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Count: Count::<Identity, Impl, OFFSET>,
             GetProperty: GetProperty::<Identity, Impl, OFFSET>,
             EnumNames: EnumNames::<Identity, Impl, OFFSET>,
@@ -3718,7 +3718,7 @@ impl IHolder_Vtbl {
             this.RequestDestroyResource(::core::mem::transmute_copy(&__midl__iholder0009)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AllocResource: AllocResource::<Identity, Impl, OFFSET>,
             FreeResource: FreeResource::<Identity, Impl, OFFSET>,
             TrackResource: TrackResource::<Identity, Impl, OFFSET>,
@@ -3760,7 +3760,7 @@ impl ILBEvents_Vtbl {
             this.EngineDefined(::core::mem::transmute(&bstrpropname), ::core::mem::transmute_copy(&varpropvalue), ::core::mem::transmute(&bstrclsideng)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             TargetUp: TargetUp::<Identity, Impl, OFFSET>,
             TargetDown: TargetDown::<Identity, Impl, OFFSET>,
             EngineDefined: EngineDefined::<Identity, Impl, OFFSET>,
@@ -3806,7 +3806,7 @@ impl IMTSActivity_Vtbl {
             this.UnbindFromThread().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SynchronousCall: SynchronousCall::<Identity, Impl, OFFSET>,
             AsyncCall: AsyncCall::<Identity, Impl, OFFSET>,
             Reserved1: Reserved1::<Identity, Impl, OFFSET>,
@@ -3829,7 +3829,7 @@ impl IMTSCall_Vtbl {
             let this = (*this).get_impl();
             this.OnCall().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnCall: OnCall::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnCall: OnCall::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMTSCall as ::windows::core::Interface>::IID
@@ -3882,7 +3882,7 @@ impl IManagedActivationEvents_Vtbl {
             this.DestroyManagedStub(::core::mem::transmute(&pinfo)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateManagedStub: CreateManagedStub::<Identity, Impl, OFFSET>,
             DestroyManagedStub: DestroyManagedStub::<Identity, Impl, OFFSET>,
         }
@@ -3936,7 +3936,7 @@ impl IManagedObjectInfo_Vtbl {
             this.SetWrapperStrength(::core::mem::transmute_copy(&bstrong)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetIUnknown: GetIUnknown::<Identity, Impl, OFFSET>,
             GetIObjectControl: GetIObjectControl::<Identity, Impl, OFFSET>,
             SetInPool: SetInPool::<Identity, Impl, OFFSET>,
@@ -3958,7 +3958,7 @@ impl IManagedPoolAction_Vtbl {
             let this = (*this).get_impl();
             this.LastRelease().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), LastRelease: LastRelease::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), LastRelease: LastRelease::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IManagedPoolAction as ::windows::core::Interface>::IID
@@ -3978,7 +3978,7 @@ impl IManagedPooledObj_Vtbl {
             let this = (*this).get_impl();
             this.SetHeld(::core::mem::transmute_copy(&m_bheld)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SetHeld: SetHeld::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SetHeld: SetHeld::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IManagedPooledObj as ::windows::core::Interface>::IID
@@ -4326,7 +4326,7 @@ impl IObjPool_Vtbl {
             this.Reserved6()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Reserved1: Reserved1::<Identity, Impl, OFFSET>,
             Reserved2: Reserved2::<Identity, Impl, OFFSET>,
             Reserved3: Reserved3::<Identity, Impl, OFFSET>,
@@ -4354,7 +4354,7 @@ impl IObjectConstruct_Vtbl {
             let this = (*this).get_impl();
             this.Construct(::core::mem::transmute(&pctorobj)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Construct: Construct::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Construct: Construct::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IObjectConstruct as ::windows::core::Interface>::IID
@@ -4437,7 +4437,7 @@ impl IObjectContext_Vtbl {
             this.IsCallerInRole(::core::mem::transmute(&bstrrole), ::core::mem::transmute_copy(&pfisinrole)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateInstance: CreateInstance::<Identity, Impl, OFFSET>,
             SetComplete: SetComplete::<Identity, Impl, OFFSET>,
             SetAbort: SetAbort::<Identity, Impl, OFFSET>,
@@ -4463,7 +4463,7 @@ impl IObjectContextActivity_Vtbl {
             let this = (*this).get_impl();
             this.GetActivityId(::core::mem::transmute_copy(&pguid)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetActivityId: GetActivityId::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetActivityId: GetActivityId::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IObjectContextActivity as ::windows::core::Interface>::IID
@@ -4514,7 +4514,7 @@ impl IObjectContextInfo_Vtbl {
             this.GetContextId(::core::mem::transmute_copy(&pguid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             IsInTransaction: IsInTransaction::<Identity, Impl, OFFSET>,
             GetTransaction: GetTransaction::<Identity, Impl, OFFSET>,
             GetTransactionId: GetTransactionId::<Identity, Impl, OFFSET>,
@@ -4574,7 +4574,7 @@ impl IObjectContextTip_Vtbl {
             let this = (*this).get_impl();
             this.GetTipUrl(::core::mem::transmute_copy(&ptipurl)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetTipUrl: GetTipUrl::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetTipUrl: GetTipUrl::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IObjectContextTip as ::windows::core::Interface>::IID
@@ -4607,7 +4607,7 @@ impl IObjectControl_Vtbl {
             this.CanBePooled()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Activate: Activate::<Identity, Impl, OFFSET>,
             Deactivate: Deactivate::<Identity, Impl, OFFSET>,
             CanBePooled: CanBePooled::<Identity, Impl, OFFSET>,
@@ -4635,7 +4635,7 @@ impl IPlaybackControl_Vtbl {
             this.FinalServerRetry().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             FinalClientRetry: FinalClientRetry::<Identity, Impl, OFFSET>,
             FinalServerRetry: FinalServerRetry::<Identity, Impl, OFFSET>,
         }
@@ -4682,7 +4682,7 @@ impl IProcessInitializer_Vtbl {
             this.Shutdown().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Startup: Startup::<Identity, Impl, OFFSET>,
             Shutdown: Shutdown::<Identity, Impl, OFFSET>,
         }
@@ -4934,7 +4934,7 @@ impl ISecurityProperty_Vtbl {
             this.ReleaseSID(::core::mem::transmute_copy(&psid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDirectCreatorSID: GetDirectCreatorSID::<Identity, Impl, OFFSET>,
             GetOriginalCreatorSID: GetOriginalCreatorSID::<Identity, Impl, OFFSET>,
             GetDirectCallerSID: GetDirectCallerSID::<Identity, Impl, OFFSET>,
@@ -4964,7 +4964,7 @@ impl ISelectCOMLBServer_Vtbl {
             this.GetLBServer(::core::mem::transmute(&punk)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Init: Init::<Identity, Impl, OFFSET>,
             GetLBServer: GetLBServer::<Identity, Impl, OFFSET>,
         }
@@ -4991,7 +4991,7 @@ impl ISendMethodEvents_Vtbl {
             this.SendMethodReturn(::core::mem::transmute_copy(&pidentity), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&dwmeth), ::core::mem::transmute_copy(&hrcall), ::core::mem::transmute_copy(&hrserver)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SendMethodCall: SendMethodCall::<Identity, Impl, OFFSET>,
             SendMethodReturn: SendMethodReturn::<Identity, Impl, OFFSET>,
         }
@@ -5030,7 +5030,7 @@ impl IServiceActivity_Vtbl {
             this.UnbindFromThread().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SynchronousCall: SynchronousCall::<Identity, Impl, OFFSET>,
             AsynchronousCall: AsynchronousCall::<Identity, Impl, OFFSET>,
             BindToCurrentThread: BindToCurrentThread::<Identity, Impl, OFFSET>,
@@ -5052,7 +5052,7 @@ impl IServiceCall_Vtbl {
             let this = (*this).get_impl();
             this.OnCall().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnCall: OnCall::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnCall: OnCall::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IServiceCall as ::windows::core::Interface>::IID
@@ -5069,7 +5069,7 @@ impl IServiceComTIIntrinsicsConfig_Vtbl {
             let this = (*this).get_impl();
             this.ComTIIntrinsicsConfig(::core::mem::transmute_copy(&comtiintrinsicsconfig)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), ComTIIntrinsicsConfig: ComTIIntrinsicsConfig::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), ComTIIntrinsicsConfig: ComTIIntrinsicsConfig::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IServiceComTIIntrinsicsConfig as ::windows::core::Interface>::IID
@@ -5086,7 +5086,7 @@ impl IServiceIISIntrinsicsConfig_Vtbl {
             let this = (*this).get_impl();
             this.IISIntrinsicsConfig(::core::mem::transmute_copy(&iisintrinsicsconfig)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), IISIntrinsicsConfig: IISIntrinsicsConfig::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), IISIntrinsicsConfig: IISIntrinsicsConfig::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IServiceIISIntrinsicsConfig as ::windows::core::Interface>::IID
@@ -5104,7 +5104,7 @@ impl IServiceInheritanceConfig_Vtbl {
             this.ContainingContextTreatment(::core::mem::transmute_copy(&inheritanceconfig)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ContainingContextTreatment: ContainingContextTreatment::<Identity, Impl, OFFSET>,
         }
     }
@@ -5130,7 +5130,7 @@ impl IServicePartitionConfig_Vtbl {
             this.PartitionID(::core::mem::transmute_copy(&guidpartitionid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             PartitionConfig: PartitionConfig::<Identity, Impl, OFFSET>,
             PartitionID: PartitionID::<Identity, Impl, OFFSET>,
         }
@@ -5163,7 +5163,7 @@ impl IServicePool_Vtbl {
             this.Shutdown().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             GetObject: GetObject::<Identity, Impl, OFFSET>,
             Shutdown: Shutdown::<Identity, Impl, OFFSET>,
@@ -5248,7 +5248,7 @@ impl IServicePoolConfig_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetMaxPoolSize: SetMaxPoolSize::<Identity, Impl, OFFSET>,
             MaxPoolSize: MaxPoolSize::<Identity, Impl, OFFSET>,
             SetMinPoolSize: SetMinPoolSize::<Identity, Impl, OFFSET>,
@@ -5289,7 +5289,7 @@ impl IServiceSxsConfig_Vtbl {
             this.SxsDirectory(::core::mem::transmute(&szsxsdirectory)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SxsConfig: SxsConfig::<Identity, Impl, OFFSET>,
             SxsName: SxsName::<Identity, Impl, OFFSET>,
             SxsDirectory: SxsDirectory::<Identity, Impl, OFFSET>,
@@ -5310,7 +5310,7 @@ impl IServiceSynchronizationConfig_Vtbl {
             let this = (*this).get_impl();
             this.ConfigureSynchronization(::core::mem::transmute_copy(&synchconfig)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), ConfigureSynchronization: ConfigureSynchronization::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), ConfigureSynchronization: ConfigureSynchronization::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IServiceSynchronizationConfig as ::windows::core::Interface>::IID
@@ -5354,7 +5354,7 @@ impl IServiceThreadPoolConfig_Vtbl {
             this.SetBindingInfo(::core::mem::transmute_copy(&binding)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SelectThreadPool: SelectThreadPool::<Identity, Impl, OFFSET>,
             SetBindingInfo: SetBindingInfo::<Identity, Impl, OFFSET>,
         }
@@ -5374,7 +5374,7 @@ impl IServiceTrackerConfig_Vtbl {
             let this = (*this).get_impl();
             this.TrackerConfig(::core::mem::transmute_copy(&trackerconfig), ::core::mem::transmute(&sztrackerappname), ::core::mem::transmute(&sztrackerctxname)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), TrackerConfig: TrackerConfig::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), TrackerConfig: TrackerConfig::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IServiceTrackerConfig as ::windows::core::Interface>::IID
@@ -5436,7 +5436,7 @@ impl IServiceTransactionConfigBase_Vtbl {
             this.NewTransactionDescription(::core::mem::transmute(&sztxdesc)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ConfigureTransaction: ConfigureTransaction::<Identity, Impl, OFFSET>,
             IsolationLevel: IsolationLevel::<Identity, Impl, OFFSET>,
             TransactionTimeout: TransactionTimeout::<Identity, Impl, OFFSET>,
@@ -5607,7 +5607,7 @@ impl ISystemAppEventData_Vtbl {
             this.OnDataChanged(::core::mem::transmute_copy(&dwpid), ::core::mem::transmute_copy(&dwmask), ::core::mem::transmute_copy(&dwnumbersinks), ::core::mem::transmute(&bstrdwmethodmask), ::core::mem::transmute_copy(&dwreason), ::core::mem::transmute_copy(&u64tracehandle)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Startup: Startup::<Identity, Impl, OFFSET>,
             OnDataChanged: OnDataChanged::<Identity, Impl, OFFSET>,
         }
@@ -5682,7 +5682,7 @@ impl IThreadPoolKnobs_Vtbl {
             this.SetQueueDepth(::core::mem::transmute_copy(&lcqueuedepth)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetMaxThreads: GetMaxThreads::<Identity, Impl, OFFSET>,
             GetCurrentThreads: GetCurrentThreads::<Identity, Impl, OFFSET>,
             SetMaxThreads: SetMaxThreads::<Identity, Impl, OFFSET>,
@@ -5766,7 +5766,7 @@ impl ITransactionContextEx_Vtbl {
             this.Abort().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateInstance: CreateInstance::<Identity, Impl, OFFSET>,
             Commit: Commit::<Identity, Impl, OFFSET>,
             Abort: Abort::<Identity, Impl, OFFSET>,
@@ -5896,7 +5896,7 @@ impl ITransactionProperty_Vtbl {
             this.Reserved17()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Reserved1: Reserved1::<Identity, Impl, OFFSET>,
             Reserved2: Reserved2::<Identity, Impl, OFFSET>,
             Reserved3: Reserved3::<Identity, Impl, OFFSET>,
@@ -5984,7 +5984,7 @@ impl ITransactionProxy_Vtbl {
             this.IsReusable(::core::mem::transmute_copy(&pfisreusable)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Commit: Commit::<Identity, Impl, OFFSET>,
             Abort: Abort::<Identity, Impl, OFFSET>,
             Promote: Promote::<Identity, Impl, OFFSET>,
@@ -6022,7 +6022,7 @@ impl ITransactionResourcePool_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             PutResource: PutResource::<Identity, Impl, OFFSET>,
             GetResource: GetResource::<Identity, Impl, OFFSET>,
         }
@@ -6049,7 +6049,7 @@ impl ITransactionStatus_Vtbl {
             this.GetTransactionStatus(::core::mem::transmute_copy(&phrstatus)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetTransactionStatus: SetTransactionStatus::<Identity, Impl, OFFSET>,
             GetTransactionStatus: GetTransactionStatus::<Identity, Impl, OFFSET>,
         }
@@ -6069,7 +6069,7 @@ impl ITxProxyHolder_Vtbl {
             let this = (*this).get_impl();
             this.GetIdentifier(::core::mem::transmute_copy(&pguidltx))
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetIdentifier: GetIdentifier::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetIdentifier: GetIdentifier::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ITxProxyHolder as ::windows::core::Interface>::IID
@@ -6260,7 +6260,7 @@ impl ObjectControl_Vtbl {
             this.CanBePooled(::core::mem::transmute_copy(&pbpoolable)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Activate: Activate::<Identity, Impl, OFFSET>,
             Deactivate: Deactivate::<Identity, Impl, OFFSET>,
             CanBePooled: CanBePooled::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/System/ComponentServices/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/ComponentServices/mod.rs
@@ -537,7 +537,7 @@ unsafe impl ::windows::core::Interface for IAsyncErrorNotify {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAsyncErrorNotify_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnError: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hr: ::windows::core::HRESULT) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_System_Com\"`*"]
@@ -1214,7 +1214,7 @@ unsafe impl ::windows::core::Interface for ICOMLBArguments {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICOMLBArguments_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCLSID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pclsid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub SetCLSID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pclsid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub GetMachineName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cchsvr: u32, szservername: ::windows::core::PWSTR) -> ::windows::core::HRESULT,
@@ -1585,7 +1585,7 @@ unsafe impl ::windows::core::Interface for ICheckSxsConfig {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICheckSxsConfig_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub IsSameSxsConfig: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wszsxsname: ::windows::core::PCWSTR, wszsxsdirectory: ::windows::core::PCWSTR, wszsxsappname: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_ComponentServices\"`*"]
@@ -1652,7 +1652,7 @@ unsafe impl ::windows::core::Interface for IComActivityEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IComActivityEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnActivityCreate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, guidactivity: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub OnActivityDestroy: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, guidactivity: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub OnActivityEnter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, guidcurrent: *const ::windows::core::GUID, guidentered: *const ::windows::core::GUID, dwthread: u32) -> ::windows::core::HRESULT,
@@ -1724,7 +1724,7 @@ unsafe impl ::windows::core::Interface for IComApp2Events {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IComApp2Events_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnAppActivation2: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, guidapp: ::windows::core::GUID, guidprocess: ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub OnAppShutdown2: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, guidapp: ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub OnAppForceShutdown2: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, guidapp: ::windows::core::GUID) -> ::windows::core::HRESULT,
@@ -1786,7 +1786,7 @@ unsafe impl ::windows::core::Interface for IComAppEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IComAppEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnAppActivation: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, guidapp: ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub OnAppShutdown: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, guidapp: ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub OnAppForceShutdown: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, guidapp: ::windows::core::GUID) -> ::windows::core::HRESULT,
@@ -1889,7 +1889,7 @@ unsafe impl ::windows::core::Interface for IComCRMEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IComCRMEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnCRMRecoveryStart: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, guidapp: ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub OnCRMRecoveryDone: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, guidapp: ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub OnCRMCheckpoint: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, guidapp: ::windows::core::GUID) -> ::windows::core::HRESULT,
@@ -1961,7 +1961,7 @@ unsafe impl ::windows::core::Interface for IComExceptionEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IComExceptionEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnExceptionUser: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, code: u32, address: u64, pszstacktrace: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_ComponentServices\"`*"]
@@ -2015,7 +2015,7 @@ unsafe impl ::windows::core::Interface for IComIdentityEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IComIdentityEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnIISRequestInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, objid: u64, pszclientip: ::windows::core::PCWSTR, pszserverip: ::windows::core::PCWSTR, pszurl: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_ComponentServices\"`*"]
@@ -2067,7 +2067,7 @@ unsafe impl ::windows::core::Interface for IComInstance2Events {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IComInstance2Events_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnObjectCreate2: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, guidactivity: *const ::windows::core::GUID, clsid: *const ::windows::core::GUID, tsid: *const ::windows::core::GUID, ctxtid: u64, objectid: u64, guidpartition: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub OnObjectDestroy2: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, ctxtid: u64) -> ::windows::core::HRESULT,
 }
@@ -2120,7 +2120,7 @@ unsafe impl ::windows::core::Interface for IComInstanceEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IComInstanceEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnObjectCreate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, guidactivity: *const ::windows::core::GUID, clsid: *const ::windows::core::GUID, tsid: *const ::windows::core::GUID, ctxtid: u64, objectid: u64) -> ::windows::core::HRESULT,
     pub OnObjectDestroy: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, ctxtid: u64) -> ::windows::core::HRESULT,
 }
@@ -2192,7 +2192,7 @@ unsafe impl ::windows::core::Interface for IComLTxEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IComLTxEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub OnLtxTransactionStart: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, guidltx: ::windows::core::GUID, tsid: ::windows::core::GUID, froot: super::super::Foundation::BOOL, nisolationlevel: i32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -2257,7 +2257,7 @@ unsafe impl ::windows::core::Interface for IComMethod2Events {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IComMethod2Events_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnMethodCall2: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, oid: u64, guidcid: *const ::windows::core::GUID, guidrid: *const ::windows::core::GUID, dwthread: u32, imeth: u32) -> ::windows::core::HRESULT,
     pub OnMethodReturn2: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, oid: u64, guidcid: *const ::windows::core::GUID, guidrid: *const ::windows::core::GUID, dwthread: u32, imeth: u32, hresult: ::windows::core::HRESULT) -> ::windows::core::HRESULT,
     pub OnMethodException2: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, oid: u64, guidcid: *const ::windows::core::GUID, guidrid: *const ::windows::core::GUID, dwthread: u32, imeth: u32) -> ::windows::core::HRESULT,
@@ -2314,7 +2314,7 @@ unsafe impl ::windows::core::Interface for IComMethodEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IComMethodEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnMethodCall: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, oid: u64, guidcid: *const ::windows::core::GUID, guidrid: *const ::windows::core::GUID, imeth: u32) -> ::windows::core::HRESULT,
     pub OnMethodReturn: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, oid: u64, guidcid: *const ::windows::core::GUID, guidrid: *const ::windows::core::GUID, imeth: u32, hresult: ::windows::core::HRESULT) -> ::windows::core::HRESULT,
     pub OnMethodException: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, oid: u64, guidcid: *const ::windows::core::GUID, guidrid: *const ::windows::core::GUID, imeth: u32) -> ::windows::core::HRESULT,
@@ -2376,7 +2376,7 @@ unsafe impl ::windows::core::Interface for IComMtaThreadPoolKnobs {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IComMtaThreadPoolKnobs_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub MTASetMaxThreadCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwmaxthreads: u32) -> ::windows::core::HRESULT,
     pub MTAGetMaxThreadCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwmaxthreads: *mut u32) -> ::windows::core::HRESULT,
     pub MTASetThrottleValue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwthrottle: u32) -> ::windows::core::HRESULT,
@@ -2431,7 +2431,7 @@ unsafe impl ::windows::core::Interface for IComObjectConstruction2Events {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IComObjectConstruction2Events_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnObjectConstruct2: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, guidobject: *const ::windows::core::GUID, sconstructstring: ::windows::core::PCWSTR, oid: u64, guidpartition: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_ComponentServices\"`*"]
@@ -2483,7 +2483,7 @@ unsafe impl ::windows::core::Interface for IComObjectConstructionEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IComObjectConstructionEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnObjectConstruct: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, guidobject: *const ::windows::core::GUID, sconstructstring: ::windows::core::PCWSTR, oid: u64) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_ComponentServices\"`*"]
@@ -2547,7 +2547,7 @@ unsafe impl ::windows::core::Interface for IComObjectEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IComObjectEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnObjectActivate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, ctxtid: u64, objectid: u64) -> ::windows::core::HRESULT,
     pub OnObjectDeactivate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, ctxtid: u64, objectid: u64) -> ::windows::core::HRESULT,
     pub OnDisableCommit: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, ctxtid: u64) -> ::windows::core::HRESULT,
@@ -2610,7 +2610,7 @@ unsafe impl ::windows::core::Interface for IComObjectPool2Events {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IComObjectPool2Events_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnObjPoolPutObject2: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, guidobject: *const ::windows::core::GUID, nreason: i32, dwavailable: u32, oid: u64) -> ::windows::core::HRESULT,
     pub OnObjPoolGetObject2: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, guidactivity: *const ::windows::core::GUID, guidobject: *const ::windows::core::GUID, dwavailable: u32, oid: u64, guidpartition: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub OnObjPoolRecycleToTx2: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, guidactivity: *const ::windows::core::GUID, guidobject: *const ::windows::core::GUID, guidtx: *const ::windows::core::GUID, objid: u64) -> ::windows::core::HRESULT,
@@ -2671,7 +2671,7 @@ unsafe impl ::windows::core::Interface for IComObjectPoolEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IComObjectPoolEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnObjPoolPutObject: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, guidobject: *const ::windows::core::GUID, nreason: i32, dwavailable: u32, oid: u64) -> ::windows::core::HRESULT,
     pub OnObjPoolGetObject: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, guidactivity: *const ::windows::core::GUID, guidobject: *const ::windows::core::GUID, dwavailable: u32, oid: u64) -> ::windows::core::HRESULT,
     pub OnObjPoolRecycleToTx: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, guidactivity: *const ::windows::core::GUID, guidobject: *const ::windows::core::GUID, guidtx: *const ::windows::core::GUID, objid: u64) -> ::windows::core::HRESULT,
@@ -2735,7 +2735,7 @@ unsafe impl ::windows::core::Interface for IComObjectPoolEvents2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IComObjectPoolEvents2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnObjPoolCreateObject: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, guidobject: *const ::windows::core::GUID, dwobjscreated: u32, oid: u64) -> ::windows::core::HRESULT,
     pub OnObjPoolDestroyObject: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, guidobject: *const ::windows::core::GUID, dwobjscreated: u32, oid: u64) -> ::windows::core::HRESULT,
     pub OnObjPoolCreateDecision: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, dwthreadswaiting: u32, dwavail: u32, dwcreated: u32, dwmin: u32, dwmax: u32) -> ::windows::core::HRESULT,
@@ -2806,7 +2806,7 @@ unsafe impl ::windows::core::Interface for IComQCEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IComQCEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnQCRecord: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, objid: u64, szqueue: ::windows::core::PCWSTR, guidmsgid: *const ::windows::core::GUID, guidworkflowid: *const ::windows::core::GUID, msmqhr: ::windows::core::HRESULT) -> ::windows::core::HRESULT,
     pub OnQCQueueOpen: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, szqueue: ::windows::core::PCWSTR, queueid: u64, hr: ::windows::core::HRESULT) -> ::windows::core::HRESULT,
     pub OnQCReceive: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, queueid: u64, guidmsgid: *const ::windows::core::GUID, guidworkflowid: *const ::windows::core::GUID, hr: ::windows::core::HRESULT) -> ::windows::core::HRESULT,
@@ -2897,7 +2897,7 @@ unsafe impl ::windows::core::Interface for IComResourceEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IComResourceEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub OnResourceCreate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, objectid: u64, psztype: ::windows::core::PCWSTR, resid: u64, enlisted: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -2972,7 +2972,7 @@ unsafe impl ::windows::core::Interface for IComSecurityEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IComSecurityEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub OnAuthenticate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, guidactivity: *const ::windows::core::GUID, objectid: u64, guidiid: *const ::windows::core::GUID, imeth: u32, cbbyteorig: u32, psidoriginaluser: *const u8, cbbytecur: u32, psidcurrentuser: *const u8, bcurrentuserinpersonatinginproc: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -3064,7 +3064,7 @@ unsafe impl ::windows::core::Interface for IComStaThreadPoolKnobs {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IComStaThreadPoolKnobs_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetMinThreadCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, minthreads: u32) -> ::windows::core::HRESULT,
     pub GetMinThreadCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, minthreads: *mut u32) -> ::windows::core::HRESULT,
     pub SetMaxThreadCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, maxthreads: u32) -> ::windows::core::HRESULT,
@@ -3323,7 +3323,7 @@ unsafe impl ::windows::core::Interface for IComThreadEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IComThreadEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnThreadStart: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, threadid: u64, dwthread: u32, dwtheadcnt: u32) -> ::windows::core::HRESULT,
     pub OnThreadTerminate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, threadid: u64, dwthread: u32, dwtheadcnt: u32) -> ::windows::core::HRESULT,
     pub OnThreadBindToApartment: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, threadid: u64, aptid: u64, dwactcnt: u32, dwlowcnt: u32) -> ::windows::core::HRESULT,
@@ -3390,7 +3390,7 @@ unsafe impl ::windows::core::Interface for IComTrackingInfoCollection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IComTrackingInfoCollection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Type: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptype: *mut TRACKING_COLL_TYPE) -> ::windows::core::HRESULT,
     pub Count: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcount: *mut u32) -> ::windows::core::HRESULT,
     pub Item: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ulindex: u32, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -3444,7 +3444,7 @@ unsafe impl ::windows::core::Interface for IComTrackingInfoEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IComTrackingInfoEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnNewTrackingInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptoplevelcollection: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_ComponentServices\"`*"]
@@ -3499,7 +3499,7 @@ unsafe impl ::windows::core::Interface for IComTrackingInfoObject {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IComTrackingInfoObject_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub GetValue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, szpropertyname: ::windows::core::PCWSTR, pvarout: *mut super::Com::VARIANT) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole")))]
@@ -3556,7 +3556,7 @@ unsafe impl ::windows::core::Interface for IComTrackingInfoProperties {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IComTrackingInfoProperties_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub PropCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcount: *mut u32) -> ::windows::core::HRESULT,
     pub GetPropName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ulindex: u32, ppszpropname: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
 }
@@ -3625,7 +3625,7 @@ unsafe impl ::windows::core::Interface for IComTransaction2Events {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IComTransaction2Events_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub OnTransactionStart2: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, guidtx: *const ::windows::core::GUID, tsid: *const ::windows::core::GUID, froot: super::super::Foundation::BOOL, nisolationlevel: i32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -3702,7 +3702,7 @@ unsafe impl ::windows::core::Interface for IComTransactionEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IComTransactionEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub OnTransactionStart: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, guidtx: *const ::windows::core::GUID, tsid: *const ::windows::core::GUID, froot: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -3762,7 +3762,7 @@ unsafe impl ::windows::core::Interface for IComUserEvent {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IComUserEvent_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub OnUserEvent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *const COMSVCSEVENTINFO, pvarevent: *const super::Com::VARIANT) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole")))]
@@ -3834,7 +3834,7 @@ unsafe impl ::windows::core::Interface for IContextProperties {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IContextProperties_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Count: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, plcount: *mut i32) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub GetProperty: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, name: ::core::mem::ManuallyDrop<::windows::core::BSTR>, pproperty: *mut super::Com::VARIANT) -> ::windows::core::HRESULT,
@@ -3903,7 +3903,7 @@ unsafe impl ::windows::core::Interface for IContextSecurityPerimeter {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IContextSecurityPerimeter_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetPerimeterFlag: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pflag: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -3968,7 +3968,7 @@ unsafe impl ::windows::core::Interface for IContextState {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IContextState_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetDeactivateOnReturn: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bdeactivate: i16) -> ::windows::core::HRESULT,
     pub GetDeactivateOnReturn: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbdeactivate: *mut i16) -> ::windows::core::HRESULT,
     pub SetMyTransactionVote: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, txvote: TransactionVote) -> ::windows::core::HRESULT,
@@ -4023,7 +4023,7 @@ unsafe impl ::windows::core::Interface for ICreateWithLocalTransaction {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICreateWithLocalTransaction_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateInstanceWithSysTx: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptransaction: *mut ::core::ffi::c_void, rclsid: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, pobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_ComponentServices\"`*"]
@@ -4076,7 +4076,7 @@ unsafe impl ::windows::core::Interface for ICreateWithTipTransactionEx {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICreateWithTipTransactionEx_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateInstance: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrtipurl: ::core::mem::ManuallyDrop<::windows::core::BSTR>, rclsid: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, pobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_ComponentServices\"`*"]
@@ -4132,7 +4132,7 @@ unsafe impl ::windows::core::Interface for ICreateWithTransactionEx {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICreateWithTransactionEx_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_DistributedTransactionCoordinator")]
     pub CreateInstance: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptransaction: *mut ::core::ffi::c_void, rclsid: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, pobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_DistributedTransactionCoordinator"))]
@@ -4236,7 +4236,7 @@ unsafe impl ::windows::core::Interface for ICrmCompensator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICrmCompensator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetLogControl: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, plogcontrol: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub BeginPrepare: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
@@ -4352,7 +4352,7 @@ unsafe impl ::windows::core::Interface for ICrmCompensatorVariants {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICrmCompensatorVariants_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetLogControlVariants: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, plogcontrol: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub BeginPrepareVariants: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -4441,7 +4441,7 @@ unsafe impl ::windows::core::Interface for ICrmFormatLogRecords {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICrmFormatLogRecords_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetColumnCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, plcolumncount: *mut i32) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub GetColumnHeaders: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pheaders: *mut super::Com::VARIANT) -> ::windows::core::HRESULT,
@@ -4529,7 +4529,7 @@ unsafe impl ::windows::core::Interface for ICrmLogControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICrmLogControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub TransactionUOW: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pval: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub RegisterCompensator: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lpcwstrprogidcompensator: ::windows::core::PCWSTR, lpcwstrdescription: ::windows::core::PCWSTR, lcrmregflags: i32) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -4602,7 +4602,7 @@ unsafe impl ::windows::core::Interface for ICrmMonitor {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICrmMonitor_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub GetClerks: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pclerks: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -4830,7 +4830,7 @@ unsafe impl ::windows::core::Interface for ICrmMonitorLogRecords {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICrmMonitorLogRecords_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Count: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pval: *mut i32) -> ::windows::core::HRESULT,
     pub TransactionState: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pval: *mut CrmTransactionState) -> ::windows::core::HRESULT,
     pub StructuredRecords: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pval: *mut i16) -> ::windows::core::HRESULT,
@@ -4909,7 +4909,7 @@ unsafe impl ::windows::core::Interface for IDispenserDriver {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDispenserDriver_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateResource: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, restypid: usize, presid: *mut usize, psecsfreebeforedestroy: *mut i32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub RateResource: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, restypid: usize, resid: usize, frequirestransactionenlistment: super::super::Foundation::BOOL, prating: *mut u32) -> ::windows::core::HRESULT,
@@ -4974,7 +4974,7 @@ unsafe impl ::windows::core::Interface for IDispenserManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDispenserManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub RegisterDispenser: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, __midl__idispensermanager0000: *mut ::core::ffi::c_void, szdispensername: ::windows::core::PCWSTR, __midl__idispensermanager0001: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetContext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, __midl__idispensermanager0002: *mut usize, __midl__idispensermanager0003: *mut usize) -> ::windows::core::HRESULT,
 }
@@ -5034,7 +5034,7 @@ unsafe impl ::windows::core::Interface for IEnumNames {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumNames_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgname: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -5198,7 +5198,7 @@ unsafe impl ::windows::core::Interface for IGetAppTrackerData {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IGetAppTrackerData_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetApplicationProcesses: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, partitionid: *const ::windows::core::GUID, applicationid: *const ::windows::core::GUID, flags: u32, numapplicationprocesses: *mut u32, applicationprocesses: *mut *mut ApplicationProcessSummary) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -5271,7 +5271,7 @@ unsafe impl ::windows::core::Interface for IGetContextProperties {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IGetContextProperties_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Count: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, plcount: *mut i32) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub GetProperty: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, name: ::core::mem::ManuallyDrop<::windows::core::BSTR>, pproperty: *mut super::Com::VARIANT) -> ::windows::core::HRESULT,
@@ -5440,7 +5440,7 @@ unsafe impl ::windows::core::Interface for IHolder {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IHolder_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AllocResource: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, __midl__iholder0000: usize, __midl__iholder0001: *mut usize) -> ::windows::core::HRESULT,
     pub FreeResource: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, __midl__iholder0002: usize) -> ::windows::core::HRESULT,
     pub TrackResource: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, __midl__iholder0003: usize) -> ::windows::core::HRESULT,
@@ -5510,7 +5510,7 @@ unsafe impl ::windows::core::Interface for ILBEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ILBEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub TargetUp: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrservername: ::core::mem::ManuallyDrop<::windows::core::BSTR>, bstrclsideng: ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub TargetDown: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrservername: ::core::mem::ManuallyDrop<::windows::core::BSTR>, bstrclsideng: ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -5582,7 +5582,7 @@ unsafe impl ::windows::core::Interface for IMTSActivity {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMTSActivity_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SynchronousCall: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcall: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub AsyncCall: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcall: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Reserved1: unsafe extern "system" fn(this: *mut ::core::ffi::c_void),
@@ -5635,7 +5635,7 @@ unsafe impl ::windows::core::Interface for IMTSCall {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMTSCall_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnCall: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_System_Com\"`*"]
@@ -5775,7 +5775,7 @@ unsafe impl ::windows::core::Interface for IManagedActivationEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IManagedActivationEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub CreateManagedStub: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *mut ::core::ffi::c_void, fdist: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -5850,7 +5850,7 @@ unsafe impl ::windows::core::Interface for IManagedObjectInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IManagedObjectInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetIUnknown: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punk: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetIObjectControl: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pctrl: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -5908,7 +5908,7 @@ unsafe impl ::windows::core::Interface for IManagedPoolAction {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IManagedPoolAction_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub LastRelease: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_ComponentServices\"`*"]
@@ -5962,7 +5962,7 @@ unsafe impl ::windows::core::Interface for IManagedPooledObj {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IManagedPooledObj_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub SetHeld: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, m_bheld: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -6436,7 +6436,7 @@ unsafe impl ::windows::core::Interface for IObjPool {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IObjPool_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Reserved1: unsafe extern "system" fn(this: *mut ::core::ffi::c_void),
     pub Reserved2: unsafe extern "system" fn(this: *mut ::core::ffi::c_void),
     pub Reserved3: unsafe extern "system" fn(this: *mut ::core::ffi::c_void),
@@ -6496,7 +6496,7 @@ unsafe impl ::windows::core::Interface for IObjectConstruct {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IObjectConstruct_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub Construct: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pctorobj: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -6653,7 +6653,7 @@ unsafe impl ::windows::core::Interface for IObjectContext {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IObjectContext_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateInstance: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, rclsid: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetComplete: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetAbort: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -6718,7 +6718,7 @@ unsafe impl ::windows::core::Interface for IObjectContextActivity {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IObjectContextActivity_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetActivityId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pguid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_ComponentServices\"`*"]
@@ -6782,7 +6782,7 @@ unsafe impl ::windows::core::Interface for IObjectContextInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IObjectContextInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub IsInTransaction: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> super::super::Foundation::BOOL,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -6928,7 +6928,7 @@ unsafe impl ::windows::core::Interface for IObjectContextTip {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IObjectContextTip_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetTipUrl: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptipurl: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_ComponentServices\"`*"]
@@ -6985,7 +6985,7 @@ unsafe impl ::windows::core::Interface for IObjectControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IObjectControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Activate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Deactivate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void),
     #[cfg(feature = "Win32_Foundation")]
@@ -7042,7 +7042,7 @@ unsafe impl ::windows::core::Interface for IPlaybackControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPlaybackControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub FinalClientRetry: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub FinalServerRetry: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -7176,7 +7176,7 @@ unsafe impl ::windows::core::Interface for IProcessInitializer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IProcessInitializer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Startup: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punkprocesscontrol: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Shutdown: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -7553,7 +7553,7 @@ unsafe impl ::windows::core::Interface for ISecurityProperty {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISecurityProperty_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetDirectCreatorSID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psid: *mut super::super::Foundation::PSID) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -7627,7 +7627,7 @@ unsafe impl ::windows::core::Interface for ISelectCOMLBServer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISelectCOMLBServer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Init: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetLBServer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punk: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -7680,7 +7680,7 @@ unsafe impl ::windows::core::Interface for ISendMethodEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISendMethodEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SendMethodCall: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pidentity: *const ::core::ffi::c_void, riid: *const ::windows::core::GUID, dwmeth: u32) -> ::windows::core::HRESULT,
     pub SendMethodReturn: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pidentity: *const ::core::ffi::c_void, riid: *const ::windows::core::GUID, dwmeth: u32, hrcall: ::windows::core::HRESULT, hrserver: ::windows::core::HRESULT) -> ::windows::core::HRESULT,
 }
@@ -7745,7 +7745,7 @@ unsafe impl ::windows::core::Interface for IServiceActivity {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IServiceActivity_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SynchronousCall: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, piservicecall: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub AsynchronousCall: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, piservicecall: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub BindToCurrentThread: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -7797,7 +7797,7 @@ unsafe impl ::windows::core::Interface for IServiceCall {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IServiceCall_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnCall: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_ComponentServices\"`*"]
@@ -7846,7 +7846,7 @@ unsafe impl ::windows::core::Interface for IServiceComTIIntrinsicsConfig {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IServiceComTIIntrinsicsConfig_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ComTIIntrinsicsConfig: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, comtiintrinsicsconfig: CSC_COMTIIntrinsicsConfig) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_ComponentServices\"`*"]
@@ -7895,7 +7895,7 @@ unsafe impl ::windows::core::Interface for IServiceIISIntrinsicsConfig {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IServiceIISIntrinsicsConfig_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub IISIntrinsicsConfig: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, iisintrinsicsconfig: CSC_IISIntrinsicsConfig) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_ComponentServices\"`*"]
@@ -7944,7 +7944,7 @@ unsafe impl ::windows::core::Interface for IServiceInheritanceConfig {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IServiceInheritanceConfig_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ContainingContextTreatment: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, inheritanceconfig: CSC_InheritanceConfig) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_ComponentServices\"`*"]
@@ -7996,7 +7996,7 @@ unsafe impl ::windows::core::Interface for IServicePartitionConfig {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IServicePartitionConfig_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub PartitionConfig: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, partitionconfig: CSC_PartitionConfig) -> ::windows::core::HRESULT,
     pub PartitionID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, guidpartitionid: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
 }
@@ -8055,7 +8055,7 @@ unsafe impl ::windows::core::Interface for IServicePool {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IServicePool_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppoolconfig: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetObject: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Shutdown: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -8148,7 +8148,7 @@ unsafe impl ::windows::core::Interface for IServicePoolConfig {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IServicePoolConfig_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetMaxPoolSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwmaxpool: u32) -> ::windows::core::HRESULT,
     pub MaxPoolSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwmaxpool: *mut u32) -> ::windows::core::HRESULT,
     pub SetMinPoolSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwminpool: u32) -> ::windows::core::HRESULT,
@@ -8230,7 +8230,7 @@ unsafe impl ::windows::core::Interface for IServiceSxsConfig {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IServiceSxsConfig_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SxsConfig: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, scsconfig: CSC_SxsConfig) -> ::windows::core::HRESULT,
     pub SxsName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, szsxsname: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub SxsDirectory: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, szsxsdirectory: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
@@ -8281,7 +8281,7 @@ unsafe impl ::windows::core::Interface for IServiceSynchronizationConfig {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IServiceSynchronizationConfig_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ConfigureSynchronization: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, synchconfig: CSC_SynchronizationConfig) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_ComponentServices\"`*"]
@@ -8444,7 +8444,7 @@ unsafe impl ::windows::core::Interface for IServiceThreadPoolConfig {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IServiceThreadPoolConfig_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SelectThreadPool: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, threadpool: CSC_ThreadPool) -> ::windows::core::HRESULT,
     pub SetBindingInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, binding: CSC_Binding) -> ::windows::core::HRESULT,
 }
@@ -8498,7 +8498,7 @@ unsafe impl ::windows::core::Interface for IServiceTrackerConfig {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IServiceTrackerConfig_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub TrackerConfig: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, trackerconfig: CSC_TrackerConfig, sztrackerappname: ::windows::core::PCWSTR, sztrackerctxname: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_ComponentServices\"`*"]
@@ -8658,7 +8658,7 @@ unsafe impl ::windows::core::Interface for IServiceTransactionConfigBase {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IServiceTransactionConfigBase_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ConfigureTransaction: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, transactionconfig: CSC_TransactionConfig) -> ::windows::core::HRESULT,
     pub IsolationLevel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, option: COMAdminTxIsolationLevelOptions) -> ::windows::core::HRESULT,
     pub TransactionTimeout: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ultimeoutsec: u32) -> ::windows::core::HRESULT,
@@ -9020,7 +9020,7 @@ unsafe impl ::windows::core::Interface for ISystemAppEventData {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISystemAppEventData_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Startup: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub OnDataChanged: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwpid: u32, dwmask: u32, dwnumbersinks: u32, bstrdwmethodmask: ::core::mem::ManuallyDrop<::windows::core::BSTR>, dwreason: u32, u64tracehandle: u64) -> ::windows::core::HRESULT,
 }
@@ -9097,7 +9097,7 @@ unsafe impl ::windows::core::Interface for IThreadPoolKnobs {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IThreadPoolKnobs_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetMaxThreads: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, plcmaxthreads: *mut i32) -> ::windows::core::HRESULT,
     pub GetCurrentThreads: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, plccurrentthreads: *mut i32) -> ::windows::core::HRESULT,
     pub SetMaxThreads: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lcmaxthreads: i32) -> ::windows::core::HRESULT,
@@ -9257,7 +9257,7 @@ unsafe impl ::windows::core::Interface for ITransactionContextEx {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITransactionContextEx_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateInstance: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, rclsid: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, pobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Commit: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Abort: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -9360,7 +9360,7 @@ unsafe impl ::windows::core::Interface for ITransactionProperty {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITransactionProperty_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Reserved1: unsafe extern "system" fn(this: *mut ::core::ffi::c_void),
     pub Reserved2: unsafe extern "system" fn(this: *mut ::core::ffi::c_void),
     pub Reserved3: unsafe extern "system" fn(this: *mut ::core::ffi::c_void),
@@ -9455,7 +9455,7 @@ unsafe impl ::windows::core::Interface for ITransactionProxy {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITransactionProxy_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Commit: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, guid: ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub Abort: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_DistributedTransactionCoordinator")]
@@ -9530,7 +9530,7 @@ unsafe impl ::windows::core::Interface for ITransactionResourcePool {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITransactionResourcePool_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub PutResource: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppool: *mut ::core::ffi::c_void, punk: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetResource: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppool: *mut ::core::ffi::c_void, ppunk: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -9583,7 +9583,7 @@ unsafe impl ::windows::core::Interface for ITransactionStatus {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITransactionStatus_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetTransactionStatus: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hrstatus: ::windows::core::HRESULT) -> ::windows::core::HRESULT,
     pub GetTransactionStatus: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, phrstatus: *mut ::windows::core::HRESULT) -> ::windows::core::HRESULT,
 }
@@ -9633,7 +9633,7 @@ unsafe impl ::windows::core::Interface for ITxProxyHolder {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITxProxyHolder_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetIdentifier: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pguidltx: *mut ::windows::core::GUID),
 }
 #[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_System_Com\"`*"]
@@ -9843,7 +9843,7 @@ unsafe impl ::windows::core::Interface for ObjectControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ObjectControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Activate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Deactivate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CanBePooled: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbpoolable: *mut i16) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/System/Contacts/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Contacts/impl.rs
@@ -22,7 +22,7 @@ impl IContact_Vtbl {
             this.CommitChanges(::core::mem::transmute_copy(&dwcommitflags)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetContactID: GetContactID::<Identity, Impl, OFFSET>,
             GetPath: GetPath::<Identity, Impl, OFFSET>,
             CommitChanges: CommitChanges::<Identity, Impl, OFFSET>,
@@ -122,7 +122,7 @@ impl IContactAggregationAggregate_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Save: Save::<Identity, Impl, OFFSET>,
             GetComponentItems: GetComponentItems::<Identity, Impl, OFFSET>,
             Link: Link::<Identity, Impl, OFFSET>,
@@ -192,7 +192,7 @@ impl IContactAggregationAggregateCollection_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             FindFirst: FindFirst::<Identity, Impl, OFFSET>,
             FindFirstByAntiLinkId: FindFirstByAntiLinkId::<Identity, Impl, OFFSET>,
             FindNext: FindNext::<Identity, Impl, OFFSET>,
@@ -374,7 +374,7 @@ impl IContactAggregationContact_Vtbl {
             this.SetSyncIdentityHash(::core::mem::transmute_copy(&psyncidentityhash)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Delete: Delete::<Identity, Impl, OFFSET>,
             Save: Save::<Identity, Impl, OFFSET>,
             MoveToAggregate: MoveToAggregate::<Identity, Impl, OFFSET>,
@@ -465,7 +465,7 @@ impl IContactAggregationContactCollection_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             FindFirst: FindFirst::<Identity, Impl, OFFSET>,
             FindNext: FindNext::<Identity, Impl, OFFSET>,
             FindFirstByIdentityHash: FindFirstByIdentityHash::<Identity, Impl, OFFSET>,
@@ -567,7 +567,7 @@ impl IContactAggregationGroup_Vtbl {
             this.SetName(::core::mem::transmute(&pname)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Delete: Delete::<Identity, Impl, OFFSET>,
             Save: Save::<Identity, Impl, OFFSET>,
             Add: Add::<Identity, Impl, OFFSET>,
@@ -638,7 +638,7 @@ impl IContactAggregationGroupCollection_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             FindFirst: FindFirst::<Identity, Impl, OFFSET>,
             FindFirstByGlobalObjectId: FindFirstByGlobalObjectId::<Identity, Impl, OFFSET>,
             FindNext: FindNext::<Identity, Impl, OFFSET>,
@@ -808,7 +808,7 @@ impl IContactAggregationLink_Vtbl {
             this.SetSyncIdentityHash(::core::mem::transmute_copy(&psyncidentityhash)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Delete: Delete::<Identity, Impl, OFFSET>,
             Save: Save::<Identity, Impl, OFFSET>,
             AccountId: AccountId::<Identity, Impl, OFFSET>,
@@ -886,7 +886,7 @@ impl IContactAggregationLinkCollection_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             FindFirst: FindFirst::<Identity, Impl, OFFSET>,
             FindFirstByRemoteId: FindFirstByRemoteId::<Identity, Impl, OFFSET>,
             FindNext: FindNext::<Identity, Impl, OFFSET>,
@@ -1068,7 +1068,7 @@ impl IContactAggregationManager_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetVersionInfo: GetVersionInfo::<Identity, Impl, OFFSET>,
             CreateOrOpenGroup: CreateOrOpenGroup::<Identity, Impl, OFFSET>,
             CreateExternalContact: CreateExternalContact::<Identity, Impl, OFFSET>,
@@ -1303,7 +1303,7 @@ impl IContactAggregationServerPerson_Vtbl {
             this.SetObjectId(::core::mem::transmute(&pobjectid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Delete: Delete::<Identity, Impl, OFFSET>,
             Save: Save::<Identity, Impl, OFFSET>,
             AggregateId: AggregateId::<Identity, Impl, OFFSET>,
@@ -1411,7 +1411,7 @@ impl IContactAggregationServerPersonCollection_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             FindFirst: FindFirst::<Identity, Impl, OFFSET>,
             FindFirstByServerId: FindFirstByServerId::<Identity, Impl, OFFSET>,
             FindFirstByAggregateId: FindFirstByAggregateId::<Identity, Impl, OFFSET>,
@@ -1454,7 +1454,7 @@ impl IContactCollection_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Reset: Reset::<Identity, Impl, OFFSET>,
             Next: Next::<Identity, Impl, OFFSET>,
             GetCurrent: GetCurrent::<Identity, Impl, OFFSET>,
@@ -1524,7 +1524,7 @@ impl IContactManager_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             Load: Load::<Identity, Impl, OFFSET>,
             MergeContactIDs: MergeContactIDs::<Identity, Impl, OFFSET>,
@@ -1624,7 +1624,7 @@ impl IContactProperties_Vtbl {
             this.GetPropertyCollection(::core::mem::transmute_copy(&pppropertycollection), ::core::mem::transmute_copy(&dwflags), ::core::mem::transmute(&pszmultivaluename), ::core::mem::transmute_copy(&dwlabelcount), ::core::mem::transmute_copy(&ppszlabels), ::core::mem::transmute_copy(&fanylabelmatches)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetString: GetString::<Identity, Impl, OFFSET>,
             GetDate: GetDate::<Identity, Impl, OFFSET>,
             GetBinary: GetBinary::<Identity, Impl, OFFSET>,
@@ -1695,7 +1695,7 @@ impl IContactPropertyCollection_Vtbl {
             this.GetPropertyArrayElementID(::core::mem::transmute(&pszarrayelementid), ::core::mem::transmute_copy(&ccharrayelementid), ::core::mem::transmute_copy(&pdwccharrayelementidrequired)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Reset: Reset::<Identity, Impl, OFFSET>,
             Next: Next::<Identity, Impl, OFFSET>,
             GetPropertyName: GetPropertyName::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/System/Contacts/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Contacts/mod.rs
@@ -50,7 +50,7 @@ unsafe impl ::windows::core::Interface for IContact {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IContact_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetContactID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszcontactid: ::windows::core::PWSTR, cchcontactid: u32, pdwcchcontactidrequired: *mut u32) -> ::windows::core::HRESULT,
     pub GetPath: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszpath: ::windows::core::PWSTR, cchpath: u32, pdwcchpathrequired: *mut u32) -> ::windows::core::HRESULT,
     pub CommitChanges: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwcommitflags: u32) -> ::windows::core::HRESULT,
@@ -136,7 +136,7 @@ unsafe impl ::windows::core::Interface for IContactAggregationAggregate {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IContactAggregationAggregate_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Save: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetComponentItems: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcomponentitems: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Link: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, paggregateid: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
@@ -209,7 +209,7 @@ unsafe impl ::windows::core::Interface for IContactAggregationAggregateCollectio
 #[repr(C)]
 #[doc(hidden)]
 pub struct IContactAggregationAggregateCollection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub FindFirst: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppaggregate: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub FindFirstByAntiLinkId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pantilinkid: ::windows::core::PCWSTR, ppaggregate: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub FindNext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppaggregate: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -334,7 +334,7 @@ unsafe impl ::windows::core::Interface for IContactAggregationContact {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IContactAggregationContact_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Delete: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Save: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub MoveToAggregate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, paggregateid: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
@@ -431,7 +431,7 @@ unsafe impl ::windows::core::Interface for IContactAggregationContactCollection 
 #[repr(C)]
 #[doc(hidden)]
 pub struct IContactAggregationContactCollection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub FindFirst: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppitem: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub FindNext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppitem: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub FindFirstByIdentityHash: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psourcetype: ::windows::core::PCWSTR, paccountid: ::windows::core::PCWSTR, pidentityhash: *const CONTACT_AGGREGATION_BLOB, ppitem: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -524,7 +524,7 @@ unsafe impl ::windows::core::Interface for IContactAggregationGroup {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IContactAggregationGroup_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Delete: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Save: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Add: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, paggregateid: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
@@ -595,7 +595,7 @@ unsafe impl ::windows::core::Interface for IContactAggregationGroupCollection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IContactAggregationGroupCollection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub FindFirst: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppgroup: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub FindFirstByGlobalObjectId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pglobalobjectid: *const ::windows::core::GUID, ppgroup: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub FindNext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppgroup: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -722,7 +722,7 @@ unsafe impl ::windows::core::Interface for IContactAggregationLink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IContactAggregationLink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Delete: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Save: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub AccountId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppaccountid: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
@@ -810,7 +810,7 @@ unsafe impl ::windows::core::Interface for IContactAggregationLinkCollection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IContactAggregationLinkCollection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub FindFirst: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppservercontactlink: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub FindFirstByRemoteId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psourcetype: ::windows::core::PCWSTR, paccountid: ::windows::core::PCWSTR, premoteid: *const CONTACT_AGGREGATION_BLOB, ppservercontactlink: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub FindNext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppservercontactlink: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -936,7 +936,7 @@ unsafe impl ::windows::core::Interface for IContactAggregationManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IContactAggregationManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetVersionInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, plmajorversion: *mut i32, plminorversion: *mut i32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub CreateOrOpenGroup: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pgroupname: ::windows::core::PCWSTR, options: CONTACT_AGGREGATION_CREATE_OR_OPEN_OPTIONS, pcreatedgroup: *mut super::super::Foundation::BOOL, ppgroup: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1101,7 +1101,7 @@ unsafe impl ::windows::core::Interface for IContactAggregationServerPerson {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IContactAggregationServerPerson_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Delete: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Save: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub AggregateId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppaggregateid: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
@@ -1208,7 +1208,7 @@ unsafe impl ::windows::core::Interface for IContactAggregationServerPersonCollec
 #[repr(C)]
 #[doc(hidden)]
 pub struct IContactAggregationServerPersonCollection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub FindFirst: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppserverperson: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub FindFirstByServerId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pserverid: ::windows::core::PCWSTR, ppserverperson: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub FindFirstByAggregateId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, paggregateid: ::windows::core::PCWSTR, ppserverperson: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1269,7 +1269,7 @@ unsafe impl ::windows::core::Interface for IContactCollection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IContactCollection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetCurrent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppcontact: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1352,7 +1352,7 @@ unsafe impl ::windows::core::Interface for IContactManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IContactManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszappname: ::windows::core::PCWSTR, pszappversion: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub Load: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszcontactid: ::windows::core::PCWSTR, ppcontact: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub MergeContactIDs: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psznewcontactid: ::windows::core::PCWSTR, pszoldcontactid: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
@@ -1498,7 +1498,7 @@ unsafe impl ::windows::core::Interface for IContactProperties {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IContactProperties_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetString: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszpropertyname: ::windows::core::PCWSTR, dwflags: u32, pszvalue: ::windows::core::PWSTR, cchvalue: u32, pdwcchpropertyvaluerequired: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub GetDate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszpropertyname: ::windows::core::PCWSTR, dwflags: u32, pftdatetime: *mut super::super::Foundation::FILETIME) -> ::windows::core::HRESULT,
@@ -1597,7 +1597,7 @@ unsafe impl ::windows::core::Interface for IContactPropertyCollection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IContactPropertyCollection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetPropertyName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszpropertyname: ::windows::core::PWSTR, cchpropertyname: u32, pdwcchpropertynamerequired: *mut u32) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/System/DesktopSharing/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/DesktopSharing/impl.rs
@@ -437,7 +437,7 @@ impl IRDPSRAPIAudioStream_Vtbl {
             this.FreeBuffer().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             Start: Start::<Identity, Impl, OFFSET>,
             Stop: Stop::<Identity, Impl, OFFSET>,
@@ -469,7 +469,7 @@ impl IRDPSRAPIClipboardUseEvents_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnPasteFromClipboard: OnPasteFromClipboard::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnPasteFromClipboard: OnPasteFromClipboard::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IRDPSRAPIClipboardUseEvents as ::windows::core::Interface>::IID
@@ -499,7 +499,7 @@ impl IRDPSRAPIDebug_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetCLXCmdLine: SetCLXCmdLine::<Identity, Impl, OFFSET>,
             CLXCmdLine: CLXCmdLine::<Identity, Impl, OFFSET>,
         }
@@ -750,7 +750,7 @@ impl IRDPSRAPIPerfCounterLogger_Vtbl {
             let this = (*this).get_impl();
             this.LogValue(::core::mem::transmute_copy(&lvalue)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), LogValue: LogValue::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), LogValue: LogValue::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IRDPSRAPIPerfCounterLogger as ::windows::core::Interface>::IID
@@ -773,7 +773,7 @@ impl IRDPSRAPIPerfCounterLoggingManager_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CreateLogger: CreateLogger::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CreateLogger: CreateLogger::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IRDPSRAPIPerfCounterLoggingManager as ::windows::core::Interface>::IID
@@ -1137,7 +1137,7 @@ impl IRDPSRAPITransportStream_Vtbl {
             this.Close().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AllocBuffer: AllocBuffer::<Identity, Impl, OFFSET>,
             FreeBuffer: FreeBuffer::<Identity, Impl, OFFSET>,
             WriteBuffer: WriteBuffer::<Identity, Impl, OFFSET>,
@@ -1252,7 +1252,7 @@ impl IRDPSRAPITransportStreamBuffer_Vtbl {
             this.SetContext(::core::mem::transmute(&pcontext)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Storage: Storage::<Identity, Impl, OFFSET>,
             StorageSize: StorageSize::<Identity, Impl, OFFSET>,
             PayloadSize: PayloadSize::<Identity, Impl, OFFSET>,
@@ -1293,7 +1293,7 @@ impl IRDPSRAPITransportStreamEvents_Vtbl {
             this.OnStreamClosed(::core::mem::transmute_copy(&hrreason))
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnWriteCompleted: OnWriteCompleted::<Identity, Impl, OFFSET>,
             OnReadCompleted: OnReadCompleted::<Identity, Impl, OFFSET>,
             OnStreamClosed: OnStreamClosed::<Identity, Impl, OFFSET>,
@@ -1780,7 +1780,7 @@ impl IRDPViewerInputSink_Vtbl {
             this.EndTouchFrame().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SendMouseButtonEvent: SendMouseButtonEvent::<Identity, Impl, OFFSET>,
             SendMouseMoveEvent: SendMouseMoveEvent::<Identity, Impl, OFFSET>,
             SendMouseWheelEvent: SendMouseWheelEvent::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/System/DesktopSharing/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/DesktopSharing/mod.rs
@@ -657,7 +657,7 @@ unsafe impl ::windows::core::Interface for IRDPSRAPIAudioStream {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRDPSRAPIAudioStream_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pnperiodinhundrednsintervals: *mut i64) -> ::windows::core::HRESULT,
     pub Start: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Stop: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -716,7 +716,7 @@ unsafe impl ::windows::core::Interface for IRDPSRAPIClipboardUseEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRDPSRAPIClipboardUseEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub OnPasteFromClipboard: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, clipboardformat: u32, pattendee: *mut ::core::ffi::c_void, pretval: *mut i16) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -772,7 +772,7 @@ unsafe impl ::windows::core::Interface for IRDPSRAPIDebug {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRDPSRAPIDebug_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetCLXCmdLine: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, clxcmdline: ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub CLXCmdLine: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pclxcmdline: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
 }
@@ -1135,7 +1135,7 @@ unsafe impl ::windows::core::Interface for IRDPSRAPIPerfCounterLogger {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRDPSRAPIPerfCounterLogger_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub LogValue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lvalue: i64) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_DesktopSharing\"`*"]
@@ -1185,7 +1185,7 @@ unsafe impl ::windows::core::Interface for IRDPSRAPIPerfCounterLoggingManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRDPSRAPIPerfCounterLoggingManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateLogger: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrcountername: ::core::mem::ManuallyDrop<::windows::core::BSTR>, pplogger: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_DesktopSharing\"`, `\"Win32_System_Com\"`*"]
@@ -1797,7 +1797,7 @@ unsafe impl ::windows::core::Interface for IRDPSRAPITransportStream {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRDPSRAPITransportStream_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AllocBuffer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, maxpayload: i32, ppbuffer: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub FreeBuffer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbuffer: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub WriteBuffer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbuffer: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1887,7 +1887,7 @@ unsafe impl ::windows::core::Interface for IRDPSRAPITransportStreamBuffer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRDPSRAPITransportStreamBuffer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Storage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppbstorage: *mut *mut u8) -> ::windows::core::HRESULT,
     pub StorageSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, plmaxstore: *mut i32) -> ::windows::core::HRESULT,
     pub PayloadSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, plretval: *mut i32) -> ::windows::core::HRESULT,
@@ -1957,7 +1957,7 @@ unsafe impl ::windows::core::Interface for IRDPSRAPITransportStreamEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRDPSRAPITransportStreamEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnWriteCompleted: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbuffer: *mut ::core::ffi::c_void),
     pub OnReadCompleted: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbuffer: *mut ::core::ffi::c_void),
     pub OnStreamClosed: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hrreason: ::windows::core::HRESULT),
@@ -2592,7 +2592,7 @@ unsafe impl ::windows::core::Interface for IRDPViewerInputSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRDPViewerInputSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SendMouseButtonEvent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, buttontype: RDPSRAPI_MOUSE_BUTTON_TYPE, vbbuttondown: i16, xpos: u32, ypos: u32) -> ::windows::core::HRESULT,
     pub SendMouseMoveEvent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, xpos: u32, ypos: u32) -> ::windows::core::HRESULT,
     pub SendMouseWheelEvent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wheelrotation: u16) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Debug/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Debug/impl.rs
@@ -52,7 +52,7 @@ impl AsyncIDebugApplicationNodeEvents_Vtbl {
             this.Finish_onAttach().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Begin_onAddChild: Begin_onAddChild::<Identity, Impl, OFFSET>,
             Finish_onAddChild: Finish_onAddChild::<Identity, Impl, OFFSET>,
             Begin_onRemoveChild: Begin_onRemoveChild::<Identity, Impl, OFFSET>,
@@ -216,7 +216,7 @@ impl IActiveScript_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetScriptSite: SetScriptSite::<Identity, Impl, OFFSET>,
             GetScriptSite: GetScriptSite::<Identity, Impl, OFFSET>,
             SetScriptState: SetScriptState::<Identity, Impl, OFFSET>,
@@ -360,7 +360,7 @@ impl IActiveScriptAuthor_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddNamedItem: AddNamedItem::<Identity, Impl, OFFSET>,
             AddScriptlet: AddScriptlet::<Identity, Impl, OFFSET>,
             ParseScriptText: ParseScriptText::<Identity, Impl, OFFSET>,
@@ -395,7 +395,7 @@ impl IActiveScriptAuthorProcedure_Vtbl {
             let this = (*this).get_impl();
             this.ParseProcedureText(::core::mem::transmute(&pszcode), ::core::mem::transmute(&pszformalparams), ::core::mem::transmute(&pszprocedurename), ::core::mem::transmute(&pszitemname), ::core::mem::transmute(&pszdelimiter), ::core::mem::transmute_copy(&dwcookie), ::core::mem::transmute_copy(&dwflags), ::core::mem::transmute(&pdispfor)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), ParseProcedureText: ParseProcedureText::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), ParseProcedureText: ParseProcedureText::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IActiveScriptAuthorProcedure as ::windows::core::Interface>::IID
@@ -431,7 +431,7 @@ impl IActiveScriptDebug32_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetScriptTextAttributes: GetScriptTextAttributes::<Identity, Impl, OFFSET>,
             GetScriptletTextAttributes: GetScriptletTextAttributes::<Identity, Impl, OFFSET>,
             EnumCodeContextsOfPosition: EnumCodeContextsOfPosition::<Identity, Impl, OFFSET>,
@@ -471,7 +471,7 @@ impl IActiveScriptDebug64_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetScriptTextAttributes: GetScriptTextAttributes::<Identity, Impl, OFFSET>,
             GetScriptletTextAttributes: GetScriptletTextAttributes::<Identity, Impl, OFFSET>,
             EnumCodeContextsOfPosition: EnumCodeContextsOfPosition::<Identity, Impl, OFFSET>,
@@ -505,7 +505,7 @@ impl IActiveScriptEncode_Vtbl {
             this.GetEncodeProgId(::core::mem::transmute_copy(&pbstrout)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             EncodeSection: EncodeSection::<Identity, Impl, OFFSET>,
             DecodeScript: DecodeScript::<Identity, Impl, OFFSET>,
             GetEncodeProgId: GetEncodeProgId::<Identity, Impl, OFFSET>,
@@ -554,7 +554,7 @@ impl IActiveScriptError_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetExceptionInfo: GetExceptionInfo::<Identity, Impl, OFFSET>,
             GetSourcePosition: GetSourcePosition::<Identity, Impl, OFFSET>,
             GetSourceLineText: GetSourceLineText::<Identity, Impl, OFFSET>,
@@ -643,7 +643,7 @@ impl IActiveScriptErrorDebug110_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetExceptionThrownKind: GetExceptionThrownKind::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetExceptionThrownKind: GetExceptionThrownKind::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IActiveScriptErrorDebug110 as ::windows::core::Interface>::IID
@@ -660,7 +660,7 @@ impl IActiveScriptGarbageCollector_Vtbl {
             let this = (*this).get_impl();
             this.CollectGarbage(::core::mem::transmute_copy(&scriptgctype)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CollectGarbage: CollectGarbage::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CollectGarbage: CollectGarbage::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IActiveScriptGarbageCollector as ::windows::core::Interface>::IID
@@ -677,7 +677,7 @@ impl IActiveScriptHostEncode_Vtbl {
             let this = (*this).get_impl();
             this.EncodeScriptHostFile(::core::mem::transmute(&bstrinfile), ::core::mem::transmute_copy(&pbstroutfile), ::core::mem::transmute_copy(&cflags), ::core::mem::transmute(&bstrdefaultlang)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), EncodeScriptHostFile: EncodeScriptHostFile::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), EncodeScriptHostFile: EncodeScriptHostFile::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IActiveScriptHostEncode as ::windows::core::Interface>::IID
@@ -711,7 +711,7 @@ impl IActiveScriptParse32_Vtbl {
             this.ParseScriptText(::core::mem::transmute(&pstrcode), ::core::mem::transmute(&pstritemname), ::core::mem::transmute(&punkcontext), ::core::mem::transmute(&pstrdelimiter), ::core::mem::transmute_copy(&dwsourcecontextcookie), ::core::mem::transmute_copy(&ulstartinglinenumber), ::core::mem::transmute_copy(&dwflags), ::core::mem::transmute_copy(&pvarresult), ::core::mem::transmute_copy(&pexcepinfo)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             InitNew: InitNew::<Identity, Impl, OFFSET>,
             AddScriptlet: AddScriptlet::<Identity, Impl, OFFSET>,
             ParseScriptText: ParseScriptText::<Identity, Impl, OFFSET>,
@@ -749,7 +749,7 @@ impl IActiveScriptParse64_Vtbl {
             this.ParseScriptText(::core::mem::transmute(&pstrcode), ::core::mem::transmute(&pstritemname), ::core::mem::transmute(&punkcontext), ::core::mem::transmute(&pstrdelimiter), ::core::mem::transmute_copy(&dwsourcecontextcookie), ::core::mem::transmute_copy(&ulstartinglinenumber), ::core::mem::transmute_copy(&dwflags), ::core::mem::transmute_copy(&pvarresult), ::core::mem::transmute_copy(&pexcepinfo)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             InitNew: InitNew::<Identity, Impl, OFFSET>,
             AddScriptlet: AddScriptlet::<Identity, Impl, OFFSET>,
             ParseScriptText: ParseScriptText::<Identity, Impl, OFFSET>,
@@ -805,7 +805,7 @@ impl IActiveScriptParseProcedure32_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), ParseProcedureText: ParseProcedureText::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), ParseProcedureText: ParseProcedureText::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IActiveScriptParseProcedure32 as ::windows::core::Interface>::IID
@@ -831,7 +831,7 @@ impl IActiveScriptParseProcedure64_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), ParseProcedureText: ParseProcedureText::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), ParseProcedureText: ParseProcedureText::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IActiveScriptParseProcedure64 as ::windows::core::Interface>::IID
@@ -857,7 +857,7 @@ impl IActiveScriptParseProcedureOld32_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), ParseProcedureText: ParseProcedureText::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), ParseProcedureText: ParseProcedureText::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IActiveScriptParseProcedureOld32 as ::windows::core::Interface>::IID
@@ -883,7 +883,7 @@ impl IActiveScriptParseProcedureOld64_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), ParseProcedureText: ParseProcedureText::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), ParseProcedureText: ParseProcedureText::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IActiveScriptParseProcedureOld64 as ::windows::core::Interface>::IID
@@ -931,7 +931,7 @@ impl IActiveScriptProfilerCallback_Vtbl {
             this.OnFunctionExit(::core::mem::transmute_copy(&scriptid), ::core::mem::transmute_copy(&functionid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             Shutdown: Shutdown::<Identity, Impl, OFFSET>,
             ScriptCompiled: ScriptCompiled::<Identity, Impl, OFFSET>,
@@ -1012,7 +1012,7 @@ impl IActiveScriptProfilerControl_Vtbl {
             this.StopProfiling(::core::mem::transmute_copy(&hrshutdownreason)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             StartProfiling: StartProfiling::<Identity, Impl, OFFSET>,
             SetProfilerEventMask: SetProfilerEventMask::<Identity, Impl, OFFSET>,
             StopProfiling: StopProfiling::<Identity, Impl, OFFSET>,
@@ -1142,7 +1142,7 @@ impl IActiveScriptProfilerHeapEnum_Vtbl {
             this.GetNameIdMap(::core::mem::transmute_copy(&pnamelist), ::core::mem::transmute_copy(&pcelt)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             GetOptionalInfo: GetOptionalInfo::<Identity, Impl, OFFSET>,
             FreeObjectAndOptionalInfo: FreeObjectAndOptionalInfo::<Identity, Impl, OFFSET>,
@@ -1180,7 +1180,7 @@ impl IActiveScriptProperty_Vtbl {
             this.SetProperty(::core::mem::transmute_copy(&dwproperty), ::core::mem::transmute_copy(&pvarindex), ::core::mem::transmute_copy(&pvarvalue)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetProperty: GetProperty::<Identity, Impl, OFFSET>,
             SetProperty: SetProperty::<Identity, Impl, OFFSET>,
         }
@@ -1206,7 +1206,7 @@ impl IActiveScriptSIPInfo_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetSIPOID: GetSIPOID::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetSIPOID: GetSIPOID::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IActiveScriptSIPInfo as ::windows::core::Interface>::IID
@@ -1281,7 +1281,7 @@ impl IActiveScriptSite_Vtbl {
             this.OnLeaveScript().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetLCID: GetLCID::<Identity, Impl, OFFSET>,
             GetItemInfo: GetItemInfo::<Identity, Impl, OFFSET>,
             GetDocVersionString: GetDocVersionString::<Identity, Impl, OFFSET>,
@@ -1347,7 +1347,7 @@ impl IActiveScriptSiteDebug32_Vtbl {
             this.OnScriptErrorDebug(::core::mem::transmute(&perrordebug), ::core::mem::transmute_copy(&pfenterdebugger), ::core::mem::transmute_copy(&pfcallonscripterrorwhencontinuing)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDocumentContextFromPosition: GetDocumentContextFromPosition::<Identity, Impl, OFFSET>,
             GetApplication: GetApplication::<Identity, Impl, OFFSET>,
             GetRootApplicationNode: GetRootApplicationNode::<Identity, Impl, OFFSET>,
@@ -1409,7 +1409,7 @@ impl IActiveScriptSiteDebug64_Vtbl {
             this.OnScriptErrorDebug(::core::mem::transmute(&perrordebug), ::core::mem::transmute_copy(&pfenterdebugger), ::core::mem::transmute_copy(&pfcallonscripterrorwhencontinuing)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDocumentContextFromPosition: GetDocumentContextFromPosition::<Identity, Impl, OFFSET>,
             GetApplication: GetApplication::<Identity, Impl, OFFSET>,
             GetRootApplicationNode: GetRootApplicationNode::<Identity, Impl, OFFSET>,
@@ -1441,7 +1441,7 @@ impl IActiveScriptSiteDebugEx_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnCanNotJITScriptErrorDebug: OnCanNotJITScriptErrorDebug::<Identity, Impl, OFFSET>,
         }
     }
@@ -1460,7 +1460,7 @@ impl IActiveScriptSiteInterruptPoll_Vtbl {
             let this = (*this).get_impl();
             this.QueryContinue().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), QueryContinue: QueryContinue::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), QueryContinue: QueryContinue::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IActiveScriptSiteInterruptPoll as ::windows::core::Interface>::IID
@@ -1477,7 +1477,7 @@ impl IActiveScriptSiteTraceInfo_Vtbl {
             let this = (*this).get_impl();
             this.SendScriptTraceInfo(::core::mem::transmute_copy(&stieventtype), ::core::mem::transmute(&guidcontextid), ::core::mem::transmute_copy(&dwscriptcontextcookie), ::core::mem::transmute_copy(&lscriptstatementstart), ::core::mem::transmute_copy(&lscriptstatementend), ::core::mem::transmute_copy(&dwreserved)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SendScriptTraceInfo: SendScriptTraceInfo::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SendScriptTraceInfo: SendScriptTraceInfo::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IActiveScriptSiteTraceInfo as ::windows::core::Interface>::IID
@@ -1500,7 +1500,7 @@ impl IActiveScriptSiteUIControl_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetUIBehavior: GetUIBehavior::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetUIBehavior: GetUIBehavior::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IActiveScriptSiteUIControl as ::windows::core::Interface>::IID
@@ -1533,7 +1533,7 @@ impl IActiveScriptSiteWindow_Vtbl {
             this.EnableModeless(::core::mem::transmute_copy(&fenable)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetWindow: GetWindow::<Identity, Impl, OFFSET>,
             EnableModeless: EnableModeless::<Identity, Impl, OFFSET>,
         }
@@ -1566,7 +1566,7 @@ impl IActiveScriptStats_Vtbl {
             this.ResetStats().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetStat: GetStat::<Identity, Impl, OFFSET>,
             GetStatEx: GetStatEx::<Identity, Impl, OFFSET>,
             ResetStats: ResetStats::<Identity, Impl, OFFSET>,
@@ -1593,7 +1593,7 @@ impl IActiveScriptStringCompare_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), StrComp: StrComp::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), StrComp: StrComp::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IActiveScriptStringCompare as ::windows::core::Interface>::IID
@@ -1617,7 +1617,7 @@ impl IActiveScriptTraceInfo_Vtbl {
             this.StopScriptTracing().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             StartScriptTracing: StartScriptTracing::<Identity, Impl, OFFSET>,
             StopScriptTracing: StopScriptTracing::<Identity, Impl, OFFSET>,
         }
@@ -1729,7 +1729,7 @@ impl IApplicationDebugger_Vtbl {
             this.onDebuggerEvent(::core::mem::transmute_copy(&riid), ::core::mem::transmute(&punk)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             QueryAlive: QueryAlive::<Identity, Impl, OFFSET>,
             CreateInstanceAtDebugger: CreateInstanceAtDebugger::<Identity, Impl, OFFSET>,
             onDebugOutput: onDebugOutput::<Identity, Impl, OFFSET>,
@@ -1760,7 +1760,7 @@ impl IApplicationDebuggerUI_Vtbl {
             this.BringDocumentContextToTop(::core::mem::transmute(&pddc)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             BringDocumentToTop: BringDocumentToTop::<Identity, Impl, OFFSET>,
             BringDocumentContextToTop: BringDocumentContextToTop::<Identity, Impl, OFFSET>,
         }
@@ -1783,7 +1783,7 @@ impl IBindEventHandler_Vtbl {
             let this = (*this).get_impl();
             this.BindHandler(::core::mem::transmute(&pstrevent), ::core::mem::transmute(&pdisp)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), BindHandler: BindHandler::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), BindHandler: BindHandler::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IBindEventHandler as ::windows::core::Interface>::IID
@@ -1806,7 +1806,7 @@ impl ICodeAddressConcept_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetContainingSymbol: GetContainingSymbol::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetContainingSymbol: GetContainingSymbol::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ICodeAddressConcept as ::windows::core::Interface>::IID
@@ -1829,7 +1829,7 @@ impl IComparableConcept_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CompareObjects: CompareObjects::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CompareObjects: CompareObjects::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IComparableConcept as ::windows::core::Interface>::IID
@@ -1859,7 +1859,7 @@ impl IDataModelConcept_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             InitializeObject: InitializeObject::<Identity, Impl, OFFSET>,
             GetName: GetName::<Identity, Impl, OFFSET>,
         }
@@ -2069,7 +2069,7 @@ impl IDataModelManager_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Close: Close::<Identity, Impl, OFFSET>,
             CreateNoValue: CreateNoValue::<Identity, Impl, OFFSET>,
             CreateErrorObject: CreateErrorObject::<Identity, Impl, OFFSET>,
@@ -2180,7 +2180,7 @@ impl IDataModelNameBinder_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             BindValue: BindValue::<Identity, Impl, OFFSET>,
             BindReference: BindReference::<Identity, Impl, OFFSET>,
             EnumerateValues: EnumerateValues::<Identity, Impl, OFFSET>,
@@ -2254,7 +2254,7 @@ impl IDataModelScript_Vtbl {
             this.InvokeMain(::core::mem::transmute(&client)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetName: GetName::<Identity, Impl, OFFSET>,
             Rename: Rename::<Identity, Impl, OFFSET>,
             Populate: Populate::<Identity, Impl, OFFSET>,
@@ -2279,7 +2279,7 @@ impl IDataModelScriptClient_Vtbl {
             let this = (*this).get_impl();
             this.ReportError(::core::mem::transmute_copy(&errclass), ::core::mem::transmute_copy(&hrfail), ::core::mem::transmute(&message), ::core::mem::transmute_copy(&line), ::core::mem::transmute_copy(&position)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), ReportError: ReportError::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), ReportError: ReportError::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDataModelScriptClient as ::windows::core::Interface>::IID
@@ -2381,7 +2381,7 @@ impl IDataModelScriptDebug_Vtbl {
             this.StopDebugging(::core::mem::transmute(&debugclient)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDebugState: GetDebugState::<Identity, Impl, OFFSET>,
             GetCurrentPosition: GetCurrentPosition::<Identity, Impl, OFFSET>,
             GetStack: GetStack::<Identity, Impl, OFFSET>,
@@ -2463,7 +2463,7 @@ impl IDataModelScriptDebugBreakpoint_Vtbl {
             this.GetPosition(::core::mem::transmute_copy(&position), ::core::mem::transmute_copy(&positionspanend), ::core::mem::transmute_copy(&linetext)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetId: GetId::<Identity, Impl, OFFSET>,
             IsEnabled: IsEnabled::<Identity, Impl, OFFSET>,
             Enable: Enable::<Identity, Impl, OFFSET>,
@@ -2500,7 +2500,7 @@ impl IDataModelScriptDebugBreakpointEnumerator_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Reset: Reset::<Identity, Impl, OFFSET>,
             GetNext: GetNext::<Identity, Impl, OFFSET>,
         }
@@ -2520,7 +2520,7 @@ impl IDataModelScriptDebugClient_Vtbl {
             let this = (*this).get_impl();
             this.NotifyDebugEvent(::core::mem::transmute_copy(&peventinfo), ::core::mem::transmute(&pscript), ::core::mem::transmute(&peventdataobject), ::core::mem::transmute_copy(&resumeeventkind)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), NotifyDebugEvent: NotifyDebugEvent::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), NotifyDebugEvent: NotifyDebugEvent::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDataModelScriptDebugClient as ::windows::core::Interface>::IID
@@ -2550,7 +2550,7 @@ impl IDataModelScriptDebugStack_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetFrameCount: GetFrameCount::<Identity, Impl, OFFSET>,
             GetStackFrame: GetStackFrame::<Identity, Impl, OFFSET>,
         }
@@ -2637,7 +2637,7 @@ impl IDataModelScriptDebugStackFrame_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetName: GetName::<Identity, Impl, OFFSET>,
             GetPosition: GetPosition::<Identity, Impl, OFFSET>,
             IsTransitionPoint: IsTransitionPoint::<Identity, Impl, OFFSET>,
@@ -2669,7 +2669,7 @@ impl IDataModelScriptDebugVariableSetEnumerator_Vtbl {
             this.GetNext(::core::mem::transmute_copy(&variablename), ::core::mem::transmute_copy(&variablevalue), ::core::mem::transmute_copy(&variablemetadata)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Reset: Reset::<Identity, Impl, OFFSET>,
             GetNext: GetNext::<Identity, Impl, OFFSET>,
         }
@@ -2702,7 +2702,7 @@ impl IDataModelScriptHostContext_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             NotifyScriptChange: NotifyScriptChange::<Identity, Impl, OFFSET>,
             GetNamespaceObject: GetNamespaceObject::<Identity, Impl, OFFSET>,
         }
@@ -2777,7 +2777,7 @@ impl IDataModelScriptManager_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDefaultNameBinder: GetDefaultNameBinder::<Identity, Impl, OFFSET>,
             RegisterScriptProvider: RegisterScriptProvider::<Identity, Impl, OFFSET>,
             UnregisterScriptProvider: UnregisterScriptProvider::<Identity, Impl, OFFSET>,
@@ -2856,7 +2856,7 @@ impl IDataModelScriptProvider_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetName: GetName::<Identity, Impl, OFFSET>,
             GetExtension: GetExtension::<Identity, Impl, OFFSET>,
             CreateScript: CreateScript::<Identity, Impl, OFFSET>,
@@ -2892,7 +2892,7 @@ impl IDataModelScriptProviderEnumerator_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Reset: Reset::<Identity, Impl, OFFSET>,
             GetNext: GetNext::<Identity, Impl, OFFSET>,
         }
@@ -2946,7 +2946,7 @@ impl IDataModelScriptTemplate_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetName: GetName::<Identity, Impl, OFFSET>,
             GetDescription: GetDescription::<Identity, Impl, OFFSET>,
             GetContent: GetContent::<Identity, Impl, OFFSET>,
@@ -2980,7 +2980,7 @@ impl IDataModelScriptTemplateEnumerator_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Reset: Reset::<Identity, Impl, OFFSET>,
             GetNext: GetNext::<Identity, Impl, OFFSET>,
         }
@@ -3007,7 +3007,7 @@ impl IDebugAdvanced_Vtbl {
             this.SetThreadContext(::core::mem::transmute_copy(&context), ::core::mem::transmute_copy(&contextsize)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetThreadContext: GetThreadContext::<Identity, Impl, OFFSET>,
             SetThreadContext: SetThreadContext::<Identity, Impl, OFFSET>,
         }
@@ -3064,7 +3064,7 @@ impl IDebugAdvanced2_Vtbl {
             this.GetSystemObjectInformation(::core::mem::transmute_copy(&which), ::core::mem::transmute_copy(&arg64), ::core::mem::transmute_copy(&arg32), ::core::mem::transmute_copy(&buffer), ::core::mem::transmute_copy(&buffersize), ::core::mem::transmute_copy(&infosize)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetThreadContext: GetThreadContext::<Identity, Impl, OFFSET>,
             SetThreadContext: SetThreadContext::<Identity, Impl, OFFSET>,
             Request: Request::<Identity, Impl, OFFSET>,
@@ -3144,7 +3144,7 @@ impl IDebugAdvanced3_Vtbl {
             this.GetSymbolInformationWide(::core::mem::transmute_copy(&which), ::core::mem::transmute_copy(&arg64), ::core::mem::transmute_copy(&arg32), ::core::mem::transmute_copy(&buffer), ::core::mem::transmute_copy(&buffersize), ::core::mem::transmute_copy(&infosize), ::core::mem::transmute_copy(&stringbuffer), ::core::mem::transmute_copy(&stringbuffersize), ::core::mem::transmute_copy(&stringsize)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetThreadContext: GetThreadContext::<Identity, Impl, OFFSET>,
             SetThreadContext: SetThreadContext::<Identity, Impl, OFFSET>,
             Request: Request::<Identity, Impl, OFFSET>,
@@ -3233,7 +3233,7 @@ impl IDebugAdvanced4_Vtbl {
             this.GetSymbolInformationWideEx(::core::mem::transmute_copy(&which), ::core::mem::transmute_copy(&arg64), ::core::mem::transmute_copy(&arg32), ::core::mem::transmute_copy(&buffer), ::core::mem::transmute_copy(&buffersize), ::core::mem::transmute_copy(&infosize), ::core::mem::transmute_copy(&stringbuffer), ::core::mem::transmute_copy(&stringbuffersize), ::core::mem::transmute_copy(&stringsize), ::core::mem::transmute_copy(&pinfoex)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetThreadContext: GetThreadContext::<Identity, Impl, OFFSET>,
             SetThreadContext: SetThreadContext::<Identity, Impl, OFFSET>,
             Request: Request::<Identity, Impl, OFFSET>,
@@ -3818,7 +3818,7 @@ impl IDebugApplicationNode100_Vtbl {
             this.QueryIsChildNode(::core::mem::transmute(&psearchkey)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetFilterForEventSink: SetFilterForEventSink::<Identity, Impl, OFFSET>,
             GetExcludedDocuments: GetExcludedDocuments::<Identity, Impl, OFFSET>,
             QueryIsChildNode: QueryIsChildNode::<Identity, Impl, OFFSET>,
@@ -3858,7 +3858,7 @@ impl IDebugApplicationNodeEvents_Vtbl {
             this.onAttach(::core::mem::transmute(&prddpparent)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             onAddChild: onAddChild::<Identity, Impl, OFFSET>,
             onRemoveChild: onRemoveChild::<Identity, Impl, OFFSET>,
             onDetach: onDetach::<Identity, Impl, OFFSET>,
@@ -3968,7 +3968,7 @@ impl IDebugApplicationThread11032_Vtbl {
             this.AsynchronousCallIntoThread(::core::mem::transmute(&pptc), ::core::mem::transmute_copy(&dwparam1), ::core::mem::transmute_copy(&dwparam2), ::core::mem::transmute_copy(&dwparam3)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetActiveThreadRequestCount: GetActiveThreadRequestCount::<Identity, Impl, OFFSET>,
             IsSuspendedForBreakPoint: IsSuspendedForBreakPoint::<Identity, Impl, OFFSET>,
             IsThreadCallable: IsThreadCallable::<Identity, Impl, OFFSET>,
@@ -4030,7 +4030,7 @@ impl IDebugApplicationThread11064_Vtbl {
             this.AsynchronousCallIntoThread(::core::mem::transmute(&pptc), ::core::mem::transmute_copy(&dwparam1), ::core::mem::transmute_copy(&dwparam2), ::core::mem::transmute_copy(&dwparam3)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetActiveThreadRequestCount: GetActiveThreadRequestCount::<Identity, Impl, OFFSET>,
             IsSuspendedForBreakPoint: IsSuspendedForBreakPoint::<Identity, Impl, OFFSET>,
             IsThreadCallable: IsThreadCallable::<Identity, Impl, OFFSET>,
@@ -4091,7 +4091,7 @@ impl IDebugApplicationThreadEvents110_Vtbl {
             this.OnBeginThreadRequest().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnSuspendForBreakPoint: OnSuspendForBreakPoint::<Identity, Impl, OFFSET>,
             OnResumeFromBreakPoint: OnResumeFromBreakPoint::<Identity, Impl, OFFSET>,
             OnThreadRequestComplete: OnThreadRequestComplete::<Identity, Impl, OFFSET>,
@@ -4144,7 +4144,7 @@ impl IDebugAsyncOperation_Vtbl {
             this.GetResult(::core::mem::transmute_copy(&phrresult), ::core::mem::transmute_copy(&ppunkresult)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSyncDebugOperation: GetSyncDebugOperation::<Identity, Impl, OFFSET>,
             Start: Start::<Identity, Impl, OFFSET>,
             Abort: Abort::<Identity, Impl, OFFSET>,
@@ -4167,7 +4167,7 @@ impl IDebugAsyncOperationCallBack_Vtbl {
             let this = (*this).get_impl();
             this.onComplete().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), onComplete: onComplete::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), onComplete: onComplete::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDebugAsyncOperationCallBack as ::windows::core::Interface>::IID
@@ -4353,7 +4353,7 @@ impl IDebugBreakpoint_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetId: GetId::<Identity, Impl, OFFSET>,
             GetType: GetType::<Identity, Impl, OFFSET>,
             GetAdder: GetAdder::<Identity, Impl, OFFSET>,
@@ -4585,7 +4585,7 @@ impl IDebugBreakpoint2_Vtbl {
             this.SetOffsetExpressionWide(::core::mem::transmute(&expression)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetId: GetId::<Identity, Impl, OFFSET>,
             GetType: GetType::<Identity, Impl, OFFSET>,
             GetAdder: GetAdder::<Identity, Impl, OFFSET>,
@@ -4833,7 +4833,7 @@ impl IDebugBreakpoint3_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetId: GetId::<Identity, Impl, OFFSET>,
             GetType: GetType::<Identity, Impl, OFFSET>,
             GetAdder: GetAdder::<Identity, Impl, OFFSET>,
@@ -5208,7 +5208,7 @@ impl IDebugClient_Vtbl {
             this.FlushCallbacks().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AttachKernel: AttachKernel::<Identity, Impl, OFFSET>,
             GetKernelConnectionOptions: GetKernelConnectionOptions::<Identity, Impl, OFFSET>,
             SetKernelConnectionOptions: SetKernelConnectionOptions::<Identity, Impl, OFFSET>,
@@ -5650,7 +5650,7 @@ impl IDebugClient2_Vtbl {
             this.AbandonCurrentProcess().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AttachKernel: AttachKernel::<Identity, Impl, OFFSET>,
             GetKernelConnectionOptions: GetKernelConnectionOptions::<Identity, Impl, OFFSET>,
             SetKernelConnectionOptions: SetKernelConnectionOptions::<Identity, Impl, OFFSET>,
@@ -6130,7 +6130,7 @@ impl IDebugClient3_Vtbl {
             this.CreateProcessAndAttachWide(::core::mem::transmute_copy(&server), ::core::mem::transmute(&commandline), ::core::mem::transmute_copy(&createflags), ::core::mem::transmute_copy(&processid), ::core::mem::transmute_copy(&attachflags)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AttachKernel: AttachKernel::<Identity, Impl, OFFSET>,
             GetKernelConnectionOptions: GetKernelConnectionOptions::<Identity, Impl, OFFSET>,
             SetKernelConnectionOptions: SetKernelConnectionOptions::<Identity, Impl, OFFSET>,
@@ -6656,7 +6656,7 @@ impl IDebugClient4_Vtbl {
             this.GetDumpFileWide(::core::mem::transmute_copy(&index), ::core::mem::transmute_copy(&buffer), ::core::mem::transmute_copy(&buffersize), ::core::mem::transmute_copy(&namesize), ::core::mem::transmute_copy(&handle), ::core::mem::transmute_copy(&r#type)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AttachKernel: AttachKernel::<Identity, Impl, OFFSET>,
             GetKernelConnectionOptions: GetKernelConnectionOptions::<Identity, Impl, OFFSET>,
             SetKernelConnectionOptions: SetKernelConnectionOptions::<Identity, Impl, OFFSET>,
@@ -7410,7 +7410,7 @@ impl IDebugClient5_Vtbl {
             this.SetQuitLockStringWide(::core::mem::transmute(&string)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AttachKernel: AttachKernel::<Identity, Impl, OFFSET>,
             GetKernelConnectionOptions: GetKernelConnectionOptions::<Identity, Impl, OFFSET>,
             SetKernelConnectionOptions: SetKernelConnectionOptions::<Identity, Impl, OFFSET>,
@@ -8199,7 +8199,7 @@ impl IDebugClient6_Vtbl {
             this.SetEventContextCallbacks(::core::mem::transmute(&callbacks)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AttachKernel: AttachKernel::<Identity, Impl, OFFSET>,
             GetKernelConnectionOptions: GetKernelConnectionOptions::<Identity, Impl, OFFSET>,
             SetKernelConnectionOptions: SetKernelConnectionOptions::<Identity, Impl, OFFSET>,
@@ -8995,7 +8995,7 @@ impl IDebugClient7_Vtbl {
             this.SetClientContext(::core::mem::transmute_copy(&context), ::core::mem::transmute_copy(&contextsize)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AttachKernel: AttachKernel::<Identity, Impl, OFFSET>,
             GetKernelConnectionOptions: GetKernelConnectionOptions::<Identity, Impl, OFFSET>,
             SetKernelConnectionOptions: SetKernelConnectionOptions::<Identity, Impl, OFFSET>,
@@ -9798,7 +9798,7 @@ impl IDebugClient8_Vtbl {
             this.OpenDumpFileWide2(::core::mem::transmute(&filename), ::core::mem::transmute_copy(&filehandle), ::core::mem::transmute_copy(&alternatearch)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AttachKernel: AttachKernel::<Identity, Impl, OFFSET>,
             GetKernelConnectionOptions: GetKernelConnectionOptions::<Identity, Impl, OFFSET>,
             SetKernelConnectionOptions: SetKernelConnectionOptions::<Identity, Impl, OFFSET>,
@@ -9924,7 +9924,7 @@ impl IDebugCodeContext_Vtbl {
             this.SetBreakPoint(::core::mem::transmute_copy(&bps)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDocumentContext: GetDocumentContext::<Identity, Impl, OFFSET>,
             SetBreakPoint: SetBreakPoint::<Identity, Impl, OFFSET>,
         }
@@ -10669,7 +10669,7 @@ impl IDebugControl_Vtbl {
             this.GetLastEventInformation(::core::mem::transmute_copy(&r#type), ::core::mem::transmute_copy(&processid), ::core::mem::transmute_copy(&threadid), ::core::mem::transmute_copy(&extrainformation), ::core::mem::transmute_copy(&extrainformationsize), ::core::mem::transmute_copy(&extrainformationused), ::core::mem::transmute_copy(&description), ::core::mem::transmute_copy(&descriptionsize), ::core::mem::transmute_copy(&descriptionused)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetInterrupt: GetInterrupt::<Identity, Impl, OFFSET>,
             SetInterrupt: SetInterrupt::<Identity, Impl, OFFSET>,
             GetInterruptTimeout: GetInterruptTimeout::<Identity, Impl, OFFSET>,
@@ -11576,7 +11576,7 @@ impl IDebugControl2_Vtbl {
             this.OutputTextReplacements(::core::mem::transmute_copy(&outputcontrol), ::core::mem::transmute_copy(&flags)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetInterrupt: GetInterrupt::<Identity, Impl, OFFSET>,
             SetInterrupt: SetInterrupt::<Identity, Impl, OFFSET>,
             GetInterruptTimeout: GetInterruptTimeout::<Identity, Impl, OFFSET>,
@@ -12611,7 +12611,7 @@ impl IDebugControl3_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetInterrupt: GetInterrupt::<Identity, Impl, OFFSET>,
             SetInterrupt: SetInterrupt::<Identity, Impl, OFFSET>,
             GetInterruptTimeout: GetInterruptTimeout::<Identity, Impl, OFFSET>,
@@ -14019,7 +14019,7 @@ impl IDebugControl4_Vtbl {
             this.ResetManagedStatus(::core::mem::transmute_copy(&flags)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetInterrupt: GetInterrupt::<Identity, Impl, OFFSET>,
             SetInterrupt: SetInterrupt::<Identity, Impl, OFFSET>,
             GetInterruptTimeout: GetInterruptTimeout::<Identity, Impl, OFFSET>,
@@ -15516,7 +15516,7 @@ impl IDebugControl5_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetInterrupt: GetInterrupt::<Identity, Impl, OFFSET>,
             SetInterrupt: SetInterrupt::<Identity, Impl, OFFSET>,
             GetInterruptTimeout: GetInterruptTimeout::<Identity, Impl, OFFSET>,
@@ -17036,7 +17036,7 @@ impl IDebugControl6_Vtbl {
             this.GetSynchronizationStatus(::core::mem::transmute_copy(&sendsattempted), ::core::mem::transmute_copy(&secondssincelastresponse)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetInterrupt: GetInterrupt::<Identity, Impl, OFFSET>,
             SetInterrupt: SetInterrupt::<Identity, Impl, OFFSET>,
             GetInterruptTimeout: GetInterruptTimeout::<Identity, Impl, OFFSET>,
@@ -18564,7 +18564,7 @@ impl IDebugControl7_Vtbl {
             this.GetDebuggeeType2(::core::mem::transmute_copy(&flags), ::core::mem::transmute_copy(&class), ::core::mem::transmute_copy(&qualifier)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetInterrupt: GetInterrupt::<Identity, Impl, OFFSET>,
             SetInterrupt: SetInterrupt::<Identity, Impl, OFFSET>,
             GetInterruptTimeout: GetInterruptTimeout::<Identity, Impl, OFFSET>,
@@ -18756,7 +18756,7 @@ impl IDebugCookie_Vtbl {
             let this = (*this).get_impl();
             this.SetDebugCookie(::core::mem::transmute_copy(&dwdebugappcookie)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SetDebugCookie: SetDebugCookie::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SetDebugCookie: SetDebugCookie::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDebugCookie as ::windows::core::Interface>::IID
@@ -18936,7 +18936,7 @@ impl IDebugDataSpaces_Vtbl {
             this.ReadProcessorSystemData(::core::mem::transmute_copy(&processor), ::core::mem::transmute_copy(&index), ::core::mem::transmute_copy(&buffer), ::core::mem::transmute_copy(&buffersize), ::core::mem::transmute_copy(&datasize)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ReadVirtual: ReadVirtual::<Identity, Impl, OFFSET>,
             WriteVirtual: WriteVirtual::<Identity, Impl, OFFSET>,
             SearchVirtual: SearchVirtual::<Identity, Impl, OFFSET>,
@@ -19200,7 +19200,7 @@ impl IDebugDataSpaces2_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ReadVirtual: ReadVirtual::<Identity, Impl, OFFSET>,
             WriteVirtual: WriteVirtual::<Identity, Impl, OFFSET>,
             SearchVirtual: SearchVirtual::<Identity, Impl, OFFSET>,
@@ -19512,7 +19512,7 @@ impl IDebugDataSpaces3_Vtbl {
             this.EndEnumTagged(::core::mem::transmute_copy(&handle)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ReadVirtual: ReadVirtual::<Identity, Impl, OFFSET>,
             WriteVirtual: WriteVirtual::<Identity, Impl, OFFSET>,
             SearchVirtual: SearchVirtual::<Identity, Impl, OFFSET>,
@@ -19907,7 +19907,7 @@ impl IDebugDataSpaces4_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ReadVirtual: ReadVirtual::<Identity, Impl, OFFSET>,
             WriteVirtual: WriteVirtual::<Identity, Impl, OFFSET>,
             SearchVirtual: SearchVirtual::<Identity, Impl, OFFSET>,
@@ -19995,7 +19995,7 @@ impl IDebugDocumentContext_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDocument: GetDocument::<Identity, Impl, OFFSET>,
             EnumCodeContexts: EnumCodeContexts::<Identity, Impl, OFFSET>,
         }
@@ -20139,7 +20139,7 @@ impl IDebugDocumentHelper32_Vtbl {
             this.BringDocumentContextToTop(::core::mem::transmute(&pddc)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Init: Init::<Identity, Impl, OFFSET>,
             Attach: Attach::<Identity, Impl, OFFSET>,
             Detach: Detach::<Identity, Impl, OFFSET>,
@@ -20299,7 +20299,7 @@ impl IDebugDocumentHelper64_Vtbl {
             this.BringDocumentContextToTop(::core::mem::transmute(&pddc)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Init: Init::<Identity, Impl, OFFSET>,
             Attach: Attach::<Identity, Impl, OFFSET>,
             Detach: Detach::<Identity, Impl, OFFSET>,
@@ -20381,7 +20381,7 @@ impl IDebugDocumentHost_Vtbl {
             this.NotifyChanged().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDeferredText: GetDeferredText::<Identity, Impl, OFFSET>,
             GetScriptTextAttributes: GetScriptTextAttributes::<Identity, Impl, OFFSET>,
             OnCreateDocumentContext: OnCreateDocumentContext::<Identity, Impl, OFFSET>,
@@ -20424,7 +20424,7 @@ impl IDebugDocumentInfo_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetName: GetName::<Identity, Impl, OFFSET>,
             GetDocumentClassId: GetDocumentClassId::<Identity, Impl, OFFSET>,
         }
@@ -20612,7 +20612,7 @@ impl IDebugDocumentTextEvents_Vtbl {
             this.onUpdateDocumentAttributes(::core::mem::transmute_copy(&textdocattr)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             onDestroy: onDestroy::<Identity, Impl, OFFSET>,
             onInsertText: onInsertText::<Identity, Impl, OFFSET>,
             onRemoveText: onRemoveText::<Identity, Impl, OFFSET>,
@@ -20658,7 +20658,7 @@ impl IDebugDocumentTextExternalAuthor_Vtbl {
             this.NotifyChanged().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetPathName: GetPathName::<Identity, Impl, OFFSET>,
             GetFileName: GetFileName::<Identity, Impl, OFFSET>,
             NotifyChanged: NotifyChanged::<Identity, Impl, OFFSET>,
@@ -20768,7 +20768,7 @@ impl IDebugEventCallbacks_Vtbl {
             this.ChangeSymbolState(::core::mem::transmute_copy(&flags), ::core::mem::transmute_copy(&argument)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetInterestMask: GetInterestMask::<Identity, Impl, OFFSET>,
             Breakpoint: Breakpoint::<Identity, Impl, OFFSET>,
             Exception: Exception::<Identity, Impl, OFFSET>,
@@ -20889,7 +20889,7 @@ impl IDebugEventCallbacksWide_Vtbl {
             this.ChangeSymbolState(::core::mem::transmute_copy(&flags), ::core::mem::transmute_copy(&argument)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetInterestMask: GetInterestMask::<Identity, Impl, OFFSET>,
             Breakpoint: Breakpoint::<Identity, Impl, OFFSET>,
             Exception: Exception::<Identity, Impl, OFFSET>,
@@ -21024,7 +21024,7 @@ impl IDebugEventContextCallbacks_Vtbl {
             this.ChangeSymbolState(::core::mem::transmute_copy(&flags), ::core::mem::transmute_copy(&argument)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetInterestMask: GetInterestMask::<Identity, Impl, OFFSET>,
             Breakpoint: Breakpoint::<Identity, Impl, OFFSET>,
             Exception: Exception::<Identity, Impl, OFFSET>,
@@ -21081,7 +21081,7 @@ impl IDebugExpression_Vtbl {
             this.GetResultAsDebugProperty(::core::mem::transmute_copy(&phrresult), ::core::mem::transmute_copy(&ppdp)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Start: Start::<Identity, Impl, OFFSET>,
             Abort: Abort::<Identity, Impl, OFFSET>,
             QueryIsComplete: QueryIsComplete::<Identity, Impl, OFFSET>,
@@ -21104,7 +21104,7 @@ impl IDebugExpressionCallBack_Vtbl {
             let this = (*this).get_impl();
             this.onComplete().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), onComplete: onComplete::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), onComplete: onComplete::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDebugExpressionCallBack as ::windows::core::Interface>::IID
@@ -21134,7 +21134,7 @@ impl IDebugExpressionContext_Vtbl {
             this.GetLanguageInfo(::core::mem::transmute_copy(&pbstrlanguagename), ::core::mem::transmute_copy(&planguageid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ParseLanguageText: ParseLanguageText::<Identity, Impl, OFFSET>,
             GetLanguageInfo: GetLanguageInfo::<Identity, Impl, OFFSET>,
         }
@@ -21230,7 +21230,7 @@ impl IDebugFormatter_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetStringForVariant: GetStringForVariant::<Identity, Impl, OFFSET>,
             GetVariantForString: GetVariantForString::<Identity, Impl, OFFSET>,
             GetStringForVarType: GetStringForVarType::<Identity, Impl, OFFSET>,
@@ -21285,7 +21285,7 @@ impl IDebugHelper_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreatePropertyBrowser: CreatePropertyBrowser::<Identity, Impl, OFFSET>,
             CreatePropertyBrowserEx: CreatePropertyBrowserEx::<Identity, Impl, OFFSET>,
             CreateSimpleConnectionPoint: CreateSimpleConnectionPoint::<Identity, Impl, OFFSET>,
@@ -21337,7 +21337,7 @@ impl IDebugHost_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetHostDefinedInterface: GetHostDefinedInterface::<Identity, Impl, OFFSET>,
             GetCurrentContext: GetCurrentContext::<Identity, Impl, OFFSET>,
             GetDefaultMetadata: GetDefaultMetadata::<Identity, Impl, OFFSET>,
@@ -21413,7 +21413,7 @@ impl IDebugHostContext_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), IsEqualTo: IsEqualTo::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), IsEqualTo: IsEqualTo::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDebugHostContext as ::windows::core::Interface>::IID
@@ -21485,7 +21485,7 @@ impl IDebugHostErrorSink_Vtbl {
             let this = (*this).get_impl();
             this.ReportError(::core::mem::transmute_copy(&errclass), ::core::mem::transmute_copy(&hrerror), ::core::mem::transmute(&message)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), ReportError: ReportError::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), ReportError: ReportError::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDebugHostErrorSink as ::windows::core::Interface>::IID
@@ -21509,7 +21509,7 @@ impl IDebugHostEvaluator_Vtbl {
             this.EvaluateExtendedExpression(::core::mem::transmute(&context), ::core::mem::transmute(&expression), ::core::mem::transmute(&bindingcontext), ::core::mem::transmute_copy(&result), ::core::mem::transmute_copy(&metadata)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             EvaluateExpression: EvaluateExpression::<Identity, Impl, OFFSET>,
             EvaluateExtendedExpression: EvaluateExtendedExpression::<Identity, Impl, OFFSET>,
         }
@@ -21553,7 +21553,7 @@ impl IDebugHostExtensibility_Vtbl {
             this.DestroyFunctionAlias(::core::mem::transmute(&aliasname)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateFunctionAlias: CreateFunctionAlias::<Identity, Impl, OFFSET>,
             DestroyFunctionAlias: DestroyFunctionAlias::<Identity, Impl, OFFSET>,
         }
@@ -21678,7 +21678,7 @@ impl IDebugHostMemory_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ReadBytes: ReadBytes::<Identity, Impl, OFFSET>,
             WriteBytes: WriteBytes::<Identity, Impl, OFFSET>,
             ReadPointers: ReadPointers::<Identity, Impl, OFFSET>,
@@ -21832,7 +21832,7 @@ impl IDebugHostModuleSignature_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), IsMatch: IsMatch::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), IsMatch: IsMatch::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDebugHostModuleSignature as ::windows::core::Interface>::IID
@@ -21894,7 +21894,7 @@ impl IDebugHostScriptHost_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CreateContext: CreateContext::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CreateContext: CreateContext::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDebugHostScriptHost as ::windows::core::Interface>::IID
@@ -21917,7 +21917,7 @@ impl IDebugHostStatus_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), PollUserInterrupt: PollUserInterrupt::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), PollUserInterrupt: PollUserInterrupt::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDebugHostStatus as ::windows::core::Interface>::IID
@@ -22013,7 +22013,7 @@ impl IDebugHostSymbol_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetContext: GetContext::<Identity, Impl, OFFSET>,
             EnumerateChildren: EnumerateChildren::<Identity, Impl, OFFSET>,
             GetSymbolKind: GetSymbolKind::<Identity, Impl, OFFSET>,
@@ -22074,7 +22074,7 @@ impl IDebugHostSymbolEnumerator_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Reset: Reset::<Identity, Impl, OFFSET>,
             GetNext: GetNext::<Identity, Impl, OFFSET>,
         }
@@ -22167,7 +22167,7 @@ impl IDebugHostSymbols_Vtbl {
             this.GetMostDerivedObject(::core::mem::transmute(&pcontext), ::core::mem::transmute(&location), ::core::mem::transmute(&objecttype), ::core::mem::transmute_copy(&derivedlocation), ::core::mem::transmute_copy(&derivedtype)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateModuleSignature: CreateModuleSignature::<Identity, Impl, OFFSET>,
             CreateTypeSignature: CreateTypeSignature::<Identity, Impl, OFFSET>,
             CreateTypeSignatureForModuleRange: CreateTypeSignatureForModuleRange::<Identity, Impl, OFFSET>,
@@ -22537,7 +22537,7 @@ impl IDebugHostTypeSignature_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetHashCode: GetHashCode::<Identity, Impl, OFFSET>,
             IsMatch: IsMatch::<Identity, Impl, OFFSET>,
             CompareAgainst: CompareAgainst::<Identity, Impl, OFFSET>,
@@ -22565,7 +22565,7 @@ impl IDebugInputCallbacks_Vtbl {
             this.EndInput().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             StartInput: StartInput::<Identity, Impl, OFFSET>,
             EndInput: EndInput::<Identity, Impl, OFFSET>,
         }
@@ -22585,7 +22585,7 @@ impl IDebugOutputCallbacks_Vtbl {
             let this = (*this).get_impl();
             this.Output(::core::mem::transmute_copy(&mask), ::core::mem::transmute(&text)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Output: Output::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Output: Output::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDebugOutputCallbacks as ::windows::core::Interface>::IID
@@ -22621,7 +22621,7 @@ impl IDebugOutputCallbacks2_Vtbl {
             this.Output2(::core::mem::transmute_copy(&which), ::core::mem::transmute_copy(&flags), ::core::mem::transmute_copy(&arg), ::core::mem::transmute(&text)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Output: Output::<Identity, Impl, OFFSET>,
             GetInterestMask: GetInterestMask::<Identity, Impl, OFFSET>,
             Output2: Output2::<Identity, Impl, OFFSET>,
@@ -22642,7 +22642,7 @@ impl IDebugOutputCallbacksWide_Vtbl {
             let this = (*this).get_impl();
             this.Output(::core::mem::transmute_copy(&mask), ::core::mem::transmute(&text)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Output: Output::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Output: Output::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDebugOutputCallbacksWide as ::windows::core::Interface>::IID
@@ -22659,7 +22659,7 @@ impl IDebugOutputStream_Vtbl {
             let this = (*this).get_impl();
             this.Write(::core::mem::transmute(&psz)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Write: Write::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Write: Write::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDebugOutputStream as ::windows::core::Interface>::IID
@@ -22677,7 +22677,7 @@ impl IDebugPlmClient_Vtbl {
             this.LaunchPlmPackageForDebugWide(::core::mem::transmute_copy(&server), ::core::mem::transmute_copy(&timeout), ::core::mem::transmute(&packagefullname), ::core::mem::transmute(&appname), ::core::mem::transmute(&arguments), ::core::mem::transmute_copy(&processid), ::core::mem::transmute_copy(&threadid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             LaunchPlmPackageForDebugWide: LaunchPlmPackageForDebugWide::<Identity, Impl, OFFSET>,
         }
     }
@@ -22703,7 +22703,7 @@ impl IDebugPlmClient2_Vtbl {
             this.LaunchPlmBgTaskForDebugWide(::core::mem::transmute_copy(&server), ::core::mem::transmute_copy(&timeout), ::core::mem::transmute(&packagefullname), ::core::mem::transmute(&backgroundtaskid), ::core::mem::transmute_copy(&processid), ::core::mem::transmute_copy(&threadid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             LaunchPlmPackageForDebugWide: LaunchPlmPackageForDebugWide::<Identity, Impl, OFFSET>,
             LaunchPlmBgTaskForDebugWide: LaunchPlmBgTaskForDebugWide::<Identity, Impl, OFFSET>,
         }
@@ -22784,7 +22784,7 @@ impl IDebugPlmClient3_Vtbl {
             this.ActivateAndDebugPlmBgTaskWide(::core::mem::transmute_copy(&server), ::core::mem::transmute(&packagefullname), ::core::mem::transmute(&backgroundtaskid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             LaunchPlmPackageForDebugWide: LaunchPlmPackageForDebugWide::<Identity, Impl, OFFSET>,
             LaunchPlmBgTaskForDebugWide: LaunchPlmBgTaskForDebugWide::<Identity, Impl, OFFSET>,
             QueryPlmPackageWide: QueryPlmPackageWide::<Identity, Impl, OFFSET>,
@@ -22865,7 +22865,7 @@ impl IDebugProperty_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetPropertyInfo: GetPropertyInfo::<Identity, Impl, OFFSET>,
             GetExtendedInfo: GetExtendedInfo::<Identity, Impl, OFFSET>,
             SetValueAsString: SetValueAsString::<Identity, Impl, OFFSET>,
@@ -22894,7 +22894,7 @@ impl IDebugPropertyEnumType_All_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetName: GetName::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetName: GetName::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDebugPropertyEnumType_All as ::windows::core::Interface>::IID
@@ -23057,7 +23057,7 @@ impl IDebugRegisters_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetNumberRegisters: GetNumberRegisters::<Identity, Impl, OFFSET>,
             GetDescription: GetDescription::<Identity, Impl, OFFSET>,
             GetIndexByName: GetIndexByName::<Identity, Impl, OFFSET>,
@@ -23336,7 +23336,7 @@ impl IDebugRegisters2_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetNumberRegisters: GetNumberRegisters::<Identity, Impl, OFFSET>,
             GetDescription: GetDescription::<Identity, Impl, OFFSET>,
             GetIndexByName: GetIndexByName::<Identity, Impl, OFFSET>,
@@ -23380,7 +23380,7 @@ impl IDebugSessionProvider_Vtbl {
             let this = (*this).get_impl();
             this.StartDebugSession(::core::mem::transmute(&pda)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), StartDebugSession: StartDebugSession::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), StartDebugSession: StartDebugSession::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDebugSessionProvider as ::windows::core::Interface>::IID
@@ -23455,7 +23455,7 @@ impl IDebugStackFrame_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCodeContext: GetCodeContext::<Identity, Impl, OFFSET>,
             GetDescriptionString: GetDescriptionString::<Identity, Impl, OFFSET>,
             GetLanguageString: GetLanguageString::<Identity, Impl, OFFSET>,
@@ -23526,7 +23526,7 @@ impl IDebugStackFrameSniffer_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), EnumStackFrames: EnumStackFrames::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), EnumStackFrames: EnumStackFrames::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDebugStackFrameSniffer as ::windows::core::Interface>::IID
@@ -23653,7 +23653,7 @@ impl IDebugSymbolGroup_Vtbl {
             this.OutputAsType(::core::mem::transmute_copy(&index), ::core::mem::transmute(&r#type)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetNumberSymbols: GetNumberSymbols::<Identity, Impl, OFFSET>,
             AddSymbol: AddSymbol::<Identity, Impl, OFFSET>,
             RemoveSymbolByName: RemoveSymbolByName::<Identity, Impl, OFFSET>,
@@ -23847,7 +23847,7 @@ impl IDebugSymbolGroup2_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetNumberSymbols: GetNumberSymbols::<Identity, Impl, OFFSET>,
             AddSymbol: AddSymbol::<Identity, Impl, OFFSET>,
             RemoveSymbolByName: RemoveSymbolByName::<Identity, Impl, OFFSET>,
@@ -24277,7 +24277,7 @@ impl IDebugSymbols_Vtbl {
             this.GetSourceFileLineOffsets(::core::mem::transmute(&file), ::core::mem::transmute_copy(&buffer), ::core::mem::transmute_copy(&bufferlines), ::core::mem::transmute_copy(&filelines)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSymbolOptions: GetSymbolOptions::<Identity, Impl, OFFSET>,
             AddSymbolOptions: AddSymbolOptions::<Identity, Impl, OFFSET>,
             RemoveSymbolOptions: RemoveSymbolOptions::<Identity, Impl, OFFSET>,
@@ -24787,7 +24787,7 @@ impl IDebugSymbols2_Vtbl {
             this.SetTypeOptions(::core::mem::transmute_copy(&options)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSymbolOptions: GetSymbolOptions::<Identity, Impl, OFFSET>,
             AddSymbolOptions: AddSymbolOptions::<Identity, Impl, OFFSET>,
             RemoveSymbolOptions: RemoveSymbolOptions::<Identity, Impl, OFFSET>,
@@ -25791,7 +25791,7 @@ impl IDebugSymbols3_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSymbolOptions: GetSymbolOptions::<Identity, Impl, OFFSET>,
             AddSymbolOptions: AddSymbolOptions::<Identity, Impl, OFFSET>,
             RemoveSymbolOptions: RemoveSymbolOptions::<Identity, Impl, OFFSET>,
@@ -26903,7 +26903,7 @@ impl IDebugSymbols4_Vtbl {
             this.OutputSymbolByInlineContext(::core::mem::transmute_copy(&outputcontrol), ::core::mem::transmute_copy(&flags), ::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&inlinecontext)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSymbolOptions: GetSymbolOptions::<Identity, Impl, OFFSET>,
             AddSymbolOptions: AddSymbolOptions::<Identity, Impl, OFFSET>,
             RemoveSymbolOptions: RemoveSymbolOptions::<Identity, Impl, OFFSET>,
@@ -28040,7 +28040,7 @@ impl IDebugSymbols5_Vtbl {
             this.SetScopeFrameByIndexEx(::core::mem::transmute_copy(&flags), ::core::mem::transmute_copy(&index)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSymbolOptions: GetSymbolOptions::<Identity, Impl, OFFSET>,
             AddSymbolOptions: AddSymbolOptions::<Identity, Impl, OFFSET>,
             RemoveSymbolOptions: RemoveSymbolOptions::<Identity, Impl, OFFSET>,
@@ -28215,7 +28215,7 @@ impl IDebugSyncOperation_Vtbl {
             this.InProgressAbort().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTargetThread: GetTargetThread::<Identity, Impl, OFFSET>,
             Execute: Execute::<Identity, Impl, OFFSET>,
             InProgressAbort: InProgressAbort::<Identity, Impl, OFFSET>,
@@ -28543,7 +28543,7 @@ impl IDebugSystemObjects_Vtbl {
             this.GetCurrentProcessExecutableName(::core::mem::transmute_copy(&buffer), ::core::mem::transmute_copy(&buffersize), ::core::mem::transmute_copy(&exesize)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetEventThread: GetEventThread::<Identity, Impl, OFFSET>,
             GetEventProcess: GetEventProcess::<Identity, Impl, OFFSET>,
             GetCurrentThreadId: GetCurrentThreadId::<Identity, Impl, OFFSET>,
@@ -28945,7 +28945,7 @@ impl IDebugSystemObjects2_Vtbl {
             this.SetImplicitProcessDataOffset(::core::mem::transmute_copy(&offset)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetEventThread: GetEventThread::<Identity, Impl, OFFSET>,
             GetEventProcess: GetEventProcess::<Identity, Impl, OFFSET>,
             GetCurrentThreadId: GetCurrentThreadId::<Identity, Impl, OFFSET>,
@@ -29436,7 +29436,7 @@ impl IDebugSystemObjects3_Vtbl {
             this.GetCurrentSystemServerName(::core::mem::transmute_copy(&buffer), ::core::mem::transmute_copy(&buffersize), ::core::mem::transmute_copy(&namesize)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetEventThread: GetEventThread::<Identity, Impl, OFFSET>,
             GetEventProcess: GetEventProcess::<Identity, Impl, OFFSET>,
             GetCurrentThreadId: GetCurrentThreadId::<Identity, Impl, OFFSET>,
@@ -29948,7 +29948,7 @@ impl IDebugSystemObjects4_Vtbl {
             this.GetCurrentSystemServerNameWide(::core::mem::transmute_copy(&buffer), ::core::mem::transmute_copy(&buffersize), ::core::mem::transmute_copy(&namesize)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetEventThread: GetEventThread::<Identity, Impl, OFFSET>,
             GetEventProcess: GetEventProcess::<Identity, Impl, OFFSET>,
             GetCurrentThreadId: GetCurrentThreadId::<Identity, Impl, OFFSET>,
@@ -30011,7 +30011,7 @@ impl IDebugThreadCall32_Vtbl {
             let this = (*this).get_impl();
             this.ThreadCallHandler(::core::mem::transmute_copy(&dwparam1), ::core::mem::transmute_copy(&dwparam2), ::core::mem::transmute_copy(&dwparam3)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), ThreadCallHandler: ThreadCallHandler::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), ThreadCallHandler: ThreadCallHandler::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDebugThreadCall32 as ::windows::core::Interface>::IID
@@ -30028,7 +30028,7 @@ impl IDebugThreadCall64_Vtbl {
             let this = (*this).get_impl();
             this.ThreadCallHandler(::core::mem::transmute_copy(&dwparam1), ::core::mem::transmute_copy(&dwparam2), ::core::mem::transmute_copy(&dwparam3)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), ThreadCallHandler: ThreadCallHandler::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), ThreadCallHandler: ThreadCallHandler::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDebugThreadCall64 as ::windows::core::Interface>::IID
@@ -30070,7 +30070,7 @@ impl IDynamicConceptProviderConcept_Vtbl {
             this.NotifyDestruct().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetConcept: GetConcept::<Identity, Impl, OFFSET>,
             SetConcept: SetConcept::<Identity, Impl, OFFSET>,
             NotifyParent: NotifyParent::<Identity, Impl, OFFSET>,
@@ -30112,7 +30112,7 @@ impl IDynamicKeyProviderConcept_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetKey: GetKey::<Identity, Impl, OFFSET>,
             SetKey: SetKey::<Identity, Impl, OFFSET>,
             EnumerateKeys: EnumerateKeys::<Identity, Impl, OFFSET>,
@@ -30158,7 +30158,7 @@ impl IEnumDebugApplicationNodes_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -30205,7 +30205,7 @@ impl IEnumDebugCodeContexts_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -30252,7 +30252,7 @@ impl IEnumDebugExpressionContexts_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -30314,7 +30314,7 @@ impl IEnumDebugExtendedPropertyInfo_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -30374,7 +30374,7 @@ impl IEnumDebugPropertyInfo_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -30425,7 +30425,7 @@ impl IEnumDebugStackFrames_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -30473,7 +30473,7 @@ impl IEnumJsStackFrames_Vtbl {
             let this = (*this).get_impl();
             this.Reset().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Next: Next::<Identity, Impl, OFFSET>, Reset: Reset::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Next: Next::<Identity, Impl, OFFSET>, Reset: Reset::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IEnumJsStackFrames as ::windows::core::Interface>::IID
@@ -30515,7 +30515,7 @@ impl IEnumRemoteDebugApplicationThreads_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -30562,7 +30562,7 @@ impl IEnumRemoteDebugApplications_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -30590,7 +30590,7 @@ impl IEquatableConcept_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), AreObjectsEqual: AreObjectsEqual::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), AreObjectsEqual: AreObjectsEqual::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IEquatableConcept as ::windows::core::Interface>::IID
@@ -30607,7 +30607,7 @@ impl IHostDataModelAccess_Vtbl {
             let this = (*this).get_impl();
             this.GetDataModel(::core::mem::transmute_copy(&manager), ::core::mem::transmute_copy(&host)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetDataModel: GetDataModel::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetDataModel: GetDataModel::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IHostDataModelAccess as ::windows::core::Interface>::IID
@@ -30643,7 +30643,7 @@ impl IIndexableConcept_Vtbl {
             this.SetAt(::core::mem::transmute(&contextobject), ::core::mem::transmute_copy(&indexercount), ::core::mem::transmute_copy(&indexers), ::core::mem::transmute(&value)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDimensionality: GetDimensionality::<Identity, Impl, OFFSET>,
             GetAt: GetAt::<Identity, Impl, OFFSET>,
             SetAt: SetAt::<Identity, Impl, OFFSET>,
@@ -30683,7 +30683,7 @@ impl IIterableConcept_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDefaultIndexDimensionality: GetDefaultIndexDimensionality::<Identity, Impl, OFFSET>,
             GetIterator: GetIterator::<Identity, Impl, OFFSET>,
         }
@@ -30709,7 +30709,7 @@ impl IJsDebug_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OpenVirtualProcess: OpenVirtualProcess::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OpenVirtualProcess: OpenVirtualProcess::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IJsDebug as ::windows::core::Interface>::IID
@@ -30760,7 +30760,7 @@ impl IJsDebugBreakPoint_Vtbl {
             this.GetDocumentPosition(::core::mem::transmute_copy(&pdocumentid), ::core::mem::transmute_copy(&pcharacteroffset), ::core::mem::transmute_copy(&pstatementcharcount)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             IsEnabled: IsEnabled::<Identity, Impl, OFFSET>,
             Enable: Enable::<Identity, Impl, OFFSET>,
             Disable: Disable::<Identity, Impl, OFFSET>,
@@ -30862,7 +30862,7 @@ impl IJsDebugDataTarget_Vtbl {
             this.GetThreadContext(::core::mem::transmute_copy(&threadid), ::core::mem::transmute_copy(&contextflags), ::core::mem::transmute_copy(&contextsize), ::core::mem::transmute_copy(&pcontext)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ReadMemory: ReadMemory::<Identity, Impl, OFFSET>,
             WriteMemory: WriteMemory::<Identity, Impl, OFFSET>,
             AllocateVirtualMemory: AllocateVirtualMemory::<Identity, Impl, OFFSET>,
@@ -30944,7 +30944,7 @@ impl IJsDebugFrame_Vtbl {
             this.Evaluate(::core::mem::transmute(&pexpressiontext), ::core::mem::transmute_copy(&ppdebugproperty), ::core::mem::transmute_copy(&perror)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetStackRange: GetStackRange::<Identity, Impl, OFFSET>,
             GetName: GetName::<Identity, Impl, OFFSET>,
             GetDocumentPositionWithId: GetDocumentPositionWithId::<Identity, Impl, OFFSET>,
@@ -31009,7 +31009,7 @@ impl IJsDebugProcess_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateStackWalker: CreateStackWalker::<Identity, Impl, OFFSET>,
             CreateBreakPoint: CreateBreakPoint::<Identity, Impl, OFFSET>,
             PerformAsyncBreak: PerformAsyncBreak::<Identity, Impl, OFFSET>,
@@ -31050,7 +31050,7 @@ impl IJsDebugProperty_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetPropertyInfo: GetPropertyInfo::<Identity, Impl, OFFSET>,
             GetMembers: GetMembers::<Identity, Impl, OFFSET>,
         }
@@ -31076,7 +31076,7 @@ impl IJsDebugStackWalker_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetNext: GetNext::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetNext: GetNext::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IJsDebugStackWalker as ::windows::core::Interface>::IID
@@ -31106,7 +31106,7 @@ impl IJsEnumDebugProperty_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             GetCount: GetCount::<Identity, Impl, OFFSET>,
         }
@@ -31133,7 +31133,7 @@ impl IKeyEnumerator_Vtbl {
             this.GetNext(::core::mem::transmute_copy(&key), ::core::mem::transmute_copy(&value), ::core::mem::transmute_copy(&metadata)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Reset: Reset::<Identity, Impl, OFFSET>,
             GetNext: GetNext::<Identity, Impl, OFFSET>,
         }
@@ -31178,7 +31178,7 @@ impl IKeyStore_Vtbl {
             this.ClearKeys().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetKey: GetKey::<Identity, Impl, OFFSET>,
             SetKey: SetKey::<Identity, Impl, OFFSET>,
             GetKeyValue: GetKeyValue::<Identity, Impl, OFFSET>,
@@ -31226,7 +31226,7 @@ impl IMachineDebugManager_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddApplication: AddApplication::<Identity, Impl, OFFSET>,
             RemoveApplication: RemoveApplication::<Identity, Impl, OFFSET>,
             EnumApplications: EnumApplications::<Identity, Impl, OFFSET>,
@@ -31272,7 +31272,7 @@ impl IMachineDebugManagerCookie_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddApplication: AddApplication::<Identity, Impl, OFFSET>,
             RemoveApplication: RemoveApplication::<Identity, Impl, OFFSET>,
             EnumApplications: EnumApplications::<Identity, Impl, OFFSET>,
@@ -31300,7 +31300,7 @@ impl IMachineDebugManagerEvents_Vtbl {
             this.onRemoveApplication(::core::mem::transmute(&pda), ::core::mem::transmute_copy(&dwappcookie)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             onAddApplication: onAddApplication::<Identity, Impl, OFFSET>,
             onRemoveApplication: onRemoveApplication::<Identity, Impl, OFFSET>,
         }
@@ -31327,7 +31327,7 @@ impl IModelIterator_Vtbl {
             this.GetNext(::core::mem::transmute_copy(&object), ::core::mem::transmute_copy(&dimensions), ::core::mem::transmute_copy(&indexers), ::core::mem::transmute_copy(&metadata)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Reset: Reset::<Identity, Impl, OFFSET>,
             GetNext: GetNext::<Identity, Impl, OFFSET>,
         }
@@ -31402,7 +31402,7 @@ impl IModelKeyReference_Vtbl {
             this.SetKeyValue(::core::mem::transmute(&object)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetKeyName: GetKeyName::<Identity, Impl, OFFSET>,
             GetOriginalObject: GetOriginalObject::<Identity, Impl, OFFSET>,
             GetContextObject: GetContextObject::<Identity, Impl, OFFSET>,
@@ -31444,7 +31444,7 @@ impl IModelMethod_Vtbl {
             let this = (*this).get_impl();
             this.Call(::core::mem::transmute(&pcontextobject), ::core::mem::transmute_copy(&argcount), ::core::mem::transmute_copy(&pparguments), ::core::mem::transmute_copy(&ppresult), ::core::mem::transmute_copy(&ppmetadata)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Call: Call::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Call: Call::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IModelMethod as ::windows::core::Interface>::IID
@@ -31771,7 +31771,7 @@ impl IModelObject_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetContext: GetContext::<Identity, Impl, OFFSET>,
             GetKind: GetKind::<Identity, Impl, OFFSET>,
             GetIntrinsicValue: GetIntrinsicValue::<Identity, Impl, OFFSET>,
@@ -31835,7 +31835,7 @@ impl IModelPropertyAccessor_Vtbl {
             this.SetValue(::core::mem::transmute(&key), ::core::mem::transmute(&contextobject), ::core::mem::transmute(&value)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetValue: GetValue::<Identity, Impl, OFFSET>,
             SetValue: SetValue::<Identity, Impl, OFFSET>,
         }
@@ -31862,7 +31862,7 @@ impl IObjectSafety_Vtbl {
             this.SetInterfaceSafetyOptions(::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&dwoptionsetmask), ::core::mem::transmute_copy(&dwenabledoptions)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetInterfaceSafetyOptions: GetInterfaceSafetyOptions::<Identity, Impl, OFFSET>,
             SetInterfaceSafetyOptions: SetInterfaceSafetyOptions::<Identity, Impl, OFFSET>,
         }
@@ -31916,7 +31916,7 @@ impl IPerPropertyBrowsing2_Vtbl {
             this.SetPredefinedValue(::core::mem::transmute_copy(&dispid), ::core::mem::transmute_copy(&dwcookie)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDisplayString: GetDisplayString::<Identity, Impl, OFFSET>,
             MapPropertyToPage: MapPropertyToPage::<Identity, Impl, OFFSET>,
             GetPredefinedStrings: GetPredefinedStrings::<Identity, Impl, OFFSET>,
@@ -31945,7 +31945,7 @@ impl IPreferredRuntimeTypeConcept_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CastToPreferredRuntimeType: CastToPreferredRuntimeType::<Identity, Impl, OFFSET>,
         }
     }
@@ -32013,7 +32013,7 @@ impl IProcessDebugManager32_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateApplication: CreateApplication::<Identity, Impl, OFFSET>,
             GetDefaultApplication: GetDefaultApplication::<Identity, Impl, OFFSET>,
             AddApplication: AddApplication::<Identity, Impl, OFFSET>,
@@ -32085,7 +32085,7 @@ impl IProcessDebugManager64_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateApplication: CreateApplication::<Identity, Impl, OFFSET>,
             GetDefaultApplication: GetDefaultApplication::<Identity, Impl, OFFSET>,
             AddApplication: AddApplication::<Identity, Impl, OFFSET>,
@@ -32114,7 +32114,7 @@ impl IProvideExpressionContexts_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), EnumExpressionContexts: EnumExpressionContexts::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), EnumExpressionContexts: EnumExpressionContexts::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IProvideExpressionContexts as ::windows::core::Interface>::IID
@@ -32138,7 +32138,7 @@ impl IRawEnumerator_Vtbl {
             this.GetNext(::core::mem::transmute_copy(&name), ::core::mem::transmute_copy(&kind), ::core::mem::transmute_copy(&value)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Reset: Reset::<Identity, Impl, OFFSET>,
             GetNext: GetNext::<Identity, Impl, OFFSET>,
         }
@@ -32255,7 +32255,7 @@ impl IRemoteDebugApplication_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ResumeFromBreakPoint: ResumeFromBreakPoint::<Identity, Impl, OFFSET>,
             CauseBreak: CauseBreak::<Identity, Impl, OFFSET>,
             ConnectDebugger: ConnectDebugger::<Identity, Impl, OFFSET>,
@@ -32309,7 +32309,7 @@ impl IRemoteDebugApplication110_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetDebuggerOptions: SetDebuggerOptions::<Identity, Impl, OFFSET>,
             GetCurrentDebuggerOptions: GetCurrentDebuggerOptions::<Identity, Impl, OFFSET>,
             GetMainThread: GetMainThread::<Identity, Impl, OFFSET>,
@@ -32385,7 +32385,7 @@ impl IRemoteDebugApplicationEvents_Vtbl {
             this.OnBreakFlagChange(::core::mem::transmute_copy(&abf), ::core::mem::transmute(&prdatsteppingthread)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnConnectDebugger: OnConnectDebugger::<Identity, Impl, OFFSET>,
             OnDisconnectDebugger: OnDisconnectDebugger::<Identity, Impl, OFFSET>,
             OnSetName: OnSetName::<Identity, Impl, OFFSET>,
@@ -32504,7 +32504,7 @@ impl IRemoteDebugApplicationThread_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSystemThreadId: GetSystemThreadId::<Identity, Impl, OFFSET>,
             GetApplication: GetApplication::<Identity, Impl, OFFSET>,
             EnumStackFrames: EnumStackFrames::<Identity, Impl, OFFSET>,
@@ -32531,7 +32531,7 @@ impl IRemoteDebugCriticalErrorEvent110_Vtbl {
             let this = (*this).get_impl();
             this.GetErrorInfo(::core::mem::transmute_copy(&pbstrsource), ::core::mem::transmute_copy(&pmessageid), ::core::mem::transmute_copy(&pbstrmessage), ::core::mem::transmute_copy(&pplocation)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetErrorInfo: GetErrorInfo::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetErrorInfo: GetErrorInfo::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IRemoteDebugCriticalErrorEvent110 as ::windows::core::Interface>::IID
@@ -32548,7 +32548,7 @@ impl IRemoteDebugInfoEvent110_Vtbl {
             let this = (*this).get_impl();
             this.GetEventInfo(::core::mem::transmute_copy(&pmessagetype), ::core::mem::transmute_copy(&pbstrmessage), ::core::mem::transmute_copy(&pbstrurl), ::core::mem::transmute_copy(&pplocation)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetEventInfo: GetEventInfo::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetEventInfo: GetEventInfo::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IRemoteDebugInfoEvent110 as ::windows::core::Interface>::IID
@@ -32713,7 +32713,7 @@ impl IScriptInvocationContext_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetContextType: GetContextType::<Identity, Impl, OFFSET>,
             GetContextDescription: GetContextDescription::<Identity, Impl, OFFSET>,
             GetContextObject: GetContextObject::<Identity, Impl, OFFSET>,
@@ -32840,7 +32840,7 @@ impl IScriptNode_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Alive: Alive::<Identity, Impl, OFFSET>,
             Delete: Delete::<Identity, Impl, OFFSET>,
             GetParent: GetParent::<Identity, Impl, OFFSET>,
@@ -32978,7 +32978,7 @@ impl ISimpleConnectionPoint_Vtbl {
             this.Unadvise(::core::mem::transmute_copy(&dwcookie)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetEventCount: GetEventCount::<Identity, Impl, OFFSET>,
             DescribeEvents: DescribeEvents::<Identity, Impl, OFFSET>,
             Advise: Advise::<Identity, Impl, OFFSET>,
@@ -33006,7 +33006,7 @@ impl IStringDisplayableConcept_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), ToDisplayString: ToDisplayString::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), ToDisplayString: ToDisplayString::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IStringDisplayableConcept as ::windows::core::Interface>::IID
@@ -33026,7 +33026,7 @@ impl ITridentEventSink_Vtbl {
             let this = (*this).get_impl();
             this.FireEvent(::core::mem::transmute(&pstrevent), ::core::mem::transmute_copy(&pdp), ::core::mem::transmute_copy(&pvarres), ::core::mem::transmute_copy(&pei)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), FireEvent: FireEvent::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), FireEvent: FireEvent::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ITridentEventSink as ::windows::core::Interface>::IID
@@ -33046,7 +33046,7 @@ impl IWebAppDiagnosticsObjectInitialization_Vtbl {
             let this = (*this).get_impl();
             this.Initialize(::core::mem::transmute_copy(&hpassedhandle), ::core::mem::transmute(&pdebugapplication)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Initialize: Initialize::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Initialize: Initialize::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWebAppDiagnosticsObjectInitialization as ::windows::core::Interface>::IID
@@ -33076,7 +33076,7 @@ impl IWebAppDiagnosticsSetup_Vtbl {
             this.CreateObjectWithSiteAtWebApp(::core::mem::transmute_copy(&rclsid), ::core::mem::transmute_copy(&dwclscontext), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&hpasstoobject)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             DiagnosticsSupported: DiagnosticsSupported::<Identity, Impl, OFFSET>,
             CreateObjectWithSiteAtWebApp: CreateObjectWithSiteAtWebApp::<Identity, Impl, OFFSET>,
         }

--- a/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Debug/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Debug/mod.rs
@@ -4258,7 +4258,7 @@ unsafe impl ::windows::core::Interface for AsyncIDebugApplicationNodeEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct AsyncIDebugApplicationNodeEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Begin_onAddChild: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, prddpchild: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Finish_onAddChild: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Begin_onRemoveChild: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, prddpchild: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -4611,7 +4611,7 @@ unsafe impl ::windows::core::Interface for IActiveScript {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IActiveScript_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetScriptSite: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pass: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetScriptSite: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetScriptState: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ss: SCRIPTSTATE) -> ::windows::core::HRESULT,
@@ -4765,7 +4765,7 @@ unsafe impl ::windows::core::Interface for IActiveScriptAuthor {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IActiveScriptAuthor_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub AddNamedItem: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszname: ::windows::core::PCWSTR, dwflags: u32, pdisp: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -4846,7 +4846,7 @@ unsafe impl ::windows::core::Interface for IActiveScriptAuthorProcedure {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IActiveScriptAuthorProcedure_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub ParseProcedureText: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszcode: ::windows::core::PCWSTR, pszformalparams: ::windows::core::PCWSTR, pszprocedurename: ::windows::core::PCWSTR, pszitemname: ::windows::core::PCWSTR, pszdelimiter: ::windows::core::PCWSTR, dwcookie: u32, dwflags: u32, pdispfor: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -4913,7 +4913,7 @@ unsafe impl ::windows::core::Interface for IActiveScriptDebug32 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IActiveScriptDebug32_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetScriptTextAttributes: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pstrcode: ::windows::core::PCWSTR, unumcodechars: u32, pstrdelimiter: ::windows::core::PCWSTR, dwflags: u32, pattr: *mut u16) -> ::windows::core::HRESULT,
     pub GetScriptletTextAttributes: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pstrcode: ::windows::core::PCWSTR, unumcodechars: u32, pstrdelimiter: ::windows::core::PCWSTR, dwflags: u32, pattr: *mut u16) -> ::windows::core::HRESULT,
     pub EnumCodeContextsOfPosition: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwsourcecontext: u32, ucharacteroffset: u32, unumchars: u32, ppescc: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -4979,7 +4979,7 @@ unsafe impl ::windows::core::Interface for IActiveScriptDebug64 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IActiveScriptDebug64_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetScriptTextAttributes: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pstrcode: ::windows::core::PCWSTR, unumcodechars: u32, pstrdelimiter: ::windows::core::PCWSTR, dwflags: u32, pattr: *mut u16) -> ::windows::core::HRESULT,
     pub GetScriptletTextAttributes: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pstrcode: ::windows::core::PCWSTR, unumcodechars: u32, pstrdelimiter: ::windows::core::PCWSTR, dwflags: u32, pattr: *mut u16) -> ::windows::core::HRESULT,
     pub EnumCodeContextsOfPosition: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwsourcecontext: u64, ucharacteroffset: u32, unumchars: u32, ppescc: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -5042,7 +5042,7 @@ unsafe impl ::windows::core::Interface for IActiveScriptEncode {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IActiveScriptEncode_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub EncodeSection: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pchin: ::windows::core::PCWSTR, cchin: u32, pchout: ::windows::core::PWSTR, cchout: u32, pcchret: *mut u32) -> ::windows::core::HRESULT,
     pub DecodeScript: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pchin: ::windows::core::PCWSTR, cchin: u32, pchout: ::windows::core::PWSTR, cchout: u32, pcchret: *mut u32) -> ::windows::core::HRESULT,
     pub GetEncodeProgId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstrout: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
@@ -5103,7 +5103,7 @@ unsafe impl ::windows::core::Interface for IActiveScriptError {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IActiveScriptError_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub GetExceptionInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pexcepinfo: *mut super::super::Com::EXCEPINFO) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -5318,7 +5318,7 @@ unsafe impl ::windows::core::Interface for IActiveScriptErrorDebug110 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IActiveScriptErrorDebug110_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetExceptionThrownKind: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pexceptionkind: *mut SCRIPT_ERROR_DEBUG_EXCEPTION_THROWN_KIND) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
@@ -5367,7 +5367,7 @@ unsafe impl ::windows::core::Interface for IActiveScriptGarbageCollector {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IActiveScriptGarbageCollector_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CollectGarbage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, scriptgctype: SCRIPTGCTYPE) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
@@ -5416,7 +5416,7 @@ unsafe impl ::windows::core::Interface for IActiveScriptHostEncode {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IActiveScriptHostEncode_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub EncodeScriptHostFile: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrinfile: ::core::mem::ManuallyDrop<::windows::core::BSTR>, pbstroutfile: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>, cflags: u32, bstrdefaultlang: ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
@@ -5489,7 +5489,7 @@ unsafe impl ::windows::core::Interface for IActiveScriptParse32 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IActiveScriptParse32_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub InitNew: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
     pub AddScriptlet: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pstrdefaultname: ::windows::core::PCWSTR, pstrcode: ::windows::core::PCWSTR, pstritemname: ::windows::core::PCWSTR, pstrsubitemname: ::windows::core::PCWSTR, pstreventname: ::windows::core::PCWSTR, pstrdelimiter: ::windows::core::PCWSTR, dwsourcecontextcookie: u32, ulstartinglinenumber: u32, dwflags: u32, pbstrname: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>, pexcepinfo: *mut super::super::Com::EXCEPINFO) -> ::windows::core::HRESULT,
@@ -5570,7 +5570,7 @@ unsafe impl ::windows::core::Interface for IActiveScriptParse64 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IActiveScriptParse64_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub InitNew: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
     pub AddScriptlet: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pstrdefaultname: ::windows::core::PCWSTR, pstrcode: ::windows::core::PCWSTR, pstritemname: ::windows::core::PCWSTR, pstrsubitemname: ::windows::core::PCWSTR, pstreventname: ::windows::core::PCWSTR, pstrdelimiter: ::windows::core::PCWSTR, dwsourcecontextcookie: u64, ulstartinglinenumber: u32, dwflags: u32, pbstrname: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>, pexcepinfo: *mut super::super::Com::EXCEPINFO) -> ::windows::core::HRESULT,
@@ -5786,7 +5786,7 @@ unsafe impl ::windows::core::Interface for IActiveScriptParseProcedure32 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IActiveScriptParseProcedure32_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub ParseProcedureText: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pstrcode: ::windows::core::PCWSTR, pstrformalparams: ::windows::core::PCWSTR, pstrprocedurename: ::windows::core::PCWSTR, pstritemname: ::windows::core::PCWSTR, punkcontext: *mut ::core::ffi::c_void, pstrdelimiter: ::windows::core::PCWSTR, dwsourcecontextcookie: u32, ulstartinglinenumber: u32, dwflags: u32, ppdisp: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -5849,7 +5849,7 @@ unsafe impl ::windows::core::Interface for IActiveScriptParseProcedure64 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IActiveScriptParseProcedure64_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub ParseProcedureText: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pstrcode: ::windows::core::PCWSTR, pstrformalparams: ::windows::core::PCWSTR, pstrprocedurename: ::windows::core::PCWSTR, pstritemname: ::windows::core::PCWSTR, punkcontext: *mut ::core::ffi::c_void, pstrdelimiter: ::windows::core::PCWSTR, dwsourcecontextcookie: u64, ulstartinglinenumber: u32, dwflags: u32, ppdisp: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -5911,7 +5911,7 @@ unsafe impl ::windows::core::Interface for IActiveScriptParseProcedureOld32 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IActiveScriptParseProcedureOld32_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub ParseProcedureText: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pstrcode: ::windows::core::PCWSTR, pstrformalparams: ::windows::core::PCWSTR, pstritemname: ::windows::core::PCWSTR, punkcontext: *mut ::core::ffi::c_void, pstrdelimiter: ::windows::core::PCWSTR, dwsourcecontextcookie: u32, ulstartinglinenumber: u32, dwflags: u32, ppdisp: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -5973,7 +5973,7 @@ unsafe impl ::windows::core::Interface for IActiveScriptParseProcedureOld64 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IActiveScriptParseProcedureOld64_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub ParseProcedureText: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pstrcode: ::windows::core::PCWSTR, pstrformalparams: ::windows::core::PCWSTR, pstritemname: ::windows::core::PCWSTR, punkcontext: *mut ::core::ffi::c_void, pstrdelimiter: ::windows::core::PCWSTR, dwsourcecontextcookie: u64, ulstartinglinenumber: u32, dwflags: u32, ppdisp: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -6048,7 +6048,7 @@ unsafe impl ::windows::core::Interface for IActiveScriptProfilerCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IActiveScriptProfilerCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwcontext: u32) -> ::windows::core::HRESULT,
     pub Shutdown: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hrreason: ::windows::core::HRESULT) -> ::windows::core::HRESULT,
     pub ScriptCompiled: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, scriptid: i32, r#type: PROFILER_SCRIPT_TYPE, pidebugdocumentcontext: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -6325,7 +6325,7 @@ unsafe impl ::windows::core::Interface for IActiveScriptProfilerControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IActiveScriptProfilerControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub StartProfiling: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, clsidprofilerobject: *const ::windows::core::GUID, dweventmask: u32, dwcontext: u32) -> ::windows::core::HRESULT,
     pub SetProfilerEventMask: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dweventmask: u32) -> ::windows::core::HRESULT,
     pub StopProfiling: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hrshutdownreason: ::windows::core::HRESULT) -> ::windows::core::HRESULT,
@@ -6802,7 +6802,7 @@ unsafe impl ::windows::core::Interface for IActiveScriptProfilerHeapEnum {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IActiveScriptProfilerHeapEnum_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, heapobjects: *mut *mut PROFILER_HEAP_OBJECT, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub GetOptionalInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, heapobject: *const PROFILER_HEAP_OBJECT, celt: u32, optionalinfo: *mut PROFILER_HEAP_OBJECT_OPTIONAL_INFO) -> ::windows::core::HRESULT,
     pub FreeObjectAndOptionalInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, heapobjects: *const *const PROFILER_HEAP_OBJECT) -> ::windows::core::HRESULT,
@@ -6862,7 +6862,7 @@ unsafe impl ::windows::core::Interface for IActiveScriptProperty {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IActiveScriptProperty_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub GetProperty: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwproperty: u32, pvarindex: *const super::super::Com::VARIANT, pvarvalue: *mut super::super::Com::VARIANT) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole")))]
@@ -6919,7 +6919,7 @@ unsafe impl ::windows::core::Interface for IActiveScriptSIPInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IActiveScriptSIPInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetSIPOID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, poid_sip: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
@@ -7001,7 +7001,7 @@ unsafe impl ::windows::core::Interface for IActiveScriptSite {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IActiveScriptSite_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetLCID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, plcid: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
     pub GetItemInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pstrname: ::windows::core::PCWSTR, dwreturnmask: u32, ppiunkitem: *mut *mut ::core::ffi::c_void, ppti: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -7080,7 +7080,7 @@ unsafe impl ::windows::core::Interface for IActiveScriptSiteDebug32 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IActiveScriptSiteDebug32_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDocumentContextFromPosition: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwsourcecontext: u32, ucharacteroffset: u32, unumchars: u32, ppsc: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetApplication: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppda: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetRootApplicationNode: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppdanroot: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -7152,7 +7152,7 @@ unsafe impl ::windows::core::Interface for IActiveScriptSiteDebug64 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IActiveScriptSiteDebug64_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDocumentContextFromPosition: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwsourcecontext: u64, ucharacteroffset: u32, unumchars: u32, ppsc: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetApplication: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppda: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetRootApplicationNode: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppdanroot: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -7213,7 +7213,7 @@ unsafe impl ::windows::core::Interface for IActiveScriptSiteDebugEx {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IActiveScriptSiteDebugEx_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub OnCanNotJITScriptErrorDebug: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, perrordebug: *mut ::core::ffi::c_void, pfcallonscripterrorwhencontinuing: *mut super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -7265,7 +7265,7 @@ unsafe impl ::windows::core::Interface for IActiveScriptSiteInterruptPoll {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IActiveScriptSiteInterruptPoll_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub QueryContinue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
@@ -7314,7 +7314,7 @@ unsafe impl ::windows::core::Interface for IActiveScriptSiteTraceInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IActiveScriptSiteTraceInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SendScriptTraceInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, stieventtype: SCRIPTTRACEINFO, guidcontextid: ::windows::core::GUID, dwscriptcontextcookie: u32, lscriptstatementstart: i32, lscriptstatementend: i32, dwreserved: u64) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
@@ -7364,7 +7364,7 @@ unsafe impl ::windows::core::Interface for IActiveScriptSiteUIControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IActiveScriptSiteUIControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetUIBehavior: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, uicitem: SCRIPTUICITEM, puichandling: *mut SCRIPTUICHANDLING) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
@@ -7424,7 +7424,7 @@ unsafe impl ::windows::core::Interface for IActiveScriptSiteWindow {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IActiveScriptSiteWindow_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetWindow: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, phwnd: *mut super::super::super::Foundation::HWND) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -7486,7 +7486,7 @@ unsafe impl ::windows::core::Interface for IActiveScriptStats {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IActiveScriptStats_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetStat: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, stid: u32, pluhi: *mut u32, plulo: *mut u32) -> ::windows::core::HRESULT,
     pub GetStatEx: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, guid: *const ::windows::core::GUID, pluhi: *mut u32, plulo: *mut u32) -> ::windows::core::HRESULT,
     pub ResetStats: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -7538,7 +7538,7 @@ unsafe impl ::windows::core::Interface for IActiveScriptStringCompare {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IActiveScriptStringCompare_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub StrComp: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bszstr1: ::core::mem::ManuallyDrop<::windows::core::BSTR>, bszstr2: ::core::mem::ManuallyDrop<::windows::core::BSTR>, iret: *mut i32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
@@ -7593,7 +7593,7 @@ unsafe impl ::windows::core::Interface for IActiveScriptTraceInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IActiveScriptTraceInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub StartScriptTracing: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psitetraceinfo: *mut ::core::ffi::c_void, guidcontextid: ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub StopScriptTracing: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -7760,7 +7760,7 @@ unsafe impl ::windows::core::Interface for IApplicationDebugger {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IApplicationDebugger_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub QueryAlive: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CreateInstanceAtDebugger: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, rclsid: *const ::windows::core::GUID, punkouter: *mut ::core::ffi::c_void, dwclscontext: u32, riid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub onDebugOutput: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pstr: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
@@ -7823,7 +7823,7 @@ unsafe impl ::windows::core::Interface for IApplicationDebuggerUI {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IApplicationDebuggerUI_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub BringDocumentToTop: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pddt: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub BringDocumentContextToTop: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pddc: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -7879,7 +7879,7 @@ unsafe impl ::windows::core::Interface for IBindEventHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IBindEventHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub BindHandler: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pstrevent: ::windows::core::PCWSTR, pdisp: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -7935,7 +7935,7 @@ unsafe impl ::windows::core::Interface for ICodeAddressConcept {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICodeAddressConcept_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetContainingSymbol: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcontextobject: *mut ::core::ffi::c_void, ppsymbol: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
@@ -7989,7 +7989,7 @@ unsafe impl ::windows::core::Interface for IComparableConcept {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IComparableConcept_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CompareObjects: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, contextobject: *mut ::core::ffi::c_void, otherobject: *mut ::core::ffi::c_void, comparisonresult: *mut i32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
@@ -8047,7 +8047,7 @@ unsafe impl ::windows::core::Interface for IDataModelConcept {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDataModelConcept_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub InitializeObject: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, modelobject: *mut ::core::ffi::c_void, matchingtypesignature: *mut ::core::ffi::c_void, wildcardmatches: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, modelname: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
 }
@@ -8225,7 +8225,7 @@ unsafe impl ::windows::core::Interface for IDataModelManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDataModelManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Close: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CreateNoValue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, object: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CreateErrorObject: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hrerror: ::windows::core::HRESULT, pwszmessage: ::windows::core::PCWSTR, object: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -8540,7 +8540,7 @@ unsafe impl ::windows::core::Interface for IDataModelNameBinder {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDataModelNameBinder_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub BindValue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, contextobject: *mut ::core::ffi::c_void, name: ::windows::core::PCWSTR, value: *mut *mut ::core::ffi::c_void, metadata: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub BindReference: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, contextobject: *mut ::core::ffi::c_void, name: ::windows::core::PCWSTR, reference: *mut *mut ::core::ffi::c_void, metadata: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub EnumerateValues: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, contextobject: *mut ::core::ffi::c_void, enumerator: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -8626,7 +8626,7 @@ unsafe impl ::windows::core::Interface for IDataModelScript {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDataModelScript_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, scriptname: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub Rename: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, scriptname: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
@@ -8687,7 +8687,7 @@ unsafe impl ::windows::core::Interface for IDataModelScriptClient {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDataModelScriptClient_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ReportError: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, errclass: ErrorClass, hrfail: ::windows::core::HRESULT, message: ::windows::core::PCWSTR, line: u32, position: u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
@@ -8774,7 +8774,7 @@ unsafe impl ::windows::core::Interface for IDataModelScriptDebug {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDataModelScriptDebug_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDebugState: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ScriptDebugState,
     pub GetCurrentPosition: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, currentposition: *mut ScriptDebugPosition, positionspanend: *mut ScriptDebugPosition, linetext: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub GetStack: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, stack: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -8956,7 +8956,7 @@ unsafe impl ::windows::core::Interface for IDataModelScriptDebugBreakpoint {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDataModelScriptDebugBreakpoint_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u64,
     pub IsEnabled: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> bool,
     pub Enable: unsafe extern "system" fn(this: *mut ::core::ffi::c_void),
@@ -9014,7 +9014,7 @@ unsafe impl ::windows::core::Interface for IDataModelScriptDebugBreakpointEnumer
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDataModelScriptDebugBreakpointEnumerator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetNext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, breakpoint: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -9068,7 +9068,7 @@ unsafe impl ::windows::core::Interface for IDataModelScriptDebugClient {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDataModelScriptDebugClient_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub NotifyDebugEvent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, peventinfo: *const ScriptDebugEventInformation, pscript: *mut ::core::ffi::c_void, peventdataobject: *mut ::core::ffi::c_void, resumeeventkind: *mut ScriptExecutionKind) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
@@ -9121,7 +9121,7 @@ unsafe impl ::windows::core::Interface for IDataModelScriptDebugStack {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDataModelScriptDebugStack_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetFrameCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u64,
     pub GetStackFrame: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, framenumber: u64, stackframe: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -9197,7 +9197,7 @@ unsafe impl ::windows::core::Interface for IDataModelScriptDebugStackFrame {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDataModelScriptDebugStackFrame_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, name: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub GetPosition: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, position: *mut ScriptDebugPosition, positionspanend: *mut ScriptDebugPosition, linetext: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub IsTransitionPoint: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, istransitionpoint: *mut bool) -> ::windows::core::HRESULT,
@@ -9255,7 +9255,7 @@ unsafe impl ::windows::core::Interface for IDataModelScriptDebugVariableSetEnume
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDataModelScriptDebugVariableSetEnumerator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetNext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, variablename: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>, variablevalue: *mut *mut ::core::ffi::c_void, variablemetadata: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -9312,7 +9312,7 @@ unsafe impl ::windows::core::Interface for IDataModelScriptHostContext {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDataModelScriptHostContext_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub NotifyScriptChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, script: *mut ::core::ffi::c_void, changekind: ScriptChangeKind) -> ::windows::core::HRESULT,
     pub GetNamespaceObject: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, namespaceobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -9393,7 +9393,7 @@ unsafe impl ::windows::core::Interface for IDataModelScriptManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDataModelScriptManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDefaultNameBinder: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppnamebinder: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub RegisterScriptProvider: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, provider: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub UnregisterScriptProvider: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, provider: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -9464,7 +9464,7 @@ unsafe impl ::windows::core::Interface for IDataModelScriptProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDataModelScriptProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, name: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub GetExtension: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, extension: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub CreateScript: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, script: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -9521,7 +9521,7 @@ unsafe impl ::windows::core::Interface for IDataModelScriptProviderEnumerator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDataModelScriptProviderEnumerator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetNext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, provider: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -9582,7 +9582,7 @@ unsafe impl ::windows::core::Interface for IDataModelScriptTemplate {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDataModelScriptTemplate_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, templatename: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub GetDescription: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, templatedescription: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
@@ -9640,7 +9640,7 @@ unsafe impl ::windows::core::Interface for IDataModelScriptTemplateEnumerator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDataModelScriptTemplateEnumerator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetNext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, templatecontent: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -9693,7 +9693,7 @@ unsafe impl ::windows::core::Interface for IDebugAdvanced {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugAdvanced_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetThreadContext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, context: *mut ::core::ffi::c_void, contextsize: u32) -> ::windows::core::HRESULT,
     pub SetThreadContext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, context: *const ::core::ffi::c_void, contextsize: u32) -> ::windows::core::HRESULT,
 }
@@ -9767,7 +9767,7 @@ unsafe impl ::windows::core::Interface for IDebugAdvanced2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugAdvanced2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetThreadContext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, context: *mut ::core::ffi::c_void, contextsize: u32) -> ::windows::core::HRESULT,
     pub SetThreadContext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, context: *const ::core::ffi::c_void, contextsize: u32) -> ::windows::core::HRESULT,
     pub Request: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, request: u32, inbuffer: *const ::core::ffi::c_void, inbuffersize: u32, outbuffer: *mut ::core::ffi::c_void, outbuffersize: u32, outsize: *mut u32) -> ::windows::core::HRESULT,
@@ -9861,7 +9861,7 @@ unsafe impl ::windows::core::Interface for IDebugAdvanced3 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugAdvanced3_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetThreadContext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, context: *mut ::core::ffi::c_void, contextsize: u32) -> ::windows::core::HRESULT,
     pub SetThreadContext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, context: *const ::core::ffi::c_void, contextsize: u32) -> ::windows::core::HRESULT,
     pub Request: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, request: u32, inbuffer: *const ::core::ffi::c_void, inbuffersize: u32, outbuffer: *mut ::core::ffi::c_void, outbuffersize: u32, outsize: *mut u32) -> ::windows::core::HRESULT,
@@ -9974,7 +9974,7 @@ unsafe impl ::windows::core::Interface for IDebugAdvanced4 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugAdvanced4_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetThreadContext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, context: *mut ::core::ffi::c_void, contextsize: u32) -> ::windows::core::HRESULT,
     pub SetThreadContext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, context: *const ::core::ffi::c_void, contextsize: u32) -> ::windows::core::HRESULT,
     pub Request: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, request: u32, inbuffer: *const ::core::ffi::c_void, inbuffersize: u32, outbuffer: *mut ::core::ffi::c_void, outbuffersize: u32, outsize: *mut u32) -> ::windows::core::HRESULT,
@@ -10820,7 +10820,7 @@ unsafe impl ::windows::core::Interface for IDebugApplicationNode100 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugApplicationNode100_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetFilterForEventSink: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwcookie: u32, filter: APPLICATION_NODE_EVENT_FILTER) -> ::windows::core::HRESULT,
     pub GetExcludedDocuments: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, filter: APPLICATION_NODE_EVENT_FILTER, pdocuments: *mut TEXT_DOCUMENT_ARRAY) -> ::windows::core::HRESULT,
     pub QueryIsChildNode: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psearchkey: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -10889,7 +10889,7 @@ unsafe impl ::windows::core::Interface for IDebugApplicationNodeEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugApplicationNodeEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub onAddChild: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, prddpchild: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub onRemoveChild: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, prddpchild: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub onDetach: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -11087,7 +11087,7 @@ unsafe impl ::windows::core::Interface for IDebugApplicationThread11032 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugApplicationThread11032_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetActiveThreadRequestCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, puithreadrequests: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub IsSuspendedForBreakPoint: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfissuspended: *mut super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -11164,7 +11164,7 @@ unsafe impl ::windows::core::Interface for IDebugApplicationThread11064 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugApplicationThread11064_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetActiveThreadRequestCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, puithreadrequests: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub IsSuspendedForBreakPoint: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfissuspended: *mut super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -11375,7 +11375,7 @@ unsafe impl ::windows::core::Interface for IDebugApplicationThreadEvents110 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugApplicationThreadEvents110_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnSuspendForBreakPoint: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub OnResumeFromBreakPoint: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub OnThreadRequestComplete: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -11443,7 +11443,7 @@ unsafe impl ::windows::core::Interface for IDebugAsyncOperation {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugAsyncOperation_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetSyncDebugOperation: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppsdo: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Start: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, padocb: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Abort: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -11496,7 +11496,7 @@ unsafe impl ::windows::core::Interface for IDebugAsyncOperationCallBack {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugAsyncOperationCallBack_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub onComplete: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
@@ -11619,7 +11619,7 @@ unsafe impl ::windows::core::Interface for IDebugBreakpoint {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugBreakpoint_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, id: *mut u32) -> ::windows::core::HRESULT,
     pub GetType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, breaktype: *mut u32, proctype: *mut u32) -> ::windows::core::HRESULT,
     pub GetAdder: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, adder: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -11780,7 +11780,7 @@ unsafe impl ::windows::core::Interface for IDebugBreakpoint2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugBreakpoint2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, id: *mut u32) -> ::windows::core::HRESULT,
     pub GetType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, breaktype: *mut u32, proctype: *mut u32) -> ::windows::core::HRESULT,
     pub GetAdder: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, adder: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -11949,7 +11949,7 @@ unsafe impl ::windows::core::Interface for IDebugBreakpoint3 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugBreakpoint3_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, id: *mut u32) -> ::windows::core::HRESULT,
     pub GetType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, breaktype: *mut u32, proctype: *mut u32) -> ::windows::core::HRESULT,
     pub GetAdder: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, adder: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -12235,7 +12235,7 @@ unsafe impl ::windows::core::Interface for IDebugClient {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugClient_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AttachKernel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, flags: u32, connectoptions: ::windows::core::PCSTR) -> ::windows::core::HRESULT,
     pub GetKernelConnectionOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, buffer: ::windows::core::PSTR, buffersize: u32, optionssize: *mut u32) -> ::windows::core::HRESULT,
     pub SetKernelConnectionOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, options: ::windows::core::PCSTR) -> ::windows::core::HRESULT,
@@ -12571,7 +12571,7 @@ unsafe impl ::windows::core::Interface for IDebugClient2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugClient2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AttachKernel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, flags: u32, connectoptions: ::windows::core::PCSTR) -> ::windows::core::HRESULT,
     pub GetKernelConnectionOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, buffer: ::windows::core::PSTR, buffersize: u32, optionssize: *mut u32) -> ::windows::core::HRESULT,
     pub SetKernelConnectionOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, options: ::windows::core::PCSTR) -> ::windows::core::HRESULT,
@@ -12949,7 +12949,7 @@ unsafe impl ::windows::core::Interface for IDebugClient3 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugClient3_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AttachKernel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, flags: u32, connectoptions: ::windows::core::PCSTR) -> ::windows::core::HRESULT,
     pub GetKernelConnectionOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, buffer: ::windows::core::PSTR, buffersize: u32, optionssize: *mut u32) -> ::windows::core::HRESULT,
     pub SetKernelConnectionOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, options: ::windows::core::PCSTR) -> ::windows::core::HRESULT,
@@ -13360,7 +13360,7 @@ unsafe impl ::windows::core::Interface for IDebugClient4 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugClient4_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AttachKernel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, flags: u32, connectoptions: ::windows::core::PCSTR) -> ::windows::core::HRESULT,
     pub GetKernelConnectionOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, buffer: ::windows::core::PSTR, buffersize: u32, optionssize: *mut u32) -> ::windows::core::HRESULT,
     pub SetKernelConnectionOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, options: ::windows::core::PCSTR) -> ::windows::core::HRESULT,
@@ -13934,7 +13934,7 @@ unsafe impl ::windows::core::Interface for IDebugClient5 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugClient5_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AttachKernel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, flags: u32, connectoptions: ::windows::core::PCSTR) -> ::windows::core::HRESULT,
     pub GetKernelConnectionOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, buffer: ::windows::core::PSTR, buffersize: u32, optionssize: *mut u32) -> ::windows::core::HRESULT,
     pub SetKernelConnectionOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, options: ::windows::core::PCSTR) -> ::windows::core::HRESULT,
@@ -14543,7 +14543,7 @@ unsafe impl ::windows::core::Interface for IDebugClient6 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugClient6_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AttachKernel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, flags: u32, connectoptions: ::windows::core::PCSTR) -> ::windows::core::HRESULT,
     pub GetKernelConnectionOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, buffer: ::windows::core::PSTR, buffersize: u32, optionssize: *mut u32) -> ::windows::core::HRESULT,
     pub SetKernelConnectionOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, options: ::windows::core::PCSTR) -> ::windows::core::HRESULT,
@@ -15156,7 +15156,7 @@ unsafe impl ::windows::core::Interface for IDebugClient7 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugClient7_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AttachKernel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, flags: u32, connectoptions: ::windows::core::PCSTR) -> ::windows::core::HRESULT,
     pub GetKernelConnectionOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, buffer: ::windows::core::PSTR, buffersize: u32, optionssize: *mut u32) -> ::windows::core::HRESULT,
     pub SetKernelConnectionOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, options: ::windows::core::PCSTR) -> ::windows::core::HRESULT,
@@ -15776,7 +15776,7 @@ unsafe impl ::windows::core::Interface for IDebugClient8 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugClient8_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AttachKernel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, flags: u32, connectoptions: ::windows::core::PCSTR) -> ::windows::core::HRESULT,
     pub GetKernelConnectionOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, buffer: ::windows::core::PSTR, buffersize: u32, optionssize: *mut u32) -> ::windows::core::HRESULT,
     pub SetKernelConnectionOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, options: ::windows::core::PCSTR) -> ::windows::core::HRESULT,
@@ -15923,7 +15923,7 @@ unsafe impl ::windows::core::Interface for IDebugCodeContext {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugCodeContext_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDocumentContext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppsc: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetBreakPoint: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bps: BREAKPOINT_STATE) -> ::windows::core::HRESULT,
 }
@@ -16395,7 +16395,7 @@ unsafe impl ::windows::core::Interface for IDebugControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetInterrupt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetInterrupt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, flags: u32) -> ::windows::core::HRESULT,
     pub GetInterruptTimeout: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, seconds: *mut u32) -> ::windows::core::HRESULT,
@@ -17033,7 +17033,7 @@ unsafe impl ::windows::core::Interface for IDebugControl2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugControl2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetInterrupt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetInterrupt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, flags: u32) -> ::windows::core::HRESULT,
     pub GetInterruptTimeout: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, seconds: *mut u32) -> ::windows::core::HRESULT,
@@ -17741,7 +17741,7 @@ unsafe impl ::windows::core::Interface for IDebugControl3 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugControl3_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetInterrupt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetInterrupt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, flags: u32) -> ::windows::core::HRESULT,
     pub GetInterruptTimeout: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, seconds: *mut u32) -> ::windows::core::HRESULT,
@@ -18767,7 +18767,7 @@ unsafe impl ::windows::core::Interface for IDebugControl4 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugControl4_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetInterrupt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetInterrupt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, flags: u32) -> ::windows::core::HRESULT,
     pub GetInterruptTimeout: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, seconds: *mut u32) -> ::windows::core::HRESULT,
@@ -19888,7 +19888,7 @@ unsafe impl ::windows::core::Interface for IDebugControl5 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugControl5_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetInterrupt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetInterrupt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, flags: u32) -> ::windows::core::HRESULT,
     pub GetInterruptTimeout: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, seconds: *mut u32) -> ::windows::core::HRESULT,
@@ -21033,7 +21033,7 @@ unsafe impl ::windows::core::Interface for IDebugControl6 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugControl6_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetInterrupt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetInterrupt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, flags: u32) -> ::windows::core::HRESULT,
     pub GetInterruptTimeout: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, seconds: *mut u32) -> ::windows::core::HRESULT,
@@ -22183,7 +22183,7 @@ unsafe impl ::windows::core::Interface for IDebugControl7 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugControl7_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetInterrupt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetInterrupt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, flags: u32) -> ::windows::core::HRESULT,
     pub GetInterruptTimeout: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, seconds: *mut u32) -> ::windows::core::HRESULT,
@@ -22465,7 +22465,7 @@ unsafe impl ::windows::core::Interface for IDebugCookie {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugCookie_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetDebugCookie: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwdebugappcookie: u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
@@ -22579,7 +22579,7 @@ unsafe impl ::windows::core::Interface for IDebugDataSpaces {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugDataSpaces_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ReadVirtual: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, offset: u64, buffer: *mut ::core::ffi::c_void, buffersize: u32, bytesread: *mut u32) -> ::windows::core::HRESULT,
     pub WriteVirtual: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, offset: u64, buffer: *const ::core::ffi::c_void, buffersize: u32, byteswritten: *mut u32) -> ::windows::core::HRESULT,
     pub SearchVirtual: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, offset: u64, length: u64, pattern: *const ::core::ffi::c_void, patternsize: u32, patterngranularity: u32, matchoffset: *mut u64) -> ::windows::core::HRESULT,
@@ -22736,7 +22736,7 @@ unsafe impl ::windows::core::Interface for IDebugDataSpaces2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugDataSpaces2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ReadVirtual: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, offset: u64, buffer: *mut ::core::ffi::c_void, buffersize: u32, bytesread: *mut u32) -> ::windows::core::HRESULT,
     pub WriteVirtual: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, offset: u64, buffer: *const ::core::ffi::c_void, buffersize: u32, byteswritten: *mut u32) -> ::windows::core::HRESULT,
     pub SearchVirtual: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, offset: u64, length: u64, pattern: *const ::core::ffi::c_void, patternsize: u32, patterngranularity: u32, matchoffset: *mut u64) -> ::windows::core::HRESULT,
@@ -22921,7 +22921,7 @@ unsafe impl ::windows::core::Interface for IDebugDataSpaces3 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugDataSpaces3_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ReadVirtual: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, offset: u64, buffer: *mut ::core::ffi::c_void, buffersize: u32, bytesread: *mut u32) -> ::windows::core::HRESULT,
     pub WriteVirtual: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, offset: u64, buffer: *const ::core::ffi::c_void, buffersize: u32, byteswritten: *mut u32) -> ::windows::core::HRESULT,
     pub SearchVirtual: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, offset: u64, length: u64, pattern: *const ::core::ffi::c_void, patternsize: u32, patterngranularity: u32, matchoffset: *mut u64) -> ::windows::core::HRESULT,
@@ -23147,7 +23147,7 @@ unsafe impl ::windows::core::Interface for IDebugDataSpaces4 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugDataSpaces4_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ReadVirtual: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, offset: u64, buffer: *mut ::core::ffi::c_void, buffersize: u32, bytesread: *mut u32) -> ::windows::core::HRESULT,
     pub WriteVirtual: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, offset: u64, buffer: *const ::core::ffi::c_void, buffersize: u32, byteswritten: *mut u32) -> ::windows::core::HRESULT,
     pub SearchVirtual: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, offset: u64, length: u64, pattern: *const ::core::ffi::c_void, patternsize: u32, patterngranularity: u32, matchoffset: *mut u64) -> ::windows::core::HRESULT,
@@ -23315,7 +23315,7 @@ unsafe impl ::windows::core::Interface for IDebugDocumentContext {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugDocumentContext_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDocument: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppsd: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub EnumCodeContexts: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppescc: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -23451,7 +23451,7 @@ unsafe impl ::windows::core::Interface for IDebugDocumentHelper32 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugDocumentHelper32_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Init: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pda: *mut ::core::ffi::c_void, pszshortname: ::windows::core::PCWSTR, pszlongname: ::windows::core::PCWSTR, docattr: u32) -> ::windows::core::HRESULT,
     pub Attach: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pddhparent: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Detach: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -23606,7 +23606,7 @@ unsafe impl ::windows::core::Interface for IDebugDocumentHelper64 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugDocumentHelper64_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Init: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pda: *mut ::core::ffi::c_void, pszshortname: ::windows::core::PCWSTR, pszlongname: ::windows::core::PCWSTR, docattr: u32) -> ::windows::core::HRESULT,
     pub Attach: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pddhparent: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Detach: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -23698,7 +23698,7 @@ unsafe impl ::windows::core::Interface for IDebugDocumentHost {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugDocumentHost_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDeferredText: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwtextstartcookie: u32, pchartext: ::windows::core::PWSTR, pstatextattr: *mut u16, pcnumchars: *mut u32, cmaxchars: u32) -> ::windows::core::HRESULT,
     pub GetScriptTextAttributes: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pstrcode: ::windows::core::PCWSTR, unumcodechars: u32, pstrdelimiter: ::windows::core::PCWSTR, dwflags: u32, pattr: *mut u16) -> ::windows::core::HRESULT,
     pub OnCreateDocumentContext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppunkouter: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -23760,7 +23760,7 @@ unsafe impl ::windows::core::Interface for IDebugDocumentInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugDocumentInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dnt: DOCUMENTNAMETYPE, pbstrname: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub GetDocumentClassId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pclsiddocument: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
 }
@@ -24152,7 +24152,7 @@ unsafe impl ::windows::core::Interface for IDebugDocumentTextEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugDocumentTextEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub onDestroy: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub onInsertText: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ccharacterposition: u32, cnumtoinsert: u32) -> ::windows::core::HRESULT,
     pub onRemoveText: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ccharacterposition: u32, cnumtoremove: u32) -> ::windows::core::HRESULT,
@@ -24215,7 +24215,7 @@ unsafe impl ::windows::core::Interface for IDebugDocumentTextExternalAuthor {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugDocumentTextExternalAuthor_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetPathName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstrlongname: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>, pfisoriginalfile: *mut super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -24325,7 +24325,7 @@ unsafe impl ::windows::core::Interface for IDebugEventCallbacks {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugEventCallbacks_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetInterestMask: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, mask: *mut u32) -> ::windows::core::HRESULT,
     pub Breakpoint: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bp: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -24446,7 +24446,7 @@ unsafe impl ::windows::core::Interface for IDebugEventCallbacksWide {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugEventCallbacksWide_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetInterestMask: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, mask: *mut u32) -> ::windows::core::HRESULT,
     pub Breakpoint: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bp: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -24567,7 +24567,7 @@ unsafe impl ::windows::core::Interface for IDebugEventContextCallbacks {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugEventContextCallbacks_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetInterestMask: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, mask: *mut u32) -> ::windows::core::HRESULT,
     pub Breakpoint: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bp: *mut ::core::ffi::c_void, context: *const ::core::ffi::c_void, contextsize: u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -24647,7 +24647,7 @@ unsafe impl ::windows::core::Interface for IDebugExpression {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugExpression_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Start: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdecb: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Abort: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub QueryIsComplete: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -24700,7 +24700,7 @@ unsafe impl ::windows::core::Interface for IDebugExpressionCallBack {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugExpressionCallBack_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub onComplete: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
@@ -24757,7 +24757,7 @@ unsafe impl ::windows::core::Interface for IDebugExpressionContext {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugExpressionContext_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ParseLanguageText: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pstrcode: ::windows::core::PCWSTR, nradix: u32, pstrdelimiter: ::windows::core::PCWSTR, dwflags: u32, ppe: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetLanguageInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstrlanguagename: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>, planguageid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
 }
@@ -24924,7 +24924,7 @@ unsafe impl ::windows::core::Interface for IDebugFormatter {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugFormatter_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub GetStringForVariant: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pvar: *const super::super::Com::VARIANT, nradix: u32, pbstrvalue: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole")))]
@@ -25011,7 +25011,7 @@ unsafe impl ::windows::core::Interface for IDebugHelper {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugHelper_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub CreatePropertyBrowser: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pvar: *const super::super::Com::VARIANT, bstrname: ::windows::core::PCWSTR, pdat: *mut ::core::ffi::c_void, ppdob: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole")))]
@@ -25080,7 +25080,7 @@ unsafe impl ::windows::core::Interface for IDebugHost {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugHost_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetHostDefinedInterface: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hostunk: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetCurrentContext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, context: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetDefaultMetadata: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, defaultmetadatastore: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -25338,7 +25338,7 @@ unsafe impl ::windows::core::Interface for IDebugHostContext {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugHostContext_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub IsEqualTo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcontext: *mut ::core::ffi::c_void, pisequal: *mut bool) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
@@ -25504,7 +25504,7 @@ unsafe impl ::windows::core::Interface for IDebugHostErrorSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugHostErrorSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ReportError: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, errclass: ErrorClass, hrerror: ::windows::core::HRESULT, message: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
@@ -25566,7 +25566,7 @@ unsafe impl ::windows::core::Interface for IDebugHostEvaluator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugHostEvaluator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub EvaluateExpression: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, context: *mut ::core::ffi::c_void, expression: ::windows::core::PCWSTR, bindingcontext: *mut ::core::ffi::c_void, result: *mut *mut ::core::ffi::c_void, metadata: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub EvaluateExtendedExpression: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, context: *mut ::core::ffi::c_void, expression: ::windows::core::PCWSTR, bindingcontext: *mut ::core::ffi::c_void, result: *mut *mut ::core::ffi::c_void, metadata: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -25710,7 +25710,7 @@ unsafe impl ::windows::core::Interface for IDebugHostExtensibility {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugHostExtensibility_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateFunctionAlias: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, aliasname: ::windows::core::PCWSTR, functionobject: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub DestroyFunctionAlias: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, aliasname: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
 }
@@ -25908,7 +25908,7 @@ unsafe impl ::windows::core::Interface for IDebugHostMemory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugHostMemory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ReadBytes: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, context: *mut ::core::ffi::c_void, location: Location, buffer: *mut ::core::ffi::c_void, buffersize: u64, bytesread: *mut u64) -> ::windows::core::HRESULT,
     pub WriteBytes: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, context: *mut ::core::ffi::c_void, location: Location, buffer: *const ::core::ffi::c_void, buffersize: u64, byteswritten: *mut u64) -> ::windows::core::HRESULT,
     pub ReadPointers: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, context: *mut ::core::ffi::c_void, location: Location, count: u64, pointers: *mut u64) -> ::windows::core::HRESULT,
@@ -26336,7 +26336,7 @@ unsafe impl ::windows::core::Interface for IDebugHostModuleSignature {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugHostModuleSignature_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub IsMatch: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pmodule: *mut ::core::ffi::c_void, ismatch: *mut bool) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
@@ -26493,7 +26493,7 @@ unsafe impl ::windows::core::Interface for IDebugHostScriptHost {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugHostScriptHost_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateContext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, script: *mut ::core::ffi::c_void, scriptcontext: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
@@ -26543,7 +26543,7 @@ unsafe impl ::windows::core::Interface for IDebugHostStatus {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugHostStatus_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub PollUserInterrupt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, interruptrequested: *mut bool) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
@@ -26623,7 +26623,7 @@ unsafe impl ::windows::core::Interface for IDebugHostSymbol {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugHostSymbol_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetContext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, context: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub EnumerateChildren: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, kind: SymbolKind, name: ::windows::core::PCWSTR, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetSymbolKind: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, kind: *mut SymbolKind) -> ::windows::core::HRESULT,
@@ -26781,7 +26781,7 @@ unsafe impl ::windows::core::Interface for IDebugHostSymbolEnumerator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugHostSymbolEnumerator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetNext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, symbol: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -26884,7 +26884,7 @@ unsafe impl ::windows::core::Interface for IDebugHostSymbols {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugHostSymbols_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateModuleSignature: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszmodulename: ::windows::core::PCWSTR, pwszminversion: ::windows::core::PCWSTR, pwszmaxversion: ::windows::core::PCWSTR, ppmodulesignature: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CreateTypeSignature: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, signaturespecification: ::windows::core::PCWSTR, module: *mut ::core::ffi::c_void, typesignature: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CreateTypeSignatureForModuleRange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, signaturespecification: ::windows::core::PCWSTR, modulename: ::windows::core::PCWSTR, minversion: ::windows::core::PCWSTR, maxversion: ::windows::core::PCWSTR, typesignature: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -27346,7 +27346,7 @@ unsafe impl ::windows::core::Interface for IDebugHostTypeSignature {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugHostTypeSignature_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetHashCode: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hashcode: *mut u32) -> ::windows::core::HRESULT,
     pub IsMatch: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, r#type: *mut ::core::ffi::c_void, ismatch: *mut bool, wildcardmatches: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CompareAgainst: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, typesignature: *mut ::core::ffi::c_void, result: *mut SignatureComparison) -> ::windows::core::HRESULT,
@@ -27400,7 +27400,7 @@ unsafe impl ::windows::core::Interface for IDebugInputCallbacks {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugInputCallbacks_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub StartInput: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, buffersize: u32) -> ::windows::core::HRESULT,
     pub EndInput: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -27453,7 +27453,7 @@ unsafe impl ::windows::core::Interface for IDebugOutputCallbacks {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugOutputCallbacks_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Output: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, mask: u32, text: ::windows::core::PCSTR) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
@@ -27515,7 +27515,7 @@ unsafe impl ::windows::core::Interface for IDebugOutputCallbacks2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugOutputCallbacks2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Output: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, mask: u32, text: ::windows::core::PCSTR) -> ::windows::core::HRESULT,
     pub GetInterestMask: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, mask: *mut u32) -> ::windows::core::HRESULT,
     pub Output2: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, which: u32, flags: u32, arg: u64, text: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
@@ -27569,7 +27569,7 @@ unsafe impl ::windows::core::Interface for IDebugOutputCallbacksWide {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugOutputCallbacksWide_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Output: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, mask: u32, text: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
@@ -27621,7 +27621,7 @@ unsafe impl ::windows::core::Interface for IDebugOutputStream {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugOutputStream_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Write: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psz: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
@@ -27675,7 +27675,7 @@ unsafe impl ::windows::core::Interface for IDebugPlmClient {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugPlmClient_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub LaunchPlmPackageForDebugWide: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, server: u64, timeout: u32, packagefullname: ::windows::core::PCWSTR, appname: ::windows::core::PCWSTR, arguments: ::windows::core::PCWSTR, processid: *mut u32, threadid: *mut u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
@@ -27736,7 +27736,7 @@ unsafe impl ::windows::core::Interface for IDebugPlmClient2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugPlmClient2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub LaunchPlmPackageForDebugWide: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, server: u64, timeout: u32, packagefullname: ::windows::core::PCWSTR, appname: ::windows::core::PCWSTR, arguments: ::windows::core::PCWSTR, processid: *mut u32, threadid: *mut u32) -> ::windows::core::HRESULT,
     pub LaunchPlmBgTaskForDebugWide: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, server: u64, timeout: u32, packagefullname: ::windows::core::PCWSTR, backgroundtaskid: ::windows::core::PCWSTR, processid: *mut u32, threadid: *mut u32) -> ::windows::core::HRESULT,
 }
@@ -27856,7 +27856,7 @@ unsafe impl ::windows::core::Interface for IDebugPlmClient3 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugPlmClient3_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub LaunchPlmPackageForDebugWide: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, server: u64, timeout: u32, packagefullname: ::windows::core::PCWSTR, appname: ::windows::core::PCWSTR, arguments: ::windows::core::PCWSTR, processid: *mut u32, threadid: *mut u32) -> ::windows::core::HRESULT,
     pub LaunchPlmBgTaskForDebugWide: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, server: u64, timeout: u32, packagefullname: ::windows::core::PCWSTR, backgroundtaskid: ::windows::core::PCWSTR, processid: *mut u32, threadid: *mut u32) -> ::windows::core::HRESULT,
     pub QueryPlmPackageWide: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, server: u64, packagefullname: ::windows::core::PCWSTR, stream: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -27936,7 +27936,7 @@ unsafe impl ::windows::core::Interface for IDebugProperty {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugProperty_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetPropertyInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwfieldspec: u32, nradix: u32, ppropertyinfo: *mut DebugPropertyInfo) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub GetExtendedInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cinfos: u32, rgguidextendedinfo: *const ::windows::core::GUID, rgvar: *mut super::super::Com::VARIANT) -> ::windows::core::HRESULT,
@@ -27993,7 +27993,7 @@ unsafe impl ::windows::core::Interface for IDebugPropertyEnumType_All {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugPropertyEnumType_All_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, __midl__idebugpropertyenumtype_all0000: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
@@ -28346,7 +28346,7 @@ unsafe impl ::windows::core::Interface for IDebugRegisters {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugRegisters_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetNumberRegisters: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, number: *mut u32) -> ::windows::core::HRESULT,
     pub GetDescription: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, register: u32, namebuffer: ::windows::core::PSTR, namebuffersize: u32, namesize: *mut u32, desc: *mut DEBUG_REGISTER_DESCRIPTION) -> ::windows::core::HRESULT,
     pub GetIndexByName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, name: ::windows::core::PCSTR, index: *mut u32) -> ::windows::core::HRESULT,
@@ -28536,7 +28536,7 @@ unsafe impl ::windows::core::Interface for IDebugRegisters2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugRegisters2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetNumberRegisters: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, number: *mut u32) -> ::windows::core::HRESULT,
     pub GetDescription: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, register: u32, namebuffer: ::windows::core::PSTR, namebuffersize: u32, namesize: *mut u32, desc: *mut DEBUG_REGISTER_DESCRIPTION) -> ::windows::core::HRESULT,
     pub GetIndexByName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, name: ::windows::core::PCSTR, index: *mut u32) -> ::windows::core::HRESULT,
@@ -28637,7 +28637,7 @@ unsafe impl ::windows::core::Interface for IDebugSessionProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugSessionProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub StartDebugSession: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pda: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
@@ -28713,7 +28713,7 @@ unsafe impl ::windows::core::Interface for IDebugStackFrame {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugStackFrame_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCodeContext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppcc: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub GetDescriptionString: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, flong: super::super::super::Foundation::BOOL, pbstrdescription: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
@@ -28873,7 +28873,7 @@ unsafe impl ::windows::core::Interface for IDebugStackFrameSniffer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugStackFrameSniffer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub EnumStackFrames: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppedsf: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
@@ -29105,7 +29105,7 @@ unsafe impl ::windows::core::Interface for IDebugSymbolGroup {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugSymbolGroup_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetNumberSymbols: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, number: *mut u32) -> ::windows::core::HRESULT,
     pub AddSymbol: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, name: ::windows::core::PCSTR, index: *mut u32) -> ::windows::core::HRESULT,
     pub RemoveSymbolByName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, name: ::windows::core::PCSTR) -> ::windows::core::HRESULT,
@@ -29266,7 +29266,7 @@ unsafe impl ::windows::core::Interface for IDebugSymbolGroup2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugSymbolGroup2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetNumberSymbols: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, number: *mut u32) -> ::windows::core::HRESULT,
     pub AddSymbol: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, name: ::windows::core::PCSTR, index: *mut u32) -> ::windows::core::HRESULT,
     pub RemoveSymbolByName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, name: ::windows::core::PCSTR) -> ::windows::core::HRESULT,
@@ -29570,7 +29570,7 @@ unsafe impl ::windows::core::Interface for IDebugSymbols {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugSymbols_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetSymbolOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, options: *mut u32) -> ::windows::core::HRESULT,
     pub AddSymbolOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, options: u32) -> ::windows::core::HRESULT,
     pub RemoveSymbolOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, options: u32) -> ::windows::core::HRESULT,
@@ -29931,7 +29931,7 @@ unsafe impl ::windows::core::Interface for IDebugSymbols2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugSymbols2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetSymbolOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, options: *mut u32) -> ::windows::core::HRESULT,
     pub AddSymbolOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, options: u32) -> ::windows::core::HRESULT,
     pub RemoveSymbolOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, options: u32) -> ::windows::core::HRESULT,
@@ -30608,7 +30608,7 @@ unsafe impl ::windows::core::Interface for IDebugSymbols3 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugSymbols3_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetSymbolOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, options: *mut u32) -> ::windows::core::HRESULT,
     pub AddSymbolOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, options: u32) -> ::windows::core::HRESULT,
     pub RemoveSymbolOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, options: u32) -> ::windows::core::HRESULT,
@@ -31376,7 +31376,7 @@ unsafe impl ::windows::core::Interface for IDebugSymbols4 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugSymbols4_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetSymbolOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, options: *mut u32) -> ::windows::core::HRESULT,
     pub AddSymbolOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, options: u32) -> ::windows::core::HRESULT,
     pub RemoveSymbolOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, options: u32) -> ::windows::core::HRESULT,
@@ -32164,7 +32164,7 @@ unsafe impl ::windows::core::Interface for IDebugSymbols5 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugSymbols5_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetSymbolOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, options: *mut u32) -> ::windows::core::HRESULT,
     pub AddSymbolOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, options: u32) -> ::windows::core::HRESULT,
     pub RemoveSymbolOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, options: u32) -> ::windows::core::HRESULT,
@@ -32364,7 +32364,7 @@ unsafe impl ::windows::core::Interface for IDebugSyncOperation {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugSyncOperation_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetTargetThread: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppattarget: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Execute: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppunkresult: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub InProgressAbort: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -32522,7 +32522,7 @@ unsafe impl ::windows::core::Interface for IDebugSystemObjects {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugSystemObjects_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetEventThread: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, id: *mut u32) -> ::windows::core::HRESULT,
     pub GetEventProcess: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, id: *mut u32) -> ::windows::core::HRESULT,
     pub GetCurrentThreadId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, id: *mut u32) -> ::windows::core::HRESULT,
@@ -32724,7 +32724,7 @@ unsafe impl ::windows::core::Interface for IDebugSystemObjects2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugSystemObjects2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetEventThread: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, id: *mut u32) -> ::windows::core::HRESULT,
     pub GetEventProcess: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, id: *mut u32) -> ::windows::core::HRESULT,
     pub GetCurrentThreadId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, id: *mut u32) -> ::windows::core::HRESULT,
@@ -32963,7 +32963,7 @@ unsafe impl ::windows::core::Interface for IDebugSystemObjects3 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugSystemObjects3_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetEventThread: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, id: *mut u32) -> ::windows::core::HRESULT,
     pub GetEventProcess: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, id: *mut u32) -> ::windows::core::HRESULT,
     pub GetCurrentThreadId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, id: *mut u32) -> ::windows::core::HRESULT,
@@ -33217,7 +33217,7 @@ unsafe impl ::windows::core::Interface for IDebugSystemObjects4 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugSystemObjects4_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetEventThread: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, id: *mut u32) -> ::windows::core::HRESULT,
     pub GetEventProcess: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, id: *mut u32) -> ::windows::core::HRESULT,
     pub GetCurrentThreadId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, id: *mut u32) -> ::windows::core::HRESULT,
@@ -33310,7 +33310,7 @@ unsafe impl ::windows::core::Interface for IDebugThreadCall32 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugThreadCall32_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ThreadCallHandler: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwparam1: u32, dwparam2: u32, dwparam3: u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
@@ -33359,7 +33359,7 @@ unsafe impl ::windows::core::Interface for IDebugThreadCall64 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDebugThreadCall64_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ThreadCallHandler: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwparam1: u64, dwparam2: u64, dwparam3: u64) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
@@ -33434,7 +33434,7 @@ unsafe impl ::windows::core::Interface for IDynamicConceptProviderConcept {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDynamicConceptProviderConcept_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetConcept: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, contextobject: *mut ::core::ffi::c_void, conceptid: *const ::windows::core::GUID, conceptinterface: *mut *mut ::core::ffi::c_void, conceptmetadata: *mut *mut ::core::ffi::c_void, hasconcept: *mut bool) -> ::windows::core::HRESULT,
     pub SetConcept: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, contextobject: *mut ::core::ffi::c_void, conceptid: *const ::windows::core::GUID, conceptinterface: *mut ::core::ffi::c_void, conceptmetadata: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub NotifyParent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, parentmodel: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -33507,7 +33507,7 @@ unsafe impl ::windows::core::Interface for IDynamicKeyProviderConcept {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDynamicKeyProviderConcept_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetKey: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, contextobject: *mut ::core::ffi::c_void, key: ::windows::core::PCWSTR, keyvalue: *mut *mut ::core::ffi::c_void, metadata: *mut *mut ::core::ffi::c_void, haskey: *mut bool) -> ::windows::core::HRESULT,
     pub SetKey: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, contextobject: *mut ::core::ffi::c_void, key: ::windows::core::PCWSTR, keyvalue: *mut ::core::ffi::c_void, metadata: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub EnumerateKeys: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, contextobject: *mut ::core::ffi::c_void, ppenumerator: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -33568,7 +33568,7 @@ unsafe impl ::windows::core::Interface for IEnumDebugApplicationNodes {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumDebugApplicationNodes_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, pprddp: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -33630,7 +33630,7 @@ unsafe impl ::windows::core::Interface for IEnumDebugCodeContexts {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumDebugCodeContexts_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, pscc: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -33692,7 +33692,7 @@ unsafe impl ::windows::core::Interface for IEnumDebugExpressionContexts {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumDebugExpressionContexts_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, ppdec: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -33760,7 +33760,7 @@ unsafe impl ::windows::core::Interface for IEnumDebugExtendedPropertyInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumDebugExtendedPropertyInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgextendedpropertyinfo: *mut ExtendedDebugPropertyInfo, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole")))]
@@ -33830,7 +33830,7 @@ unsafe impl ::windows::core::Interface for IEnumDebugPropertyInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumDebugPropertyInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, pi: *mut DebugPropertyInfo, pceltsfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -33895,7 +33895,7 @@ unsafe impl ::windows::core::Interface for IEnumDebugStackFrames {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumDebugStackFrames_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, prgdsfd: *mut DebugStackFrameDescriptor, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -34037,7 +34037,7 @@ unsafe impl ::windows::core::Interface for IEnumJsStackFrames {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumJsStackFrames_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cframecount: u32, pframes: *mut JS_NATIVE_FRAME, pcfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -34097,7 +34097,7 @@ unsafe impl ::windows::core::Interface for IEnumRemoteDebugApplicationThreads {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumRemoteDebugApplicationThreads_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, pprdat: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -34159,7 +34159,7 @@ unsafe impl ::windows::core::Interface for IEnumRemoteDebugApplications {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumRemoteDebugApplications_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, ppda: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -34216,7 +34216,7 @@ unsafe impl ::windows::core::Interface for IEquatableConcept {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEquatableConcept_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AreObjectsEqual: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, contextobject: *mut ::core::ffi::c_void, otherobject: *mut ::core::ffi::c_void, isequal: *mut bool) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
@@ -34265,7 +34265,7 @@ unsafe impl ::windows::core::Interface for IHostDataModelAccess {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IHostDataModelAccess_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDataModel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, manager: *mut *mut ::core::ffi::c_void, host: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
@@ -34331,7 +34331,7 @@ unsafe impl ::windows::core::Interface for IIndexableConcept {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IIndexableConcept_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDimensionality: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, contextobject: *mut ::core::ffi::c_void, dimensionality: *mut u64) -> ::windows::core::HRESULT,
     pub GetAt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, contextobject: *mut ::core::ffi::c_void, indexercount: u64, indexers: *const *mut ::core::ffi::c_void, object: *mut *mut ::core::ffi::c_void, metadata: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetAt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, contextobject: *mut ::core::ffi::c_void, indexercount: u64, indexers: *const *mut ::core::ffi::c_void, value: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -34393,7 +34393,7 @@ unsafe impl ::windows::core::Interface for IIterableConcept {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IIterableConcept_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDefaultIndexDimensionality: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, contextobject: *mut ::core::ffi::c_void, dimensionality: *mut u64) -> ::windows::core::HRESULT,
     pub GetIterator: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, contextobject: *mut ::core::ffi::c_void, iterator: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -34447,7 +34447,7 @@ unsafe impl ::windows::core::Interface for IJsDebug {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IJsDebug_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OpenVirtualProcess: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, processid: u32, runtimejsbaseaddress: u64, pdatatarget: *mut ::core::ffi::c_void, ppprocess: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
@@ -34511,7 +34511,7 @@ unsafe impl ::windows::core::Interface for IJsDebugBreakPoint {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IJsDebugBreakPoint_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub IsEnabled: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pisenabled: *mut super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -34596,7 +34596,7 @@ unsafe impl ::windows::core::Interface for IJsDebugDataTarget {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IJsDebugDataTarget_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ReadMemory: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, address: u64, flags: JsDebugReadMemoryFlags, pbuffer: *mut u8, size: u32, pbytesread: *mut u32) -> ::windows::core::HRESULT,
     pub WriteMemory: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, address: u64, pmemory: *const u8, size: u32) -> ::windows::core::HRESULT,
     pub AllocateVirtualMemory: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, address: u64, size: u32, allocationtype: u32, pageprotection: u32, pallocatedaddress: *mut u64) -> ::windows::core::HRESULT,
@@ -34677,7 +34677,7 @@ unsafe impl ::windows::core::Interface for IJsDebugFrame {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IJsDebugFrame_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetStackRange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pstart: *mut u64, pend: *mut u64) -> ::windows::core::HRESULT,
     pub GetName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pname: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub GetDocumentPositionWithId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdocumentid: *mut u64, pcharacteroffset: *mut u32, pstatementcharcount: *mut u32) -> ::windows::core::HRESULT,
@@ -34749,7 +34749,7 @@ unsafe impl ::windows::core::Interface for IJsDebugProcess {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IJsDebugProcess_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateStackWalker: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, threadid: u32, ppstackwalker: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub CreateBreakPoint: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, documentid: u64, characteroffset: u32, charactercount: u32, isenabled: super::super::super::Foundation::BOOL, ppdebugbreakpoint: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -34809,7 +34809,7 @@ unsafe impl ::windows::core::Interface for IJsDebugProperty {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IJsDebugProperty_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetPropertyInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, nradix: u32, ppropertyinfo: *mut JsDebugPropertyInfo) -> ::windows::core::HRESULT,
     pub GetMembers: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, members: JS_PROPERTY_MEMBERS, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -34860,7 +34860,7 @@ unsafe impl ::windows::core::Interface for IJsDebugStackWalker {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IJsDebugStackWalker_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetNext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppframe: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
@@ -34913,7 +34913,7 @@ unsafe impl ::windows::core::Interface for IJsEnumDebugProperty {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IJsEnumDebugProperty_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, count: u32, ppdebugproperty: *mut *mut ::core::ffi::c_void, pactualcount: *mut u32) -> ::windows::core::HRESULT,
     pub GetCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcount: *mut u32) -> ::windows::core::HRESULT,
 }
@@ -34966,7 +34966,7 @@ unsafe impl ::windows::core::Interface for IKeyEnumerator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IKeyEnumerator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetNext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, key: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>, value: *mut *mut ::core::ffi::c_void, metadata: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -35043,7 +35043,7 @@ unsafe impl ::windows::core::Interface for IKeyStore {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IKeyStore_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetKey: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, key: ::windows::core::PCWSTR, object: *mut *mut ::core::ffi::c_void, metadata: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetKey: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, key: ::windows::core::PCWSTR, object: *mut ::core::ffi::c_void, metadata: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetKeyValue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, key: ::windows::core::PCWSTR, object: *mut *mut ::core::ffi::c_void, metadata: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -35107,7 +35107,7 @@ unsafe impl ::windows::core::Interface for IMachineDebugManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMachineDebugManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddApplication: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pda: *mut ::core::ffi::c_void, pdwappcookie: *mut u32) -> ::windows::core::HRESULT,
     pub RemoveApplication: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwappcookie: u32) -> ::windows::core::HRESULT,
     pub EnumApplications: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppeda: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -35169,7 +35169,7 @@ unsafe impl ::windows::core::Interface for IMachineDebugManagerCookie {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMachineDebugManagerCookie_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddApplication: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pda: *mut ::core::ffi::c_void, dwdebugappcookie: u32, pdwappcookie: *mut u32) -> ::windows::core::HRESULT,
     pub RemoveApplication: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwdebugappcookie: u32, dwappcookie: u32) -> ::windows::core::HRESULT,
     pub EnumApplications: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppeda: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -35229,7 +35229,7 @@ unsafe impl ::windows::core::Interface for IMachineDebugManagerEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMachineDebugManagerEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub onAddApplication: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pda: *mut ::core::ffi::c_void, dwappcookie: u32) -> ::windows::core::HRESULT,
     pub onRemoveApplication: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pda: *mut ::core::ffi::c_void, dwappcookie: u32) -> ::windows::core::HRESULT,
 }
@@ -35282,7 +35282,7 @@ unsafe impl ::windows::core::Interface for IModelIterator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IModelIterator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetNext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, object: *mut *mut ::core::ffi::c_void, dimensions: u64, indexers: *mut *mut ::core::ffi::c_void, metadata: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -35360,7 +35360,7 @@ unsafe impl ::windows::core::Interface for IModelKeyReference {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IModelKeyReference_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetKeyName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, keyname: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub GetOriginalObject: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, originalobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetContextObject: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, containingobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -35516,7 +35516,7 @@ unsafe impl ::windows::core::Interface for IModelMethod {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IModelMethod_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Call: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcontextobject: *mut ::core::ffi::c_void, argcount: u64, pparguments: *const *mut ::core::ffi::c_void, ppresult: *mut *mut ::core::ffi::c_void, ppmetadata: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
@@ -35732,7 +35732,7 @@ unsafe impl ::windows::core::Interface for IModelObject {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IModelObject_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetContext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, context: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetKind: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, kind: *mut ModelObjectKind) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -35832,7 +35832,7 @@ unsafe impl ::windows::core::Interface for IModelPropertyAccessor {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IModelPropertyAccessor_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetValue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, key: ::windows::core::PCWSTR, contextobject: *mut ::core::ffi::c_void, value: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetValue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, key: ::windows::core::PCWSTR, contextobject: *mut ::core::ffi::c_void, value: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -35885,7 +35885,7 @@ unsafe impl ::windows::core::Interface for IObjectSafety {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IObjectSafety_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetInterfaceSafetyOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, pdwsupportedoptions: *mut u32, pdwenabledoptions: *mut u32) -> ::windows::core::HRESULT,
     pub SetInterfaceSafetyOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, dwoptionsetmask: u32, dwenabledoptions: u32) -> ::windows::core::HRESULT,
 }
@@ -35948,7 +35948,7 @@ unsafe impl ::windows::core::Interface for IPerPropertyBrowsing2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPerPropertyBrowsing2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDisplayString: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dispid: i32, pbstr: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub MapPropertyToPage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dispid: i32, pclsidproppage: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Ole")]
@@ -36007,7 +36007,7 @@ unsafe impl ::windows::core::Interface for IPreferredRuntimeTypeConcept {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPreferredRuntimeTypeConcept_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CastToPreferredRuntimeType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, contextobject: *mut ::core::ffi::c_void, object: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
@@ -36078,7 +36078,7 @@ unsafe impl ::windows::core::Interface for IProcessDebugManager32 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IProcessDebugManager32_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateApplication: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppda: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetDefaultApplication: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppda: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub AddApplication: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pda: *mut ::core::ffi::c_void, pdwappcookie: *mut u32) -> ::windows::core::HRESULT,
@@ -36153,7 +36153,7 @@ unsafe impl ::windows::core::Interface for IProcessDebugManager64 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IProcessDebugManager64_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateApplication: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppda: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetDefaultApplication: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppda: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub AddApplication: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pda: *mut ::core::ffi::c_void, pdwappcookie: *mut u32) -> ::windows::core::HRESULT,
@@ -36207,7 +36207,7 @@ unsafe impl ::windows::core::Interface for IProvideExpressionContexts {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IProvideExpressionContexts_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub EnumExpressionContexts: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppedec: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
@@ -36259,7 +36259,7 @@ unsafe impl ::windows::core::Interface for IRawEnumerator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRawEnumerator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetNext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, name: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>, kind: *mut SymbolKind, value: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -36354,7 +36354,7 @@ unsafe impl ::windows::core::Interface for IRemoteDebugApplication {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRemoteDebugApplication_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ResumeFromBreakPoint: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, prptfocus: *mut ::core::ffi::c_void, bra: BREAKRESUMEACTION, era: ERRORRESUMEACTION) -> ::windows::core::HRESULT,
     pub CauseBreak: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub ConnectDebugger: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pad: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -36421,7 +36421,7 @@ unsafe impl ::windows::core::Interface for IRemoteDebugApplication110 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRemoteDebugApplication110_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetDebuggerOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, mask: SCRIPT_DEBUGGER_OPTIONS, value: SCRIPT_DEBUGGER_OPTIONS) -> ::windows::core::HRESULT,
     pub GetCurrentDebuggerOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcurrentoptions: *mut SCRIPT_DEBUGGER_OPTIONS) -> ::windows::core::HRESULT,
     pub GetMainThread: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppthread: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -36523,7 +36523,7 @@ unsafe impl ::windows::core::Interface for IRemoteDebugApplicationEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRemoteDebugApplicationEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnConnectDebugger: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pad: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub OnDisconnectDebugger: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub OnSetName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pstrname: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
@@ -36616,7 +36616,7 @@ unsafe impl ::windows::core::Interface for IRemoteDebugApplicationThread {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRemoteDebugApplicationThread_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetSystemThreadId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwthreadid: *mut u32) -> ::windows::core::HRESULT,
     pub GetApplication: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pprda: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub EnumStackFrames: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppedsf: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -36673,7 +36673,7 @@ unsafe impl ::windows::core::Interface for IRemoteDebugCriticalErrorEvent110 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRemoteDebugCriticalErrorEvent110_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetErrorInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstrsource: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>, pmessageid: *mut i32, pbstrmessage: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>, pplocation: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
@@ -36722,7 +36722,7 @@ unsafe impl ::windows::core::Interface for IRemoteDebugInfoEvent110 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRemoteDebugInfoEvent110_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetEventInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pmessagetype: *mut DEBUG_EVENT_INFO_TYPE, pbstrmessage: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>, pbstrurl: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>, pplocation: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
@@ -36962,7 +36962,7 @@ unsafe impl ::windows::core::Interface for IScriptInvocationContext {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IScriptInvocationContext_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetContextType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinvocationcontexttype: *mut SCRIPT_INVOCATION_CONTEXT_TYPE) -> ::windows::core::HRESULT,
     pub GetContextDescription: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdescription: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub GetContextObject: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppcontextobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -37059,7 +37059,7 @@ unsafe impl ::windows::core::Interface for IScriptNode {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IScriptNode_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Alive: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Delete: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetParent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppsnparent: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -37352,7 +37352,7 @@ unsafe impl ::windows::core::Interface for ISimpleConnectionPoint {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISimpleConnectionPoint_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetEventCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pulcount: *mut u32) -> ::windows::core::HRESULT,
     pub DescribeEvents: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ievent: u32, cevents: u32, prgid: *mut i32, prgbstr: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>, pceventsfetched: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
@@ -37412,7 +37412,7 @@ unsafe impl ::windows::core::Interface for IStringDisplayableConcept {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IStringDisplayableConcept_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ToDisplayString: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, contextobject: *mut ::core::ffi::c_void, metadata: *mut ::core::ffi::c_void, displaystring: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
@@ -37466,7 +37466,7 @@ unsafe impl ::windows::core::Interface for ITridentEventSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITridentEventSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub FireEvent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pstrevent: ::windows::core::PCWSTR, pdp: *const super::super::Com::DISPPARAMS, pvarres: *mut super::super::Com::VARIANT, pei: *mut super::super::Com::EXCEPINFO) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole")))]
@@ -37524,7 +37524,7 @@ unsafe impl ::windows::core::Interface for IWebAppDiagnosticsObjectInitializatio
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWebAppDiagnosticsObjectInitialization_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hpassedhandle: super::super::super::Foundation::HANDLE_PTR, pdebugapplication: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -37580,7 +37580,7 @@ unsafe impl ::windows::core::Interface for IWebAppDiagnosticsSetup {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWebAppDiagnosticsSetup_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub DiagnosticsSupported: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pretval: *mut i16) -> ::windows::core::HRESULT,
     pub CreateObjectWithSiteAtWebApp: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, rclsid: *const ::windows::core::GUID, dwclscontext: u32, riid: *const ::windows::core::GUID, hpasstoobject: usize) -> ::windows::core::HRESULT,
 }

--- a/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Etw/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Etw/impl.rs
@@ -94,7 +94,7 @@ impl ITraceEvent_Vtbl {
             this.SetProviderId(::core::mem::transmute_copy(&providerid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Clone: Clone::<Identity, Impl, OFFSET>,
             GetUserContext: GetUserContext::<Identity, Impl, OFFSET>,
             GetEventRecord: GetEventRecord::<Identity, Impl, OFFSET>,
@@ -137,7 +137,7 @@ impl ITraceEventCallback_Vtbl {
             this.OnEvent(::core::mem::transmute(&event), ::core::mem::transmute(&relogger)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnBeginProcessTrace: OnBeginProcessTrace::<Identity, Impl, OFFSET>,
             OnFinalizeProcessTrace: OnFinalizeProcessTrace::<Identity, Impl, OFFSET>,
             OnEvent: OnEvent::<Identity, Impl, OFFSET>,
@@ -228,7 +228,7 @@ impl ITraceRelogger_Vtbl {
             this.Cancel().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddLogfileTraceStream: AddLogfileTraceStream::<Identity, Impl, OFFSET>,
             AddRealtimeTraceStream: AddRealtimeTraceStream::<Identity, Impl, OFFSET>,
             RegisterCallback: RegisterCallback::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Etw/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Etw/mod.rs
@@ -961,7 +961,7 @@ unsafe impl ::windows::core::Interface for ITraceEvent {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITraceEvent_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Clone: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, newevent: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetUserContext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, usercontext: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetEventRecord: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, eventrecord: *mut *mut EVENT_RECORD) -> ::windows::core::HRESULT,
@@ -1038,7 +1038,7 @@ unsafe impl ::windows::core::Interface for ITraceEventCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITraceEventCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnBeginProcessTrace: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, headerevent: *mut ::core::ffi::c_void, relogger: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub OnFinalizeProcessTrace: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, relogger: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub OnEvent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, event: *mut ::core::ffi::c_void, relogger: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1130,7 +1130,7 @@ unsafe impl ::windows::core::Interface for ITraceRelogger {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITraceRelogger_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddLogfileTraceStream: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, logfilename: ::core::mem::ManuallyDrop<::windows::core::BSTR>, usercontext: *const ::core::ffi::c_void, tracehandle: *mut RELOGSTREAM_HANDLE) -> ::windows::core::HRESULT,
     pub AddRealtimeTraceStream: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, loggername: ::core::mem::ManuallyDrop<::windows::core::BSTR>, usercontext: *const ::core::ffi::c_void, tracehandle: *mut RELOGSTREAM_HANDLE) -> ::windows::core::HRESULT,
     pub RegisterCallback: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, callback: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/System/DistributedTransactionCoordinator/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/DistributedTransactionCoordinator/impl.rs
@@ -15,7 +15,7 @@ impl IDtcLuConfigure_Vtbl {
             let this = (*this).get_impl();
             this.Delete(::core::mem::transmute_copy(&puclupair), ::core::mem::transmute_copy(&cblupair)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Add: Add::<Identity, Impl, OFFSET>, Delete: Delete::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Add: Add::<Identity, Impl, OFFSET>, Delete: Delete::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDtcLuConfigure as ::windows::core::Interface>::IID
@@ -25,7 +25,7 @@ pub trait IDtcLuRecovery_Impl: Sized {}
 impl ::windows::core::RuntimeName for IDtcLuRecovery {}
 impl IDtcLuRecovery_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IDtcLuRecovery_Impl, const OFFSET: isize>() -> IDtcLuRecovery_Vtbl {
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>() }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>() }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDtcLuRecovery as ::windows::core::Interface>::IID
@@ -48,7 +48,7 @@ impl IDtcLuRecoveryFactory_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Create: Create::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Create: Create::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDtcLuRecoveryFactory as ::windows::core::Interface>::IID
@@ -65,7 +65,7 @@ impl IDtcLuRecoveryInitiatedByDtc_Vtbl {
             let this = (*this).get_impl();
             this.GetWork(::core::mem::transmute_copy(&pwork), ::core::mem::transmute_copy(&ppv)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetWork: GetWork::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetWork: GetWork::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDtcLuRecoveryInitiatedByDtc as ::windows::core::Interface>::IID
@@ -82,7 +82,7 @@ impl IDtcLuRecoveryInitiatedByDtcStatusWork_Vtbl {
             let this = (*this).get_impl();
             this.HandleCheckLuStatus(::core::mem::transmute_copy(&lrecoveryseqnum)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), HandleCheckLuStatus: HandleCheckLuStatus::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), HandleCheckLuStatus: HandleCheckLuStatus::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDtcLuRecoveryInitiatedByDtcStatusWork as ::windows::core::Interface>::IID
@@ -175,7 +175,7 @@ impl IDtcLuRecoveryInitiatedByDtcTransWork_Vtbl {
             this.ObsoleteRecoverySeqNum(::core::mem::transmute_copy(&lnewrecoveryseqnum)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetLogNameSizes: GetLogNameSizes::<Identity, Impl, OFFSET>,
             GetOurXln: GetOurXln::<Identity, Impl, OFFSET>,
             HandleConfirmationFromOurXln: HandleConfirmationFromOurXln::<Identity, Impl, OFFSET>,
@@ -213,7 +213,7 @@ impl IDtcLuRecoveryInitiatedByLu_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetObjectToHandleWorkFromLu: GetObjectToHandleWorkFromLu::<Identity, Impl, OFFSET>,
         }
     }
@@ -275,7 +275,7 @@ impl IDtcLuRecoveryInitiatedByLuWork_Vtbl {
             this.ConversationLost().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             HandleTheirXln: HandleTheirXln::<Identity, Impl, OFFSET>,
             GetOurLogNameSize: GetOurLogNameSize::<Identity, Impl, OFFSET>,
             GetOurXln: GetOurXln::<Identity, Impl, OFFSET>,
@@ -335,7 +335,7 @@ impl IDtcLuRmEnlistment_Vtbl {
             this.RequestCommit().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Unplug: Unplug::<Identity, Impl, OFFSET>,
             BackedOut: BackedOut::<Identity, Impl, OFFSET>,
             BackOut: BackOut::<Identity, Impl, OFFSET>,
@@ -359,7 +359,7 @@ impl IDtcLuRmEnlistmentFactory_Vtbl {
             let this = (*this).get_impl();
             this.Create(::core::mem::transmute_copy(&puclupair), ::core::mem::transmute_copy(&cblupair), ::core::mem::transmute(&pitransaction), ::core::mem::transmute_copy(&ptransid), ::core::mem::transmute_copy(&cbtransid), ::core::mem::transmute(&prmenlistmentsink), ::core::mem::transmute_copy(&pprmenlistment)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Create: Create::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Create: Create::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDtcLuRmEnlistmentFactory as ::windows::core::Interface>::IID
@@ -425,7 +425,7 @@ impl IDtcLuRmEnlistmentSink_Vtbl {
             this.RequestCommit().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AckUnplug: AckUnplug::<Identity, Impl, OFFSET>,
             TmDown: TmDown::<Identity, Impl, OFFSET>,
             SessionLost: SessionLost::<Identity, Impl, OFFSET>,
@@ -492,7 +492,7 @@ impl IDtcLuSubordinateDtc_Vtbl {
             this.RequestCommit().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Unplug: Unplug::<Identity, Impl, OFFSET>,
             BackedOut: BackedOut::<Identity, Impl, OFFSET>,
             BackOut: BackOut::<Identity, Impl, OFFSET>,
@@ -518,7 +518,7 @@ impl IDtcLuSubordinateDtcFactory_Vtbl {
             this.Create(::core::mem::transmute_copy(&puclupair), ::core::mem::transmute_copy(&cblupair), ::core::mem::transmute(&punktransactionouter), ::core::mem::transmute_copy(&isolevel), ::core::mem::transmute_copy(&isoflags), ::core::mem::transmute(&poptions), ::core::mem::transmute_copy(&pptransaction), ::core::mem::transmute_copy(&ptransid), ::core::mem::transmute_copy(&cbtransid), ::core::mem::transmute(&psubordinatedtcsink), ::core::mem::transmute_copy(&ppsubordinatedtc))
                 .into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Create: Create::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Create: Create::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDtcLuSubordinateDtcFactory as ::windows::core::Interface>::IID
@@ -578,7 +578,7 @@ impl IDtcLuSubordinateDtcSink_Vtbl {
             this.RequestCommit().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AckUnplug: AckUnplug::<Identity, Impl, OFFSET>,
             TmDown: TmDown::<Identity, Impl, OFFSET>,
             SessionLost: SessionLost::<Identity, Impl, OFFSET>,
@@ -716,7 +716,7 @@ impl IDtcNetworkAccessConfig_Vtbl {
             this.RestartDtcService().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetAnyNetworkAccess: GetAnyNetworkAccess::<Identity, Impl, OFFSET>,
             SetAnyNetworkAccess: SetAnyNetworkAccess::<Identity, Impl, OFFSET>,
             GetNetworkAdministrationAccess: GetNetworkAdministrationAccess::<Identity, Impl, OFFSET>,
@@ -875,7 +875,7 @@ impl IDtcToXaHelper_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Close: Close::<Identity, Impl, OFFSET>,
             TranslateTridToXid: TranslateTridToXid::<Identity, Impl, OFFSET>,
         }
@@ -895,7 +895,7 @@ impl IDtcToXaHelperFactory_Vtbl {
             let this = (*this).get_impl();
             this.Create(::core::mem::transmute(&pszdsn), ::core::mem::transmute(&pszclientdllname), ::core::mem::transmute_copy(&pguidrm), ::core::mem::transmute_copy(&ppxahelper)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Create: Create::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Create: Create::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDtcToXaHelperFactory as ::windows::core::Interface>::IID
@@ -940,7 +940,7 @@ impl IDtcToXaHelperSinglePipe_Vtbl {
             this.ReleaseRMCookie(::core::mem::transmute_copy(&i_dwrmcookie), ::core::mem::transmute_copy(&i_fnormal))
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             XARMCreate: XARMCreate::<Identity, Impl, OFFSET>,
             ConvertTridToXID: ConvertTridToXID::<Identity, Impl, OFFSET>,
             EnlistWithRM: EnlistWithRM::<Identity, Impl, OFFSET>,
@@ -984,7 +984,7 @@ impl IDtcToXaMapper_Vtbl {
             this.ReleaseResourceManager(::core::mem::transmute_copy(&dwrmcookie)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RequestNewResourceManager: RequestNewResourceManager::<Identity, Impl, OFFSET>,
             TranslateTridToXid: TranslateTridToXid::<Identity, Impl, OFFSET>,
             EnlistResourceManager: EnlistResourceManager::<Identity, Impl, OFFSET>,
@@ -1006,7 +1006,7 @@ impl IGetDispenser_Vtbl {
             let this = (*this).get_impl();
             this.GetDispenser(::core::mem::transmute_copy(&iid), ::core::mem::transmute_copy(&ppvobject)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetDispenser: GetDispenser::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetDispenser: GetDispenser::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IGetDispenser as ::windows::core::Interface>::IID
@@ -1032,7 +1032,7 @@ impl IKernelTransaction_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetHandle: GetHandle::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetHandle: GetHandle::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IKernelTransaction as ::windows::core::Interface>::IID
@@ -1056,7 +1056,7 @@ impl ILastResourceManager_Vtbl {
             this.RecoveryDone().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             TransactionCommitted: TransactionCommitted::<Identity, Impl, OFFSET>,
             RecoveryDone: RecoveryDone::<Identity, Impl, OFFSET>,
         }
@@ -1083,7 +1083,7 @@ impl IPrepareInfo_Vtbl {
             this.GetPrepareInfo(::core::mem::transmute_copy(&pprepinfo)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetPrepareInfoSize: GetPrepareInfoSize::<Identity, Impl, OFFSET>,
             GetPrepareInfo: GetPrepareInfo::<Identity, Impl, OFFSET>,
         }
@@ -1116,7 +1116,7 @@ impl IPrepareInfo2_Vtbl {
             this.GetPrepareInfo(::core::mem::transmute_copy(&cbprepareinfo), ::core::mem::transmute_copy(&pprepinfo)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetPrepareInfoSize: GetPrepareInfoSize::<Identity, Impl, OFFSET>,
             GetPrepareInfo: GetPrepareInfo::<Identity, Impl, OFFSET>,
         }
@@ -1146,7 +1146,7 @@ impl IRMHelper_Vtbl {
             this.RMInfo(::core::mem::transmute_copy(&pxa_switch), ::core::mem::transmute_copy(&fcdeclcallingconv), ::core::mem::transmute(&pszopenstring), ::core::mem::transmute(&pszclosestring), ::core::mem::transmute(&guidrmrecovery)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RMCount: RMCount::<Identity, Impl, OFFSET>,
             RMInfo: RMInfo::<Identity, Impl, OFFSET>,
         }
@@ -1191,7 +1191,7 @@ impl IResourceManager_Vtbl {
             this.GetDistributedTransactionManager(::core::mem::transmute_copy(&iid), ::core::mem::transmute_copy(&ppvobject)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Enlist: Enlist::<Identity, Impl, OFFSET>,
             Reenlist: Reenlist::<Identity, Impl, OFFSET>,
             ReenlistmentComplete: ReenlistmentComplete::<Identity, Impl, OFFSET>,
@@ -1255,7 +1255,7 @@ impl IResourceManagerFactory_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Create: Create::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Create: Create::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IResourceManagerFactory as ::windows::core::Interface>::IID
@@ -1315,7 +1315,7 @@ impl IResourceManagerSink_Vtbl {
             let this = (*this).get_impl();
             this.TMDown().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), TMDown: TMDown::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), TMDown: TMDown::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IResourceManagerSink as ::windows::core::Interface>::IID
@@ -1363,7 +1363,7 @@ impl ITipHelper_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Pull: Pull::<Identity, Impl, OFFSET>,
             PullAsync: PullAsync::<Identity, Impl, OFFSET>,
             GetLocalTmUrl: GetLocalTmUrl::<Identity, Impl, OFFSET>,
@@ -1384,7 +1384,7 @@ impl ITipPullSink_Vtbl {
             let this = (*this).get_impl();
             this.PullComplete(::core::mem::transmute_copy(&i_hrpull)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), PullComplete: PullComplete::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), PullComplete: PullComplete::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ITipPullSink as ::windows::core::Interface>::IID
@@ -1420,7 +1420,7 @@ impl ITipTransaction_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Push: Push::<Identity, Impl, OFFSET>,
             GetTransactionUrl: GetTransactionUrl::<Identity, Impl, OFFSET>,
         }
@@ -1453,7 +1453,7 @@ impl ITmNodeName_Vtbl {
             this.GetNodeName(::core::mem::transmute_copy(&cbnodenamebuffersize), ::core::mem::transmute(&pnodenamebuffer)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetNodeNameSize: GetNodeNameSize::<Identity, Impl, OFFSET>,
             GetNodeName: GetNodeName::<Identity, Impl, OFFSET>,
         }
@@ -1495,7 +1495,7 @@ impl ITransaction_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Commit: Commit::<Identity, Impl, OFFSET>,
             Abort: Abort::<Identity, Impl, OFFSET>,
             GetTransactionInfo: GetTransactionInfo::<Identity, Impl, OFFSET>,
@@ -1587,7 +1587,7 @@ impl ITransactionDispenser_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetOptionsObject: GetOptionsObject::<Identity, Impl, OFFSET>,
             BeginTransaction: BeginTransaction::<Identity, Impl, OFFSET>,
         }
@@ -1623,7 +1623,7 @@ impl ITransactionEnlistmentAsync_Vtbl {
             this.AbortRequestDone(::core::mem::transmute_copy(&hr)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             PrepareRequestDone: PrepareRequestDone::<Identity, Impl, OFFSET>,
             CommitRequestDone: CommitRequestDone::<Identity, Impl, OFFSET>,
             AbortRequestDone: AbortRequestDone::<Identity, Impl, OFFSET>,
@@ -1657,7 +1657,7 @@ impl ITransactionExport_Vtbl {
             this.GetTransactionCookie(::core::mem::transmute(&punktransaction), ::core::mem::transmute_copy(&cbtransactioncookie), ::core::mem::transmute_copy(&rgbtransactioncookie), ::core::mem::transmute_copy(&pcbused)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Export: Export::<Identity, Impl, OFFSET>,
             GetTransactionCookie: GetTransactionCookie::<Identity, Impl, OFFSET>,
         }
@@ -1696,7 +1696,7 @@ impl ITransactionExportFactory_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetRemoteClassId: GetRemoteClassId::<Identity, Impl, OFFSET>,
             Create: Create::<Identity, Impl, OFFSET>,
         }
@@ -1716,7 +1716,7 @@ impl ITransactionImport_Vtbl {
             let this = (*this).get_impl();
             this.Import(::core::mem::transmute_copy(&cbtransactioncookie), ::core::mem::transmute_copy(&rgbtransactioncookie), ::core::mem::transmute_copy(&piid), ::core::mem::transmute_copy(&ppvtransaction)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Import: Import::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Import: Import::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ITransactionImport as ::windows::core::Interface>::IID
@@ -1746,7 +1746,7 @@ impl ITransactionImportWhereabouts_Vtbl {
             this.GetWhereabouts(::core::mem::transmute_copy(&cbwhereabouts), ::core::mem::transmute_copy(&rgbwhereabouts), ::core::mem::transmute_copy(&pcbused)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetWhereaboutsSize: GetWhereaboutsSize::<Identity, Impl, OFFSET>,
             GetWhereabouts: GetWhereabouts::<Identity, Impl, OFFSET>,
         }
@@ -1766,7 +1766,7 @@ impl ITransactionLastEnlistmentAsync_Vtbl {
             let this = (*this).get_impl();
             this.TransactionOutcome(::core::mem::transmute_copy(&xactstat), ::core::mem::transmute_copy(&pboidreason)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), TransactionOutcome: TransactionOutcome::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), TransactionOutcome: TransactionOutcome::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ITransactionLastEnlistmentAsync as ::windows::core::Interface>::IID
@@ -1790,7 +1790,7 @@ impl ITransactionLastResourceAsync_Vtbl {
             this.ForgetRequest(::core::mem::transmute_copy(&pnewuow)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             DelegateCommit: DelegateCommit::<Identity, Impl, OFFSET>,
             ForgetRequest: ForgetRequest::<Identity, Impl, OFFSET>,
         }
@@ -1817,7 +1817,7 @@ impl ITransactionOptions_Vtbl {
             this.GetOptions(::core::mem::transmute_copy(&poptions)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetOptions: SetOptions::<Identity, Impl, OFFSET>,
             GetOptions: GetOptions::<Identity, Impl, OFFSET>,
         }
@@ -1859,7 +1859,7 @@ impl ITransactionOutcomeEvents_Vtbl {
             this.Indoubt().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Committed: Committed::<Identity, Impl, OFFSET>,
             Aborted: Aborted::<Identity, Impl, OFFSET>,
             HeuristicDecision: HeuristicDecision::<Identity, Impl, OFFSET>,
@@ -1912,7 +1912,7 @@ impl ITransactionPhase0EnlistmentAsync_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Enable: Enable::<Identity, Impl, OFFSET>,
             WaitForEnlistment: WaitForEnlistment::<Identity, Impl, OFFSET>,
             Phase0Done: Phase0Done::<Identity, Impl, OFFSET>,
@@ -1941,7 +1941,7 @@ impl ITransactionPhase0Factory_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Create: Create::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Create: Create::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ITransactionPhase0Factory as ::windows::core::Interface>::IID
@@ -1968,7 +1968,7 @@ impl ITransactionPhase0NotifyAsync_Vtbl {
             this.EnlistCompleted(::core::mem::transmute_copy(&status)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Phase0Request: Phase0Request::<Identity, Impl, OFFSET>,
             EnlistCompleted: EnlistCompleted::<Identity, Impl, OFFSET>,
         }
@@ -2019,7 +2019,7 @@ impl ITransactionReceiver_Vtbl {
             this.Reset().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             UnmarshalPropagationToken: UnmarshalPropagationToken::<Identity, Impl, OFFSET>,
             GetReturnTokenSize: GetReturnTokenSize::<Identity, Impl, OFFSET>,
             MarshalReturnToken: MarshalReturnToken::<Identity, Impl, OFFSET>,
@@ -2047,7 +2047,7 @@ impl ITransactionReceiverFactory_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Create: Create::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Create: Create::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ITransactionReceiverFactory as ::windows::core::Interface>::IID
@@ -2086,7 +2086,7 @@ impl ITransactionResource_Vtbl {
             this.TMDown().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             PrepareRequest: PrepareRequest::<Identity, Impl, OFFSET>,
             CommitRequest: CommitRequest::<Identity, Impl, OFFSET>,
             AbortRequest: AbortRequest::<Identity, Impl, OFFSET>,
@@ -2130,7 +2130,7 @@ impl ITransactionResourceAsync_Vtbl {
             this.TMDown().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             PrepareRequest: PrepareRequest::<Identity, Impl, OFFSET>,
             CommitRequest: CommitRequest::<Identity, Impl, OFFSET>,
             AbortRequest: AbortRequest::<Identity, Impl, OFFSET>,
@@ -2183,7 +2183,7 @@ impl ITransactionTransmitter_Vtbl {
             this.Reset().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Set: Set::<Identity, Impl, OFFSET>,
             GetPropagationTokenSize: GetPropagationTokenSize::<Identity, Impl, OFFSET>,
             MarshalPropagationToken: MarshalPropagationToken::<Identity, Impl, OFFSET>,
@@ -2212,7 +2212,7 @@ impl ITransactionTransmitterFactory_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Create: Create::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Create: Create::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ITransactionTransmitterFactory as ::windows::core::Interface>::IID
@@ -2229,7 +2229,7 @@ impl ITransactionVoterBallotAsync2_Vtbl {
             let this = (*this).get_impl();
             this.VoteRequestDone(::core::mem::transmute_copy(&hr), ::core::mem::transmute_copy(&pboidreason)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), VoteRequestDone: VoteRequestDone::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), VoteRequestDone: VoteRequestDone::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ITransactionVoterBallotAsync2 as ::windows::core::Interface>::IID
@@ -2252,7 +2252,7 @@ impl ITransactionVoterFactory2_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Create: Create::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Create: Create::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ITransactionVoterFactory2 as ::windows::core::Interface>::IID
@@ -2296,7 +2296,7 @@ impl IXAConfig_Vtbl {
             this.Terminate().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             Terminate: Terminate::<Identity, Impl, OFFSET>,
         }
@@ -2316,7 +2316,7 @@ impl IXAObtainRMInfo_Vtbl {
             let this = (*this).get_impl();
             this.ObtainRMInfo(::core::mem::transmute(&pirmhelper)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), ObtainRMInfo: ObtainRMInfo::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), ObtainRMInfo: ObtainRMInfo::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IXAObtainRMInfo as ::windows::core::Interface>::IID
@@ -2339,7 +2339,7 @@ impl IXATransLookup_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Lookup: Lookup::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Lookup: Lookup::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IXATransLookup as ::windows::core::Interface>::IID
@@ -2365,7 +2365,7 @@ impl IXATransLookup2_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Lookup: Lookup::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Lookup: Lookup::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IXATransLookup2 as ::windows::core::Interface>::IID

--- a/crates/libs/windows/src/Windows/Win32/System/DistributedTransactionCoordinator/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/DistributedTransactionCoordinator/mod.rs
@@ -99,7 +99,7 @@ unsafe impl ::windows::core::Interface for IDtcLuConfigure {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDtcLuConfigure_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Add: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, puclupair: *const u8, cblupair: u32) -> ::windows::core::HRESULT,
     pub Delete: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, puclupair: *const u8, cblupair: u32) -> ::windows::core::HRESULT,
 }
@@ -145,7 +145,7 @@ unsafe impl ::windows::core::Interface for IDtcLuRecovery {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDtcLuRecovery_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
 }
 #[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`*"]
 #[repr(transparent)]
@@ -194,7 +194,7 @@ unsafe impl ::windows::core::Interface for IDtcLuRecoveryFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDtcLuRecoveryFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Create: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, puclupair: *const u8, cblupair: u32, pprecovery: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`*"]
@@ -243,7 +243,7 @@ unsafe impl ::windows::core::Interface for IDtcLuRecoveryInitiatedByDtc {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDtcLuRecoveryInitiatedByDtc_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetWork: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwork: *mut DTCINITIATEDRECOVERYWORK, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`*"]
@@ -292,7 +292,7 @@ unsafe impl ::windows::core::Interface for IDtcLuRecoveryInitiatedByDtcStatusWor
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDtcLuRecoveryInitiatedByDtcStatusWork_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub HandleCheckLuStatus: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lrecoveryseqnum: i32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`*"]
@@ -379,7 +379,7 @@ unsafe impl ::windows::core::Interface for IDtcLuRecoveryInitiatedByDtcTransWork
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDtcLuRecoveryInitiatedByDtcTransWork_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetLogNameSizes: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcbourlogname: *mut u32, pcbremotelogname: *mut u32) -> ::windows::core::HRESULT,
     pub GetOurXln: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pxln: *mut DTCLUXLN, pourlogname: *mut u8, premotelogname: *mut u8, pdwprotocol: *mut u32) -> ::windows::core::HRESULT,
     pub HandleConfirmationFromOurXln: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, confirmation: DTCLUXLNCONFIRMATION) -> ::windows::core::HRESULT,
@@ -444,7 +444,7 @@ unsafe impl ::windows::core::Interface for IDtcLuRecoveryInitiatedByLu {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDtcLuRecoveryInitiatedByLu_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetObjectToHandleWorkFromLu: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppwork: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`*"]
@@ -514,7 +514,7 @@ unsafe impl ::windows::core::Interface for IDtcLuRecoveryInitiatedByLuWork {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDtcLuRecoveryInitiatedByLuWork_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub HandleTheirXln: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lrecoveryseqnum: i32, xln: DTCLUXLN, premotelogname: *mut u8, cbremotelogname: u32, pourlogname: *mut u8, cbourlogname: u32, dwprotocol: u32, presponse: *mut DTCLUXLNRESPONSE) -> ::windows::core::HRESULT,
     pub GetOurLogNameSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcbourlogname: *mut u32) -> ::windows::core::HRESULT,
     pub GetOurXln: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pxln: *mut DTCLUXLN, pourlogname: *mut u8, pdwprotocol: *mut u32) -> ::windows::core::HRESULT,
@@ -590,7 +590,7 @@ unsafe impl ::windows::core::Interface for IDtcLuRmEnlistment {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDtcLuRmEnlistment_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Unplug: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fconversationlost: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -651,7 +651,7 @@ unsafe impl ::windows::core::Interface for IDtcLuRmEnlistmentFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDtcLuRmEnlistmentFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Create: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, puclupair: *mut u8, cblupair: u32, pitransaction: *mut ::core::ffi::c_void, ptransid: *mut u8, cbtransid: u32, prmenlistmentsink: *mut ::core::ffi::c_void, pprmenlistment: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`*"]
@@ -724,7 +724,7 @@ unsafe impl ::windows::core::Interface for IDtcLuRmEnlistmentSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDtcLuRmEnlistmentSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AckUnplug: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub TmDown: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SessionLost: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -804,7 +804,7 @@ unsafe impl ::windows::core::Interface for IDtcLuSubordinateDtc {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDtcLuSubordinateDtc_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Unplug: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fconversationlost: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -867,7 +867,7 @@ unsafe impl ::windows::core::Interface for IDtcLuSubordinateDtcFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDtcLuSubordinateDtcFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Create: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, puclupair: *mut u8, cblupair: u32, punktransactionouter: *mut ::core::ffi::c_void, isolevel: i32, isoflags: u32, poptions: *mut ::core::ffi::c_void, pptransaction: *mut *mut ::core::ffi::c_void, ptransid: *mut u8, cbtransid: u32, psubordinatedtcsink: *mut ::core::ffi::c_void, ppsubordinatedtc: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`*"]
@@ -937,7 +937,7 @@ unsafe impl ::windows::core::Interface for IDtcLuSubordinateDtcSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDtcLuSubordinateDtcSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AckUnplug: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub TmDown: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SessionLost: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1077,7 +1077,7 @@ unsafe impl ::windows::core::Interface for IDtcNetworkAccessConfig {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDtcNetworkAccessConfig_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetAnyNetworkAccess: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbanynetworkaccess: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -1607,7 +1607,7 @@ unsafe impl ::windows::core::Interface for IDtcToXaHelper {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDtcToXaHelper_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Close: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, i_fdorecovery: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -1667,7 +1667,7 @@ unsafe impl ::windows::core::Interface for IDtcToXaHelperFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDtcToXaHelperFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Create: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszdsn: ::windows::core::PCSTR, pszclientdllname: ::windows::core::PCSTR, pguidrm: *mut ::windows::core::GUID, ppxahelper: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`*"]
@@ -1741,7 +1741,7 @@ unsafe impl ::windows::core::Interface for IDtcToXaHelperSinglePipe {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDtcToXaHelperSinglePipe_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub XARMCreate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszdsn: ::windows::core::PCSTR, pszclientdll: ::windows::core::PCSTR, pdwrmcookie: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub ConvertTridToXID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwitrans: *mut u32, dwrmcookie: u32, pxid: *mut XID) -> ::windows::core::HRESULT,
@@ -1814,7 +1814,7 @@ unsafe impl ::windows::core::Interface for IDtcToXaMapper {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDtcToXaMapper_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub RequestNewResourceManager: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszdsn: ::windows::core::PCSTR, pszclientdllname: ::windows::core::PCSTR, pdwrmcookie: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub TranslateTridToXid: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwitransaction: *const u32, dwrmcookie: u32, pxid: *mut XID) -> ::windows::core::HRESULT,
@@ -1869,7 +1869,7 @@ unsafe impl ::windows::core::Interface for IGetDispenser {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IGetDispenser_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDispenser: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, iid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`*"]
@@ -1921,7 +1921,7 @@ unsafe impl ::windows::core::Interface for IKernelTransaction {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IKernelTransaction_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetHandle: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, phandle: *mut super::super::Foundation::HANDLE) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -1976,7 +1976,7 @@ unsafe impl ::windows::core::Interface for ILastResourceManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ILastResourceManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub TransactionCommitted: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pprepinfo: *const u8, cbprepinfo: u32) -> ::windows::core::HRESULT,
     pub RecoveryDone: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -2029,7 +2029,7 @@ unsafe impl ::windows::core::Interface for IPrepareInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPrepareInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetPrepareInfoSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcbprepinfo: *mut u32) -> ::windows::core::HRESULT,
     pub GetPrepareInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pprepinfo: *mut u8) -> ::windows::core::HRESULT,
 }
@@ -2083,7 +2083,7 @@ unsafe impl ::windows::core::Interface for IPrepareInfo2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPrepareInfo2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetPrepareInfoSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcbprepinfo: *mut u32) -> ::windows::core::HRESULT,
     pub GetPrepareInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cbprepareinfo: u32, pprepinfo: *mut u8) -> ::windows::core::HRESULT,
 }
@@ -2143,7 +2143,7 @@ unsafe impl ::windows::core::Interface for IRMHelper {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRMHelper_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub RMCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwctotalnumberofrms: u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub RMInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pxa_switch: *mut xa_switch_t, fcdeclcallingconv: super::super::Foundation::BOOL, pszopenstring: ::windows::core::PCSTR, pszclosestring: ::windows::core::PCSTR, guidrmrecovery: ::windows::core::GUID) -> ::windows::core::HRESULT,
@@ -2210,7 +2210,7 @@ unsafe impl ::windows::core::Interface for IResourceManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IResourceManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Enlist: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptransaction: *mut ::core::ffi::c_void, pres: *mut ::core::ffi::c_void, puow: *mut BOID, pisolevel: *mut i32, ppenlist: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Reenlist: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pprepinfo: *const u8, cbprepinfo: u32, ltimeout: u32, pxactstat: *mut XACTSTAT) -> ::windows::core::HRESULT,
     pub ReenlistmentComplete: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -2367,7 +2367,7 @@ unsafe impl ::windows::core::Interface for IResourceManagerFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IResourceManagerFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Create: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pguidrm: *const ::windows::core::GUID, pszrmname: ::windows::core::PCSTR, piresmgrsink: *mut ::core::ffi::c_void, ppresmgr: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`*"]
@@ -2604,7 +2604,7 @@ unsafe impl ::windows::core::Interface for IResourceManagerSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IResourceManagerSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub TMDown: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`*"]
@@ -2665,7 +2665,7 @@ unsafe impl ::windows::core::Interface for ITipHelper {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITipHelper_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Pull: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, i_psztxurl: *const u8, o_ppitransaction: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub PullAsync: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, i_psztxurl: *const u8, i_ptippullsink: *mut ::core::ffi::c_void, o_ppitransaction: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetLocalTmUrl: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, o_ppszlocaltmurl: *mut *mut u8) -> ::windows::core::HRESULT,
@@ -2716,7 +2716,7 @@ unsafe impl ::windows::core::Interface for ITipPullSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITipPullSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub PullComplete: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, i_hrpull: ::windows::core::HRESULT) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`*"]
@@ -2770,7 +2770,7 @@ unsafe impl ::windows::core::Interface for ITipTransaction {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITipTransaction_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Push: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, i_pszremotetmurl: *const u8, o_ppszremotetxurl: *mut ::windows::core::PSTR) -> ::windows::core::HRESULT,
     pub GetTransactionUrl: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, o_ppszlocaltxurl: *mut ::windows::core::PSTR) -> ::windows::core::HRESULT,
 }
@@ -2824,7 +2824,7 @@ unsafe impl ::windows::core::Interface for ITmNodeName {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITmNodeName_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetNodeNameSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcbnodenamesize: *mut u32) -> ::windows::core::HRESULT,
     pub GetNodeName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cbnodenamebuffersize: u32, pnodenamebuffer: ::windows::core::PWSTR) -> ::windows::core::HRESULT,
 }
@@ -2892,7 +2892,7 @@ unsafe impl ::windows::core::Interface for ITransaction {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITransaction_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Commit: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fretaining: super::super::Foundation::BOOL, grftc: u32, grfrm: u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -3149,7 +3149,7 @@ unsafe impl ::windows::core::Interface for ITransactionDispenser {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITransactionDispenser_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetOptionsObject: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppoptions: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub BeginTransaction: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punkouter: *mut ::core::ffi::c_void, isolevel: i32, isoflags: u32, poptions: *mut ::core::ffi::c_void, pptransaction: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -3210,7 +3210,7 @@ unsafe impl ::windows::core::Interface for ITransactionEnlistmentAsync {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITransactionEnlistmentAsync_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub PrepareRequestDone: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hr: ::windows::core::HRESULT, pmk: *mut ::core::ffi::c_void, pboidreason: *const BOID) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -3274,7 +3274,7 @@ unsafe impl ::windows::core::Interface for ITransactionExport {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITransactionExport_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Export: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punktransaction: *mut ::core::ffi::c_void, pcbtransactioncookie: *mut u32) -> ::windows::core::HRESULT,
     pub GetTransactionCookie: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punktransaction: *mut ::core::ffi::c_void, cbtransactioncookie: u32, rgbtransactioncookie: *mut u8, pcbused: *mut u32) -> ::windows::core::HRESULT,
 }
@@ -3329,7 +3329,7 @@ unsafe impl ::windows::core::Interface for ITransactionExportFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITransactionExportFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetRemoteClassId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pclsid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub Create: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cbwhereabouts: u32, rgbwhereabouts: *const u8, ppexport: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -3383,7 +3383,7 @@ unsafe impl ::windows::core::Interface for ITransactionImport {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITransactionImport_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Import: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cbtransactioncookie: u32, rgbtransactioncookie: *const u8, piid: *const ::windows::core::GUID, ppvtransaction: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`*"]
@@ -3436,7 +3436,7 @@ unsafe impl ::windows::core::Interface for ITransactionImportWhereabouts {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITransactionImportWhereabouts_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetWhereaboutsSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcbwhereabouts: *mut u32) -> ::windows::core::HRESULT,
     pub GetWhereabouts: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cbwhereabouts: u32, rgbwhereabouts: *mut u8, pcbused: *mut u32) -> ::windows::core::HRESULT,
 }
@@ -3486,7 +3486,7 @@ unsafe impl ::windows::core::Interface for ITransactionLastEnlistmentAsync {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITransactionLastEnlistmentAsync_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub TransactionOutcome: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, xactstat: XACTSTAT, pboidreason: *const BOID) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`*"]
@@ -3538,7 +3538,7 @@ unsafe impl ::windows::core::Interface for ITransactionLastResourceAsync {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITransactionLastResourceAsync_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub DelegateCommit: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, grfrm: u32) -> ::windows::core::HRESULT,
     pub ForgetRequest: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pnewuow: *const BOID) -> ::windows::core::HRESULT,
 }
@@ -3591,7 +3591,7 @@ unsafe impl ::windows::core::Interface for ITransactionOptions {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITransactionOptions_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, poptions: *const XACTOPT) -> ::windows::core::HRESULT,
     pub GetOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, poptions: *mut XACTOPT) -> ::windows::core::HRESULT,
 }
@@ -3660,7 +3660,7 @@ unsafe impl ::windows::core::Interface for ITransactionOutcomeEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITransactionOutcomeEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Committed: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fretaining: super::super::Foundation::BOOL, pnewuow: *const BOID, hr: ::windows::core::HRESULT) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -3731,7 +3731,7 @@ unsafe impl ::windows::core::Interface for ITransactionPhase0EnlistmentAsync {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITransactionPhase0EnlistmentAsync_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Enable: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub WaitForEnlistment: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Phase0Done: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -3788,7 +3788,7 @@ unsafe impl ::windows::core::Interface for ITransactionPhase0Factory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITransactionPhase0Factory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Create: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pphase0notify: *mut ::core::ffi::c_void, ppphase0enlistment: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`*"]
@@ -3845,7 +3845,7 @@ unsafe impl ::windows::core::Interface for ITransactionPhase0NotifyAsync {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITransactionPhase0NotifyAsync_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Phase0Request: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fabortinghint: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -3909,7 +3909,7 @@ unsafe impl ::windows::core::Interface for ITransactionReceiver {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITransactionReceiver_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub UnmarshalPropagationToken: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cbtoken: u32, rgbtoken: *const u8, pptransaction: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetReturnTokenSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcbreturntoken: *mut u32) -> ::windows::core::HRESULT,
     pub MarshalReturnToken: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cbreturntoken: u32, rgbreturntoken: *mut u8, pcbused: *mut u32) -> ::windows::core::HRESULT,
@@ -3962,7 +3962,7 @@ unsafe impl ::windows::core::Interface for ITransactionReceiverFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITransactionReceiverFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Create: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppreceiver: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`*"]
@@ -4032,7 +4032,7 @@ unsafe impl ::windows::core::Interface for ITransactionResource {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITransactionResource_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub PrepareRequest: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fretaining: super::super::Foundation::BOOL, grfrm: u32, fwantmoniker: super::super::Foundation::BOOL, fsinglephase: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -4111,7 +4111,7 @@ unsafe impl ::windows::core::Interface for ITransactionResourceAsync {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITransactionResourceAsync_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub PrepareRequest: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fretaining: super::super::Foundation::BOOL, grfrm: u32, fwantmoniker: super::super::Foundation::BOOL, fsinglephase: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -4185,7 +4185,7 @@ unsafe impl ::windows::core::Interface for ITransactionTransmitter {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITransactionTransmitter_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Set: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptransaction: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetPropagationTokenSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcbtoken: *mut u32) -> ::windows::core::HRESULT,
     pub MarshalPropagationToken: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cbtoken: u32, rgbtoken: *mut u8, pcbused: *mut u32) -> ::windows::core::HRESULT,
@@ -4239,7 +4239,7 @@ unsafe impl ::windows::core::Interface for ITransactionTransmitterFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITransactionTransmitterFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Create: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pptransmitter: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`*"]
@@ -4288,7 +4288,7 @@ unsafe impl ::windows::core::Interface for ITransactionVoterBallotAsync2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITransactionVoterBallotAsync2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub VoteRequestDone: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hr: ::windows::core::HRESULT, pboidreason: *const BOID) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`*"]
@@ -4342,7 +4342,7 @@ unsafe impl ::windows::core::Interface for ITransactionVoterFactory2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITransactionVoterFactory2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Create: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptransaction: *mut ::core::ffi::c_void, pvoternotify: *mut ::core::ffi::c_void, ppvoterballot: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`*"]
@@ -4480,7 +4480,7 @@ unsafe impl ::windows::core::Interface for IXAConfig {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXAConfig_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, clsidhelperdll: ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub Terminate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -4533,7 +4533,7 @@ unsafe impl ::windows::core::Interface for IXAObtainRMInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXAObtainRMInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ObtainRMInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pirmhelper: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`*"]
@@ -4583,7 +4583,7 @@ unsafe impl ::windows::core::Interface for IXATransLookup {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXATransLookup_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Lookup: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pptransaction: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`*"]
@@ -4635,7 +4635,7 @@ unsafe impl ::windows::core::Interface for IXATransLookup2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXATransLookup2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Lookup: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pxid: *const XID, pptransaction: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]

--- a/crates/libs/windows/src/Windows/Win32/System/GroupPolicy/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/GroupPolicy/impl.rs
@@ -61,7 +61,7 @@ impl IGPEInformation_Vtbl {
             this.PolicyChanged(::core::mem::transmute_copy(&bmachine), ::core::mem::transmute_copy(&badd), ::core::mem::transmute_copy(&pguidextension), ::core::mem::transmute_copy(&pguidsnapin)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetName: GetName::<Identity, Impl, OFFSET>,
             GetDisplayName: GetDisplayName::<Identity, Impl, OFFSET>,
             GetRegistryKey: GetRegistryKey::<Identity, Impl, OFFSET>,
@@ -4751,7 +4751,7 @@ impl IGroupPolicyObject_Vtbl {
             this.GetPropertySheetPages(::core::mem::transmute_copy(&hpages), ::core::mem::transmute_copy(&upagecount)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             New: New::<Identity, Impl, OFFSET>,
             OpenDSGPO: OpenDSGPO::<Identity, Impl, OFFSET>,
             OpenLocalMachineGPO: OpenLocalMachineGPO::<Identity, Impl, OFFSET>,
@@ -4806,7 +4806,7 @@ impl IRSOPInformation_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetNamespace: GetNamespace::<Identity, Impl, OFFSET>,
             GetFlags: GetFlags::<Identity, Impl, OFFSET>,
             GetEventLogEntryText: GetEventLogEntryText::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/System/GroupPolicy/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/GroupPolicy/mod.rs
@@ -489,7 +489,7 @@ unsafe impl ::windows::core::Interface for IGPEInformation {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IGPEInformation_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszname: ::windows::core::PWSTR, cchmaxlength: i32) -> ::windows::core::HRESULT,
     pub GetDisplayName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszname: ::windows::core::PWSTR, cchmaxlength: i32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Registry")]
@@ -6808,7 +6808,7 @@ unsafe impl ::windows::core::Interface for IGroupPolicyObject {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IGroupPolicyObject_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub New: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszdomainname: ::windows::core::PCWSTR, pszdisplayname: ::windows::core::PCWSTR, dwflags: u32) -> ::windows::core::HRESULT,
     pub OpenDSGPO: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszpath: ::windows::core::PCWSTR, dwflags: u32) -> ::windows::core::HRESULT,
     pub OpenLocalMachineGPO: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwflags: u32) -> ::windows::core::HRESULT,
@@ -6895,7 +6895,7 @@ unsafe impl ::windows::core::Interface for IRSOPInformation {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRSOPInformation_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetNamespace: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwsection: u32, pszname: ::windows::core::PWSTR, cchmaxlength: i32) -> ::windows::core::HRESULT,
     pub GetFlags: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwflags: *mut u32) -> ::windows::core::HRESULT,
     pub GetEventLogEntryText: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszeventsource: ::windows::core::PCWSTR, pszeventlogname: ::windows::core::PCWSTR, pszeventtime: ::windows::core::PCWSTR, dweventid: u32, ppsztext: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/System/Iis/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Iis/impl.rs
@@ -19,7 +19,7 @@ impl AsyncIFtpAuthenticationProvider_Vtbl {
             this.Finish_AuthenticateUser(::core::mem::transmute_copy(&ppszcanonicalusername), ::core::mem::transmute_copy(&pfauthenticated)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Begin_AuthenticateUser: Begin_AuthenticateUser::<Identity, Impl, OFFSET>,
             Finish_AuthenticateUser: Finish_AuthenticateUser::<Identity, Impl, OFFSET>,
         }
@@ -52,7 +52,7 @@ impl AsyncIFtpAuthorizationProvider_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Begin_GetUserAccessPermission: Begin_GetUserAccessPermission::<Identity, Impl, OFFSET>,
             Finish_GetUserAccessPermission: Finish_GetUserAccessPermission::<Identity, Impl, OFFSET>,
         }
@@ -85,7 +85,7 @@ impl AsyncIFtpHomeDirectoryProvider_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Begin_GetUserHomeDirectoryData: Begin_GetUserHomeDirectoryData::<Identity, Impl, OFFSET>,
             Finish_GetUserHomeDirectoryData: Finish_GetUserHomeDirectoryData::<Identity, Impl, OFFSET>,
         }
@@ -112,7 +112,7 @@ impl AsyncIFtpLogProvider_Vtbl {
             this.Finish_Log().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Begin_Log: Begin_Log::<Identity, Impl, OFFSET>,
             Finish_Log: Finish_Log::<Identity, Impl, OFFSET>,
         }
@@ -148,7 +148,7 @@ impl AsyncIFtpPostprocessProvider_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Begin_HandlePostprocess: Begin_HandlePostprocess::<Identity, Impl, OFFSET>,
             Finish_HandlePostprocess: Finish_HandlePostprocess::<Identity, Impl, OFFSET>,
         }
@@ -184,7 +184,7 @@ impl AsyncIFtpPreprocessProvider_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Begin_HandlePreprocess: Begin_HandlePreprocess::<Identity, Impl, OFFSET>,
             Finish_HandlePreprocess: Finish_HandlePreprocess::<Identity, Impl, OFFSET>,
         }
@@ -220,7 +220,7 @@ impl AsyncIFtpRoleProvider_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Begin_IsUserInRole: Begin_IsUserInRole::<Identity, Impl, OFFSET>,
             Finish_IsUserInRole: Finish_IsUserInRole::<Identity, Impl, OFFSET>,
         }
@@ -259,7 +259,7 @@ impl AsyncIMSAdminBaseSinkW_Vtbl {
             this.Finish_ShutdownNotify().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Begin_SinkNotify: Begin_SinkNotify::<Identity, Impl, OFFSET>,
             Finish_SinkNotify: Finish_SinkNotify::<Identity, Impl, OFFSET>,
             Begin_ShutdownNotify: Begin_ShutdownNotify::<Identity, Impl, OFFSET>,
@@ -294,7 +294,7 @@ impl IADMEXT_Vtbl {
             this.Terminate().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             EnumDcomCLSIDs: EnumDcomCLSIDs::<Identity, Impl, OFFSET>,
             Terminate: Terminate::<Identity, Impl, OFFSET>,
@@ -318,7 +318,7 @@ impl IFtpAuthenticationProvider_Vtbl {
             let this = (*this).get_impl();
             this.AuthenticateUser(::core::mem::transmute(&pszsessionid), ::core::mem::transmute(&pszsitename), ::core::mem::transmute(&pszusername), ::core::mem::transmute(&pszpassword), ::core::mem::transmute_copy(&ppszcanonicalusername), ::core::mem::transmute_copy(&pfauthenticated)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), AuthenticateUser: AuthenticateUser::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), AuthenticateUser: AuthenticateUser::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IFtpAuthenticationProvider as ::windows::core::Interface>::IID
@@ -341,7 +341,7 @@ impl IFtpAuthorizationProvider_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetUserAccessPermission: GetUserAccessPermission::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetUserAccessPermission: GetUserAccessPermission::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IFtpAuthorizationProvider as ::windows::core::Interface>::IID
@@ -364,7 +364,7 @@ impl IFtpHomeDirectoryProvider_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetUserHomeDirectoryData: GetUserHomeDirectoryData::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetUserHomeDirectoryData: GetUserHomeDirectoryData::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IFtpHomeDirectoryProvider as ::windows::core::Interface>::IID
@@ -381,7 +381,7 @@ impl IFtpLogProvider_Vtbl {
             let this = (*this).get_impl();
             this.Log(::core::mem::transmute_copy(&ploggingparameters)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Log: Log::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Log: Log::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IFtpLogProvider as ::windows::core::Interface>::IID
@@ -407,7 +407,7 @@ impl IFtpPostprocessProvider_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), HandlePostprocess: HandlePostprocess::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), HandlePostprocess: HandlePostprocess::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IFtpPostprocessProvider as ::windows::core::Interface>::IID
@@ -433,7 +433,7 @@ impl IFtpPreprocessProvider_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), HandlePreprocess: HandlePreprocess::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), HandlePreprocess: HandlePreprocess::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IFtpPreprocessProvider as ::windows::core::Interface>::IID
@@ -453,7 +453,7 @@ impl IFtpProviderConstruct_Vtbl {
             let this = (*this).get_impl();
             this.Construct(::core::mem::transmute_copy(&configurationentries)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Construct: Construct::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Construct: Construct::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IFtpProviderConstruct as ::windows::core::Interface>::IID
@@ -479,7 +479,7 @@ impl IFtpRoleProvider_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), IsUserInRole: IsUserInRole::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), IsUserInRole: IsUserInRole::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IFtpRoleProvider as ::windows::core::Interface>::IID
@@ -581,7 +581,7 @@ impl IMSAdminBaseSinkW_Vtbl {
             this.ShutdownNotify().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SinkNotify: SinkNotify::<Identity, Impl, OFFSET>,
             ShutdownNotify: ShutdownNotify::<Identity, Impl, OFFSET>,
         }
@@ -815,7 +815,7 @@ impl IMSAdminBaseW_Vtbl {
             this.GetServerGuid().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddKey: AddKey::<Identity, Impl, OFFSET>,
             DeleteKey: DeleteKey::<Identity, Impl, OFFSET>,
             DeleteChildKeys: DeleteChildKeys::<Identity, Impl, OFFSET>,
@@ -864,7 +864,7 @@ impl IMSImpExpHelpW_Vtbl {
             let this = (*this).get_impl();
             this.EnumeratePathsInFile(::core::mem::transmute(&pszfilename), ::core::mem::transmute(&pszkeytype), ::core::mem::transmute_copy(&dwmdbuffersize), ::core::mem::transmute(&pszbuffer), ::core::mem::transmute_copy(&pdwmdrequiredbuffersize)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), EnumeratePathsInFile: EnumeratePathsInFile::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), EnumeratePathsInFile: EnumeratePathsInFile::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMSImpExpHelpW as ::windows::core::Interface>::IID

--- a/crates/libs/windows/src/Windows/Win32/System/Iis/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Iis/mod.rs
@@ -95,7 +95,7 @@ unsafe impl ::windows::core::Interface for AsyncIFtpAuthenticationProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct AsyncIFtpAuthenticationProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Begin_AuthenticateUser: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszsessionid: ::windows::core::PCWSTR, pszsitename: ::windows::core::PCWSTR, pszusername: ::windows::core::PCWSTR, pszpassword: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub Finish_AuthenticateUser: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppszcanonicalusername: *mut ::windows::core::PWSTR, pfauthenticated: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -158,7 +158,7 @@ unsafe impl ::windows::core::Interface for AsyncIFtpAuthorizationProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct AsyncIFtpAuthorizationProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Begin_GetUserAccessPermission: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszsessionid: ::windows::core::PCWSTR, pszsitename: ::windows::core::PCWSTR, pszvirtualpath: ::windows::core::PCWSTR, pszusername: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub Finish_GetUserAccessPermission: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pftpaccess: *mut FTP_ACCESS) -> ::windows::core::HRESULT,
 }
@@ -217,7 +217,7 @@ unsafe impl ::windows::core::Interface for AsyncIFtpHomeDirectoryProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct AsyncIFtpHomeDirectoryProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Begin_GetUserHomeDirectoryData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszsessionid: ::windows::core::PCWSTR, pszsitename: ::windows::core::PCWSTR, pszusername: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub Finish_GetUserHomeDirectoryData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppszhomedirectorydata: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
 }
@@ -270,7 +270,7 @@ unsafe impl ::windows::core::Interface for AsyncIFtpLogProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct AsyncIFtpLogProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Begin_Log: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ploggingparameters: *const LOGGING_PARAMETERS) -> ::windows::core::HRESULT,
     pub Finish_Log: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -326,7 +326,7 @@ unsafe impl ::windows::core::Interface for AsyncIFtpPostprocessProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct AsyncIFtpPostprocessProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Begin_HandlePostprocess: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppostprocessparameters: *const POST_PROCESS_PARAMETERS) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -385,7 +385,7 @@ unsafe impl ::windows::core::Interface for AsyncIFtpPreprocessProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct AsyncIFtpPreprocessProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Begin_HandlePreprocess: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppreprocessparameters: *const PRE_PROCESS_PARAMETERS) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -450,7 +450,7 @@ unsafe impl ::windows::core::Interface for AsyncIFtpRoleProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct AsyncIFtpRoleProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Begin_IsUserInRole: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszsessionid: ::windows::core::PCWSTR, pszsitename: ::windows::core::PCWSTR, pszusername: ::windows::core::PCWSTR, pszrole: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub Finish_IsUserInRole: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfisinrole: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -512,7 +512,7 @@ unsafe impl ::windows::core::Interface for AsyncIMSAdminBaseSinkW {
 #[repr(C)]
 #[doc(hidden)]
 pub struct AsyncIMSAdminBaseSinkW_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Begin_SinkNotify: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwmdnumelements: u32, pcochangelist: *const MD_CHANGE_OBJECT_W) -> ::windows::core::HRESULT,
     pub Finish_SinkNotify: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Begin_ShutdownNotify: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -570,7 +570,7 @@ unsafe impl ::windows::core::Interface for IADMEXT {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IADMEXT_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub EnumDcomCLSIDs: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pclsiddcom: *mut ::windows::core::GUID, dwenumindex: u32) -> ::windows::core::HRESULT,
     pub Terminate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -629,7 +629,7 @@ unsafe impl ::windows::core::Interface for IFtpAuthenticationProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IFtpAuthenticationProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub AuthenticateUser: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszsessionid: ::windows::core::PCWSTR, pszsitename: ::windows::core::PCWSTR, pszusername: ::windows::core::PCWSTR, pszpassword: ::windows::core::PCWSTR, ppszcanonicalusername: *mut ::windows::core::PWSTR, pfauthenticated: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -688,7 +688,7 @@ unsafe impl ::windows::core::Interface for IFtpAuthorizationProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IFtpAuthorizationProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetUserAccessPermission: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszsessionid: ::windows::core::PCWSTR, pszsitename: ::windows::core::PCWSTR, pszvirtualpath: ::windows::core::PCWSTR, pszusername: ::windows::core::PCWSTR, pftpaccess: *mut FTP_ACCESS) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Iis\"`*"]
@@ -743,7 +743,7 @@ unsafe impl ::windows::core::Interface for IFtpHomeDirectoryProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IFtpHomeDirectoryProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetUserHomeDirectoryData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszsessionid: ::windows::core::PCWSTR, pszsitename: ::windows::core::PCWSTR, pszusername: ::windows::core::PCWSTR, ppszhomedirectorydata: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Iis\"`*"]
@@ -792,7 +792,7 @@ unsafe impl ::windows::core::Interface for IFtpLogProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IFtpLogProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Log: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ploggingparameters: *const LOGGING_PARAMETERS) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Iis\"`*"]
@@ -844,7 +844,7 @@ unsafe impl ::windows::core::Interface for IFtpPostprocessProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IFtpPostprocessProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub HandlePostprocess: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppostprocessparameters: *const POST_PROCESS_PARAMETERS, pftpprocessstatus: *mut FTP_PROCESS_STATUS) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -899,7 +899,7 @@ unsafe impl ::windows::core::Interface for IFtpPreprocessProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IFtpPreprocessProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub HandlePreprocess: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppreprocessparameters: *const PRE_PROCESS_PARAMETERS, pftpprocessstatus: *mut FTP_PROCESS_STATUS) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -953,7 +953,7 @@ unsafe impl ::windows::core::Interface for IFtpProviderConstruct {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IFtpProviderConstruct_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub Construct: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, configurationentries: *const super::Com::SAFEARRAY) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -1014,7 +1014,7 @@ unsafe impl ::windows::core::Interface for IFtpRoleProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IFtpRoleProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub IsUserInRole: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszsessionid: ::windows::core::PCWSTR, pszsitename: ::windows::core::PCWSTR, pszusername: ::windows::core::PCWSTR, pszrole: ::windows::core::PCWSTR, pfisinrole: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -1662,7 +1662,7 @@ unsafe impl ::windows::core::Interface for IMSAdminBaseSinkW {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMSAdminBaseSinkW_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SinkNotify: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwmdnumelements: u32, pcochangelist: *const MD_CHANGE_OBJECT_W) -> ::windows::core::HRESULT,
     pub ShutdownNotify: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -1888,7 +1888,7 @@ unsafe impl ::windows::core::Interface for IMSAdminBaseW {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMSAdminBaseW_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddKey: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hmdhandle: u32, pszmdpath: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub DeleteKey: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hmdhandle: u32, pszmdpath: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub DeleteChildKeys: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hmdhandle: u32, pszmdpath: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
@@ -1986,7 +1986,7 @@ unsafe impl ::windows::core::Interface for IMSImpExpHelpW {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMSImpExpHelpW_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub EnumeratePathsInFile: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszfilename: ::windows::core::PCWSTR, pszkeytype: ::windows::core::PCWSTR, dwmdbuffersize: u32, pszbuffer: ::windows::core::PWSTR, pdwmdrequiredbuffersize: *mut u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Iis\"`*"]

--- a/crates/libs/windows/src/Windows/Win32/System/Mmc/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Mmc/impl.rs
@@ -733,7 +733,7 @@ impl IColumnData_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetColumnConfigData: SetColumnConfigData::<Identity, Impl, OFFSET>,
             GetColumnConfigData: GetColumnConfigData::<Identity, Impl, OFFSET>,
             SetColumnSortData: SetColumnSortData::<Identity, Impl, OFFSET>,
@@ -801,7 +801,7 @@ impl IComponent_Vtbl {
             this.CompareObjects(::core::mem::transmute(&lpdataobjecta), ::core::mem::transmute(&lpdataobjectb)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             Notify: Notify::<Identity, Impl, OFFSET>,
             Destroy: Destroy::<Identity, Impl, OFFSET>,
@@ -921,7 +921,7 @@ impl IComponentData_Vtbl {
             this.CompareObjects(::core::mem::transmute(&lpdataobjecta), ::core::mem::transmute(&lpdataobjectb)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             CreateComponent: CreateComponent::<Identity, Impl, OFFSET>,
             Notify: Notify::<Identity, Impl, OFFSET>,
@@ -1072,7 +1072,7 @@ impl IConsole_Vtbl {
             this.NewWindow(::core::mem::transmute_copy(&hscopeitem), ::core::mem::transmute_copy(&loptions)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetHeader: SetHeader::<Identity, Impl, OFFSET>,
             SetToolbar: SetToolbar::<Identity, Impl, OFFSET>,
             QueryResultView: QueryResultView::<Identity, Impl, OFFSET>,
@@ -1198,7 +1198,7 @@ impl IConsoleNameSpace_Vtbl {
             this.GetParentItem(::core::mem::transmute_copy(&item), ::core::mem::transmute_copy(&pitemparent), ::core::mem::transmute_copy(&pcookie)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             InsertItem: InsertItem::<Identity, Impl, OFFSET>,
             DeleteItem: DeleteItem::<Identity, Impl, OFFSET>,
             SetItem: SetItem::<Identity, Impl, OFFSET>,
@@ -1260,7 +1260,7 @@ impl IConsolePower_Vtbl {
             this.ResetIdleTimer(::core::mem::transmute_copy(&dwflags)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetExecutionState: SetExecutionState::<Identity, Impl, OFFSET>,
             ResetIdleTimer: ResetIdleTimer::<Identity, Impl, OFFSET>,
         }
@@ -1289,7 +1289,7 @@ impl IConsolePowerSink_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnPowerBroadcast: OnPowerBroadcast::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnPowerBroadcast: OnPowerBroadcast::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IConsolePowerSink as ::windows::core::Interface>::IID
@@ -1340,7 +1340,7 @@ impl IConsoleVerb_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetVerbState: GetVerbState::<Identity, Impl, OFFSET>,
             SetVerbState: SetVerbState::<Identity, Impl, OFFSET>,
             SetDefaultVerb: SetDefaultVerb::<Identity, Impl, OFFSET>,
@@ -1362,7 +1362,7 @@ impl IContextMenuCallback_Vtbl {
             let this = (*this).get_impl();
             this.AddItem(::core::mem::transmute_copy(&pitem)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), AddItem: AddItem::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), AddItem: AddItem::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IContextMenuCallback as ::windows::core::Interface>::IID
@@ -1379,7 +1379,7 @@ impl IContextMenuCallback2_Vtbl {
             let this = (*this).get_impl();
             this.AddItem(::core::mem::transmute_copy(&pitem)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), AddItem: AddItem::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), AddItem: AddItem::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IContextMenuCallback2 as ::windows::core::Interface>::IID
@@ -1465,7 +1465,7 @@ impl IControlbar_Vtbl {
             this.Detach(::core::mem::transmute(&lpunknown)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Create: Create::<Identity, Impl, OFFSET>,
             Attach: Attach::<Identity, Impl, OFFSET>,
             Detach: Detach::<Identity, Impl, OFFSET>,
@@ -1486,7 +1486,7 @@ impl IDisplayHelp_Vtbl {
             let this = (*this).get_impl();
             this.ShowTopic(::core::mem::transmute(&pszhelptopic)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), ShowTopic: ShowTopic::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), ShowTopic: ShowTopic::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDisplayHelp as ::windows::core::Interface>::IID
@@ -1528,7 +1528,7 @@ impl IEnumTASK_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -1560,7 +1560,7 @@ impl IExtendContextMenu_Vtbl {
             this.Command(::core::mem::transmute_copy(&lcommandid), ::core::mem::transmute(&pidataobject)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddMenuItems: AddMenuItems::<Identity, Impl, OFFSET>,
             Command: Command::<Identity, Impl, OFFSET>,
         }
@@ -1590,7 +1590,7 @@ impl IExtendControlbar_Vtbl {
             this.ControlbarNotify(::core::mem::transmute_copy(&event), ::core::mem::transmute_copy(&arg), ::core::mem::transmute_copy(&param2)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetControlbar: SetControlbar::<Identity, Impl, OFFSET>,
             ControlbarNotify: ControlbarNotify::<Identity, Impl, OFFSET>,
         }
@@ -1620,7 +1620,7 @@ impl IExtendPropertySheet_Vtbl {
             this.QueryPagesFor(::core::mem::transmute(&lpdataobject)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreatePropertyPages: CreatePropertyPages::<Identity, Impl, OFFSET>,
             QueryPagesFor: QueryPagesFor::<Identity, Impl, OFFSET>,
         }
@@ -1724,7 +1724,7 @@ impl IExtendTaskPad_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             TaskNotify: TaskNotify::<Identity, Impl, OFFSET>,
             EnumTasks: EnumTasks::<Identity, Impl, OFFSET>,
             GetTitle: GetTitle::<Identity, Impl, OFFSET>,
@@ -1751,7 +1751,7 @@ impl IExtendView_Vtbl {
             let this = (*this).get_impl();
             this.GetViews(::core::mem::transmute(&pdataobject), ::core::mem::transmute(&pviewextensioncallback)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetViews: GetViews::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetViews: GetViews::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IExtendView as ::windows::core::Interface>::IID
@@ -1811,7 +1811,7 @@ impl IHeaderCtrl_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             InsertColumn: InsertColumn::<Identity, Impl, OFFSET>,
             DeleteColumn: DeleteColumn::<Identity, Impl, OFFSET>,
             SetColumnText: SetColumnText::<Identity, Impl, OFFSET>,
@@ -1879,7 +1879,7 @@ impl IImageList_Vtbl {
             this.ImageListSetStrip(::core::mem::transmute_copy(&pbmapsm), ::core::mem::transmute_copy(&pbmaplg), ::core::mem::transmute_copy(&nstartloc), ::core::mem::transmute_copy(&cmask)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ImageListSetIcon: ImageListSetIcon::<Identity, Impl, OFFSET>,
             ImageListSetStrip: ImageListSetStrip::<Identity, Impl, OFFSET>,
         }
@@ -1899,7 +1899,7 @@ impl IMMCVersionInfo_Vtbl {
             let this = (*this).get_impl();
             this.GetMMCVersion(::core::mem::transmute_copy(&pversionmajor), ::core::mem::transmute_copy(&pversionminor)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetMMCVersion: GetMMCVersion::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetMMCVersion: GetMMCVersion::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMMCVersionInfo as ::windows::core::Interface>::IID
@@ -1932,7 +1932,7 @@ impl IMenuButton_Vtbl {
             this.SetButtonState(::core::mem::transmute_copy(&idcommand), ::core::mem::transmute_copy(&nstate), ::core::mem::transmute_copy(&bstate)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddButton: AddButton::<Identity, Impl, OFFSET>,
             SetButton: SetButton::<Identity, Impl, OFFSET>,
             SetButtonState: SetButtonState::<Identity, Impl, OFFSET>,
@@ -1972,7 +1972,7 @@ impl IMessageView_Vtbl {
             this.Clear().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetTitleText: SetTitleText::<Identity, Impl, OFFSET>,
             SetBodyText: SetBodyText::<Identity, Impl, OFFSET>,
             SetIcon: SetIcon::<Identity, Impl, OFFSET>,
@@ -2003,7 +2003,7 @@ impl INodeProperties_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetProperty: GetProperty::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetProperty: GetProperty::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<INodeProperties as ::windows::core::Interface>::IID
@@ -2030,7 +2030,7 @@ impl IPropertySheetCallback_Vtbl {
             this.RemovePage(::core::mem::transmute_copy(&hpage)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddPage: AddPage::<Identity, Impl, OFFSET>,
             RemovePage: RemovePage::<Identity, Impl, OFFSET>,
         }
@@ -2078,7 +2078,7 @@ impl IPropertySheetProvider_Vtbl {
             this.Show(::core::mem::transmute_copy(&window), ::core::mem::transmute_copy(&page)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreatePropertySheet: CreatePropertySheet::<Identity, Impl, OFFSET>,
             FindPropertySheet: FindPropertySheet::<Identity, Impl, OFFSET>,
             AddPrimaryPages: AddPrimaryPages::<Identity, Impl, OFFSET>,
@@ -2126,7 +2126,7 @@ impl IRequiredExtensions_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             EnableAllExtensions: EnableAllExtensions::<Identity, Impl, OFFSET>,
             GetFirstExtension: GetFirstExtension::<Identity, Impl, OFFSET>,
             GetNextExtension: GetNextExtension::<Identity, Impl, OFFSET>,
@@ -2247,7 +2247,7 @@ impl IResultData_Vtbl {
             this.SetItemCount(::core::mem::transmute_copy(&nitemcount), ::core::mem::transmute_copy(&dwoptions)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             InsertItem: InsertItem::<Identity, Impl, OFFSET>,
             DeleteItem: DeleteItem::<Identity, Impl, OFFSET>,
             FindItemByLParam: FindItemByLParam::<Identity, Impl, OFFSET>,
@@ -2303,7 +2303,7 @@ impl IResultDataCompare_Vtbl {
             let this = (*this).get_impl();
             this.Compare(::core::mem::transmute_copy(&luserparam), ::core::mem::transmute_copy(&cookiea), ::core::mem::transmute_copy(&cookieb), ::core::mem::transmute_copy(&pnresult)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Compare: Compare::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Compare: Compare::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IResultDataCompare as ::windows::core::Interface>::IID
@@ -2329,7 +2329,7 @@ impl IResultDataCompareEx_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Compare: Compare::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Compare: Compare::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IResultDataCompareEx as ::windows::core::Interface>::IID
@@ -2368,7 +2368,7 @@ impl IResultOwnerData_Vtbl {
             this.SortItems(::core::mem::transmute_copy(&ncolumn), ::core::mem::transmute_copy(&dwsortoptions), ::core::mem::transmute_copy(&luserparam)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             FindItem: FindItem::<Identity, Impl, OFFSET>,
             CacheHint: CacheHint::<Identity, Impl, OFFSET>,
             SortItems: SortItems::<Identity, Impl, OFFSET>,
@@ -2441,7 +2441,7 @@ impl ISnapinAbout_Vtbl {
             this.GetStaticFolderImage(::core::mem::transmute_copy(&hsmallimage), ::core::mem::transmute_copy(&hsmallimageopen), ::core::mem::transmute_copy(&hlargeimage), ::core::mem::transmute_copy(&cmask)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSnapinDescription: GetSnapinDescription::<Identity, Impl, OFFSET>,
             GetProvider: GetProvider::<Identity, Impl, OFFSET>,
             GetSnapinVersion: GetSnapinVersion::<Identity, Impl, OFFSET>,
@@ -2470,7 +2470,7 @@ impl ISnapinHelp_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetHelpTopic: GetHelpTopic::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetHelpTopic: GetHelpTopic::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ISnapinHelp as ::windows::core::Interface>::IID
@@ -2526,7 +2526,7 @@ impl ISnapinProperties_Vtbl {
             this.PropertiesChanged(::core::mem::transmute_copy(&cproperties), ::core::mem::transmute_copy(&pproperties)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             QueryPropertyNames: QueryPropertyNames::<Identity, Impl, OFFSET>,
             PropertiesChanged: PropertiesChanged::<Identity, Impl, OFFSET>,
@@ -2547,7 +2547,7 @@ impl ISnapinPropertiesCallback_Vtbl {
             let this = (*this).get_impl();
             this.AddPropertyName(::core::mem::transmute(&pszpropname), ::core::mem::transmute_copy(&dwflags)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), AddPropertyName: AddPropertyName::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), AddPropertyName: AddPropertyName::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ISnapinPropertiesCallback as ::windows::core::Interface>::IID
@@ -2628,7 +2628,7 @@ impl IStringTable_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddString: AddString::<Identity, Impl, OFFSET>,
             GetString: GetString::<Identity, Impl, OFFSET>,
             GetStringLength: GetStringLength::<Identity, Impl, OFFSET>,
@@ -2693,7 +2693,7 @@ impl IToolbar_Vtbl {
             this.SetButtonState(::core::mem::transmute_copy(&idcommand), ::core::mem::transmute_copy(&nstate), ::core::mem::transmute_copy(&bstate)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddBitmap: AddBitmap::<Identity, Impl, OFFSET>,
             AddButtons: AddButtons::<Identity, Impl, OFFSET>,
             InsertButton: InsertButton::<Identity, Impl, OFFSET>,
@@ -2720,7 +2720,7 @@ impl IViewExtensionCallback_Vtbl {
             let this = (*this).get_impl();
             this.AddView(::core::mem::transmute_copy(&pextviewdata)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), AddView: AddView::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), AddView: AddView::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IViewExtensionCallback as ::windows::core::Interface>::IID

--- a/crates/libs/windows/src/Windows/Win32/System/Mmc/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Mmc/mod.rs
@@ -993,7 +993,7 @@ unsafe impl ::windows::core::Interface for IColumnData {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IColumnData_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetColumnConfigData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcolid: *const SColumnSetID, pcolsetdata: *const MMC_COLUMN_SET_DATA) -> ::windows::core::HRESULT,
     pub GetColumnConfigData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcolid: *const SColumnSetID, ppcolsetdata: *mut *mut MMC_COLUMN_SET_DATA) -> ::windows::core::HRESULT,
     pub SetColumnSortData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcolid: *const SColumnSetID, pcolsortdata: *const MMC_SORT_SET_DATA) -> ::windows::core::HRESULT,
@@ -1084,7 +1084,7 @@ unsafe impl ::windows::core::Interface for IComponent {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IComponent_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lpconsole: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
     pub Notify: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lpdataobject: *mut ::core::ffi::c_void, event: MMC_NOTIFY_TYPE, arg: super::super::Foundation::LPARAM, param3: super::super::Foundation::LPARAM) -> ::windows::core::HRESULT,
@@ -1311,7 +1311,7 @@ unsafe impl ::windows::core::Interface for IComponentData {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IComponentData_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punknown: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CreateComponent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppcomponent: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
@@ -1545,7 +1545,7 @@ unsafe impl ::windows::core::Interface for IConsole {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IConsole_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetHeader: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pheader: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetToolbar: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptoolbar: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub QueryResultView: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punknown: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1927,7 +1927,7 @@ unsafe impl ::windows::core::Interface for IConsoleNameSpace {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IConsoleNameSpace_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub InsertItem: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, item: *mut SCOPEDATAITEM) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -2089,7 +2089,7 @@ unsafe impl ::windows::core::Interface for IConsolePower {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IConsolePower_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetExecutionState: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwadd: u32, dwremove: u32) -> ::windows::core::HRESULT,
     pub ResetIdleTimer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwflags: u32) -> ::windows::core::HRESULT,
 }
@@ -2145,7 +2145,7 @@ unsafe impl ::windows::core::Interface for IConsolePowerSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IConsolePowerSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub OnPowerBroadcast: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, nevent: u32, lparam: super::super::Foundation::LPARAM, plreturn: *mut super::super::Foundation::LRESULT) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -2215,7 +2215,7 @@ unsafe impl ::windows::core::Interface for IConsoleVerb {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IConsoleVerb_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetVerbState: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ecmdid: MMC_CONSOLE_VERB, nstate: MMC_BUTTON_STATE, pstate: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -2273,7 +2273,7 @@ unsafe impl ::windows::core::Interface for IContextMenuCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IContextMenuCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddItem: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pitem: *const CONTEXTMENUITEM) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Mmc\"`*"]
@@ -2322,7 +2322,7 @@ unsafe impl ::windows::core::Interface for IContextMenuCallback2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IContextMenuCallback2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddItem: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pitem: *const CONTEXTMENUITEM2) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Mmc\"`*"]
@@ -2492,7 +2492,7 @@ unsafe impl ::windows::core::Interface for IControlbar {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IControlbar_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Create: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ntype: MMC_CONTROL_TYPE, pextendcontrolbar: *mut ::core::ffi::c_void, ppunknown: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Attach: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ntype: MMC_CONTROL_TYPE, lpunknown: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Detach: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lpunknown: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -2546,7 +2546,7 @@ unsafe impl ::windows::core::Interface for IDisplayHelp {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDisplayHelp_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ShowTopic: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszhelptopic: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Mmc\"`*"]
@@ -2605,7 +2605,7 @@ unsafe impl ::windows::core::Interface for IEnumTASK {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumTASK_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut MMC_TASK, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -2671,7 +2671,7 @@ unsafe impl ::windows::core::Interface for IExtendContextMenu {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IExtendContextMenu_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub AddMenuItems: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pidataobject: *mut ::core::ffi::c_void, picallback: *mut ::core::ffi::c_void, pinsertionallowed: *mut i32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -2739,7 +2739,7 @@ unsafe impl ::windows::core::Interface for IExtendControlbar {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IExtendControlbar_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetControlbar: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcontrolbar: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub ControlbarNotify: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, event: MMC_NOTIFY_TYPE, arg: super::super::Foundation::LPARAM, param2: super::super::Foundation::LPARAM) -> ::windows::core::HRESULT,
@@ -2806,7 +2806,7 @@ unsafe impl ::windows::core::Interface for IExtendPropertySheet {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IExtendPropertySheet_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub CreatePropertyPages: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lpprovider: *mut ::core::ffi::c_void, handle: isize, lpidataobject: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -2994,7 +2994,7 @@ unsafe impl ::windows::core::Interface for IExtendTaskPad {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IExtendTaskPad_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub TaskNotify: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdo: *mut ::core::ffi::c_void, arg: *const super::Com::VARIANT, param2: *const super::Com::VARIANT) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole")))]
@@ -3060,7 +3060,7 @@ unsafe impl ::windows::core::Interface for IExtendView {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IExtendView_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub GetViews: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdataobject: *mut ::core::ffi::c_void, pviewextensioncallback: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -3135,7 +3135,7 @@ unsafe impl ::windows::core::Interface for IHeaderCtrl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IHeaderCtrl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub InsertColumn: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ncol: i32, title: ::windows::core::PCWSTR, nformat: i32, nwidth: i32) -> ::windows::core::HRESULT,
     pub DeleteColumn: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ncol: i32) -> ::windows::core::HRESULT,
     pub SetColumnText: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ncol: i32, title: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
@@ -3295,7 +3295,7 @@ unsafe impl ::windows::core::Interface for IImageList {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IImageList_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ImageListSetIcon: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, picon: *const isize, nloc: i32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub ImageListSetStrip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbmapsm: *const isize, pbmaplg: *const isize, nstartloc: i32, cmask: super::super::Foundation::COLORREF) -> ::windows::core::HRESULT,
@@ -3348,7 +3348,7 @@ unsafe impl ::windows::core::Interface for IMMCVersionInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMMCVersionInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetMMCVersion: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pversionmajor: *mut i32, pversionminor: *mut i32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Mmc\"`*"]
@@ -3416,7 +3416,7 @@ unsafe impl ::windows::core::Interface for IMenuButton {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMenuButton_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddButton: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, idcommand: i32, lpbuttontext: ::windows::core::PCWSTR, lptooltiptext: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub SetButton: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, idcommand: i32, lpbuttontext: ::windows::core::PCWSTR, lptooltiptext: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -3485,7 +3485,7 @@ unsafe impl ::windows::core::Interface for IMessageView {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMessageView_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetTitleText: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psztitletext: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub SetBodyText: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszbodytext: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub SetIcon: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, id: IconIdentifier) -> ::windows::core::HRESULT,
@@ -3543,7 +3543,7 @@ unsafe impl ::windows::core::Interface for INodeProperties {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INodeProperties_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub GetProperty: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdataobject: *mut ::core::ffi::c_void, szpropertyname: ::core::mem::ManuallyDrop<::windows::core::BSTR>, pbstrproperty: *mut *mut u16) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -3608,7 +3608,7 @@ unsafe impl ::windows::core::Interface for IPropertySheetCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPropertySheetCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_UI_Controls")]
     pub AddPage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hpage: super::super::UI::Controls::HPROPSHEETPAGE) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_UI_Controls"))]
@@ -3696,7 +3696,7 @@ unsafe impl ::windows::core::Interface for IPropertySheetProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPropertySheetProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub CreatePropertySheet: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, title: ::windows::core::PCWSTR, r#type: u8, cookie: isize, pidataobjectm: *mut ::core::ffi::c_void, dwoptions: u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -3766,7 +3766,7 @@ unsafe impl ::windows::core::Interface for IRequiredExtensions {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRequiredExtensions_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub EnableAllExtensions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetFirstExtension: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pextclsid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub GetNextExtension: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pextclsid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
@@ -3882,7 +3882,7 @@ unsafe impl ::windows::core::Interface for IResultData {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IResultData_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub InsertItem: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, item: *mut RESULTDATAITEM) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -4100,7 +4100,7 @@ unsafe impl ::windows::core::Interface for IResultDataCompare {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IResultDataCompare_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Compare: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, luserparam: super::super::Foundation::LPARAM, cookiea: isize, cookieb: isize, pnresult: *mut i32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -4155,7 +4155,7 @@ unsafe impl ::windows::core::Interface for IResultDataCompareEx {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IResultDataCompareEx_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Compare: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, prdc: *const RDCOMPARE, pnresult: *mut i32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -4219,7 +4219,7 @@ unsafe impl ::windows::core::Interface for IResultOwnerData {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IResultOwnerData_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub FindItem: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfindinfo: *const RESULTFINDINFO, pnfoundindex: *mut i32) -> ::windows::core::HRESULT,
     pub CacheHint: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, nstartindex: i32, nendindex: i32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -4293,7 +4293,7 @@ unsafe impl ::windows::core::Interface for ISnapinAbout {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISnapinAbout_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetSnapinDescription: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lpdescription: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetProvider: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lpname: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetSnapinVersion: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lpversion: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
@@ -4353,7 +4353,7 @@ unsafe impl ::windows::core::Interface for ISnapinHelp {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISnapinHelp_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetHelpTopic: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lpcompiledhelpfile: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Mmc\"`*"]
@@ -4487,7 +4487,7 @@ unsafe impl ::windows::core::Interface for ISnapinProperties {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISnapinProperties_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pproperties: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -4547,7 +4547,7 @@ unsafe impl ::windows::core::Interface for ISnapinPropertiesCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISnapinPropertiesCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddPropertyName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszpropname: ::windows::core::PCWSTR, dwflags: u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Mmc\"`*"]
@@ -4626,7 +4626,7 @@ unsafe impl ::windows::core::Interface for IStringTable {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IStringTable_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddString: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszadd: ::windows::core::PCWSTR, pstringid: *mut u32) -> ::windows::core::HRESULT,
     pub GetString: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, stringid: u32, cchbuffer: u32, lpbuffer: ::windows::core::PWSTR, pcchout: *mut u32) -> ::windows::core::HRESULT,
     pub GetStringLength: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, stringid: u32, pcchstring: *mut u32) -> ::windows::core::HRESULT,
@@ -4713,7 +4713,7 @@ unsafe impl ::windows::core::Interface for IToolbar {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IToolbar_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
     pub AddBitmap: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, nimages: i32, hbmp: super::super::Graphics::Gdi::HBITMAP, cxsize: i32, cysize: i32, crmask: super::super::Foundation::COLORREF) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi")))]
@@ -4778,7 +4778,7 @@ unsafe impl ::windows::core::Interface for IViewExtensionCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IViewExtensionCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub AddView: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pextviewdata: *const MMC_EXT_VIEW_DATA) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]

--- a/crates/libs/windows/src/Windows/Win32/System/Ole/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Ole/impl.rs
@@ -32,7 +32,7 @@ impl ICanHandleException_Vtbl {
             let this = (*this).get_impl();
             this.CanHandleException(::core::mem::transmute_copy(&pexcepinfo), ::core::mem::transmute_copy(&pvar)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CanHandleException: CanHandleException::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CanHandleException: CanHandleException::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ICanHandleException as ::windows::core::Interface>::IID
@@ -92,7 +92,7 @@ impl IContinue_Vtbl {
             let this = (*this).get_impl();
             this.FContinue().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), FContinue: FContinue::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), FContinue: FContinue::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IContinue as ::windows::core::Interface>::IID
@@ -116,7 +116,7 @@ impl IContinueCallback_Vtbl {
             this.FContinuePrinting(::core::mem::transmute_copy(&ncntprinted), ::core::mem::transmute_copy(&ncurpage), ::core::mem::transmute(&pwszprintstatus)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             FContinue: FContinue::<Identity, Impl, OFFSET>,
             FContinuePrinting: FContinuePrinting::<Identity, Impl, OFFSET>,
         }
@@ -161,7 +161,7 @@ impl ICreateErrorInfo_Vtbl {
             this.SetHelpContext(::core::mem::transmute_copy(&dwhelpcontext)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetGUID: SetGUID::<Identity, Impl, OFFSET>,
             SetSource: SetSource::<Identity, Impl, OFFSET>,
             SetDescription: SetDescription::<Identity, Impl, OFFSET>,
@@ -320,7 +320,7 @@ impl ICreateTypeInfo_Vtbl {
             this.LayOut().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetGuid: SetGuid::<Identity, Impl, OFFSET>,
             SetTypeFlags: SetTypeFlags::<Identity, Impl, OFFSET>,
             SetDocString: SetDocString::<Identity, Impl, OFFSET>,
@@ -546,7 +546,7 @@ impl ICreateTypeLib_Vtbl {
             this.SaveAllChanges().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateTypeInfo: CreateTypeInfo::<Identity, Impl, OFFSET>,
             SetName: SetName::<Identity, Impl, OFFSET>,
             SetVersion: SetVersion::<Identity, Impl, OFFSET>,
@@ -679,7 +679,7 @@ impl IDispError_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             QueryErrorInfo: QueryErrorInfo::<Identity, Impl, OFFSET>,
             GetNext: GetNext::<Identity, Impl, OFFSET>,
             GetHresult: GetHresult::<Identity, Impl, OFFSET>,
@@ -815,7 +815,7 @@ impl IDropSource_Vtbl {
             this.GiveFeedback(::core::mem::transmute_copy(&dweffect)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             QueryContinueDrag: QueryContinueDrag::<Identity, Impl, OFFSET>,
             GiveFeedback: GiveFeedback::<Identity, Impl, OFFSET>,
         }
@@ -845,7 +845,7 @@ impl IDropSourceNotify_Vtbl {
             this.DragLeaveTarget().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             DragEnterTarget: DragEnterTarget::<Identity, Impl, OFFSET>,
             DragLeaveTarget: DragLeaveTarget::<Identity, Impl, OFFSET>,
         }
@@ -887,7 +887,7 @@ impl IDropTarget_Vtbl {
             this.Drop(::core::mem::transmute(&pdataobj), ::core::mem::transmute_copy(&grfkeystate), ::core::mem::transmute(&pt), ::core::mem::transmute_copy(&pdweffect)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             DragEnter: DragEnter::<Identity, Impl, OFFSET>,
             DragOver: DragOver::<Identity, Impl, OFFSET>,
             DragLeave: DragLeave::<Identity, Impl, OFFSET>,
@@ -925,7 +925,7 @@ impl IEnterpriseDropTarget_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetDropSourceEnterpriseId: SetDropSourceEnterpriseId::<Identity, Impl, OFFSET>,
             IsEvaluatingEdpPolicy: IsEvaluatingEdpPolicy::<Identity, Impl, OFFSET>,
         }
@@ -973,7 +973,7 @@ impl IEnumOLEVERB_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -1020,7 +1020,7 @@ impl IEnumOleDocumentViews_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -1067,7 +1067,7 @@ impl IEnumOleUndoUnits_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -1117,7 +1117,7 @@ impl IEnumVARIANT_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -1347,7 +1347,7 @@ impl IFont_Vtbl {
             this.SetHdc(::core::mem::transmute_copy(&hdc)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Name: Name::<Identity, Impl, OFFSET>,
             SetName: SetName::<Identity, Impl, OFFSET>,
             Size: Size::<Identity, Impl, OFFSET>,
@@ -1415,7 +1415,7 @@ impl IGetOleObject_Vtbl {
             let this = (*this).get_impl();
             this.GetOleObject(::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppvobj)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetOleObject: GetOleObject::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetOleObject: GetOleObject::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IGetOleObject as ::windows::core::Interface>::IID
@@ -1432,7 +1432,7 @@ impl IGetVBAObject_Vtbl {
             let this = (*this).get_impl();
             this.GetObject(::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppvobj), ::core::mem::transmute_copy(&dwreserved)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetObject: GetObject::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetObject: GetObject::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IGetVBAObject as ::windows::core::Interface>::IID
@@ -1449,7 +1449,7 @@ impl IObjectIdentity_Vtbl {
             let this = (*this).get_impl();
             this.IsEqualObject(::core::mem::transmute(&punk)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), IsEqualObject: IsEqualObject::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), IsEqualObject: IsEqualObject::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IObjectIdentity as ::windows::core::Interface>::IID
@@ -1473,7 +1473,7 @@ impl IObjectWithSite_Vtbl {
             this.GetSite(::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppvsite)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetSite: SetSite::<Identity, Impl, OFFSET>,
             GetSite: GetSite::<Identity, Impl, OFFSET>,
         }
@@ -1539,7 +1539,7 @@ impl IOleAdviseHolder_Vtbl {
             this.SendOnClose().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Advise: Advise::<Identity, Impl, OFFSET>,
             Unadvise: Unadvise::<Identity, Impl, OFFSET>,
             EnumAdvise: EnumAdvise::<Identity, Impl, OFFSET>,
@@ -1603,7 +1603,7 @@ impl IOleCache_Vtbl {
             this.SetData(::core::mem::transmute_copy(&pformatetc), ::core::mem::transmute_copy(&pmedium), ::core::mem::transmute_copy(&frelease)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Cache: Cache::<Identity, Impl, OFFSET>,
             Uncache: Uncache::<Identity, Impl, OFFSET>,
             EnumCache: EnumCache::<Identity, Impl, OFFSET>,
@@ -1666,7 +1666,7 @@ impl IOleCacheControl_Vtbl {
             this.OnStop().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnRun: OnRun::<Identity, Impl, OFFSET>,
             OnStop: OnStop::<Identity, Impl, OFFSET>,
         }
@@ -1732,7 +1732,7 @@ impl IOleClientSite_Vtbl {
             this.RequestNewObjectLayout().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SaveObject: SaveObject::<Identity, Impl, OFFSET>,
             GetMoniker: GetMoniker::<Identity, Impl, OFFSET>,
             GetContainer: GetContainer::<Identity, Impl, OFFSET>,
@@ -1766,7 +1766,7 @@ impl IOleCommandTarget_Vtbl {
             this.Exec(::core::mem::transmute_copy(&pguidcmdgroup), ::core::mem::transmute_copy(&ncmdid), ::core::mem::transmute_copy(&ncmdexecopt), ::core::mem::transmute_copy(&pvain), ::core::mem::transmute_copy(&pvaout)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             QueryStatus: QueryStatus::<Identity, Impl, OFFSET>,
             Exec: Exec::<Identity, Impl, OFFSET>,
         }
@@ -1844,7 +1844,7 @@ impl IOleControl_Vtbl {
             this.FreezeEvents(::core::mem::transmute_copy(&bfreeze)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetControlInfo: GetControlInfo::<Identity, Impl, OFFSET>,
             OnMnemonic: OnMnemonic::<Identity, Impl, OFFSET>,
             OnAmbientPropertyChange: OnAmbientPropertyChange::<Identity, Impl, OFFSET>,
@@ -1912,7 +1912,7 @@ impl IOleControlSite_Vtbl {
             this.ShowPropertyFrame().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnControlInfoChanged: OnControlInfoChanged::<Identity, Impl, OFFSET>,
             LockInPlaceActive: LockInPlaceActive::<Identity, Impl, OFFSET>,
             GetExtendedControl: GetExtendedControl::<Identity, Impl, OFFSET>,
@@ -1965,7 +1965,7 @@ impl IOleDocument_Vtbl {
             this.EnumViews(::core::mem::transmute_copy(&ppenum), ::core::mem::transmute_copy(&ppview)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateView: CreateView::<Identity, Impl, OFFSET>,
             GetDocMiscStatus: GetDocMiscStatus::<Identity, Impl, OFFSET>,
             EnumViews: EnumViews::<Identity, Impl, OFFSET>,
@@ -1986,7 +1986,7 @@ impl IOleDocumentSite_Vtbl {
             let this = (*this).get_impl();
             this.ActivateMe(::core::mem::transmute(&pviewtoactivate)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), ActivateMe: ActivateMe::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), ActivateMe: ActivateMe::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IOleDocumentSite as ::windows::core::Interface>::IID
@@ -2103,7 +2103,7 @@ impl IOleDocumentView_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetInPlaceSite: SetInPlaceSite::<Identity, Impl, OFFSET>,
             GetInPlaceSite: GetInPlaceSite::<Identity, Impl, OFFSET>,
             GetDocument: GetDocument::<Identity, Impl, OFFSET>,
@@ -2739,7 +2739,7 @@ impl IOleLink_Vtbl {
             this.Update(::core::mem::transmute(&pbc)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetUpdateOptions: SetUpdateOptions::<Identity, Impl, OFFSET>,
             GetUpdateOptions: GetUpdateOptions::<Identity, Impl, OFFSET>,
             SetSourceMoniker: SetSourceMoniker::<Identity, Impl, OFFSET>,
@@ -2952,7 +2952,7 @@ impl IOleObject_Vtbl {
             this.SetColorScheme(::core::mem::transmute_copy(&plogpal)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetClientSite: SetClientSite::<Identity, Impl, OFFSET>,
             GetClientSite: GetClientSite::<Identity, Impl, OFFSET>,
             SetHostNames: SetHostNames::<Identity, Impl, OFFSET>,
@@ -3100,7 +3100,7 @@ impl IOleUILinkContainerA_Vtbl {
             this.CancelLink(::core::mem::transmute_copy(&dwlink)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetNextLink: GetNextLink::<Identity, Impl, OFFSET>,
             SetLinkUpdateOptions: SetLinkUpdateOptions::<Identity, Impl, OFFSET>,
             GetLinkUpdateOptions: GetLinkUpdateOptions::<Identity, Impl, OFFSET>,
@@ -3178,7 +3178,7 @@ impl IOleUILinkContainerW_Vtbl {
             this.CancelLink(::core::mem::transmute_copy(&dwlink)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetNextLink: GetNextLink::<Identity, Impl, OFFSET>,
             SetLinkUpdateOptions: SetLinkUpdateOptions::<Identity, Impl, OFFSET>,
             GetLinkUpdateOptions: GetLinkUpdateOptions::<Identity, Impl, OFFSET>,
@@ -3284,7 +3284,7 @@ impl IOleUIObjInfoA_Vtbl {
             this.SetViewInfo(::core::mem::transmute_copy(&dwobject), ::core::mem::transmute_copy(&hmetapict), ::core::mem::transmute_copy(&dvaspect), ::core::mem::transmute_copy(&ncurrentscale), ::core::mem::transmute_copy(&brelativetoorig)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetObjectInfo: GetObjectInfo::<Identity, Impl, OFFSET>,
             GetConvertInfo: GetConvertInfo::<Identity, Impl, OFFSET>,
             ConvertObject: ConvertObject::<Identity, Impl, OFFSET>,
@@ -3335,7 +3335,7 @@ impl IOleUIObjInfoW_Vtbl {
             this.SetViewInfo(::core::mem::transmute_copy(&dwobject), ::core::mem::transmute_copy(&hmetapict), ::core::mem::transmute_copy(&dvaspect), ::core::mem::transmute_copy(&ncurrentscale), ::core::mem::transmute_copy(&brelativetoorig)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetObjectInfo: GetObjectInfo::<Identity, Impl, OFFSET>,
             GetConvertInfo: GetConvertInfo::<Identity, Impl, OFFSET>,
             ConvertObject: ConvertObject::<Identity, Impl, OFFSET>,
@@ -3458,7 +3458,7 @@ impl IOleUndoManager_Vtbl {
             this.Enable(::core::mem::transmute_copy(&fenable)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Open: Open::<Identity, Impl, OFFSET>,
             Close: Close::<Identity, Impl, OFFSET>,
             Add: Add::<Identity, Impl, OFFSET>,
@@ -3513,7 +3513,7 @@ impl IOleUndoUnit_Vtbl {
             this.OnNextAdd().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Do: Do::<Identity, Impl, OFFSET>,
             GetDescription: GetDescription::<Identity, Impl, OFFSET>,
             GetUnitType: GetUnitType::<Identity, Impl, OFFSET>,
@@ -3551,7 +3551,7 @@ impl IOleWindow_Vtbl {
             this.ContextSensitiveHelp(::core::mem::transmute_copy(&fentermode)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetWindow: GetWindow::<Identity, Impl, OFFSET>,
             ContextSensitiveHelp: ContextSensitiveHelp::<Identity, Impl, OFFSET>,
         }
@@ -3574,7 +3574,7 @@ impl IParseDisplayName_Vtbl {
             let this = (*this).get_impl();
             this.ParseDisplayName(::core::mem::transmute(&pbc), ::core::mem::transmute(&pszdisplayname), ::core::mem::transmute_copy(&pcheaten), ::core::mem::transmute_copy(&ppmkout)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), ParseDisplayName: ParseDisplayName::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), ParseDisplayName: ParseDisplayName::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IParseDisplayName as ::windows::core::Interface>::IID
@@ -3631,7 +3631,7 @@ impl IPerPropertyBrowsing_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDisplayString: GetDisplayString::<Identity, Impl, OFFSET>,
             MapPropertyToPage: MapPropertyToPage::<Identity, Impl, OFFSET>,
             GetPredefinedStrings: GetPredefinedStrings::<Identity, Impl, OFFSET>,
@@ -3870,7 +3870,7 @@ impl IPicture_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Handle: Handle::<Identity, Impl, OFFSET>,
             hPal: hPal::<Identity, Impl, OFFSET>,
             Type: Type::<Identity, Impl, OFFSET>,
@@ -4038,7 +4038,7 @@ impl IPicture2_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Handle: Handle::<Identity, Impl, OFFSET>,
             hPal: hPal::<Identity, Impl, OFFSET>,
             Type: Type::<Identity, Impl, OFFSET>,
@@ -4105,7 +4105,7 @@ impl IPointerInactive_Vtbl {
             this.OnInactiveSetCursor(::core::mem::transmute_copy(&prectbounds), ::core::mem::transmute_copy(&x), ::core::mem::transmute_copy(&y), ::core::mem::transmute_copy(&dwmousemsg), ::core::mem::transmute_copy(&fsetalways)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetActivationPolicy: GetActivationPolicy::<Identity, Impl, OFFSET>,
             OnInactiveMouseMove: OnInactiveMouseMove::<Identity, Impl, OFFSET>,
             OnInactiveSetCursor: OnInactiveSetCursor::<Identity, Impl, OFFSET>,
@@ -4142,7 +4142,7 @@ impl IPrint_Vtbl {
             this.Print(::core::mem::transmute_copy(&grfflags), ::core::mem::transmute_copy(&pptd), ::core::mem::transmute_copy(&pppageset), ::core::mem::transmute_copy(&pstgmoptions), ::core::mem::transmute(&pcallback), ::core::mem::transmute_copy(&nfirstpage), ::core::mem::transmute_copy(&pcpagesprinted), ::core::mem::transmute_copy(&pnlastpage)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetInitialPageNum: SetInitialPageNum::<Identity, Impl, OFFSET>,
             GetPageInfo: GetPageInfo::<Identity, Impl, OFFSET>,
             Print: Print::<Identity, Impl, OFFSET>,
@@ -4170,7 +4170,7 @@ impl IPropertyNotifySink_Vtbl {
             this.OnRequestEdit(::core::mem::transmute_copy(&dispid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnChanged: OnChanged::<Identity, Impl, OFFSET>,
             OnRequestEdit: OnRequestEdit::<Identity, Impl, OFFSET>,
         }
@@ -4260,7 +4260,7 @@ impl IPropertyPage_Vtbl {
             this.TranslateAccelerator(::core::mem::transmute_copy(&pmsg)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetPageSite: SetPageSite::<Identity, Impl, OFFSET>,
             Activate: Activate::<Identity, Impl, OFFSET>,
             Deactivate: Deactivate::<Identity, Impl, OFFSET>,
@@ -4343,7 +4343,7 @@ impl IPropertyPageSite_Vtbl {
             this.TranslateAccelerator(::core::mem::transmute_copy(&pmsg)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnStatusChange: OnStatusChange::<Identity, Impl, OFFSET>,
             GetLocaleID: GetLocaleID::<Identity, Impl, OFFSET>,
             GetPageContainer: GetPageContainer::<Identity, Impl, OFFSET>,
@@ -4374,7 +4374,7 @@ impl IProtectFocus_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), AllowFocusChange: AllowFocusChange::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), AllowFocusChange: AllowFocusChange::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IProtectFocus as ::windows::core::Interface>::IID
@@ -4425,7 +4425,7 @@ impl IProtectedModeMenuServices_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateMenu: CreateMenu::<Identity, Impl, OFFSET>,
             LoadMenu: LoadMenu::<Identity, Impl, OFFSET>,
             LoadMenuID: LoadMenuID::<Identity, Impl, OFFSET>,
@@ -4455,7 +4455,7 @@ impl IProvideClassInfo_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetClassInfo: GetClassInfo::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetClassInfo: GetClassInfo::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IProvideClassInfo as ::windows::core::Interface>::IID
@@ -4534,7 +4534,7 @@ impl IProvideRuntimeContext_Vtbl {
             let this = (*this).get_impl();
             this.GetCurrentSourceContext(::core::mem::transmute_copy(&pdwcontext), ::core::mem::transmute_copy(&pfexecutingglobalcode)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetCurrentSourceContext: GetCurrentSourceContext::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetCurrentSourceContext: GetCurrentSourceContext::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IProvideRuntimeContext as ::windows::core::Interface>::IID
@@ -4573,7 +4573,7 @@ impl IQuickActivate_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             QuickActivate: QuickActivate::<Identity, Impl, OFFSET>,
             SetContentExtent: SetContentExtent::<Identity, Impl, OFFSET>,
             GetContentExtent: GetContentExtent::<Identity, Impl, OFFSET>,
@@ -4718,7 +4718,7 @@ impl IRecordInfo_Vtbl {
             this.RecordDestroy(::core::mem::transmute_copy(&pvrecord)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RecordInit: RecordInit::<Identity, Impl, OFFSET>,
             RecordClear: RecordClear::<Identity, Impl, OFFSET>,
             RecordCopy: RecordCopy::<Identity, Impl, OFFSET>,
@@ -4762,7 +4762,7 @@ impl ISimpleFrameSite_Vtbl {
             this.PostMessageFilter(::core::mem::transmute_copy(&hwnd), ::core::mem::transmute_copy(&msg), ::core::mem::transmute_copy(&wp), ::core::mem::transmute_copy(&lp), ::core::mem::transmute_copy(&plresult), ::core::mem::transmute_copy(&dwcookie)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             PreMessageFilter: PreMessageFilter::<Identity, Impl, OFFSET>,
             PostMessageFilter: PostMessageFilter::<Identity, Impl, OFFSET>,
         }
@@ -4788,7 +4788,7 @@ impl ISpecifyPropertyPages_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetPages: GetPages::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetPages: GetPages::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ISpecifyPropertyPages as ::windows::core::Interface>::IID
@@ -4821,7 +4821,7 @@ impl ITypeChangeEvents_Vtbl {
             this.AfterTypeChange(::core::mem::transmute_copy(&changekind), ::core::mem::transmute(&ptinfoafter), ::core::mem::transmute(&pstrname)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RequestTypeChange: RequestTypeChange::<Identity, Impl, OFFSET>,
             AfterTypeChange: AfterTypeChange::<Identity, Impl, OFFSET>,
         }
@@ -4850,7 +4850,7 @@ impl ITypeFactory_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CreateFromTypeInfo: CreateFromTypeInfo::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CreateFromTypeInfo: CreateFromTypeInfo::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ITypeFactory as ::windows::core::Interface>::IID
@@ -4892,7 +4892,7 @@ impl ITypeMarshal_Vtbl {
             this.Free(::core::mem::transmute_copy(&pvtype)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Size: Size::<Identity, Impl, OFFSET>,
             Marshal: Marshal::<Identity, Impl, OFFSET>,
             Unmarshal: Unmarshal::<Identity, Impl, OFFSET>,
@@ -4917,7 +4917,7 @@ impl IVBFormat_Vtbl {
             let this = (*this).get_impl();
             this.Format(::core::mem::transmute_copy(&vdata), ::core::mem::transmute(&bstrformat), ::core::mem::transmute_copy(&lpbuffer), ::core::mem::transmute_copy(&cb), ::core::mem::transmute_copy(&lcid), ::core::mem::transmute_copy(&sfirstdayofweek), ::core::mem::transmute_copy(&sfirstweekofyear), ::core::mem::transmute_copy(&rcb)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Format: Format::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Format: Format::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IVBFormat as ::windows::core::Interface>::IID
@@ -4943,7 +4943,7 @@ impl IVBGetControl_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), EnumControls: EnumControls::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), EnumControls: EnumControls::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IVBGetControl as ::windows::core::Interface>::IID
@@ -4963,7 +4963,7 @@ impl IVariantChangeType_Vtbl {
             let this = (*this).get_impl();
             this.ChangeType(::core::mem::transmute_copy(&pvardst), ::core::mem::transmute_copy(&pvarsrc), ::core::mem::transmute_copy(&lcid), ::core::mem::transmute_copy(&vtnew)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), ChangeType: ChangeType::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), ChangeType: ChangeType::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IVariantChangeType as ::windows::core::Interface>::IID
@@ -5014,7 +5014,7 @@ impl IViewObject_Vtbl {
             this.GetAdvise(::core::mem::transmute_copy(&paspects), ::core::mem::transmute_copy(&padvf), ::core::mem::transmute_copy(&ppadvsink)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Draw: Draw::<Identity, Impl, OFFSET>,
             GetColorSet: GetColorSet::<Identity, Impl, OFFSET>,
             Freeze: Freeze::<Identity, Impl, OFFSET>,
@@ -5145,7 +5145,7 @@ impl IZoomEvents_Vtbl {
             let this = (*this).get_impl();
             this.OnZoomPercentChanged(::core::mem::transmute_copy(&ulzoompercent)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnZoomPercentChanged: OnZoomPercentChanged::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnZoomPercentChanged: OnZoomPercentChanged::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IZoomEvents as ::windows::core::Interface>::IID

--- a/crates/libs/windows/src/Windows/Win32/System/Ole/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Ole/mod.rs
@@ -5248,7 +5248,7 @@ unsafe impl ::windows::core::Interface for ICanHandleException {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICanHandleException_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
     pub CanHandleException: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pexcepinfo: *const super::Com::EXCEPINFO, pvar: *const super::Com::VARIANT) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com")))]
@@ -5416,7 +5416,7 @@ unsafe impl ::windows::core::Interface for IContinue {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IContinue_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub FContinue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Ole\"`*"]
@@ -5471,7 +5471,7 @@ unsafe impl ::windows::core::Interface for IContinueCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IContinueCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub FContinue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub FContinuePrinting: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ncntprinted: i32, ncurpage: i32, pwszprintstatus: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
 }
@@ -5542,7 +5542,7 @@ unsafe impl ::windows::core::Interface for ICreateErrorInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICreateErrorInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetGUID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, rguid: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub SetSource: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, szsource: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub SetDescription: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, szdescription: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
@@ -5693,7 +5693,7 @@ unsafe impl ::windows::core::Interface for ICreateTypeInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICreateTypeInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetGuid: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, guid: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub SetTypeFlags: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, utypeflags: u32) -> ::windows::core::HRESULT,
     pub SetDocString: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pstrdoc: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
@@ -6075,7 +6075,7 @@ unsafe impl ::windows::core::Interface for ICreateTypeLib {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICreateTypeLib_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub CreateTypeInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, szname: ::windows::core::PCWSTR, tkind: super::Com::TYPEKIND, ppctinfo: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -6288,7 +6288,7 @@ unsafe impl ::windows::core::Interface for IDispError {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDispError_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub QueryErrorInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, guiderrortype: ::windows::core::GUID, ppde: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetNext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppde: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetHresult: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, phr: *mut ::windows::core::HRESULT) -> ::windows::core::HRESULT,
@@ -6469,7 +6469,7 @@ unsafe impl ::windows::core::Interface for IDropSource {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDropSource_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_SystemServices"))]
     pub QueryContinueDrag: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fescapepressed: super::super::Foundation::BOOL, grfkeystate: super::SystemServices::MODIFIERKEYS_FLAGS) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_SystemServices")))]
@@ -6530,7 +6530,7 @@ unsafe impl ::windows::core::Interface for IDropSourceNotify {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDropSourceNotify_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub DragEnterTarget: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hwndtarget: super::super::Foundation::HWND) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -6604,7 +6604,7 @@ unsafe impl ::windows::core::Interface for IDropTarget {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDropTarget_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_SystemServices"))]
     pub DragEnter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdataobj: *mut ::core::ffi::c_void, grfkeystate: super::SystemServices::MODIFIERKEYS_FLAGS, pt: super::super::Foundation::POINTL, pdweffect: *mut DROPEFFECT) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_SystemServices")))]
@@ -6674,7 +6674,7 @@ unsafe impl ::windows::core::Interface for IEnterpriseDropTarget {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnterpriseDropTarget_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetDropSourceEnterpriseId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, identity: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub IsEvaluatingEdpPolicy: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -6739,7 +6739,7 @@ unsafe impl ::windows::core::Interface for IEnumOLEVERB {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumOLEVERB_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut OLEVERB, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_UI_WindowsAndMessaging"))]
@@ -6804,7 +6804,7 @@ unsafe impl ::windows::core::Interface for IEnumOleDocumentViews {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumOleDocumentViews_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cviews: u32, rgpview: *mut *mut ::core::ffi::c_void, pcfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cviews: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -6866,7 +6866,7 @@ unsafe impl ::windows::core::Interface for IEnumOleUndoUnits {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumOleUndoUnits_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -6930,7 +6930,7 @@ unsafe impl ::windows::core::Interface for IEnumVARIANT {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumVARIANT_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgvar: *mut super::Com::VARIANT, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com")))]
@@ -7119,7 +7119,7 @@ unsafe impl ::windows::core::Interface for IFont {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IFont_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Name: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pname: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub SetName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, name: ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
@@ -7382,7 +7382,7 @@ unsafe impl ::windows::core::Interface for IGetOleObject {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IGetOleObject_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetOleObject: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppvobj: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Ole\"`*"]
@@ -7431,7 +7431,7 @@ unsafe impl ::windows::core::Interface for IGetVBAObject {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IGetVBAObject_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetObject: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppvobj: *mut *mut ::core::ffi::c_void, dwreserved: u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Ole\"`*"]
@@ -7483,7 +7483,7 @@ unsafe impl ::windows::core::Interface for IObjectIdentity {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IObjectIdentity_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub IsEqualObject: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punk: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Ole\"`*"]
@@ -7542,7 +7542,7 @@ unsafe impl ::windows::core::Interface for IObjectWithSite {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IObjectWithSite_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetSite: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punksite: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetSite: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppvsite: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -7621,7 +7621,7 @@ unsafe impl ::windows::core::Interface for IOleAdviseHolder {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOleAdviseHolder_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub Advise: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, padvise: *mut ::core::ffi::c_void, pdwconnection: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -7712,7 +7712,7 @@ unsafe impl ::windows::core::Interface for IOleCache {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOleCache_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub Cache: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pformatetc: *const super::Com::FORMATETC, advf: u32, pdwconnection: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -7892,7 +7892,7 @@ unsafe impl ::windows::core::Interface for IOleCacheControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOleCacheControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub OnRun: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdataobject: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -7969,7 +7969,7 @@ unsafe impl ::windows::core::Interface for IOleClientSite {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOleClientSite_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SaveObject: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
     pub GetMoniker: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwassign: OLEGETMONIKER, dwwhichmoniker: OLEWHICHMK, ppmk: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -8034,7 +8034,7 @@ unsafe impl ::windows::core::Interface for IOleCommandTarget {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOleCommandTarget_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub QueryStatus: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pguidcmdgroup: *const ::windows::core::GUID, ccmds: u32, prgcmds: *mut OLECMD, pcmdtext: *mut OLECMDTEXT) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
     pub Exec: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pguidcmdgroup: *const ::windows::core::GUID, ncmdid: u32, ncmdexecopt: u32, pvain: *const super::Com::VARIANT, pvaout: *mut super::Com::VARIANT) -> ::windows::core::HRESULT,
@@ -8196,7 +8196,7 @@ unsafe impl ::windows::core::Interface for IOleControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOleControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
     pub GetControlInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pci: *mut CONTROLINFO) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_UI_WindowsAndMessaging"))]
@@ -8292,7 +8292,7 @@ unsafe impl ::windows::core::Interface for IOleControlSite {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOleControlSite_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnControlInfoChanged: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub LockInPlaceActive: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, flock: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -8376,7 +8376,7 @@ unsafe impl ::windows::core::Interface for IOleDocument {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOleDocument_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub CreateView: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pipsite: *mut ::core::ffi::c_void, pstm: *mut ::core::ffi::c_void, dwreserved: u32, ppview: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -8433,7 +8433,7 @@ unsafe impl ::windows::core::Interface for IOleDocumentSite {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOleDocumentSite_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ActivateMe: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pviewtoactivate: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Ole\"`*"]
@@ -8554,7 +8554,7 @@ unsafe impl ::windows::core::Interface for IOleDocumentView {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOleDocumentView_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetInPlaceSite: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pipsite: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetInPlaceSite: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppipsite: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetDocument: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppunk: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -10029,7 +10029,7 @@ unsafe impl ::windows::core::Interface for IOleLink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOleLink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetUpdateOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwupdateopt: u32) -> ::windows::core::HRESULT,
     pub GetUpdateOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwupdateopt: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
@@ -10211,7 +10211,7 @@ unsafe impl ::windows::core::Interface for IOleObject {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOleObject_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetClientSite: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pclientsite: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetClientSite: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppclientsite: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetHostNames: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, szcontainerapp: ::windows::core::PCWSTR, szcontainerobj: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
@@ -10461,7 +10461,7 @@ unsafe impl ::windows::core::Interface for IOleUILinkContainerA {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOleUILinkContainerA_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetNextLink: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwlink: u32) -> u32,
     pub SetLinkUpdateOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwlink: u32, dwupdateopt: u32) -> ::windows::core::HRESULT,
     pub GetLinkUpdateOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwlink: u32, lpdwupdateopt: *mut u32) -> ::windows::core::HRESULT,
@@ -10562,7 +10562,7 @@ unsafe impl ::windows::core::Interface for IOleUILinkContainerW {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOleUILinkContainerW_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetNextLink: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwlink: u32) -> u32,
     pub SetLinkUpdateOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwlink: u32, dwupdateopt: u32) -> ::windows::core::HRESULT,
     pub GetLinkUpdateOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwlink: u32, lpdwupdateopt: *mut u32) -> ::windows::core::HRESULT,
@@ -10862,7 +10862,7 @@ unsafe impl ::windows::core::Interface for IOleUIObjInfoA {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOleUIObjInfoA_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetObjectInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwobject: u32, lpdwobjsize: *mut u32, lplpszlabel: *mut ::windows::core::PSTR, lplpsztype: *mut ::windows::core::PSTR, lplpszshorttype: *mut ::windows::core::PSTR, lplpszlocation: *mut ::windows::core::PSTR) -> ::windows::core::HRESULT,
     pub GetConvertInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwobject: u32, lpclassid: *mut ::windows::core::GUID, lpwformat: *mut u16, lpconvertdefaultclassid: *mut ::windows::core::GUID, lplpclsidexclude: *mut *mut ::windows::core::GUID, lpcclsidexclude: *mut u32) -> ::windows::core::HRESULT,
     pub ConvertObject: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwobject: u32, clsidnew: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
@@ -10935,7 +10935,7 @@ unsafe impl ::windows::core::Interface for IOleUIObjInfoW {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOleUIObjInfoW_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetObjectInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwobject: u32, lpdwobjsize: *mut u32, lplpszlabel: *mut ::windows::core::PWSTR, lplpsztype: *mut ::windows::core::PWSTR, lplpszshorttype: *mut ::windows::core::PWSTR, lplpszlocation: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetConvertInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwobject: u32, lpclassid: *mut ::windows::core::GUID, lpwformat: *mut u16, lpconvertdefaultclassid: *mut ::windows::core::GUID, lplpclsidexclude: *mut *mut ::windows::core::GUID, lpcclsidexclude: *mut u32) -> ::windows::core::HRESULT,
     pub ConvertObject: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwobject: u32, clsidnew: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
@@ -11055,7 +11055,7 @@ unsafe impl ::windows::core::Interface for IOleUndoManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOleUndoManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Open: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppuu: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub Close: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppuu: *mut ::core::ffi::c_void, fcommit: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -11134,7 +11134,7 @@ unsafe impl ::windows::core::Interface for IOleUndoUnit {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOleUndoUnit_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Do: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pundomanager: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetDescription: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstr: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub GetUnitType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pclsid: *mut ::windows::core::GUID, plid: *mut i32) -> ::windows::core::HRESULT,
@@ -11197,7 +11197,7 @@ unsafe impl ::windows::core::Interface for IOleWindow {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOleWindow_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetWindow: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, phwnd: *mut super::super::Foundation::HWND) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -11259,7 +11259,7 @@ unsafe impl ::windows::core::Interface for IParseDisplayName {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IParseDisplayName_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub ParseDisplayName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbc: *mut ::core::ffi::c_void, pszdisplayname: ::windows::core::PCWSTR, pcheaten: *mut u32, ppmkout: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -11325,7 +11325,7 @@ unsafe impl ::windows::core::Interface for IPerPropertyBrowsing {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPerPropertyBrowsing_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDisplayString: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dispid: i32, pbstr: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub MapPropertyToPage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dispid: i32, pclsid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub GetPredefinedStrings: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dispid: i32, pcastringsout: *mut CALPOLESTR, pcacookiesout: *mut CADWORD) -> ::windows::core::HRESULT,
@@ -11679,7 +11679,7 @@ unsafe impl ::windows::core::Interface for IPicture {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPicture_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Handle: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, phandle: *mut u32) -> ::windows::core::HRESULT,
     pub hPal: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, phpal: *mut u32) -> ::windows::core::HRESULT,
     pub Type: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptype: *mut i16) -> ::windows::core::HRESULT,
@@ -11832,7 +11832,7 @@ unsafe impl ::windows::core::Interface for IPicture2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPicture2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Handle: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, phandle: *mut usize) -> ::windows::core::HRESULT,
     pub hPal: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, phpal: *mut usize) -> ::windows::core::HRESULT,
     pub Type: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptype: *mut i16) -> ::windows::core::HRESULT,
@@ -11999,7 +11999,7 @@ unsafe impl ::windows::core::Interface for IPointerInactive {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPointerInactive_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetActivationPolicy: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwpolicy: *mut POINTERINACTIVE) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub OnInactiveMouseMove: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, prectbounds: *const super::super::Foundation::RECT, x: i32, y: i32, grfkeystate: u32) -> ::windows::core::HRESULT,
@@ -12067,7 +12067,7 @@ unsafe impl ::windows::core::Interface for IPrint {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPrint_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetInitialPageNum: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, nfirstpage: i32) -> ::windows::core::HRESULT,
     pub GetPageInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pnfirstpage: *mut i32, pcpages: *mut i32) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
@@ -12124,7 +12124,7 @@ unsafe impl ::windows::core::Interface for IPropertyNotifySink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPropertyNotifySink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnChanged: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dispid: i32) -> ::windows::core::HRESULT,
     pub OnRequestEdit: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dispid: i32) -> ::windows::core::HRESULT,
 }
@@ -12223,7 +12223,7 @@ unsafe impl ::windows::core::Interface for IPropertyPage {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPropertyPage_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetPageSite: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppagesite: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub Activate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hwndparent: super::super::Foundation::HWND, prect: *const super::super::Foundation::RECT, bmodal: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -12423,7 +12423,7 @@ unsafe impl ::windows::core::Interface for IPropertyPageSite {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPropertyPageSite_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnStatusChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwflags: PROPPAGESTATUS) -> ::windows::core::HRESULT,
     pub GetLocaleID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, plocaleid: *mut u32) -> ::windows::core::HRESULT,
     pub GetPageContainer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppunk: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -12481,7 +12481,7 @@ unsafe impl ::windows::core::Interface for IProtectFocus {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IProtectFocus_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub AllowFocusChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfallow: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -12555,7 +12555,7 @@ unsafe impl ::windows::core::Interface for IProtectedModeMenuServices {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IProtectedModeMenuServices_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
     pub CreateMenu: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, phmenu: *mut super::super::UI::WindowsAndMessaging::HMENU) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_UI_WindowsAndMessaging"))]
@@ -12618,7 +12618,7 @@ unsafe impl ::windows::core::Interface for IProvideClassInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IProvideClassInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub GetClassInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppti: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -12840,7 +12840,7 @@ unsafe impl ::windows::core::Interface for IProvideRuntimeContext {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IProvideRuntimeContext_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCurrentSourceContext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwcontext: *mut usize, pfexecutingglobalcode: *mut i16) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Ole\"`*"]
@@ -12902,7 +12902,7 @@ unsafe impl ::windows::core::Interface for IQuickActivate {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IQuickActivate_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
     pub QuickActivate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pqacontainer: *const QACONTAINER, pqacontrol: *mut QACONTROL) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com")))]
@@ -13039,7 +13039,7 @@ unsafe impl ::windows::core::Interface for IRecordInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRecordInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub RecordInit: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pvnew: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub RecordClear: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pvexisting: *const ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub RecordCopy: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pvexisting: *const ::core::ffi::c_void, pvnew: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -13138,7 +13138,7 @@ unsafe impl ::windows::core::Interface for ISimpleFrameSite {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISimpleFrameSite_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub PreMessageFilter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hwnd: super::super::Foundation::HWND, msg: u32, wp: super::super::Foundation::WPARAM, lp: super::super::Foundation::LPARAM, plresult: *mut super::super::Foundation::LRESULT, pdwcookie: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -13195,7 +13195,7 @@ unsafe impl ::windows::core::Interface for ISpecifyPropertyPages {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISpecifyPropertyPages_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetPages: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppages: *mut CAUUID) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Ole\"`*"]
@@ -13260,7 +13260,7 @@ unsafe impl ::windows::core::Interface for ITypeChangeEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITypeChangeEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub RequestTypeChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, changekind: CHANGEKIND, ptinfobefore: *mut ::core::ffi::c_void, pstrname: ::windows::core::PCWSTR, pfcancel: *mut i32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -13322,7 +13322,7 @@ unsafe impl ::windows::core::Interface for ITypeFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITypeFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub CreateFromTypeInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptypeinfo: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -13384,7 +13384,7 @@ unsafe impl ::windows::core::Interface for ITypeMarshal {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITypeMarshal_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Size: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pvtype: *const ::core::ffi::c_void, dwdestcontext: u32, pvdestcontext: *const ::core::ffi::c_void, psize: *mut u32) -> ::windows::core::HRESULT,
     pub Marshal: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pvtype: *const ::core::ffi::c_void, dwdestcontext: u32, pvdestcontext: *const ::core::ffi::c_void, cbbufferlength: u32, pbuffer: *mut u8, pcbwritten: *mut u32) -> ::windows::core::HRESULT,
     pub Unmarshal: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pvtype: *mut ::core::ffi::c_void, dwflags: u32, cbbufferlength: u32, pbuffer: *const u8, pcbread: *mut u32) -> ::windows::core::HRESULT,
@@ -13438,7 +13438,7 @@ unsafe impl ::windows::core::Interface for IVBFormat {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVBFormat_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
     pub Format: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, vdata: *mut super::Com::VARIANT, bstrformat: ::core::mem::ManuallyDrop<::windows::core::BSTR>, lpbuffer: *mut ::core::ffi::c_void, cb: u16, lcid: i32, sfirstdayofweek: i16, sfirstweekofyear: u16, rcb: *mut u16) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com")))]
@@ -13493,7 +13493,7 @@ unsafe impl ::windows::core::Interface for IVBGetControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVBGetControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub EnumControls: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwolecontf: OLECONTF, dwwhich: ENUM_CONTROLS_WHICH_FLAGS, ppenumunk: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -13547,7 +13547,7 @@ unsafe impl ::windows::core::Interface for IVariantChangeType {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVariantChangeType_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
     pub ChangeType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pvardst: *mut super::Com::VARIANT, pvarsrc: *const super::Com::VARIANT, lcid: u32, vtnew: super::Com::VARENUM) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com")))]
@@ -13632,7 +13632,7 @@ unsafe impl ::windows::core::Interface for IViewObject {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IViewObject_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
     pub Draw: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwdrawaspect: u32, lindex: i32, pvaspect: *mut ::core::ffi::c_void, ptd: *const super::Com::DVTARGETDEVICE, hdctargetdev: super::super::Graphics::Gdi::HDC, hdcdraw: super::super::Graphics::Gdi::HDC, lprcbounds: *const super::super::Foundation::RECTL, lprcwbounds: *const super::super::Foundation::RECTL, pfncontinue: isize, dwcontinue: usize) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com")))]
@@ -13969,7 +13969,7 @@ unsafe impl ::windows::core::Interface for IZoomEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IZoomEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnZoomPercentChanged: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ulzoompercent: u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Ole\"`*"]

--- a/crates/libs/windows/src/Windows/Win32/System/ParentalControls/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/ParentalControls/impl.rs
@@ -57,7 +57,7 @@ impl IWPCProviderConfig_Vtbl {
             this.RequestOverride(::core::mem::transmute_copy(&hwnd), ::core::mem::transmute(&bstrpath), ::core::mem::transmute_copy(&dwflags)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetUserSummary: GetUserSummary::<Identity, Impl, OFFSET>,
             Configure: Configure::<Identity, Impl, OFFSET>,
             RequestOverride: RequestOverride::<Identity, Impl, OFFSET>,
@@ -85,7 +85,7 @@ impl IWPCProviderState_Vtbl {
             this.Disable().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Enable: Enable::<Identity, Impl, OFFSET>,
             Disable: Disable::<Identity, Impl, OFFSET>,
         }
@@ -111,7 +111,7 @@ impl IWPCProviderSupport_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetCurrent: GetCurrent::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetCurrent: GetCurrent::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWPCProviderSupport as ::windows::core::Interface>::IID
@@ -162,7 +162,7 @@ impl IWPCSettings_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             IsLoggingRequired: IsLoggingRequired::<Identity, Impl, OFFSET>,
             GetLastSettingsChangeTime: GetLastSettingsChangeTime::<Identity, Impl, OFFSET>,
             GetRestrictions: GetRestrictions::<Identity, Impl, OFFSET>,
@@ -285,7 +285,7 @@ impl IWindowsParentalControlsCore_Vtbl {
             this.GetWebFilterInfo(::core::mem::transmute_copy(&pguidid), ::core::mem::transmute_copy(&ppszname)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetVisibility: GetVisibility::<Identity, Impl, OFFSET>,
             GetUserSettings: GetUserSettings::<Identity, Impl, OFFSET>,
             GetWebSettings: GetWebSettings::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/System/ParentalControls/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/ParentalControls/mod.rs
@@ -142,7 +142,7 @@ unsafe impl ::windows::core::Interface for IWPCProviderConfig {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWPCProviderConfig_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetUserSummary: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrsid: ::core::mem::ManuallyDrop<::windows::core::BSTR>, pbstrusersummary: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub Configure: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hwnd: super::super::Foundation::HWND, bstrsid: ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
@@ -202,7 +202,7 @@ unsafe impl ::windows::core::Interface for IWPCProviderState {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWPCProviderState_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Enable: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Disable: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -253,7 +253,7 @@ unsafe impl ::windows::core::Interface for IWPCProviderSupport {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWPCProviderSupport_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCurrent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pguidprovider: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_ParentalControls\"`*"]
@@ -315,7 +315,7 @@ unsafe impl ::windows::core::Interface for IWPCSettings {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWPCSettings_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub IsLoggingRequired: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfrequired: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -574,7 +574,7 @@ unsafe impl ::windows::core::Interface for IWindowsParentalControlsCore {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWindowsParentalControlsCore_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetVisibility: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pevisibility: *mut WPCFLAG_VISIBILITY) -> ::windows::core::HRESULT,
     pub GetUserSettings: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcszsid: ::windows::core::PCWSTR, ppsettings: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetWebSettings: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcszsid: ::windows::core::PCWSTR, ppsettings: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/System/Performance/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Performance/impl.rs
@@ -705,7 +705,7 @@ impl ICounterItem_Vtbl {
             this.GetStatistics(::core::mem::transmute_copy(&max), ::core::mem::transmute_copy(&min), ::core::mem::transmute_copy(&avg), ::core::mem::transmute_copy(&status)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Value: Value::<Identity, Impl, OFFSET>,
             SetColor: SetColor::<Identity, Impl, OFFSET>,
             Color: Color::<Identity, Impl, OFFSET>,
@@ -2460,7 +2460,7 @@ impl ILogFileItem_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Path: Path::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Path: Path::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ILogFileItem as ::windows::core::Interface>::IID
@@ -3530,7 +3530,7 @@ impl ISystemMonitor_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Appearance: Appearance::<Identity, Impl, OFFSET>,
             SetAppearance: SetAppearance::<Identity, Impl, OFFSET>,
             BackColor: BackColor::<Identity, Impl, OFFSET>,
@@ -3847,7 +3847,7 @@ impl ISystemMonitorEvents_Vtbl {
             this.OnDblClick(::core::mem::transmute_copy(&index))
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnCounterSelected: OnCounterSelected::<Identity, Impl, OFFSET>,
             OnCounterAdded: OnCounterAdded::<Identity, Impl, OFFSET>,
             OnCounterDeleted: OnCounterDeleted::<Identity, Impl, OFFSET>,
@@ -5043,7 +5043,7 @@ impl _ICounterItemUnion_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Value: Value::<Identity, Impl, OFFSET>,
             SetColor: SetColor::<Identity, Impl, OFFSET>,
             Color: Color::<Identity, Impl, OFFSET>,
@@ -5910,7 +5910,7 @@ impl _ISystemMonitorUnion_Vtbl {
             this.LoadSettings(::core::mem::transmute(&bstrsettingfilename)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Appearance: Appearance::<Identity, Impl, OFFSET>,
             SetAppearance: SetAppearance::<Identity, Impl, OFFSET>,
             BackColor: BackColor::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/System/Performance/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Performance/mod.rs
@@ -2892,7 +2892,7 @@ unsafe impl ::windows::core::Interface for ICounterItem {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICounterItem_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Value: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdblvalue: *mut f64) -> ::windows::core::HRESULT,
     pub SetColor: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, color: u32) -> ::windows::core::HRESULT,
     pub Color: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcolor: *mut u32) -> ::windows::core::HRESULT,
@@ -4543,7 +4543,7 @@ unsafe impl ::windows::core::Interface for ILogFileItem {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ILogFileItem_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Path: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pstrvalue: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Performance\"`, `\"Win32_System_Com\"`*"]
@@ -5528,7 +5528,7 @@ unsafe impl ::windows::core::Interface for ISystemMonitor {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISystemMonitor_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Appearance: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, iappearance: *mut i32) -> ::windows::core::HRESULT,
     pub SetAppearance: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, iappearance: i32) -> ::windows::core::HRESULT,
     pub BackColor: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcolor: *mut u32) -> ::windows::core::HRESULT,
@@ -6101,7 +6101,7 @@ unsafe impl ::windows::core::Interface for ISystemMonitorEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISystemMonitorEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnCounterSelected: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: i32),
     pub OnCounterAdded: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: i32),
     pub OnCounterDeleted: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: i32),
@@ -7268,7 +7268,7 @@ unsafe impl ::windows::core::Interface for _ICounterItemUnion {
 #[repr(C)]
 #[doc(hidden)]
 pub struct _ICounterItemUnion_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Value: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdblvalue: *mut f64) -> ::windows::core::HRESULT,
     pub SetColor: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, color: u32) -> ::windows::core::HRESULT,
     pub Color: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcolor: *mut u32) -> ::windows::core::HRESULT,
@@ -7678,7 +7678,7 @@ unsafe impl ::windows::core::Interface for _ISystemMonitorUnion {
 #[repr(C)]
 #[doc(hidden)]
 pub struct _ISystemMonitorUnion_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Appearance: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, iappearance: *mut i32) -> ::windows::core::HRESULT,
     pub SetAppearance: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, iappearance: i32) -> ::windows::core::HRESULT,
     pub BackColor: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcolor: *mut u32) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/System/RealTimeCommunications/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/RealTimeCommunications/impl.rs
@@ -19,7 +19,7 @@ impl INetworkTransportSettings_Vtbl {
             this.QuerySetting(::core::mem::transmute_copy(&settingid), ::core::mem::transmute_copy(&lengthin), ::core::mem::transmute_copy(&valuein), ::core::mem::transmute_copy(&lengthout), ::core::mem::transmute_copy(&valueout)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ApplySetting: ApplySetting::<Identity, Impl, OFFSET>,
             QuerySetting: QuerySetting::<Identity, Impl, OFFSET>,
         }
@@ -46,7 +46,7 @@ impl INotificationTransportSync_Vtbl {
             this.Flush().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CompleteDelivery: CompleteDelivery::<Identity, Impl, OFFSET>,
             Flush: Flush::<Identity, Impl, OFFSET>,
         }
@@ -382,7 +382,7 @@ impl IRTCBuddyGroup_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Name: Name::<Identity, Impl, OFFSET>,
             SetName: SetName::<Identity, Impl, OFFSET>,
             AddBuddy: AddBuddy::<Identity, Impl, OFFSET>,
@@ -853,7 +853,7 @@ impl IRTCClient_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             Shutdown: Shutdown::<Identity, Impl, OFFSET>,
             PrepareForShutdown: PrepareForShutdown::<Identity, Impl, OFFSET>,
@@ -1105,7 +1105,7 @@ impl IRTCClientPortManagement_Vtbl {
             this.GetPortRange(::core::mem::transmute_copy(&enporttype), ::core::mem::transmute_copy(&plminvalue), ::core::mem::transmute_copy(&plmaxvalue)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             StartListenAddressAndPort: StartListenAddressAndPort::<Identity, Impl, OFFSET>,
             StopListenAddressAndPort: StopListenAddressAndPort::<Identity, Impl, OFFSET>,
             GetPortRange: GetPortRange::<Identity, Impl, OFFSET>,
@@ -1292,7 +1292,7 @@ impl IRTCClientPresence_Vtbl {
             this.SetPrivacyMode(::core::mem::transmute_copy(&enmode)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             EnablePresence: EnablePresence::<Identity, Impl, OFFSET>,
             Export: Export::<Identity, Impl, OFFSET>,
             Import: Import::<Identity, Impl, OFFSET>,
@@ -1561,7 +1561,7 @@ impl IRTCClientProvisioning_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateProfile: CreateProfile::<Identity, Impl, OFFSET>,
             EnableProfile: EnableProfile::<Identity, Impl, OFFSET>,
             DisableProfile: DisableProfile::<Identity, Impl, OFFSET>,
@@ -1699,7 +1699,7 @@ impl IRTCEnumBuddies_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
@@ -1746,7 +1746,7 @@ impl IRTCEnumGroups_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
@@ -1793,7 +1793,7 @@ impl IRTCEnumParticipants_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
@@ -1840,7 +1840,7 @@ impl IRTCEnumPresenceDevices_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
@@ -1887,7 +1887,7 @@ impl IRTCEnumProfiles_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
@@ -1934,7 +1934,7 @@ impl IRTCEnumUserSearchResults_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
@@ -1981,7 +1981,7 @@ impl IRTCEnumWatchers_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
@@ -2006,7 +2006,7 @@ impl IRTCEventNotification_Vtbl {
             let this = (*this).get_impl();
             this.Event(::core::mem::transmute_copy(&rtcevent), ::core::mem::transmute(&pevent)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Event: Event::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Event: Event::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IRTCEventNotification as ::windows::core::Interface>::IID
@@ -2458,7 +2458,7 @@ impl IRTCParticipant_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             UserURI: UserURI::<Identity, Impl, OFFSET>,
             Name: Name::<Identity, Impl, OFFSET>,
             Removable: Removable::<Identity, Impl, OFFSET>,
@@ -2549,7 +2549,7 @@ impl IRTCPortManager_Vtbl {
             this.ReleaseMapping(::core::mem::transmute(&bstrinternallocaladdress), ::core::mem::transmute_copy(&linternallocalport), ::core::mem::transmute(&bstrexternallocaladdress), ::core::mem::transmute_copy(&lexternallocaladdress)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetMapping: GetMapping::<Identity, Impl, OFFSET>,
             UpdateRemoteAddress: UpdateRemoteAddress::<Identity, Impl, OFFSET>,
             ReleaseMapping: ReleaseMapping::<Identity, Impl, OFFSET>,
@@ -2637,7 +2637,7 @@ impl IRTCPresenceContact_Vtbl {
             this.SetPersistent(::core::mem::transmute_copy(&fpersistent)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             PresentityURI: PresentityURI::<Identity, Impl, OFFSET>,
             SetPresentityURI: SetPresentityURI::<Identity, Impl, OFFSET>,
             Name: Name::<Identity, Impl, OFFSET>,
@@ -2749,7 +2749,7 @@ impl IRTCPresenceDevice_Vtbl {
             this.GetPresenceData(::core::mem::transmute_copy(&pbstrnamespace), ::core::mem::transmute_copy(&pbstrdata)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Status: Status::<Identity, Impl, OFFSET>,
             Notes: Notes::<Identity, Impl, OFFSET>,
             get_PresenceProperty: get_PresenceProperty::<Identity, Impl, OFFSET>,
@@ -3093,7 +3093,7 @@ impl IRTCProfile_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Key: Key::<Identity, Impl, OFFSET>,
             Name: Name::<Identity, Impl, OFFSET>,
             XML: XML::<Identity, Impl, OFFSET>,
@@ -3640,7 +3640,7 @@ impl IRTCSession_Vtbl {
             this.put_EncryptionKey(::core::mem::transmute_copy(&lmediatype), ::core::mem::transmute(&encryptionkey)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Client: Client::<Identity, Impl, OFFSET>,
             State: State::<Identity, Impl, OFFSET>,
             Type: Type::<Identity, Impl, OFFSET>,
@@ -3815,7 +3815,7 @@ impl IRTCSessionCallControl_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Hold: Hold::<Identity, Impl, OFFSET>,
             UnHold: UnHold::<Identity, Impl, OFFSET>,
             Forward: Forward::<Identity, Impl, OFFSET>,
@@ -3843,7 +3843,7 @@ impl IRTCSessionDescriptionManager_Vtbl {
             this.EvaluateSessionDescription(::core::mem::transmute(&bstrcontenttype), ::core::mem::transmute(&bstrsessiondescription), ::core::mem::transmute_copy(&pfapplicationsession)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             EvaluateSessionDescription: EvaluateSessionDescription::<Identity, Impl, OFFSET>,
         }
     }
@@ -3966,7 +3966,7 @@ impl IRTCSessionPortManagement_Vtbl {
             let this = (*this).get_impl();
             this.SetPortManager(::core::mem::transmute(&pportmanager)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SetPortManager: SetPortManager::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SetPortManager: SetPortManager::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IRTCSessionPortManagement as ::windows::core::Interface>::IID
@@ -4283,7 +4283,7 @@ impl IRTCUserSearch_Vtbl {
             this.ExecuteSearch(::core::mem::transmute(&pquery), ::core::mem::transmute(&pprofile), ::core::mem::transmute_copy(&lcookie)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateQuery: CreateQuery::<Identity, Impl, OFFSET>,
             ExecuteSearch: ExecuteSearch::<Identity, Impl, OFFSET>,
         }
@@ -4364,7 +4364,7 @@ impl IRTCUserSearchQuery_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             put_SearchTerm: put_SearchTerm::<Identity, Impl, OFFSET>,
             get_SearchTerm: get_SearchTerm::<Identity, Impl, OFFSET>,
             SearchTerms: SearchTerms::<Identity, Impl, OFFSET>,
@@ -4395,7 +4395,7 @@ impl IRTCUserSearchResult_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), get_Value: get_Value::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), get_Value: get_Value::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IRTCUserSearchResult as ::windows::core::Interface>::IID
@@ -4665,7 +4665,7 @@ impl ITransportSettingsInternal_Vtbl {
             this.QuerySetting(::core::mem::transmute_copy(&setting)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ApplySetting: ApplySetting::<Identity, Impl, OFFSET>,
             QuerySetting: QuerySetting::<Identity, Impl, OFFSET>,
         }

--- a/crates/libs/windows/src/Windows/Win32/System/RealTimeCommunications/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/RealTimeCommunications/mod.rs
@@ -51,7 +51,7 @@ unsafe impl ::windows::core::Interface for INetworkTransportSettings {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INetworkTransportSettings_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Networking_WinSock")]
     pub ApplySetting: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, settingid: *const super::super::Networking::WinSock::TRANSPORT_SETTING_ID, lengthin: u32, valuein: *const u8, lengthout: *mut u32, valueout: *mut *mut u8) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Networking_WinSock"))]
@@ -110,7 +110,7 @@ unsafe impl ::windows::core::Interface for INotificationTransportSync {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INotificationTransportSync_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CompleteDelivery: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Flush: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -645,7 +645,7 @@ unsafe impl ::windows::core::Interface for IRTCBuddyGroup {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRTCBuddyGroup_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Name: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstrgroupname: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub SetName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrgroupname: ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub AddBuddy: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbuddy: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -950,7 +950,7 @@ unsafe impl ::windows::core::Interface for IRTCClient {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRTCClient_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Shutdown: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub PrepareForShutdown: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1413,7 +1413,7 @@ unsafe impl ::windows::core::Interface for IRTCClientPortManagement {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRTCClientPortManagement_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub StartListenAddressAndPort: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrinternallocaladdress: ::core::mem::ManuallyDrop<::windows::core::BSTR>, linternallocalport: i32) -> ::windows::core::HRESULT,
     pub StopListenAddressAndPort: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrinternallocaladdress: ::core::mem::ManuallyDrop<::windows::core::BSTR>, linternallocalport: i32) -> ::windows::core::HRESULT,
     pub GetPortRange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, enporttype: RTC_PORT_TYPE, plminvalue: *mut i32, plmaxvalue: *mut i32) -> ::windows::core::HRESULT,
@@ -1553,7 +1553,7 @@ unsafe impl ::windows::core::Interface for IRTCClientPresence {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRTCClientPresence_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub EnablePresence: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fusestorage: i16, varstorage: ::core::mem::ManuallyDrop<super::Com::VARIANT>) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole")))]
@@ -1910,7 +1910,7 @@ unsafe impl ::windows::core::Interface for IRTCClientProvisioning {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRTCClientProvisioning_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateProfile: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrprofilexml: ::core::mem::ManuallyDrop<::windows::core::BSTR>, ppprofile: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub EnableProfile: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pprofile: *mut ::core::ffi::c_void, lregisterflags: i32) -> ::windows::core::HRESULT,
     pub DisableProfile: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pprofile: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -2245,7 +2245,7 @@ unsafe impl ::windows::core::Interface for IRTCEnumBuddies {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRTCEnumBuddies_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, ppelements: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
@@ -2307,7 +2307,7 @@ unsafe impl ::windows::core::Interface for IRTCEnumGroups {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRTCEnumGroups_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, ppelements: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
@@ -2369,7 +2369,7 @@ unsafe impl ::windows::core::Interface for IRTCEnumParticipants {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRTCEnumParticipants_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, ppelements: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
@@ -2431,7 +2431,7 @@ unsafe impl ::windows::core::Interface for IRTCEnumPresenceDevices {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRTCEnumPresenceDevices_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, ppelements: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
@@ -2493,7 +2493,7 @@ unsafe impl ::windows::core::Interface for IRTCEnumProfiles {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRTCEnumProfiles_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, ppelements: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
@@ -2555,7 +2555,7 @@ unsafe impl ::windows::core::Interface for IRTCEnumUserSearchResults {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRTCEnumUserSearchResults_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, ppelements: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
@@ -2617,7 +2617,7 @@ unsafe impl ::windows::core::Interface for IRTCEnumWatchers {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRTCEnumWatchers_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, ppelements: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
@@ -2674,7 +2674,7 @@ unsafe impl ::windows::core::Interface for IRTCEventNotification {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRTCEventNotification_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub Event: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, rtcevent: RTC_EVENT, pevent: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -3231,7 +3231,7 @@ unsafe impl ::windows::core::Interface for IRTCParticipant {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRTCParticipant_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub UserURI: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstruseruri: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub Name: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstrname: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub Removable: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfremovable: *mut i16) -> ::windows::core::HRESULT,
@@ -3379,7 +3379,7 @@ unsafe impl ::windows::core::Interface for IRTCPortManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRTCPortManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetMapping: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrremoteaddress: ::core::mem::ManuallyDrop<::windows::core::BSTR>, enporttype: RTC_PORT_TYPE, pbstrinternallocaladdress: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>, plinternallocalport: *mut i32, pbstrexternallocaladdress: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>, plexternallocalport: *mut i32) -> ::windows::core::HRESULT,
     pub UpdateRemoteAddress: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrremoteaddress: ::core::mem::ManuallyDrop<::windows::core::BSTR>, bstrinternallocaladdress: ::core::mem::ManuallyDrop<::windows::core::BSTR>, linternallocalport: i32, bstrexternallocaladdress: ::core::mem::ManuallyDrop<::windows::core::BSTR>, lexternallocalport: i32) -> ::windows::core::HRESULT,
     pub ReleaseMapping: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrinternallocaladdress: ::core::mem::ManuallyDrop<::windows::core::BSTR>, linternallocalport: i32, bstrexternallocaladdress: ::core::mem::ManuallyDrop<::windows::core::BSTR>, lexternallocaladdress: i32) -> ::windows::core::HRESULT,
@@ -3455,7 +3455,7 @@ unsafe impl ::windows::core::Interface for IRTCPresenceContact {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRTCPresenceContact_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub PresentityURI: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstrpresentityuri: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub SetPresentityURI: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrpresentityuri: ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub Name: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstrname: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
@@ -3611,7 +3611,7 @@ unsafe impl ::windows::core::Interface for IRTCPresenceDevice {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRTCPresenceDevice_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Status: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, penstatus: *mut RTC_PRESENCE_STATUS) -> ::windows::core::HRESULT,
     pub Notes: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstrnotes: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub get_PresenceProperty: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, enproperty: RTC_PRESENCE_PROPERTY, pbstrproperty: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
@@ -3913,7 +3913,7 @@ unsafe impl ::windows::core::Interface for IRTCProfile {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRTCProfile_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Key: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstrkey: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub Name: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstrname: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub XML: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstrxml: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
@@ -4685,7 +4685,7 @@ unsafe impl ::windows::core::Interface for IRTCSession {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRTCSession_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Client: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppclient: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub State: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, penstate: *mut RTC_SESSION_STATE) -> ::windows::core::HRESULT,
     pub Type: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pentype: *mut RTC_SESSION_TYPE) -> ::windows::core::HRESULT,
@@ -4947,7 +4947,7 @@ unsafe impl ::windows::core::Interface for IRTCSessionCallControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRTCSessionCallControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Hold: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lcookie: isize) -> ::windows::core::HRESULT,
     pub UnHold: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lcookie: isize) -> ::windows::core::HRESULT,
     pub Forward: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrforwardtouri: ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
@@ -5004,7 +5004,7 @@ unsafe impl ::windows::core::Interface for IRTCSessionDescriptionManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRTCSessionDescriptionManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub EvaluateSessionDescription: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrcontenttype: ::core::mem::ManuallyDrop<::windows::core::BSTR>, bstrsessiondescription: ::core::mem::ManuallyDrop<::windows::core::BSTR>, pfapplicationsession: *mut i16) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"Win32_System_Com\"`*"]
@@ -5267,7 +5267,7 @@ unsafe impl ::windows::core::Interface for IRTCSessionPortManagement {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRTCSessionPortManagement_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetPortManager: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pportmanager: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"Win32_System_Com\"`*"]
@@ -5745,7 +5745,7 @@ unsafe impl ::windows::core::Interface for IRTCUserSearch {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRTCUserSearch_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateQuery: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppquery: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub ExecuteSearch: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pquery: *mut ::core::ffi::c_void, pprofile: *mut ::core::ffi::c_void, lcookie: isize) -> ::windows::core::HRESULT,
 }
@@ -5817,7 +5817,7 @@ unsafe impl ::windows::core::Interface for IRTCUserSearchQuery {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRTCUserSearchQuery_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub put_SearchTerm: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrname: ::core::mem::ManuallyDrop<::windows::core::BSTR>, bstrvalue: ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub get_SearchTerm: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrname: ::core::mem::ManuallyDrop<::windows::core::BSTR>, pbstrvalue: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub SearchTerms: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstrnames: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
@@ -5873,7 +5873,7 @@ unsafe impl ::windows::core::Interface for IRTCUserSearchResult {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRTCUserSearchResult_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub get_Value: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, encolumn: RTC_USER_SEARCH_COLUMN, pbstrvalue: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"Win32_System_Com\"`*"]
@@ -6445,7 +6445,7 @@ unsafe impl ::windows::core::Interface for ITransportSettingsInternal {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITransportSettingsInternal_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Networking_WinSock")]
     pub ApplySetting: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, setting: *mut TRANSPORT_SETTING) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Networking_WinSock"))]

--- a/crates/libs/windows/src/Windows/Win32/System/RemoteAssistance/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/RemoteAssistance/impl.rs
@@ -22,7 +22,7 @@ impl IRendezvousApplication_Vtbl {
             let this = (*this).get_impl();
             this.SetRendezvousSession(::core::mem::transmute(&prendezvoussession)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SetRendezvousSession: SetRendezvousSession::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SetRendezvousSession: SetRendezvousSession::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IRendezvousApplication as ::windows::core::Interface>::IID
@@ -82,7 +82,7 @@ impl IRendezvousSession_Vtbl {
             this.Terminate(::core::mem::transmute_copy(&hr), ::core::mem::transmute(&bstrappdata)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             State: State::<Identity, Impl, OFFSET>,
             RemoteUser: RemoteUser::<Identity, Impl, OFFSET>,
             Flags: Flags::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/System/RemoteAssistance/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/RemoteAssistance/mod.rs
@@ -120,7 +120,7 @@ unsafe impl ::windows::core::Interface for IRendezvousApplication {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRendezvousApplication_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetRendezvousSession: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, prendezvoussession: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_RemoteAssistance\"`*"]
@@ -184,7 +184,7 @@ unsafe impl ::windows::core::Interface for IRendezvousSession {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRendezvousSession_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub State: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psessionstate: *mut RENDEZVOUS_SESSION_STATE) -> ::windows::core::HRESULT,
     pub RemoteUser: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrusername: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub Flags: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pflags: *mut i32) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/System/RemoteDesktop/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/RemoteDesktop/impl.rs
@@ -359,7 +359,7 @@ impl IAudioDeviceEndpoint_Vtbl {
             this.WriteExclusiveModeParametersToSharedMemory(::core::mem::transmute_copy(&htargetprocess), ::core::mem::transmute_copy(&hnsperiod), ::core::mem::transmute_copy(&hnsbufferduration), ::core::mem::transmute_copy(&u32latencycoefficient), ::core::mem::transmute_copy(&pu32sharedmemorysize), ::core::mem::transmute_copy(&phsharedmemory)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetBuffer: SetBuffer::<Identity, Impl, OFFSET>,
             GetRTCaps: GetRTCaps::<Identity, Impl, OFFSET>,
             GetEventDrivenCapable: GetEventDrivenCapable::<Identity, Impl, OFFSET>,
@@ -427,7 +427,7 @@ impl IAudioEndpoint_Vtbl {
             this.SetEventHandle(::core::mem::transmute_copy(&eventhandle)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetFrameFormat: GetFrameFormat::<Identity, Impl, OFFSET>,
             GetFramesPerPacket: GetFramesPerPacket::<Identity, Impl, OFFSET>,
             GetLatency: GetLatency::<Identity, Impl, OFFSET>,
@@ -463,7 +463,7 @@ impl IAudioEndpointControl_Vtbl {
             this.Stop().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Start: Start::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
             Stop: Stop::<Identity, Impl, OFFSET>,
@@ -503,7 +503,7 @@ impl IAudioEndpointRT_Vtbl {
             this.SetPinActive().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCurrentPadding: GetCurrentPadding::<Identity, Impl, OFFSET>,
             ProcessingComplete: ProcessingComplete::<Identity, Impl, OFFSET>,
             SetPinInactive: SetPinInactive::<Identity, Impl, OFFSET>,
@@ -541,7 +541,7 @@ impl IAudioInputEndpointRT_Vtbl {
             this.PulseEndpoint()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetInputDataPointer: GetInputDataPointer::<Identity, Impl, OFFSET>,
             ReleaseInputDataPointer: ReleaseInputDataPointer::<Identity, Impl, OFFSET>,
             PulseEndpoint: PulseEndpoint::<Identity, Impl, OFFSET>,
@@ -578,7 +578,7 @@ impl IAudioOutputEndpointRT_Vtbl {
             this.PulseEndpoint()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetOutputDataPointer: GetOutputDataPointer::<Identity, Impl, OFFSET>,
             ReleaseOutputDataPointer: ReleaseOutputDataPointer::<Identity, Impl, OFFSET>,
             PulseEndpoint: PulseEndpoint::<Identity, Impl, OFFSET>,
@@ -885,7 +885,7 @@ impl IRemoteSystemAdditionalInfoProvider_Vtbl {
             let this = (*this).get_impl();
             this.GetAdditionalInfo(::core::mem::transmute_copy(&deduplicationid), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&mapview)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetAdditionalInfo: GetAdditionalInfo::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetAdditionalInfo: GetAdditionalInfo::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IRemoteSystemAdditionalInfoProvider as ::windows::core::Interface>::IID
@@ -902,7 +902,7 @@ impl ITSGAccountingEngine_Vtbl {
             let this = (*this).get_impl();
             this.DoAccounting(::core::mem::transmute_copy(&accountingdatatype), ::core::mem::transmute(&accountingdata)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), DoAccounting: DoAccounting::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), DoAccounting: DoAccounting::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ITSGAccountingEngine as ::windows::core::Interface>::IID
@@ -941,7 +941,7 @@ impl ITSGAuthenticateUserSink_Vtbl {
             this.DisconnectUser(::core::mem::transmute_copy(&context)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnUserAuthenticated: OnUserAuthenticated::<Identity, Impl, OFFSET>,
             OnUserAuthenticationFailed: OnUserAuthenticationFailed::<Identity, Impl, OFFSET>,
             ReauthenticateUser: ReauthenticateUser::<Identity, Impl, OFFSET>,
@@ -970,7 +970,7 @@ impl ITSGAuthenticationEngine_Vtbl {
             this.CancelAuthentication(::core::mem::transmute(&mainsessionid), ::core::mem::transmute_copy(&context)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AuthenticateUser: AuthenticateUser::<Identity, Impl, OFFSET>,
             CancelAuthentication: CancelAuthentication::<Identity, Impl, OFFSET>,
         }
@@ -990,7 +990,7 @@ impl ITSGAuthorizeConnectionSink_Vtbl {
             let this = (*this).get_impl();
             this.OnConnectionAuthorized(::core::mem::transmute_copy(&hrin), ::core::mem::transmute(&mainsessionid), ::core::mem::transmute_copy(&cbsohresponse), ::core::mem::transmute_copy(&pbsohresponse), ::core::mem::transmute_copy(&idletimeout), ::core::mem::transmute_copy(&sessiontimeout), ::core::mem::transmute_copy(&sessiontimeoutaction), ::core::mem::transmute_copy(&trustclass), ::core::mem::transmute_copy(&policyattributes)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnConnectionAuthorized: OnConnectionAuthorized::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnConnectionAuthorized: OnConnectionAuthorized::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ITSGAuthorizeConnectionSink as ::windows::core::Interface>::IID
@@ -1007,7 +1007,7 @@ impl ITSGAuthorizeResourceSink_Vtbl {
             let this = (*this).get_impl();
             this.OnChannelAuthorized(::core::mem::transmute_copy(&hrin), ::core::mem::transmute(&mainsessionid), ::core::mem::transmute_copy(&subsessionid), ::core::mem::transmute_copy(&allowedresourcenames), ::core::mem::transmute_copy(&numallowedresourcenames), ::core::mem::transmute_copy(&failedresourcenames), ::core::mem::transmute_copy(&numfailedresourcenames)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnChannelAuthorized: OnChannelAuthorized::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnChannelAuthorized: OnChannelAuthorized::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ITSGAuthorizeResourceSink as ::windows::core::Interface>::IID
@@ -1066,7 +1066,7 @@ impl ITSGPolicyEngine_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AuthorizeConnection: AuthorizeConnection::<Identity, Impl, OFFSET>,
             AuthorizeResource: AuthorizeResource::<Identity, Impl, OFFSET>,
             Refresh: Refresh::<Identity, Impl, OFFSET>,
@@ -1095,7 +1095,7 @@ impl ITsSbBaseNotifySink_Vtbl {
             this.OnReportStatus(::core::mem::transmute_copy(&messagetype), ::core::mem::transmute_copy(&messageid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnError: OnError::<Identity, Impl, OFFSET>,
             OnReportStatus: OnReportStatus::<Identity, Impl, OFFSET>,
         }
@@ -1287,7 +1287,7 @@ impl ITsSbClientConnection_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             UserName: UserName::<Identity, Impl, OFFSET>,
             Domain: Domain::<Identity, Impl, OFFSET>,
             InitialProgram: InitialProgram::<Identity, Impl, OFFSET>,
@@ -1373,7 +1373,7 @@ impl ITsSbEnvironment_Vtbl {
             this.SetEnvironmentPropertySet(::core::mem::transmute(&pval)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Name: Name::<Identity, Impl, OFFSET>,
             ServerWeight: ServerWeight::<Identity, Impl, OFFSET>,
             EnvironmentPropertySet: EnvironmentPropertySet::<Identity, Impl, OFFSET>,
@@ -1430,7 +1430,7 @@ impl ITsSbFilterPluginStore_Vtbl {
             this.DeleteProperties(::core::mem::transmute(&propertyname)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SaveProperties: SaveProperties::<Identity, Impl, OFFSET>,
             EnumerateProperties: EnumerateProperties::<Identity, Impl, OFFSET>,
             DeleteProperties: DeleteProperties::<Identity, Impl, OFFSET>,
@@ -1467,7 +1467,7 @@ impl ITsSbGenericNotifySink_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnCompleted: OnCompleted::<Identity, Impl, OFFSET>,
             GetWaitTimeout: GetWaitTimeout::<Identity, Impl, OFFSET>,
         }
@@ -1539,7 +1539,7 @@ impl ITsSbGlobalStore_Vtbl {
             this.GetFarmProperty(::core::mem::transmute(&farmname), ::core::mem::transmute(&propertyname), ::core::mem::transmute_copy(&pvarvalue)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             QueryTarget: QueryTarget::<Identity, Impl, OFFSET>,
             QuerySessionBySessionId: QuerySessionBySessionId::<Identity, Impl, OFFSET>,
             EnumerateFarms: EnumerateFarms::<Identity, Impl, OFFSET>,
@@ -1570,7 +1570,7 @@ impl ITsSbLoadBalanceResult_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), TargetName: TargetName::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), TargetName: TargetName::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ITsSbLoadBalanceResult as ::windows::core::Interface>::IID
@@ -1714,7 +1714,7 @@ impl ITsSbPlugin_Vtbl {
             this.Terminate(::core::mem::transmute_copy(&hr)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             Terminate: Terminate::<Identity, Impl, OFFSET>,
         }
@@ -1917,7 +1917,7 @@ impl ITsSbProvider_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateTargetObject: CreateTargetObject::<Identity, Impl, OFFSET>,
             CreateLoadBalanceResultObject: CreateLoadBalanceResultObject::<Identity, Impl, OFFSET>,
             CreateSessionObject: CreateSessionObject::<Identity, Impl, OFFSET>,
@@ -2022,7 +2022,7 @@ impl ITsSbProvisioningPluginNotifySink_Vtbl {
             this.OnVirtualMachineHostStatusChanged(::core::mem::transmute(&vmhost), ::core::mem::transmute_copy(&vmhostnotifystatus), ::core::mem::transmute_copy(&errorcode), ::core::mem::transmute(&errordescr)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnJobCreated: OnJobCreated::<Identity, Impl, OFFSET>,
             OnVirtualMachineStatusChanged: OnVirtualMachineStatusChanged::<Identity, Impl, OFFSET>,
             OnJobCompleted: OnJobCompleted::<Identity, Impl, OFFSET>,
@@ -2059,7 +2059,7 @@ impl ITsSbResourceNotification_Vtbl {
             this.NotifyClientConnectionStateChange(::core::mem::transmute_copy(&changetype), ::core::mem::transmute(&pconnection)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             NotifySessionChange: NotifySessionChange::<Identity, Impl, OFFSET>,
             NotifyTargetChange: NotifyTargetChange::<Identity, Impl, OFFSET>,
             NotifyClientConnectionStateChange: NotifyClientConnectionStateChange::<Identity, Impl, OFFSET>,
@@ -2093,7 +2093,7 @@ impl ITsSbResourceNotificationEx_Vtbl {
             this.NotifyClientConnectionStateChangeEx(::core::mem::transmute(&username), ::core::mem::transmute(&domain), ::core::mem::transmute(&initialprogram), ::core::mem::transmute(&poolname), ::core::mem::transmute(&targetname), ::core::mem::transmute_copy(&connectionchangetype)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             NotifySessionChangeEx: NotifySessionChangeEx::<Identity, Impl, OFFSET>,
             NotifyTargetChangeEx: NotifyTargetChangeEx::<Identity, Impl, OFFSET>,
             NotifyClientConnectionStateChangeEx: NotifyClientConnectionStateChangeEx::<Identity, Impl, OFFSET>,
@@ -2335,7 +2335,7 @@ impl ITsSbResourcePluginStore_Vtbl {
             this.SetServerDrainMode(::core::mem::transmute(&serverfqdn), ::core::mem::transmute_copy(&drainmode)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             QueryTarget: QueryTarget::<Identity, Impl, OFFSET>,
             QuerySessionBySessionId: QuerySessionBySessionId::<Identity, Impl, OFFSET>,
             AddTargetToStore: AddTargetToStore::<Identity, Impl, OFFSET>,
@@ -2388,7 +2388,7 @@ impl ITsSbServiceNotification_Vtbl {
             this.NotifyServiceSuccess().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             NotifyServiceFailure: NotifyServiceFailure::<Identity, Impl, OFFSET>,
             NotifyServiceSuccess: NotifyServiceSuccess::<Identity, Impl, OFFSET>,
         }
@@ -2568,7 +2568,7 @@ impl ITsSbSession_Vtbl {
             this.SetProtocolType(::core::mem::transmute_copy(&val)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SessionId: SessionId::<Identity, Impl, OFFSET>,
             TargetName: TargetName::<Identity, Impl, OFFSET>,
             SetTargetName: SetTargetName::<Identity, Impl, OFFSET>,
@@ -2775,7 +2775,7 @@ impl ITsSbTarget_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             TargetName: TargetName::<Identity, Impl, OFFSET>,
             SetTargetName: SetTargetName::<Identity, Impl, OFFSET>,
             FarmName: FarmName::<Identity, Impl, OFFSET>,
@@ -2931,7 +2931,7 @@ impl ITsSbTaskInfo_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             TargetId: TargetId::<Identity, Impl, OFFSET>,
             StartTime: StartTime::<Identity, Impl, OFFSET>,
             EndTime: EndTime::<Identity, Impl, OFFSET>,
@@ -3039,7 +3039,7 @@ impl IWRdsEnhancedFastReconnectArbitrator_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSessionForEnhancedFastReconnect: GetSessionForEnhancedFastReconnect::<Identity, Impl, OFFSET>,
         }
     }
@@ -3071,7 +3071,7 @@ impl IWRdsGraphicsChannel_Vtbl {
             this.Open(::core::mem::transmute(&pchannelevents), ::core::mem::transmute(&popencontext)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Write: Write::<Identity, Impl, OFFSET>,
             Close: Close::<Identity, Impl, OFFSET>,
             Open: Open::<Identity, Impl, OFFSET>,
@@ -3120,7 +3120,7 @@ impl IWRdsGraphicsChannelEvents_Vtbl {
             this.OnMetricsUpdate(::core::mem::transmute_copy(&bandwidth), ::core::mem::transmute_copy(&rtt), ::core::mem::transmute_copy(&lastsentbyteindex)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnDataReceived: OnDataReceived::<Identity, Impl, OFFSET>,
             OnClose: OnClose::<Identity, Impl, OFFSET>,
             OnChannelOpened: OnChannelOpened::<Identity, Impl, OFFSET>,
@@ -3149,7 +3149,7 @@ impl IWRdsGraphicsChannelManager_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CreateChannel: CreateChannel::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CreateChannel: CreateChannel::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWRdsGraphicsChannelManager as ::windows::core::Interface>::IID
@@ -3368,7 +3368,7 @@ impl IWRdsProtocolConnection_Vtbl {
             this.NotifyCommandProcessCreated(::core::mem::transmute_copy(&sessionid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetLogonErrorRedirector: GetLogonErrorRedirector::<Identity, Impl, OFFSET>,
             AcceptConnection: AcceptConnection::<Identity, Impl, OFFSET>,
             GetClientData: GetClientData::<Identity, Impl, OFFSET>,
@@ -3441,7 +3441,7 @@ impl IWRdsProtocolConnectionCallback_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnReady: OnReady::<Identity, Impl, OFFSET>,
             BrokenConnection: BrokenConnection::<Identity, Impl, OFFSET>,
             StopScreenUpdates: StopScreenUpdates::<Identity, Impl, OFFSET>,
@@ -3477,7 +3477,7 @@ impl IWRdsProtocolConnectionSettings_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetConnectionSetting: SetConnectionSetting::<Identity, Impl, OFFSET>,
             GetConnectionSetting: GetConnectionSetting::<Identity, Impl, OFFSET>,
         }
@@ -3519,7 +3519,7 @@ impl IWRdsProtocolLicenseConnection_Vtbl {
             this.ProtocolComplete(::core::mem::transmute_copy(&ulcomplete)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RequestLicensingCapabilities: RequestLicensingCapabilities::<Identity, Impl, OFFSET>,
             SendClientLicense: SendClientLicense::<Identity, Impl, OFFSET>,
             RequestClientLicense: RequestClientLicense::<Identity, Impl, OFFSET>,
@@ -3560,7 +3560,7 @@ impl IWRdsProtocolListener_Vtbl {
             this.StopListen().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSettings: GetSettings::<Identity, Impl, OFFSET>,
             StartListen: StartListen::<Identity, Impl, OFFSET>,
             StopListen: StopListen::<Identity, Impl, OFFSET>,
@@ -3590,7 +3590,7 @@ impl IWRdsProtocolListenerCallback_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnConnected: OnConnected::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnConnected: OnConnected::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWRdsProtocolListenerCallback as ::windows::core::Interface>::IID
@@ -3644,7 +3644,7 @@ impl IWRdsProtocolLogonErrorRedirector_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnBeginPainting: OnBeginPainting::<Identity, Impl, OFFSET>,
             RedirectStatus: RedirectStatus::<Identity, Impl, OFFSET>,
             RedirectMessage: RedirectMessage::<Identity, Impl, OFFSET>,
@@ -3718,7 +3718,7 @@ impl IWRdsProtocolManager_Vtbl {
             this.Uninitialize().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             CreateListener: CreateListener::<Identity, Impl, OFFSET>,
             NotifyServiceStateChange: NotifyServiceStateChange::<Identity, Impl, OFFSET>,
@@ -3760,7 +3760,7 @@ impl IWRdsProtocolSettings_Vtbl {
             this.MergeSettings(::core::mem::transmute_copy(&pwrdssettings), ::core::mem::transmute_copy(&wrdsconnectionsettinglevel), ::core::mem::transmute_copy(&pwrdsconnectionsettings)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSettings: GetSettings::<Identity, Impl, OFFSET>,
             MergeSettings: MergeSettings::<Identity, Impl, OFFSET>,
         }
@@ -3788,7 +3788,7 @@ impl IWRdsProtocolShadowCallback_Vtbl {
                 .into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             StopShadow: StopShadow::<Identity, Impl, OFFSET>,
             InvokeTargetShadow: InvokeTargetShadow::<Identity, Impl, OFFSET>,
         }
@@ -3821,7 +3821,7 @@ impl IWRdsProtocolShadowConnection_Vtbl {
             this.DoTarget(::core::mem::transmute_copy(&pparam1), ::core::mem::transmute_copy(&param1size), ::core::mem::transmute_copy(&pparam2), ::core::mem::transmute_copy(&param2size), ::core::mem::transmute_copy(&pparam3), ::core::mem::transmute_copy(&param3size), ::core::mem::transmute_copy(&pparam4), ::core::mem::transmute_copy(&param4size), ::core::mem::transmute(&pclientname)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Start: Start::<Identity, Impl, OFFSET>,
             Stop: Stop::<Identity, Impl, OFFSET>,
             DoTarget: DoTarget::<Identity, Impl, OFFSET>,
@@ -3864,7 +3864,7 @@ impl IWRdsWddmIddProps_Vtbl {
             this.EnableWddmIdd(::core::mem::transmute_copy(&enabled)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetHardwareId: GetHardwareId::<Identity, Impl, OFFSET>,
             OnDriverLoad: OnDriverLoad::<Identity, Impl, OFFSET>,
             OnDriverUnload: OnDriverUnload::<Identity, Impl, OFFSET>,
@@ -3892,7 +3892,7 @@ impl IWTSBitmapRenderService_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetMappedRenderer: GetMappedRenderer::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetMappedRenderer: GetMappedRenderer::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWTSBitmapRenderService as ::windows::core::Interface>::IID
@@ -3928,7 +3928,7 @@ impl IWTSBitmapRenderer_Vtbl {
             this.RemoveMapping().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Render: Render::<Identity, Impl, OFFSET>,
             GetRendererStatistics: GetRendererStatistics::<Identity, Impl, OFFSET>,
             RemoveMapping: RemoveMapping::<Identity, Impl, OFFSET>,
@@ -3952,7 +3952,7 @@ impl IWTSBitmapRendererCallback_Vtbl {
             let this = (*this).get_impl();
             this.OnTargetSizeChanged(::core::mem::transmute(&rcnewsize)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnTargetSizeChanged: OnTargetSizeChanged::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnTargetSizeChanged: OnTargetSizeChanged::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWTSBitmapRendererCallback as ::windows::core::Interface>::IID
@@ -3978,7 +3978,7 @@ impl IWTSListener_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetConfiguration: GetConfiguration::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetConfiguration: GetConfiguration::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWTSListener as ::windows::core::Interface>::IID
@@ -3998,7 +3998,7 @@ impl IWTSListenerCallback_Vtbl {
             let this = (*this).get_impl();
             this.OnNewChannelConnection(::core::mem::transmute(&pchannel), ::core::mem::transmute(&data), ::core::mem::transmute_copy(&pbaccept), ::core::mem::transmute_copy(&ppcallback)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnNewChannelConnection: OnNewChannelConnection::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnNewChannelConnection: OnNewChannelConnection::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWTSListenerCallback as ::windows::core::Interface>::IID
@@ -4034,7 +4034,7 @@ impl IWTSPlugin_Vtbl {
             this.Terminated().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             Connected: Connected::<Identity, Impl, OFFSET>,
             Disconnected: Disconnected::<Identity, Impl, OFFSET>,
@@ -4062,7 +4062,7 @@ impl IWTSPluginServiceProvider_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetService: GetService::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetService: GetService::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWTSPluginServiceProvider as ::windows::core::Interface>::IID
@@ -4269,7 +4269,7 @@ impl IWTSProtocolConnection_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetLogonErrorRedirector: GetLogonErrorRedirector::<Identity, Impl, OFFSET>,
             SendPolicyData: SendPolicyData::<Identity, Impl, OFFSET>,
             AcceptConnection: AcceptConnection::<Identity, Impl, OFFSET>,
@@ -4335,7 +4335,7 @@ impl IWTSProtocolConnectionCallback_Vtbl {
             this.DisplayIOCtl(::core::mem::transmute_copy(&displayioctl)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnReady: OnReady::<Identity, Impl, OFFSET>,
             BrokenConnection: BrokenConnection::<Identity, Impl, OFFSET>,
             StopScreenUpdates: StopScreenUpdates::<Identity, Impl, OFFSET>,
@@ -4380,7 +4380,7 @@ impl IWTSProtocolLicenseConnection_Vtbl {
             this.ProtocolComplete(::core::mem::transmute_copy(&ulcomplete)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RequestLicensingCapabilities: RequestLicensingCapabilities::<Identity, Impl, OFFSET>,
             SendClientLicense: SendClientLicense::<Identity, Impl, OFFSET>,
             RequestClientLicense: RequestClientLicense::<Identity, Impl, OFFSET>,
@@ -4409,7 +4409,7 @@ impl IWTSProtocolListener_Vtbl {
             this.StopListen().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             StartListen: StartListen::<Identity, Impl, OFFSET>,
             StopListen: StopListen::<Identity, Impl, OFFSET>,
         }
@@ -4435,7 +4435,7 @@ impl IWTSProtocolListenerCallback_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnConnected: OnConnected::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnConnected: OnConnected::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWTSProtocolListenerCallback as ::windows::core::Interface>::IID
@@ -4489,7 +4489,7 @@ impl IWTSProtocolLogonErrorRedirector_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnBeginPainting: OnBeginPainting::<Identity, Impl, OFFSET>,
             RedirectStatus: RedirectStatus::<Identity, Impl, OFFSET>,
             RedirectMessage: RedirectMessage::<Identity, Impl, OFFSET>,
@@ -4542,7 +4542,7 @@ impl IWTSProtocolManager_Vtbl {
             this.NotifySessionStateChange(::core::mem::transmute_copy(&sessionid), ::core::mem::transmute_copy(&eventid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateListener: CreateListener::<Identity, Impl, OFFSET>,
             NotifyServiceStateChange: NotifyServiceStateChange::<Identity, Impl, OFFSET>,
             NotifySessionOfServiceStart: NotifySessionOfServiceStart::<Identity, Impl, OFFSET>,
@@ -4573,7 +4573,7 @@ impl IWTSProtocolShadowCallback_Vtbl {
                 .into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             StopShadow: StopShadow::<Identity, Impl, OFFSET>,
             InvokeTargetShadow: InvokeTargetShadow::<Identity, Impl, OFFSET>,
         }
@@ -4606,7 +4606,7 @@ impl IWTSProtocolShadowConnection_Vtbl {
             this.DoTarget(::core::mem::transmute_copy(&pparam1), ::core::mem::transmute_copy(&param1size), ::core::mem::transmute_copy(&pparam2), ::core::mem::transmute_copy(&param2size), ::core::mem::transmute_copy(&pparam3), ::core::mem::transmute_copy(&param3size), ::core::mem::transmute_copy(&pparam4), ::core::mem::transmute_copy(&param4size), ::core::mem::transmute(&pclientname)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Start: Start::<Identity, Impl, OFFSET>,
             Stop: Stop::<Identity, Impl, OFFSET>,
             DoTarget: DoTarget::<Identity, Impl, OFFSET>,
@@ -4667,7 +4667,7 @@ impl IWTSSBPlugin_Vtbl {
             this.WTSSBX_GetUserExternalSession(::core::mem::transmute(&username), ::core::mem::transmute(&domainname), ::core::mem::transmute(&applicationtype), ::core::mem::transmute_copy(&redirectorinternalip), ::core::mem::transmute_copy(&psessionid), ::core::mem::transmute_copy(&pmachineconnectinfo)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             WTSSBX_MachineChangeNotification: WTSSBX_MachineChangeNotification::<Identity, Impl, OFFSET>,
             WTSSBX_SessionChangeNotification: WTSSBX_SessionChangeNotification::<Identity, Impl, OFFSET>,
@@ -4697,7 +4697,11 @@ impl IWTSVirtualChannel_Vtbl {
             let this = (*this).get_impl();
             this.Close().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Write: Write::<Identity, Impl, OFFSET>, Close: Close::<Identity, Impl, OFFSET> }
+        Self {
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
+            Write: Write::<Identity, Impl, OFFSET>,
+            Close: Close::<Identity, Impl, OFFSET>,
+        }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWTSVirtualChannel as ::windows::core::Interface>::IID
@@ -4721,7 +4725,7 @@ impl IWTSVirtualChannelCallback_Vtbl {
             this.OnClose().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnDataReceived: OnDataReceived::<Identity, Impl, OFFSET>,
             OnClose: OnClose::<Identity, Impl, OFFSET>,
         }
@@ -4747,7 +4751,7 @@ impl IWTSVirtualChannelManager_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CreateListener: CreateListener::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CreateListener: CreateListener::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWTSVirtualChannelManager as ::windows::core::Interface>::IID
@@ -4792,7 +4796,7 @@ impl IWorkspace_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetWorkspaceNames: GetWorkspaceNames::<Identity, Impl, OFFSET>,
             StartRemoteApplication: StartRemoteApplication::<Identity, Impl, OFFSET>,
             GetProcessId: GetProcessId::<Identity, Impl, OFFSET>,
@@ -4894,7 +4898,7 @@ impl IWorkspaceClientExt_Vtbl {
             this.IssueDisconnect().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetResourceId: GetResourceId::<Identity, Impl, OFFSET>,
             GetResourceDisplayName: GetResourceDisplayName::<Identity, Impl, OFFSET>,
             IssueDisconnect: IssueDisconnect::<Identity, Impl, OFFSET>,
@@ -4928,7 +4932,7 @@ impl IWorkspaceRegistration_Vtbl {
             this.RemoveResource(::core::mem::transmute_copy(&dwcookieconnection)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddResource: AddResource::<Identity, Impl, OFFSET>,
             RemoveResource: RemoveResource::<Identity, Impl, OFFSET>,
         }
@@ -4994,7 +4998,7 @@ impl IWorkspaceReportMessage_Vtbl {
             this.RegisterErrorEvent(::core::mem::transmute(&bstrwkspid), ::core::mem::transmute_copy(&dwerrortype), ::core::mem::transmute(&bstrerrormessagetype), ::core::mem::transmute_copy(&dwerrorcode)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RegisterErrorLogMessage: RegisterErrorLogMessage::<Identity, Impl, OFFSET>,
             IsErrorMessageRegistered: IsErrorMessageRegistered::<Identity, Impl, OFFSET>,
             RegisterErrorEvent: RegisterErrorEvent::<Identity, Impl, OFFSET>,
@@ -5274,7 +5278,7 @@ impl ItsPubPlugin_Vtbl {
             this.ResolveResource(::core::mem::transmute_copy(&resourcetype), ::core::mem::transmute_copy(&resourcelocation), ::core::mem::transmute_copy(&endpointname), ::core::mem::transmute(&userid), ::core::mem::transmute(&alias)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetResourceList: GetResourceList::<Identity, Impl, OFFSET>,
             GetResource: GetResource::<Identity, Impl, OFFSET>,
             GetCacheLastUpdateTime: GetCacheLastUpdateTime::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/System/RemoteDesktop/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/RemoteDesktop/mod.rs
@@ -1111,7 +1111,7 @@ unsafe impl ::windows::core::Interface for IAudioDeviceEndpoint {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAudioDeviceEndpoint_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetBuffer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, maxperiod: i64, u32latencycoefficient: u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub GetRTCaps: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbisrtcapable: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -1191,7 +1191,7 @@ unsafe impl ::windows::core::Interface for IAudioEndpoint {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAudioEndpoint_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Media_Audio")]
     pub GetFrameFormat: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppformat: *mut *mut super::super::Media::Audio::WAVEFORMATEX) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Media_Audio"))]
@@ -1256,7 +1256,7 @@ unsafe impl ::windows::core::Interface for IAudioEndpointControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAudioEndpointControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Start: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Stop: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1316,7 +1316,7 @@ unsafe impl ::windows::core::Interface for IAudioEndpointRT {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAudioEndpointRT_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCurrentPadding: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppadding: *mut i64, paecurrentposition: *mut AE_CURRENT_POSITION),
     pub ProcessingComplete: unsafe extern "system" fn(this: *mut ::core::ffi::c_void),
     pub SetPinInactive: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1376,7 +1376,7 @@ unsafe impl ::windows::core::Interface for IAudioInputEndpointRT {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAudioInputEndpointRT_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Media_Audio_Apo")]
     pub GetInputDataPointer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pconnectionproperty: *mut super::super::Media::Audio::Apo::APO_CONNECTION_PROPERTY, paetimestamp: *mut AE_CURRENT_POSITION),
     #[cfg(not(feature = "Win32_Media_Audio_Apo"))]
@@ -1438,7 +1438,7 @@ unsafe impl ::windows::core::Interface for IAudioOutputEndpointRT {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAudioOutputEndpointRT_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetOutputDataPointer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, u32framecount: u32, paetimestamp: *const AE_CURRENT_POSITION) -> usize,
     #[cfg(feature = "Win32_Media_Audio_Apo")]
     pub ReleaseOutputDataPointer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pconnectionproperty: *const super::super::Media::Audio::Apo::APO_CONNECTION_PROPERTY),
@@ -1941,7 +1941,7 @@ unsafe impl ::windows::core::Interface for IRemoteSystemAdditionalInfoProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRemoteSystemAdditionalInfoProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetAdditionalInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, deduplicationid: *mut ::core::mem::ManuallyDrop<::windows::core::HSTRING>, riid: *const ::windows::core::GUID, mapview: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`*"]
@@ -1993,7 +1993,7 @@ unsafe impl ::windows::core::Interface for ITSGAccountingEngine {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITSGAccountingEngine_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub DoAccounting: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, accountingdatatype: AAAccountingDataType, accountingdata: ::core::mem::ManuallyDrop<AAAccountingData>) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`*"]
@@ -2056,7 +2056,7 @@ unsafe impl ::windows::core::Interface for ITSGAuthenticateUserSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITSGAuthenticateUserSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub OnUserAuthenticated: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, username: ::core::mem::ManuallyDrop<::windows::core::BSTR>, userdomain: ::core::mem::ManuallyDrop<::windows::core::BSTR>, context: usize, usertoken: super::super::Foundation::HANDLE_PTR) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -2117,7 +2117,7 @@ unsafe impl ::windows::core::Interface for ITSGAuthenticationEngine {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITSGAuthenticationEngine_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AuthenticateUser: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, mainsessionid: ::windows::core::GUID, cookiedata: *const u8, numcookiebytes: u32, context: usize, psink: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CancelAuthentication: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, mainsessionid: ::windows::core::GUID, context: usize) -> ::windows::core::HRESULT,
 }
@@ -2167,7 +2167,7 @@ unsafe impl ::windows::core::Interface for ITSGAuthorizeConnectionSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITSGAuthorizeConnectionSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnConnectionAuthorized: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hrin: ::windows::core::HRESULT, mainsessionid: ::windows::core::GUID, cbsohresponse: u32, pbsohresponse: *const u8, idletimeout: u32, sessiontimeout: u32, sessiontimeoutaction: SESSION_TIMEOUT_ACTION_TYPE, trustclass: AATrustClassID, policyattributes: *const u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`*"]
@@ -2216,7 +2216,7 @@ unsafe impl ::windows::core::Interface for ITSGAuthorizeResourceSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITSGAuthorizeResourceSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnChannelAuthorized: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hrin: ::windows::core::HRESULT, mainsessionid: ::windows::core::GUID, subsessionid: i32, allowedresourcenames: *const ::core::mem::ManuallyDrop<::windows::core::BSTR>, numallowedresourcenames: u32, failedresourcenames: *const ::core::mem::ManuallyDrop<::windows::core::BSTR>, numfailedresourcenames: u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`*"]
@@ -2286,7 +2286,7 @@ unsafe impl ::windows::core::Interface for ITSGPolicyEngine {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITSGPolicyEngine_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub AuthorizeConnection: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, mainsessionid: ::windows::core::GUID, username: ::core::mem::ManuallyDrop<::windows::core::BSTR>, authtype: AAAuthSchemes, clientmachineip: ::core::mem::ManuallyDrop<::windows::core::BSTR>, clientmachinename: ::core::mem::ManuallyDrop<::windows::core::BSTR>, sohdata: *const u8, numsohbytes: u32, cookiedata: *const u8, numcookiebytes: u32, usertoken: super::super::Foundation::HANDLE_PTR, psink: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -2347,7 +2347,7 @@ unsafe impl ::windows::core::Interface for ITsSbBaseNotifySink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITsSbBaseNotifySink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnError: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hrerror: ::windows::core::HRESULT) -> ::windows::core::HRESULT,
     pub OnReportStatus: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, messagetype: CLIENT_MESSAGE_TYPE, messageid: u32) -> ::windows::core::HRESULT,
 }
@@ -2464,7 +2464,7 @@ unsafe impl ::windows::core::Interface for ITsSbClientConnection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITsSbClientConnection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub UserName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pval: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub Domain: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pval: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub InitialProgram: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pval: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
@@ -2667,7 +2667,7 @@ unsafe impl ::windows::core::Interface for ITsSbEnvironment {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITsSbEnvironment_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Name: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pval: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub ServerWeight: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pval: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com_StructuredStorage")]
@@ -2848,7 +2848,7 @@ unsafe impl ::windows::core::Interface for ITsSbFilterPluginStore {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITsSbFilterPluginStore_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com_StructuredStorage")]
     pub SaveProperties: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppropertyset: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com_StructuredStorage"))]
@@ -2911,7 +2911,7 @@ unsafe impl ::windows::core::Interface for ITsSbGenericNotifySink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITsSbGenericNotifySink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnCompleted: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, status: ::windows::core::HRESULT) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub GetWaitTimeout: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfttimeout: *mut super::super::Foundation::FILETIME) -> ::windows::core::HRESULT,
@@ -2988,7 +2988,7 @@ unsafe impl ::windows::core::Interface for ITsSbGlobalStore {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITsSbGlobalStore_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub QueryTarget: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, providername: ::core::mem::ManuallyDrop<::windows::core::BSTR>, targetname: ::core::mem::ManuallyDrop<::windows::core::BSTR>, farmname: ::core::mem::ManuallyDrop<::windows::core::BSTR>, pptarget: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub QuerySessionBySessionId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, providername: ::core::mem::ManuallyDrop<::windows::core::BSTR>, dwsessionid: u32, targetname: ::core::mem::ManuallyDrop<::windows::core::BSTR>, ppsession: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
@@ -3050,7 +3050,7 @@ unsafe impl ::windows::core::Interface for ITsSbLoadBalanceResult {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITsSbLoadBalanceResult_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub TargetName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pval: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`*"]
@@ -3577,7 +3577,7 @@ unsafe impl ::windows::core::Interface for ITsSbPlugin {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITsSbPlugin_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com_StructuredStorage")]
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pprovider: *mut ::core::ffi::c_void, pnotifysink: *mut ::core::ffi::c_void, ppropertyset: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com_StructuredStorage"))]
@@ -3956,7 +3956,7 @@ unsafe impl ::windows::core::Interface for ITsSbProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITsSbProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateTargetObject: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, targetname: ::core::mem::ManuallyDrop<::windows::core::BSTR>, environmentname: ::core::mem::ManuallyDrop<::windows::core::BSTR>, pptarget: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CreateLoadBalanceResultObject: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, targetname: ::core::mem::ManuallyDrop<::windows::core::BSTR>, pplbresult: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CreateSessionObject: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, targetname: ::core::mem::ManuallyDrop<::windows::core::BSTR>, username: ::core::mem::ManuallyDrop<::windows::core::BSTR>, domain: ::core::mem::ManuallyDrop<::windows::core::BSTR>, sessionid: u32, ppsession: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -4138,7 +4138,7 @@ unsafe impl ::windows::core::Interface for ITsSbProvisioningPluginNotifySink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITsSbProvisioningPluginNotifySink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnJobCreated: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pvmnotifyinfo: *const VM_NOTIFY_INFO) -> ::windows::core::HRESULT,
     pub OnVirtualMachineStatusChanged: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pvmnotifyentry: *const VM_NOTIFY_ENTRY, vmnotifystatus: VM_NOTIFY_STATUS, errorcode: ::windows::core::HRESULT, errordescr: ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub OnJobCompleted: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, resultcode: ::windows::core::HRESULT, resultdescription: ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
@@ -4207,7 +4207,7 @@ unsafe impl ::windows::core::Interface for ITsSbResourceNotification {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITsSbResourceNotification_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub NotifySessionChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, changetype: TSSESSION_STATE, psession: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub NotifyTargetChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, targetchangetype: u32, ptarget: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub NotifyClientConnectionStateChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, changetype: CONNECTION_CHANGE_NOTIFICATION, pconnection: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -4264,7 +4264,7 @@ unsafe impl ::windows::core::Interface for ITsSbResourceNotificationEx {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITsSbResourceNotificationEx_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub NotifySessionChangeEx: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, targetname: ::core::mem::ManuallyDrop<::windows::core::BSTR>, username: ::core::mem::ManuallyDrop<::windows::core::BSTR>, domain: ::core::mem::ManuallyDrop<::windows::core::BSTR>, sessionid: u32, sessionstate: TSSESSION_STATE) -> ::windows::core::HRESULT,
     pub NotifyTargetChangeEx: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, targetname: ::core::mem::ManuallyDrop<::windows::core::BSTR>, targetchangetype: u32) -> ::windows::core::HRESULT,
     pub NotifyClientConnectionStateChangeEx: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, username: ::core::mem::ManuallyDrop<::windows::core::BSTR>, domain: ::core::mem::ManuallyDrop<::windows::core::BSTR>, initialprogram: ::core::mem::ManuallyDrop<::windows::core::BSTR>, poolname: ::core::mem::ManuallyDrop<::windows::core::BSTR>, targetname: ::core::mem::ManuallyDrop<::windows::core::BSTR>, connectionchangetype: CONNECTION_CHANGE_NOTIFICATION) -> ::windows::core::HRESULT,
@@ -4529,7 +4529,7 @@ unsafe impl ::windows::core::Interface for ITsSbResourcePluginStore {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITsSbResourcePluginStore_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub QueryTarget: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, targetname: ::core::mem::ManuallyDrop<::windows::core::BSTR>, farmname: ::core::mem::ManuallyDrop<::windows::core::BSTR>, pptarget: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub QuerySessionBySessionId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwsessionid: u32, targetname: ::core::mem::ManuallyDrop<::windows::core::BSTR>, ppsession: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub AddTargetToStore: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptarget: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -4635,7 +4635,7 @@ unsafe impl ::windows::core::Interface for ITsSbServiceNotification {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITsSbServiceNotification_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub NotifyServiceFailure: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub NotifyServiceSuccess: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -4751,7 +4751,7 @@ unsafe impl ::windows::core::Interface for ITsSbSession {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITsSbSession_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SessionId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pval: *mut u32) -> ::windows::core::HRESULT,
     pub TargetName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, targetname: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub SetTargetName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, targetname: ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
@@ -4899,7 +4899,7 @@ unsafe impl ::windows::core::Interface for ITsSbTarget {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITsSbTarget_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub TargetName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pval: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub SetTargetName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, val: ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub FarmName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pval: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
@@ -5122,7 +5122,7 @@ unsafe impl ::windows::core::Interface for ITsSbTaskInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITsSbTaskInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub TargetId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pname: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub StartTime: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pstarttime: *mut super::super::Foundation::FILETIME) -> ::windows::core::HRESULT,
@@ -5363,7 +5363,7 @@ unsafe impl ::windows::core::Interface for IWRdsEnhancedFastReconnectArbitrator 
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWRdsEnhancedFastReconnectArbitrator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetSessionForEnhancedFastReconnect: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psessionidarray: *const i32, dwsessioncount: u32, presultsessionid: *mut i32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`*"]
@@ -5425,7 +5425,7 @@ unsafe impl ::windows::core::Interface for IWRdsGraphicsChannel {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWRdsGraphicsChannel_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Write: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cbsize: u32, pbuffer: *const u8, pcontext: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Close: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Open: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pchannelevents: *mut ::core::ffi::c_void, popencontext: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -5497,7 +5497,7 @@ unsafe impl ::windows::core::Interface for IWRdsGraphicsChannelEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWRdsGraphicsChannelEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnDataReceived: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cbsize: u32, pbuffer: *const u8) -> ::windows::core::HRESULT,
     pub OnClose: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub OnChannelOpened: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, openresult: ::windows::core::HRESULT, popencontext: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -5554,7 +5554,7 @@ unsafe impl ::windows::core::Interface for IWRdsGraphicsChannelManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWRdsGraphicsChannelManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateChannel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszchannelname: *const u8, channeltype: WRdsGraphicsChannelType, ppvirtualchannel: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`*"]
@@ -5719,7 +5719,7 @@ unsafe impl ::windows::core::Interface for IWRdsProtocolConnection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWRdsProtocolConnection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetLogonErrorRedirector: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pplogonerrorredir: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub AcceptConnection: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -5828,7 +5828,7 @@ unsafe impl ::windows::core::Interface for IWRdsProtocolConnectionCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWRdsProtocolConnectionCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnReady: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub BrokenConnection: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, reason: u32, source: u32) -> ::windows::core::HRESULT,
     pub StopScreenUpdates: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -5885,7 +5885,7 @@ unsafe impl ::windows::core::Interface for IWRdsProtocolConnectionSettings {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWRdsProtocolConnectionSettings_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetConnectionSetting: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, propertyid: ::windows::core::GUID, ppropertyentriesin: *const WTS_PROPERTY_VALUE) -> ::windows::core::HRESULT,
     pub GetConnectionSetting: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, propertyid: ::windows::core::GUID, ppropertyentriesout: *mut WTS_PROPERTY_VALUE) -> ::windows::core::HRESULT,
 }
@@ -5946,7 +5946,7 @@ unsafe impl ::windows::core::Interface for IWRdsProtocolLicenseConnection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWRdsProtocolLicenseConnection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub RequestLicensingCapabilities: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pplicensecapabilities: *mut WTS_LICENSE_CAPABILITIES, pcblicensecapabilities: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -6011,7 +6011,7 @@ unsafe impl ::windows::core::Interface for IWRdsProtocolListener {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWRdsProtocolListener_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetSettings: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wrdslistenersettinglevel: WRDS_LISTENER_SETTING_LEVEL, pwrdslistenersettings: *mut WRDS_LISTENER_SETTINGS) -> ::windows::core::HRESULT,
     pub StartListen: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcallback: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub StopListen: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -6068,7 +6068,7 @@ unsafe impl ::windows::core::Interface for IWRdsProtocolListenerCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWRdsProtocolListenerCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub OnConnected: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pconnection: *mut ::core::ffi::c_void, pwrdsconnectionsettings: *const WRDS_CONNECTION_SETTINGS, pcallback: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -6143,7 +6143,7 @@ unsafe impl ::windows::core::Interface for IWRdsProtocolLogonErrorRedirector {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWRdsProtocolLogonErrorRedirector_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnBeginPainting: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub RedirectStatus: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszmessage: ::windows::core::PCWSTR, presponse: *mut WTS_LOGON_ERROR_REDIRECTOR_RESPONSE) -> ::windows::core::HRESULT,
     pub RedirectMessage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszcaption: ::windows::core::PCWSTR, pszmessage: ::windows::core::PCWSTR, utype: u32, presponse: *mut WTS_LOGON_ERROR_REDIRECTOR_RESPONSE) -> ::windows::core::HRESULT,
@@ -6227,7 +6227,7 @@ unsafe impl ::windows::core::Interface for IWRdsProtocolManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWRdsProtocolManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, piwrdssettings: *mut ::core::ffi::c_void, pwrdssettings: *const WRDS_SETTINGS) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -6297,7 +6297,7 @@ unsafe impl ::windows::core::Interface for IWRdsProtocolSettings {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWRdsProtocolSettings_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetSettings: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wrdssettingtype: WRDS_SETTING_TYPE, wrdssettinglevel: WRDS_SETTING_LEVEL, pwrdssettings: *mut WRDS_SETTINGS) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -6360,7 +6360,7 @@ unsafe impl ::windows::core::Interface for IWRdsProtocolShadowCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWRdsProtocolShadowCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub StopShadow: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub InvokeTargetShadow: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptargetservername: ::windows::core::PCWSTR, targetsessionid: u32, pparam1: *const u8, param1size: u32, pparam2: *const u8, param2size: u32, pparam3: *const u8, param3size: u32, pparam4: *const u8, param4size: u32, pclientname: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
 }
@@ -6423,7 +6423,7 @@ unsafe impl ::windows::core::Interface for IWRdsProtocolShadowConnection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWRdsProtocolShadowConnection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Start: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptargetservername: ::windows::core::PCWSTR, targetsessionid: u32, hotkeyvk: u8, hotkeymodifiers: u16, pshadowcallback: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Stop: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub DoTarget: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pparam1: *const u8, param1size: u32, pparam2: *const u8, param2size: u32, pparam3: *const u8, param3size: u32, pparam4: *const u8, param4size: u32, pclientname: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
@@ -6493,7 +6493,7 @@ unsafe impl ::windows::core::Interface for IWRdsWddmIddProps {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWRdsWddmIddProps_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetHardwareId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdisplaydriverhardwareid: ::windows::core::PCWSTR, count: u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub OnDriverLoad: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sessionid: u32, driverhandle: super::super::Foundation::HANDLE_PTR) -> ::windows::core::HRESULT,
@@ -6555,7 +6555,7 @@ unsafe impl ::windows::core::Interface for IWTSBitmapRenderService {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWTSBitmapRenderService_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetMappedRenderer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, mappingid: u64, pmappedrenderercallback: *mut ::core::ffi::c_void, ppmappedrenderer: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`*"]
@@ -6611,7 +6611,7 @@ unsafe impl ::windows::core::Interface for IWTSBitmapRenderer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWTSBitmapRenderer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Render: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, imageformat: ::windows::core::GUID, dwwidth: u32, dwheight: u32, cbstride: i32, cbimagebuffer: u32, pimagebuffer: *const u8) -> ::windows::core::HRESULT,
     pub GetRendererStatistics: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pstatistics: *mut BITMAP_RENDERER_STATISTICS) -> ::windows::core::HRESULT,
     pub RemoveMapping: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -6664,7 +6664,7 @@ unsafe impl ::windows::core::Interface for IWTSBitmapRendererCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWTSBitmapRendererCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub OnTargetSizeChanged: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, rcnewsize: super::super::Foundation::RECT) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -6719,7 +6719,7 @@ unsafe impl ::windows::core::Interface for IWTSListener {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWTSListener_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com_StructuredStorage")]
     pub GetConfiguration: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pppropertybag: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com_StructuredStorage"))]
@@ -6776,7 +6776,7 @@ unsafe impl ::windows::core::Interface for IWTSListenerCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWTSListenerCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub OnNewChannelConnection: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pchannel: *mut ::core::ffi::c_void, data: ::core::mem::ManuallyDrop<::windows::core::BSTR>, pbaccept: *mut super::super::Foundation::BOOL, ppcallback: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -6840,7 +6840,7 @@ unsafe impl ::windows::core::Interface for IWTSPlugin {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWTSPlugin_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pchannelmgr: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Connected: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Disconnected: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwdisconnectcode: u32) -> ::windows::core::HRESULT,
@@ -6893,7 +6893,7 @@ unsafe impl ::windows::core::Interface for IWTSPluginServiceProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWTSPluginServiceProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetService: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, serviceid: ::windows::core::GUID, ppunkobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`*"]
@@ -7051,7 +7051,7 @@ unsafe impl ::windows::core::Interface for IWTSProtocolConnection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWTSProtocolConnection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetLogonErrorRedirector: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pplogonerrorredir: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub SendPolicyData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppolicydata: *const WTS_POLICY_DATA) -> ::windows::core::HRESULT,
@@ -7158,7 +7158,7 @@ unsafe impl ::windows::core::Interface for IWTSProtocolConnectionCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWTSProtocolConnectionCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnReady: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub BrokenConnection: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, reason: u32, source: u32) -> ::windows::core::HRESULT,
     pub StopScreenUpdates: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -7222,7 +7222,7 @@ unsafe impl ::windows::core::Interface for IWTSProtocolLicenseConnection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWTSProtocolLicenseConnection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub RequestLicensingCapabilities: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pplicensecapabilities: *mut WTS_LICENSE_CAPABILITIES, pcblicensecapabilities: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -7283,7 +7283,7 @@ unsafe impl ::windows::core::Interface for IWTSProtocolListener {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWTSProtocolListener_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub StartListen: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcallback: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub StopListen: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -7337,7 +7337,7 @@ unsafe impl ::windows::core::Interface for IWTSProtocolListenerCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWTSProtocolListenerCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnConnected: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pconnection: *mut ::core::ffi::c_void, pcallback: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`*"]
@@ -7409,7 +7409,7 @@ unsafe impl ::windows::core::Interface for IWTSProtocolLogonErrorRedirector {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWTSProtocolLogonErrorRedirector_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnBeginPainting: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub RedirectStatus: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszmessage: ::windows::core::PCWSTR, presponse: *mut WTS_LOGON_ERROR_REDIRECTOR_RESPONSE) -> ::windows::core::HRESULT,
     pub RedirectMessage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszcaption: ::windows::core::PCWSTR, pszmessage: ::windows::core::PCWSTR, utype: u32, presponse: *mut WTS_LOGON_ERROR_REDIRECTOR_RESPONSE) -> ::windows::core::HRESULT,
@@ -7477,7 +7477,7 @@ unsafe impl ::windows::core::Interface for IWTSProtocolManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWTSProtocolManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateListener: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wszlistenername: ::windows::core::PCWSTR, pprotocollistener: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub NotifyServiceStateChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptsservicestatechange: *const WTS_SERVICE_STATE) -> ::windows::core::HRESULT,
     pub NotifySessionOfServiceStart: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sessionid: *const WTS_SESSION_ID) -> ::windows::core::HRESULT,
@@ -7537,7 +7537,7 @@ unsafe impl ::windows::core::Interface for IWTSProtocolShadowCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWTSProtocolShadowCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub StopShadow: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub InvokeTargetShadow: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptargetservername: ::windows::core::PCWSTR, targetsessionid: u32, pparam1: *const u8, param1size: u32, pparam2: *const u8, param2size: u32, pparam3: *const u8, param3size: u32, pparam4: *const u8, param4size: u32, pclientname: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
 }
@@ -7600,7 +7600,7 @@ unsafe impl ::windows::core::Interface for IWTSProtocolShadowConnection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWTSProtocolShadowConnection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Start: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptargetservername: ::windows::core::PCWSTR, targetsessionid: u32, hotkeyvk: u8, hotkeymodifiers: u16, pshadowcallback: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Stop: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub DoTarget: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pparam1: *const u8, param1size: u32, pparam2: *const u8, param2size: u32, pparam3: *const u8, param3size: u32, pparam4: *const u8, param4size: u32, pclientname: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
@@ -7680,7 +7680,7 @@ unsafe impl ::windows::core::Interface for IWTSSBPlugin {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWTSSBPlugin_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, plugincapabilities: *mut u32) -> ::windows::core::HRESULT,
     pub WTSSBX_MachineChangeNotification: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, notificationtype: WTSSBX_NOTIFICATION_TYPE, machineid: i32, pmachineinfo: *const WTSSBX_MACHINE_INFO) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -7743,7 +7743,7 @@ unsafe impl ::windows::core::Interface for IWTSVirtualChannel {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWTSVirtualChannel_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Write: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cbsize: u32, pbuffer: *const u8, preserved: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Close: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -7796,7 +7796,7 @@ unsafe impl ::windows::core::Interface for IWTSVirtualChannelCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWTSVirtualChannelCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnDataReceived: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cbsize: u32, pbuffer: *const u8) -> ::windows::core::HRESULT,
     pub OnClose: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -7850,7 +7850,7 @@ unsafe impl ::windows::core::Interface for IWTSVirtualChannelManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWTSVirtualChannelManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateListener: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszchannelname: *const u8, uflags: u32, plistenercallback: *mut ::core::ffi::c_void, pplistener: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`*"]
@@ -7911,7 +7911,7 @@ unsafe impl ::windows::core::Interface for IWorkspace {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWorkspace_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub GetWorkspaceNames: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psawkspnames: *mut *mut super::Com::SAFEARRAY) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -8169,7 +8169,7 @@ unsafe impl ::windows::core::Interface for IWorkspaceClientExt {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWorkspaceClientExt_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetResourceId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrworkspaceid: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub GetResourceDisplayName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrworkspacedisplayname: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub IssueDisconnect: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -8227,7 +8227,7 @@ unsafe impl ::windows::core::Interface for IWorkspaceRegistration {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWorkspaceRegistration_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddResource: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punk: *mut ::core::ffi::c_void, pdwcookie: *mut u32) -> ::windows::core::HRESULT,
     pub RemoveResource: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwcookieconnection: u32) -> ::windows::core::HRESULT,
 }
@@ -8365,7 +8365,7 @@ unsafe impl ::windows::core::Interface for IWorkspaceReportMessage {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWorkspaceReportMessage_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub RegisterErrorLogMessage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrmessage: ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub IsErrorMessageRegistered: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrwkspid: ::core::mem::ManuallyDrop<::windows::core::BSTR>, dwerrortype: u32, bstrerrormessagetype: ::core::mem::ManuallyDrop<::windows::core::BSTR>, dwerrorcode: u32, pferrorexist: *mut i16) -> ::windows::core::HRESULT,
     pub RegisterErrorEvent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrwkspid: ::core::mem::ManuallyDrop<::windows::core::BSTR>, dwerrortype: u32, bstrerrormessagetype: ::core::mem::ManuallyDrop<::windows::core::BSTR>, dwerrorcode: u32) -> ::windows::core::HRESULT,
@@ -8930,7 +8930,7 @@ unsafe impl ::windows::core::Interface for ItsPubPlugin {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ItsPubPlugin_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetResourceList: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, userid: ::windows::core::PCWSTR, pceapplistsize: *mut i32, resourcelist: *mut *mut pluginResource) -> ::windows::core::HRESULT,
     pub GetResource: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, alias: ::windows::core::PCWSTR, flags: i32, resource: *mut pluginResource) -> ::windows::core::HRESULT,
     pub GetCacheLastUpdateTime: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lastupdatetime: *mut u64) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/System/RemoteManagement/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/RemoteManagement/impl.rs
@@ -893,7 +893,7 @@ pub trait IWSManResourceLocatorInternal_Impl: Sized {}
 impl ::windows::core::RuntimeName for IWSManResourceLocatorInternal {}
 impl IWSManResourceLocatorInternal_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IWSManResourceLocatorInternal_Impl, const OFFSET: isize>() -> IWSManResourceLocatorInternal_Vtbl {
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>() }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>() }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWSManResourceLocatorInternal as ::windows::core::Interface>::IID

--- a/crates/libs/windows/src/Windows/Win32/System/RemoteManagement/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/RemoteManagement/mod.rs
@@ -1925,7 +1925,7 @@ unsafe impl ::windows::core::Interface for IWSManResourceLocatorInternal {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWSManResourceLocatorInternal_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
 }
 #[doc = "*Required features: `\"Win32_System_RemoteManagement\"`, `\"Win32_System_Com\"`*"]
 #[cfg(feature = "Win32_System_Com")]

--- a/crates/libs/windows/src/Windows/Win32/System/Search/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Search/impl.rs
@@ -52,7 +52,7 @@ impl DataSource_Vtbl {
             this.removeDataSourceListener(::core::mem::transmute(&pdsl)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             getDataMember: getDataMember::<Identity, Impl, OFFSET>,
             getDataMemberName: getDataMemberName::<Identity, Impl, OFFSET>,
             getDataMemberCount: getDataMemberCount::<Identity, Impl, OFFSET>,
@@ -88,7 +88,7 @@ impl DataSourceListener_Vtbl {
             this.dataMemberRemoved(::core::mem::transmute_copy(&bstrdm)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             dataMemberChanged: dataMemberChanged::<Identity, Impl, OFFSET>,
             dataMemberAdded: dataMemberAdded::<Identity, Impl, OFFSET>,
             dataMemberRemoved: dataMemberRemoved::<Identity, Impl, OFFSET>,
@@ -156,7 +156,7 @@ impl IAccessor_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddRefAccessor: AddRefAccessor::<Identity, Impl, OFFSET>,
             CreateAccessor: CreateAccessor::<Identity, Impl, OFFSET>,
             GetBindings: GetBindings::<Identity, Impl, OFFSET>,
@@ -181,7 +181,7 @@ impl IAlterIndex_Vtbl {
             let this = (*this).get_impl();
             this.AlterIndex(::core::mem::transmute_copy(&ptableid), ::core::mem::transmute_copy(&pindexid), ::core::mem::transmute_copy(&pnewindexid), ::core::mem::transmute_copy(&cpropertysets), ::core::mem::transmute_copy(&rgpropertysets)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), AlterIndex: AlterIndex::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), AlterIndex: AlterIndex::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IAlterIndex as ::windows::core::Interface>::IID
@@ -208,7 +208,7 @@ impl IAlterTable_Vtbl {
             this.AlterTable(::core::mem::transmute_copy(&ptableid), ::core::mem::transmute_copy(&pnewtableid), ::core::mem::transmute_copy(&cpropertysets), ::core::mem::transmute_copy(&rgpropertysets)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AlterColumn: AlterColumn::<Identity, Impl, OFFSET>,
             AlterTable: AlterTable::<Identity, Impl, OFFSET>,
         }
@@ -231,7 +231,7 @@ impl IBindResource_Vtbl {
             let this = (*this).get_impl();
             this.Bind(::core::mem::transmute(&punkouter), ::core::mem::transmute(&pwszurl), ::core::mem::transmute_copy(&dwbindurlflags), ::core::mem::transmute_copy(&rguid), ::core::mem::transmute_copy(&riid), ::core::mem::transmute(&pauthenticate), ::core::mem::transmute_copy(&pimplsession), ::core::mem::transmute_copy(&pdwbindstatus), ::core::mem::transmute_copy(&ppunk)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Bind: Bind::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Bind: Bind::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IBindResource as ::windows::core::Interface>::IID
@@ -267,7 +267,7 @@ impl IChapteredRowset_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddRefChapter: AddRefChapter::<Identity, Impl, OFFSET>,
             ReleaseChapter: ReleaseChapter::<Identity, Impl, OFFSET>,
         }
@@ -309,7 +309,7 @@ impl IColumnMapper_Vtbl {
             this.IsMapUpToDate().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetPropInfoFromName: GetPropInfoFromName::<Identity, Impl, OFFSET>,
             GetPropInfoFromId: GetPropInfoFromId::<Identity, Impl, OFFSET>,
             EnumPropInfo: EnumPropInfo::<Identity, Impl, OFFSET>,
@@ -337,7 +337,7 @@ impl IColumnMapperCreator_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetColumnMapper: GetColumnMapper::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetColumnMapper: GetColumnMapper::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IColumnMapperCreator as ::windows::core::Interface>::IID
@@ -370,7 +370,7 @@ impl IColumnsInfo_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetColumnInfo: GetColumnInfo::<Identity, Impl, OFFSET>,
             MapColumnIDs: MapColumnIDs::<Identity, Impl, OFFSET>,
         }
@@ -420,7 +420,7 @@ impl IColumnsRowset_Vtbl {
             this.GetColumnsRowset(::core::mem::transmute(&punkouter), ::core::mem::transmute_copy(&coptcolumns), ::core::mem::transmute_copy(&rgoptcolumns), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&cpropertysets), ::core::mem::transmute_copy(&rgpropertysets), ::core::mem::transmute_copy(&ppcolrowset)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetAvailableColumns: GetAvailableColumns::<Identity, Impl, OFFSET>,
             GetColumnsRowset: GetColumnsRowset::<Identity, Impl, OFFSET>,
         }
@@ -459,7 +459,7 @@ impl ICommand_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Cancel: Cancel::<Identity, Impl, OFFSET>,
             Execute: Execute::<Identity, Impl, OFFSET>,
             GetDBSession: GetDBSession::<Identity, Impl, OFFSET>,
@@ -511,7 +511,7 @@ impl ICommandCost_Vtbl {
             this.SetCostLimits(::core::mem::transmute(&pwszrowsetname), ::core::mem::transmute_copy(&ccostlimits), ::core::mem::transmute_copy(&prgcostlimits), ::core::mem::transmute_copy(&dwexecutionflags)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetAccumulatedCost: GetAccumulatedCost::<Identity, Impl, OFFSET>,
             GetCostEstimate: GetCostEstimate::<Identity, Impl, OFFSET>,
             GetCostGoals: GetCostGoals::<Identity, Impl, OFFSET>,
@@ -557,7 +557,7 @@ impl ICommandPersist_Vtbl {
             this.SaveCommand(::core::mem::transmute_copy(&pcommandid), ::core::mem::transmute_copy(&dwflags)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             DeleteCommand: DeleteCommand::<Identity, Impl, OFFSET>,
             GetCurrentCommand: GetCurrentCommand::<Identity, Impl, OFFSET>,
             LoadCommand: LoadCommand::<Identity, Impl, OFFSET>,
@@ -586,7 +586,7 @@ impl ICommandPrepare_Vtbl {
             this.Unprepare().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Prepare: Prepare::<Identity, Impl, OFFSET>,
             Unprepare: Unprepare::<Identity, Impl, OFFSET>,
         }
@@ -616,7 +616,7 @@ impl ICommandProperties_Vtbl {
             this.SetProperties(::core::mem::transmute_copy(&cpropertysets), ::core::mem::transmute_copy(&rgpropertysets)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetProperties: GetProperties::<Identity, Impl, OFFSET>,
             SetProperties: SetProperties::<Identity, Impl, OFFSET>,
         }
@@ -643,7 +643,7 @@ impl ICommandStream_Vtbl {
             this.SetCommandStream(::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&rguiddialect), ::core::mem::transmute(&pcommandstream)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCommandStream: GetCommandStream::<Identity, Impl, OFFSET>,
             SetCommandStream: SetCommandStream::<Identity, Impl, OFFSET>,
         }
@@ -697,7 +697,7 @@ impl ICommandValidate_Vtbl {
             this.ValidateSyntax().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ValidateCompletely: ValidateCompletely::<Identity, Impl, OFFSET>,
             ValidateSyntax: ValidateSyntax::<Identity, Impl, OFFSET>,
         }
@@ -739,7 +739,7 @@ impl ICommandWithParameters_Vtbl {
             this.SetParameterInfo(::core::mem::transmute_copy(&cparams), ::core::mem::transmute_copy(&rgparamordinals), ::core::mem::transmute_copy(&rgparambindinfo)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetParameterInfo: GetParameterInfo::<Identity, Impl, OFFSET>,
             MapParameterNames: MapParameterNames::<Identity, Impl, OFFSET>,
             SetParameterInfo: SetParameterInfo::<Identity, Impl, OFFSET>,
@@ -931,7 +931,7 @@ impl IConditionFactory_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             MakeNot: MakeNot::<Identity, Impl, OFFSET>,
             MakeAndOr: MakeAndOr::<Identity, Impl, OFFSET>,
             MakeLeaf: MakeLeaf::<Identity, Impl, OFFSET>,
@@ -1074,7 +1074,7 @@ impl IConditionGenerator_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             RecognizeNamedEntities: RecognizeNamedEntities::<Identity, Impl, OFFSET>,
             GenerateForLeaf: GenerateForLeaf::<Identity, Impl, OFFSET>,
@@ -1096,7 +1096,7 @@ impl IConvertType_Vtbl {
             let this = (*this).get_impl();
             this.CanConvert(::core::mem::transmute_copy(&wfromtype), ::core::mem::transmute_copy(&wtotype), ::core::mem::transmute_copy(&dwconvertflags)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CanConvert: CanConvert::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CanConvert: CanConvert::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IConvertType as ::windows::core::Interface>::IID
@@ -1116,7 +1116,7 @@ impl ICreateRow_Vtbl {
             let this = (*this).get_impl();
             this.CreateRow(::core::mem::transmute(&punkouter), ::core::mem::transmute(&pwszurl), ::core::mem::transmute_copy(&dwbindurlflags), ::core::mem::transmute_copy(&rguid), ::core::mem::transmute_copy(&riid), ::core::mem::transmute(&pauthenticate), ::core::mem::transmute_copy(&pimplsession), ::core::mem::transmute_copy(&pdwbindstatus), ::core::mem::transmute_copy(&ppwsznewurl), ::core::mem::transmute_copy(&ppunk)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CreateRow: CreateRow::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CreateRow: CreateRow::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ICreateRow as ::windows::core::Interface>::IID
@@ -1146,7 +1146,7 @@ impl IDBAsynchNotify_Vtbl {
             this.OnStop(::core::mem::transmute_copy(&hchapter), ::core::mem::transmute_copy(&eoperation), ::core::mem::transmute_copy(&hrstatus), ::core::mem::transmute(&pwszstatustext)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnLowResource: OnLowResource::<Identity, Impl, OFFSET>,
             OnProgress: OnProgress::<Identity, Impl, OFFSET>,
             OnStop: OnStop::<Identity, Impl, OFFSET>,
@@ -1174,7 +1174,7 @@ impl IDBAsynchStatus_Vtbl {
             this.GetStatus(::core::mem::transmute_copy(&hchapter), ::core::mem::transmute_copy(&eoperation), ::core::mem::transmute_copy(&pulprogress), ::core::mem::transmute_copy(&pulprogressmax), ::core::mem::transmute_copy(&peasynchphase), ::core::mem::transmute_copy(&ppwszstatustext)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Abort: Abort::<Identity, Impl, OFFSET>,
             GetStatus: GetStatus::<Identity, Impl, OFFSET>,
         }
@@ -1220,7 +1220,7 @@ impl IDBCreateCommand_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CreateCommand: CreateCommand::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CreateCommand: CreateCommand::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDBCreateCommand as ::windows::core::Interface>::IID
@@ -1243,7 +1243,7 @@ impl IDBCreateSession_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CreateSession: CreateSession::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CreateSession: CreateSession::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDBCreateSession as ::windows::core::Interface>::IID
@@ -1282,7 +1282,7 @@ impl IDBDataSourceAdmin_Vtbl {
             this.ModifyDataSource(::core::mem::transmute_copy(&cpropertysets), ::core::mem::transmute_copy(&rgpropertysets)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateDataSource: CreateDataSource::<Identity, Impl, OFFSET>,
             DestroyDataSource: DestroyDataSource::<Identity, Impl, OFFSET>,
             GetCreationProperties: GetCreationProperties::<Identity, Impl, OFFSET>,
@@ -1320,7 +1320,7 @@ impl IDBInfo_Vtbl {
             this.GetLiteralInfo(::core::mem::transmute_copy(&cliterals), ::core::mem::transmute_copy(&rgliterals), ::core::mem::transmute_copy(&pcliteralinfo), ::core::mem::transmute_copy(&prgliteralinfo), ::core::mem::transmute_copy(&ppcharbuffer)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetKeywords: GetKeywords::<Identity, Impl, OFFSET>,
             GetLiteralInfo: GetLiteralInfo::<Identity, Impl, OFFSET>,
         }
@@ -1347,7 +1347,7 @@ impl IDBInitialize_Vtbl {
             this.Uninitialize().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             Uninitialize: Uninitialize::<Identity, Impl, OFFSET>,
         }
@@ -1383,7 +1383,7 @@ impl IDBPromptInitialize_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             PromptDataSource: PromptDataSource::<Identity, Impl, OFFSET>,
             PromptFileName: PromptFileName::<Identity, Impl, OFFSET>,
         }
@@ -1419,7 +1419,7 @@ impl IDBProperties_Vtbl {
             this.SetProperties(::core::mem::transmute_copy(&cpropertysets), ::core::mem::transmute_copy(&rgpropertysets)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetProperties: GetProperties::<Identity, Impl, OFFSET>,
             GetPropertyInfo: GetPropertyInfo::<Identity, Impl, OFFSET>,
             SetProperties: SetProperties::<Identity, Impl, OFFSET>,
@@ -1453,7 +1453,7 @@ impl IDBSchemaCommand_Vtbl {
             this.GetSchemas(::core::mem::transmute_copy(&pcschemas), ::core::mem::transmute_copy(&prgschemas)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCommand: GetCommand::<Identity, Impl, OFFSET>,
             GetSchemas: GetSchemas::<Identity, Impl, OFFSET>,
         }
@@ -1483,7 +1483,7 @@ impl IDBSchemaRowset_Vtbl {
             this.GetSchemas(::core::mem::transmute_copy(&pcschemas), ::core::mem::transmute_copy(&prgschemas), ::core::mem::transmute_copy(&prgrestrictionsupport)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetRowset: GetRowset::<Identity, Impl, OFFSET>,
             GetSchemas: GetSchemas::<Identity, Impl, OFFSET>,
         }
@@ -1519,7 +1519,7 @@ impl IDCInfo_Vtbl {
             this.SetInfo(::core::mem::transmute_copy(&cinfo), ::core::mem::transmute_copy(&rginfo)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetInfo: GetInfo::<Identity, Impl, OFFSET>,
             SetInfo: SetInfo::<Identity, Impl, OFFSET>,
         }
@@ -1566,7 +1566,7 @@ impl IDataConvert_Vtbl {
             this.GetConversionSize(::core::mem::transmute_copy(&wsrctype), ::core::mem::transmute_copy(&wdsttype), ::core::mem::transmute_copy(&pcbsrclength), ::core::mem::transmute_copy(&pcbdstlength), ::core::mem::transmute_copy(&psrc)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             DataConvert: DataConvert::<Identity, Impl, OFFSET>,
             CanConvert: CanConvert::<Identity, Impl, OFFSET>,
             GetConversionSize: GetConversionSize::<Identity, Impl, OFFSET>,
@@ -1639,7 +1639,7 @@ impl IDataInitialize_Vtbl {
             this.WriteStringToStorage(::core::mem::transmute(&pwszfilename), ::core::mem::transmute(&pwszinitializationstring), ::core::mem::transmute_copy(&dwcreationdisposition)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDataSource: GetDataSource::<Identity, Impl, OFFSET>,
             GetInitializationString: GetInitializationString::<Identity, Impl, OFFSET>,
             CreateDBInstance: CreateDBInstance::<Identity, Impl, OFFSET>,
@@ -1792,7 +1792,7 @@ impl IEntity_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Name: Name::<Identity, Impl, OFFSET>,
             Base: Base::<Identity, Impl, OFFSET>,
             Relationships: Relationships::<Identity, Impl, OFFSET>,
@@ -1858,7 +1858,7 @@ impl IEnumItemProperties_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -1906,7 +1906,7 @@ impl IEnumSearchRoots_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -1953,7 +1953,7 @@ impl IEnumSearchScopeRules_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -2012,7 +2012,7 @@ impl IEnumSubscription_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -2051,7 +2051,7 @@ impl IErrorLookup_Vtbl {
             this.ReleaseErrors(::core::mem::transmute_copy(&dwdynamicerrorid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetErrorDescription: GetErrorDescription::<Identity, Impl, OFFSET>,
             GetHelpInfo: GetHelpInfo::<Identity, Impl, OFFSET>,
             ReleaseErrors: ReleaseErrors::<Identity, Impl, OFFSET>,
@@ -2136,7 +2136,7 @@ impl IErrorRecords_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddErrorRecord: AddErrorRecord::<Identity, Impl, OFFSET>,
             GetBasicErrorInfo: GetBasicErrorInfo::<Identity, Impl, OFFSET>,
             GetCustomErrorObject: GetCustomErrorObject::<Identity, Impl, OFFSET>,
@@ -2166,7 +2166,7 @@ impl IGetDataSource_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetDataSource: GetDataSource::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetDataSource: GetDataSource::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IGetDataSource as ::windows::core::Interface>::IID
@@ -2202,7 +2202,7 @@ impl IGetRow_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetRowFromHROW: GetRowFromHROW::<Identity, Impl, OFFSET>,
             GetURLFromHROW: GetURLFromHROW::<Identity, Impl, OFFSET>,
         }
@@ -2228,7 +2228,7 @@ impl IGetSession_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetSession: GetSession::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetSession: GetSession::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IGetSession as ::windows::core::Interface>::IID
@@ -2251,7 +2251,7 @@ impl IGetSourceRow_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetSourceRow: GetSourceRow::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetSourceRow: GetSourceRow::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IGetSourceRow as ::windows::core::Interface>::IID
@@ -2278,7 +2278,7 @@ impl IIndexDefinition_Vtbl {
             this.DropIndex(::core::mem::transmute_copy(&ptableid), ::core::mem::transmute_copy(&pindexid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateIndex: CreateIndex::<Identity, Impl, OFFSET>,
             DropIndex: DropIndex::<Identity, Impl, OFFSET>,
         }
@@ -2301,7 +2301,7 @@ impl IInterval_Vtbl {
             let this = (*this).get_impl();
             this.GetLimits(::core::mem::transmute_copy(&pilklower), ::core::mem::transmute_copy(&ppropvarlower), ::core::mem::transmute_copy(&pilkupper), ::core::mem::transmute_copy(&ppropvarupper)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetLimits: GetLimits::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetLimits: GetLimits::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IInterval as ::windows::core::Interface>::IID
@@ -2334,7 +2334,7 @@ impl ILoadFilter_Vtbl {
             this.LoadIFilterFromStream(::core::mem::transmute(&pstm), ::core::mem::transmute_copy(&pfilteredsources), ::core::mem::transmute(&punkouter), ::core::mem::transmute_copy(&fusedefault), ::core::mem::transmute_copy(&pfilterclsid), ::core::mem::transmute_copy(&searchdecsize), ::core::mem::transmute_copy(&pwcssearchdesc), ::core::mem::transmute_copy(&ppifilt)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             LoadIFilter: LoadIFilter::<Identity, Impl, OFFSET>,
             LoadIFilterFromStorage: LoadIFilterFromStorage::<Identity, Impl, OFFSET>,
             LoadIFilterFromStream: LoadIFilterFromStream::<Identity, Impl, OFFSET>,
@@ -2412,7 +2412,7 @@ impl IMDDataset_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             FreeAxisInfo: FreeAxisInfo::<Identity, Impl, OFFSET>,
             GetAxisInfo: GetAxisInfo::<Identity, Impl, OFFSET>,
             GetAxisRowset: GetAxisRowset::<Identity, Impl, OFFSET>,
@@ -2442,7 +2442,7 @@ impl IMDFind_Vtbl {
             this.FindTuple(::core::mem::transmute_copy(&ulaxisidentifier), ::core::mem::transmute_copy(&ulstartingordinal), ::core::mem::transmute_copy(&cmembers), ::core::mem::transmute_copy(&rgpwszmember), ::core::mem::transmute_copy(&pultupleordinal)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             FindCell: FindCell::<Identity, Impl, OFFSET>,
             FindTuple: FindTuple::<Identity, Impl, OFFSET>,
         }
@@ -2465,7 +2465,7 @@ impl IMDRangeRowset_Vtbl {
             let this = (*this).get_impl();
             this.GetRangeRowset(::core::mem::transmute(&punkouter), ::core::mem::transmute_copy(&ulstartcell), ::core::mem::transmute_copy(&ulendcell), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&cpropertysets), ::core::mem::transmute_copy(&rgpropertysets), ::core::mem::transmute_copy(&pprowset)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetRangeRowset: GetRangeRowset::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetRangeRowset: GetRangeRowset::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMDRangeRowset as ::windows::core::Interface>::IID
@@ -2482,7 +2482,7 @@ impl IMetaData_Vtbl {
             let this = (*this).get_impl();
             this.GetData(::core::mem::transmute_copy(&ppszkey), ::core::mem::transmute_copy(&ppszvalue)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetData: GetData::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetData: GetData::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMetaData as ::windows::core::Interface>::IID
@@ -2499,7 +2499,7 @@ impl IMultipleResults_Vtbl {
             let this = (*this).get_impl();
             this.GetResult(::core::mem::transmute(&punkouter), ::core::mem::transmute_copy(&lresultflag), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&pcrowsaffected), ::core::mem::transmute_copy(&pprowset)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetResult: GetResult::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetResult: GetResult::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMultipleResults as ::windows::core::Interface>::IID
@@ -2535,7 +2535,7 @@ impl INamedEntity_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetValue: GetValue::<Identity, Impl, OFFSET>,
             DefaultPhrase: DefaultPhrase::<Identity, Impl, OFFSET>,
         }
@@ -2555,7 +2555,7 @@ impl INamedEntityCollector_Vtbl {
             let this = (*this).get_impl();
             this.Add(::core::mem::transmute_copy(&beginspan), ::core::mem::transmute_copy(&endspan), ::core::mem::transmute_copy(&beginactual), ::core::mem::transmute_copy(&endactual), ::core::mem::transmute(&ptype), ::core::mem::transmute(&pszvalue), ::core::mem::transmute_copy(&certainty)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Add: Add::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Add: Add::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<INamedEntityCollector as ::windows::core::Interface>::IID
@@ -2600,7 +2600,7 @@ impl IObjectAccessControl_Vtbl {
             this.SetObjectOwner(::core::mem::transmute_copy(&pobject), ::core::mem::transmute_copy(&powner)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetObjectAccessRights: GetObjectAccessRights::<Identity, Impl, OFFSET>,
             GetObjectOwner: GetObjectOwner::<Identity, Impl, OFFSET>,
             IsObjectAccessAllowed: IsObjectAccessAllowed::<Identity, Impl, OFFSET>,
@@ -2657,7 +2657,7 @@ impl IOpLockStatus_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             IsOplockValid: IsOplockValid::<Identity, Impl, OFFSET>,
             IsOplockBroken: IsOplockBroken::<Identity, Impl, OFFSET>,
             GetOplockEventHandle: GetOplockEventHandle::<Identity, Impl, OFFSET>,
@@ -2681,7 +2681,7 @@ impl IOpenRowset_Vtbl {
             let this = (*this).get_impl();
             this.OpenRowset(::core::mem::transmute(&punkouter), ::core::mem::transmute_copy(&ptableid), ::core::mem::transmute_copy(&pindexid), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&cpropertysets), ::core::mem::transmute_copy(&rgpropertysets), ::core::mem::transmute_copy(&pprowset)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OpenRowset: OpenRowset::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OpenRowset: OpenRowset::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IOpenRowset as ::windows::core::Interface>::IID
@@ -2704,7 +2704,7 @@ impl IParentRowset_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetChildRowset: GetChildRowset::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetChildRowset: GetChildRowset::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IParentRowset as ::windows::core::Interface>::IID
@@ -2724,7 +2724,7 @@ impl IProtocolHandlerSite_Vtbl {
             let this = (*this).get_impl();
             this.GetFilter(::core::mem::transmute_copy(&pclsidobj), ::core::mem::transmute(&pcwszcontenttype), ::core::mem::transmute(&pcwszextension), ::core::mem::transmute_copy(&ppfilter)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetFilter: GetFilter::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetFilter: GetFilter::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IProtocolHandlerSite as ::windows::core::Interface>::IID
@@ -2750,7 +2750,7 @@ impl IProvideMoniker_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetMoniker: GetMoniker::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetMoniker: GetMoniker::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IProvideMoniker as ::windows::core::Interface>::IID
@@ -2843,7 +2843,7 @@ impl IQueryParser_Vtbl {
             this.RestatePropertyValueToString(::core::mem::transmute(&pcondition), ::core::mem::transmute_copy(&fuseenglish), ::core::mem::transmute_copy(&ppszpropertyname), ::core::mem::transmute_copy(&ppszquerystring)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Parse: Parse::<Identity, Impl, OFFSET>,
             SetOption: SetOption::<Identity, Impl, OFFSET>,
             GetOption: GetOption::<Identity, Impl, OFFSET>,
@@ -2885,7 +2885,7 @@ impl IQueryParserManager_Vtbl {
             this.SetOption(::core::mem::transmute_copy(&option), ::core::mem::transmute_copy(&poptionvalue)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateLoadedParser: CreateLoadedParser::<Identity, Impl, OFFSET>,
             InitializeOptions: InitializeOptions::<Identity, Impl, OFFSET>,
             SetOption: SetOption::<Identity, Impl, OFFSET>,
@@ -2950,7 +2950,7 @@ impl IReadData_Vtbl {
             this.ReleaseChapter(::core::mem::transmute_copy(&hchapter)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ReadData: ReadData::<Identity, Impl, OFFSET>,
             ReleaseChapter: ReleaseChapter::<Identity, Impl, OFFSET>,
         }
@@ -2989,7 +2989,7 @@ impl IRegisterProvider_Vtbl {
             this.UnregisterProvider(::core::mem::transmute(&pwszurl), ::core::mem::transmute_copy(&dwreserved), ::core::mem::transmute_copy(&rclsidprovider)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetURLMapping: GetURLMapping::<Identity, Impl, OFFSET>,
             SetURLMapping: SetURLMapping::<Identity, Impl, OFFSET>,
             UnregisterProvider: UnregisterProvider::<Identity, Impl, OFFSET>,
@@ -3062,7 +3062,7 @@ impl IRelationship_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Name: Name::<Identity, Impl, OFFSET>,
             IsReal: IsReal::<Identity, Impl, OFFSET>,
             Destination: Destination::<Identity, Impl, OFFSET>,
@@ -3088,7 +3088,7 @@ impl IRichChunk_Vtbl {
             let this = (*this).get_impl();
             this.GetData(::core::mem::transmute_copy(&pfirstpos), ::core::mem::transmute_copy(&plength), ::core::mem::transmute_copy(&ppsz), ::core::mem::transmute_copy(&pvalue)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetData: GetData::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetData: GetData::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IRichChunk as ::windows::core::Interface>::IID
@@ -3127,7 +3127,7 @@ impl IRow_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetColumns: GetColumns::<Identity, Impl, OFFSET>,
             GetSourceRowset: GetSourceRowset::<Identity, Impl, OFFSET>,
             Open: Open::<Identity, Impl, OFFSET>,
@@ -3151,7 +3151,7 @@ impl IRowChange_Vtbl {
             let this = (*this).get_impl();
             this.SetColumns(::core::mem::transmute_copy(&ccolumns), ::core::mem::transmute_copy(&rgcolumns)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SetColumns: SetColumns::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SetColumns: SetColumns::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IRowChange as ::windows::core::Interface>::IID
@@ -3199,7 +3199,7 @@ impl IRowPosition_Vtbl {
             this.SetRowPosition(::core::mem::transmute_copy(&hchapter), ::core::mem::transmute_copy(&hrow), ::core::mem::transmute_copy(&dwpositionflags)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ClearRowPosition: ClearRowPosition::<Identity, Impl, OFFSET>,
             GetRowPosition: GetRowPosition::<Identity, Impl, OFFSET>,
             GetRowset: GetRowset::<Identity, Impl, OFFSET>,
@@ -3225,7 +3225,7 @@ impl IRowPositionChange_Vtbl {
             let this = (*this).get_impl();
             this.OnRowPositionChange(::core::mem::transmute_copy(&ereason), ::core::mem::transmute_copy(&ephase), ::core::mem::transmute_copy(&fcantdeny)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnRowPositionChange: OnRowPositionChange::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnRowPositionChange: OnRowPositionChange::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IRowPositionChange as ::windows::core::Interface>::IID
@@ -3297,7 +3297,7 @@ impl IRowset_Vtbl {
             this.RestartPosition(::core::mem::transmute_copy(&hreserved)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddRefRows: AddRefRows::<Identity, Impl, OFFSET>,
             GetData: GetData::<Identity, Impl, OFFSET>,
             GetNextRows: GetNextRows::<Identity, Impl, OFFSET>,
@@ -3330,7 +3330,7 @@ impl IRowsetAsynch_Vtbl {
             this.Stop().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RatioFinished: RatioFinished::<Identity, Impl, OFFSET>,
             Stop: Stop::<Identity, Impl, OFFSET>,
         }
@@ -3350,7 +3350,7 @@ impl IRowsetBookmark_Vtbl {
             let this = (*this).get_impl();
             this.PositionOnBookmark(::core::mem::transmute_copy(&hchapter), ::core::mem::transmute_copy(&cbbookmark), ::core::mem::transmute_copy(&pbookmark)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), PositionOnBookmark: PositionOnBookmark::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), PositionOnBookmark: PositionOnBookmark::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IRowsetBookmark as ::windows::core::Interface>::IID
@@ -3380,7 +3380,7 @@ impl IRowsetChange_Vtbl {
             this.InsertRow(::core::mem::transmute_copy(&hreserved), ::core::mem::transmute_copy(&haccessor), ::core::mem::transmute_copy(&pdata), ::core::mem::transmute_copy(&phrow)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             DeleteRows: DeleteRows::<Identity, Impl, OFFSET>,
             SetData: SetData::<Identity, Impl, OFFSET>,
             InsertRow: InsertRow::<Identity, Impl, OFFSET>,
@@ -3408,7 +3408,7 @@ impl IRowsetChangeExtInfo_Vtbl {
             this.GetPendingColumns(::core::mem::transmute_copy(&hreserved), ::core::mem::transmute_copy(&hrow), ::core::mem::transmute_copy(&ccolumnordinals), ::core::mem::transmute_copy(&rgiordinals), ::core::mem::transmute_copy(&rgcolumnstatus)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetOriginalRow: GetOriginalRow::<Identity, Impl, OFFSET>,
             GetPendingColumns: GetPendingColumns::<Identity, Impl, OFFSET>,
         }
@@ -3428,7 +3428,7 @@ impl IRowsetChapterMember_Vtbl {
             let this = (*this).get_impl();
             this.IsRowInChapter(::core::mem::transmute_copy(&hchapter), ::core::mem::transmute_copy(&hrow)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), IsRowInChapter: IsRowInChapter::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), IsRowInChapter: IsRowInChapter::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IRowsetChapterMember as ::windows::core::Interface>::IID
@@ -3464,7 +3464,7 @@ impl IRowsetCopyRows_Vtbl {
             this.DefineSource(::core::mem::transmute(&prowsetsource), ::core::mem::transmute_copy(&ccolids), ::core::mem::transmute_copy(&rgsourcecolumns), ::core::mem::transmute_copy(&rgtargetcolumns), ::core::mem::transmute_copy(&phsourceid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CloseSource: CloseSource::<Identity, Impl, OFFSET>,
             CopyByHROWS: CopyByHROWS::<Identity, Impl, OFFSET>,
             CopyRows: CopyRows::<Identity, Impl, OFFSET>,
@@ -3538,7 +3538,7 @@ impl IRowsetEvents_Vtbl {
             this.OnRowsetEvent(::core::mem::transmute_copy(&eventtype), ::core::mem::transmute_copy(&eventdata)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnNewItem: OnNewItem::<Identity, Impl, OFFSET>,
             OnChangedItem: OnChangedItem::<Identity, Impl, OFFSET>,
             OnDeletedItem: OnDeletedItem::<Identity, Impl, OFFSET>,
@@ -3570,7 +3570,7 @@ impl IRowsetFastLoad_Vtbl {
             this.Commit(::core::mem::transmute_copy(&fdone)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             InsertRow: InsertRow::<Identity, Impl, OFFSET>,
             Commit: Commit::<Identity, Impl, OFFSET>,
         }
@@ -3590,7 +3590,7 @@ impl IRowsetFind_Vtbl {
             let this = (*this).get_impl();
             this.FindNextRow(::core::mem::transmute_copy(&hchapter), ::core::mem::transmute_copy(&haccessor), ::core::mem::transmute_copy(&pfindvalue), ::core::mem::transmute_copy(&compareop), ::core::mem::transmute_copy(&cbbookmark), ::core::mem::transmute_copy(&pbookmark), ::core::mem::transmute_copy(&lrowsoffset), ::core::mem::transmute_copy(&crows), ::core::mem::transmute_copy(&pcrowsobtained), ::core::mem::transmute_copy(&prghrows)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), FindNextRow: FindNextRow::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), FindNextRow: FindNextRow::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IRowsetFind as ::windows::core::Interface>::IID
@@ -3607,7 +3607,7 @@ impl IRowsetIdentity_Vtbl {
             let this = (*this).get_impl();
             this.IsSameRow(::core::mem::transmute_copy(&hthisrow), ::core::mem::transmute_copy(&hthatrow)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), IsSameRow: IsSameRow::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), IsSameRow: IsSameRow::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IRowsetIdentity as ::windows::core::Interface>::IID
@@ -3640,7 +3640,7 @@ impl IRowsetIndex_Vtbl {
             this.SetRange(::core::mem::transmute_copy(&haccessor), ::core::mem::transmute_copy(&cstartkeycolumns), ::core::mem::transmute_copy(&pstartdata), ::core::mem::transmute_copy(&cendkeycolumns), ::core::mem::transmute_copy(&penddata), ::core::mem::transmute_copy(&dwrangeoptions)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetIndexInfo: GetIndexInfo::<Identity, Impl, OFFSET>,
             Seek: Seek::<Identity, Impl, OFFSET>,
             SetRange: SetRange::<Identity, Impl, OFFSET>,
@@ -3689,7 +3689,7 @@ impl IRowsetInfo_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetProperties: GetProperties::<Identity, Impl, OFFSET>,
             GetReferencedRowset: GetReferencedRowset::<Identity, Impl, OFFSET>,
             GetSpecification: GetSpecification::<Identity, Impl, OFFSET>,
@@ -3710,7 +3710,7 @@ impl IRowsetKeys_Vtbl {
             let this = (*this).get_impl();
             this.ListKeys(::core::mem::transmute_copy(&pccolumns), ::core::mem::transmute_copy(&prgcolumns)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), ListKeys: ListKeys::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), ListKeys: ListKeys::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IRowsetKeys as ::windows::core::Interface>::IID
@@ -3768,7 +3768,7 @@ impl IRowsetNewRowAfter_Vtbl {
             let this = (*this).get_impl();
             this.SetNewDataAfter(::core::mem::transmute_copy(&hchapter), ::core::mem::transmute_copy(&cbbmprevious), ::core::mem::transmute_copy(&pbmprevious), ::core::mem::transmute_copy(&haccessor), ::core::mem::transmute_copy(&pdata), ::core::mem::transmute_copy(&phrow)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SetNewDataAfter: SetNewDataAfter::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SetNewDataAfter: SetNewDataAfter::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IRowsetNewRowAfter as ::windows::core::Interface>::IID
@@ -3791,7 +3791,7 @@ impl IRowsetNextRowset_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetNextRowset: GetNextRowset::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetNextRowset: GetNextRowset::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IRowsetNextRowset as ::windows::core::Interface>::IID
@@ -3824,7 +3824,7 @@ impl IRowsetNotify_Vtbl {
             this.OnRowsetChange(::core::mem::transmute(&prowset), ::core::mem::transmute_copy(&ereason), ::core::mem::transmute_copy(&ephase), ::core::mem::transmute_copy(&fcantdeny)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnFieldChange: OnFieldChange::<Identity, Impl, OFFSET>,
             OnRowChange: OnRowChange::<Identity, Impl, OFFSET>,
             OnRowsetChange: OnRowsetChange::<Identity, Impl, OFFSET>,
@@ -3858,7 +3858,7 @@ impl IRowsetPrioritization_Vtbl {
             this.GetScopeStatistics(::core::mem::transmute_copy(&indexeddocumentcount), ::core::mem::transmute_copy(&oustandingaddcount), ::core::mem::transmute_copy(&oustandingmodifycount)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetScopePriority: SetScopePriority::<Identity, Impl, OFFSET>,
             GetScopePriority: GetScopePriority::<Identity, Impl, OFFSET>,
             GetScopeStatistics: GetScopeStatistics::<Identity, Impl, OFFSET>,
@@ -3886,7 +3886,7 @@ impl IRowsetQueryStatus_Vtbl {
             this.GetStatusEx(::core::mem::transmute_copy(&pdwstatus), ::core::mem::transmute_copy(&pcfiltereddocuments), ::core::mem::transmute_copy(&pcdocumentstofilter), ::core::mem::transmute_copy(&pdwratiofinisheddenominator), ::core::mem::transmute_copy(&pdwratiofinishednumerator), ::core::mem::transmute_copy(&cbbmk), ::core::mem::transmute_copy(&pbmk), ::core::mem::transmute_copy(&pirowbmk), ::core::mem::transmute_copy(&pcrowstotal)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetStatus: GetStatus::<Identity, Impl, OFFSET>,
             GetStatusEx: GetStatusEx::<Identity, Impl, OFFSET>,
         }
@@ -3916,7 +3916,7 @@ impl IRowsetRefresh_Vtbl {
             this.GetLastVisibleData(::core::mem::transmute_copy(&hrow), ::core::mem::transmute_copy(&haccessor), ::core::mem::transmute_copy(&pdata)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RefreshVisibleData: RefreshVisibleData::<Identity, Impl, OFFSET>,
             GetLastVisibleData: GetLastVisibleData::<Identity, Impl, OFFSET>,
         }
@@ -3943,7 +3943,7 @@ impl IRowsetResynch_Vtbl {
             this.ResynchRows(::core::mem::transmute_copy(&crows), ::core::mem::transmute_copy(&rghrows), ::core::mem::transmute_copy(&pcrowsresynched), ::core::mem::transmute_copy(&prghrowsresynched), ::core::mem::transmute_copy(&prgrowstatus)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetVisibleData: GetVisibleData::<Identity, Impl, OFFSET>,
             ResynchRows: ResynchRows::<Identity, Impl, OFFSET>,
         }
@@ -4051,7 +4051,7 @@ impl IRowsetView_Vtbl {
             this.GetView(::core::mem::transmute_copy(&hchapter), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&phchaptersource), ::core::mem::transmute_copy(&ppview)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateView: CreateView::<Identity, Impl, OFFSET>,
             GetView: GetView::<Identity, Impl, OFFSET>,
         }
@@ -4084,7 +4084,7 @@ impl IRowsetWatchAll_Vtbl {
             this.StopWatching().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Acknowledge: Acknowledge::<Identity, Impl, OFFSET>,
             Start: Start::<Identity, Impl, OFFSET>,
             StopWatching: StopWatching::<Identity, Impl, OFFSET>,
@@ -4105,7 +4105,7 @@ impl IRowsetWatchNotify_Vtbl {
             let this = (*this).get_impl();
             this.OnChange(::core::mem::transmute(&prowset), ::core::mem::transmute_copy(&echangereason)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnChange: OnChange::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnChange: OnChange::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IRowsetWatchNotify as ::windows::core::Interface>::IID
@@ -4187,7 +4187,7 @@ impl IRowsetWithParameters_Vtbl {
             this.Requery(::core::mem::transmute_copy(&pparams), ::core::mem::transmute_copy(&pulerrorparam), ::core::mem::transmute_copy(&phreserved)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetParameterInfo: GetParameterInfo::<Identity, Impl, OFFSET>,
             Requery: Requery::<Identity, Impl, OFFSET>,
         }
@@ -4207,7 +4207,7 @@ impl ISQLErrorInfo_Vtbl {
             let this = (*this).get_impl();
             this.GetSQLInfo(::core::mem::transmute_copy(&pbstrsqlstate), ::core::mem::transmute_copy(&plnativeerror)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetSQLInfo: GetSQLInfo::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetSQLInfo: GetSQLInfo::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ISQLErrorInfo as ::windows::core::Interface>::IID
@@ -4227,7 +4227,7 @@ impl ISQLGetDiagField_Vtbl {
             let this = (*this).get_impl();
             this.GetDiagField(::core::mem::transmute_copy(&pdiaginfo)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetDiagField: GetDiagField::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetDiagField: GetDiagField::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ISQLGetDiagField as ::windows::core::Interface>::IID
@@ -4247,7 +4247,7 @@ impl ISQLRequestDiagFields_Vtbl {
             let this = (*this).get_impl();
             this.RequestDiagFields(::core::mem::transmute_copy(&cdiagfields), ::core::mem::transmute_copy(&rgdiagfields)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), RequestDiagFields: RequestDiagFields::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), RequestDiagFields: RequestDiagFields::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ISQLRequestDiagFields as ::windows::core::Interface>::IID
@@ -4264,7 +4264,7 @@ impl ISQLServerErrorInfo_Vtbl {
             let this = (*this).get_impl();
             this.GetErrorInfo(::core::mem::transmute_copy(&pperrorinfo), ::core::mem::transmute_copy(&ppstringsbuffer)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetErrorInfo: GetErrorInfo::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetErrorInfo: GetErrorInfo::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ISQLServerErrorInfo as ::windows::core::Interface>::IID
@@ -4287,7 +4287,7 @@ impl ISchemaLocalizerSupport_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Localize: Localize::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Localize: Localize::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ISchemaLocalizerSupport as ::windows::core::Interface>::IID
@@ -4314,7 +4314,7 @@ impl ISchemaLock_Vtbl {
             this.ReleaseSchemaLock(::core::mem::transmute_copy(&hlockhandle)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSchemaLock: GetSchemaLock::<Identity, Impl, OFFSET>,
             ReleaseSchemaLock: ReleaseSchemaLock::<Identity, Impl, OFFSET>,
         }
@@ -4383,7 +4383,7 @@ impl ISchemaProvider_Vtbl {
             this.LookupAuthoredNamedEntity(::core::mem::transmute(&pentity), ::core::mem::transmute(&pszinputstring), ::core::mem::transmute(&ptokencollection), ::core::mem::transmute_copy(&ctokensbegin), ::core::mem::transmute_copy(&pctokenslength), ::core::mem::transmute_copy(&ppszvalue)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Entities: Entities::<Identity, Impl, OFFSET>,
             RootEntity: RootEntity::<Identity, Impl, OFFSET>,
             GetEntity: GetEntity::<Identity, Impl, OFFSET>,
@@ -4690,7 +4690,7 @@ impl ISearchCatalogManager_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Name: Name::<Identity, Impl, OFFSET>,
             GetParameter: GetParameter::<Identity, Impl, OFFSET>,
             SetParameter: SetParameter::<Identity, Impl, OFFSET>,
@@ -4884,7 +4884,7 @@ impl ISearchCrawlScopeManager_Vtbl {
             this.RemoveDefaultScopeRule(::core::mem::transmute(&pszurl)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddDefaultScopeRule: AddDefaultScopeRule::<Identity, Impl, OFFSET>,
             AddRoot: AddRoot::<Identity, Impl, OFFSET>,
             RemoveRoot: RemoveRoot::<Identity, Impl, OFFSET>,
@@ -4954,7 +4954,7 @@ impl ISearchItemsChangedSink_Vtbl {
             this.OnItemsChanged(::core::mem::transmute_copy(&dwnumberofchanges), ::core::mem::transmute_copy(&rgdatachangeentries), ::core::mem::transmute_copy(&rgdwdocids), ::core::mem::transmute_copy(&rghrcompletioncodes)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             StartedMonitoringScope: StartedMonitoringScope::<Identity, Impl, OFFSET>,
             StoppedMonitoringScope: StoppedMonitoringScope::<Identity, Impl, OFFSET>,
             OnItemsChanged: OnItemsChanged::<Identity, Impl, OFFSET>,
@@ -5015,7 +5015,7 @@ impl ISearchLanguageSupport_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetDiacriticSensitivity: SetDiacriticSensitivity::<Identity, Impl, OFFSET>,
             GetDiacriticSensitivity: GetDiacriticSensitivity::<Identity, Impl, OFFSET>,
             LoadWordBreaker: LoadWordBreaker::<Identity, Impl, OFFSET>,
@@ -5168,7 +5168,7 @@ impl ISearchManager_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetIndexerVersionStr: GetIndexerVersionStr::<Identity, Impl, OFFSET>,
             GetIndexerVersion: GetIndexerVersion::<Identity, Impl, OFFSET>,
             GetParameter: GetParameter::<Identity, Impl, OFFSET>,
@@ -5242,7 +5242,7 @@ impl ISearchNotifyInlineSite_Vtbl {
             this.OnCatalogStatusChange(::core::mem::transmute_copy(&guidcatalogresetsignature), ::core::mem::transmute_copy(&guidcheckpointsignature), ::core::mem::transmute_copy(&dwlastcheckpointnumber)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnItemIndexedStatusChange: OnItemIndexedStatusChange::<Identity, Impl, OFFSET>,
             OnCatalogStatusChange: OnCatalogStatusChange::<Identity, Impl, OFFSET>,
         }
@@ -5281,7 +5281,7 @@ impl ISearchPersistentItemsChangedSink_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             StartedMonitoringScope: StartedMonitoringScope::<Identity, Impl, OFFSET>,
             StoppedMonitoringScope: StoppedMonitoringScope::<Identity, Impl, OFFSET>,
             OnItemsChanged: OnItemsChanged::<Identity, Impl, OFFSET>,
@@ -5324,7 +5324,7 @@ impl ISearchProtocol_Vtbl {
             this.ShutDown().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Init: Init::<Identity, Impl, OFFSET>,
             CreateAccessor: CreateAccessor::<Identity, Impl, OFFSET>,
             CloseAccessor: CloseAccessor::<Identity, Impl, OFFSET>,
@@ -5379,7 +5379,7 @@ impl ISearchProtocolThreadContext_Vtbl {
             this.ThreadIdle(::core::mem::transmute_copy(&dwtimeelaspedsincelastcallinms)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ThreadInit: ThreadInit::<Identity, Impl, OFFSET>,
             ThreadShutdown: ThreadShutdown::<Identity, Impl, OFFSET>,
             ThreadIdle: ThreadIdle::<Identity, Impl, OFFSET>,
@@ -5590,7 +5590,7 @@ impl ISearchQueryHelper_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ConnectionString: ConnectionString::<Identity, Impl, OFFSET>,
             SetQueryContentLocale: SetQueryContentLocale::<Identity, Impl, OFFSET>,
             QueryContentLocale: QueryContentLocale::<Identity, Impl, OFFSET>,
@@ -5645,7 +5645,7 @@ impl ISearchQueryHits_Vtbl {
             this.NextHitOffset(::core::mem::transmute_copy(&pcregion), ::core::mem::transmute_copy(&paregion))
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Init: Init::<Identity, Impl, OFFSET>,
             NextHitMoniker: NextHitMoniker::<Identity, Impl, OFFSET>,
             NextHitOffset: NextHitOffset::<Identity, Impl, OFFSET>,
@@ -5862,7 +5862,7 @@ impl ISearchRoot_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetSchedule: SetSchedule::<Identity, Impl, OFFSET>,
             Schedule: Schedule::<Identity, Impl, OFFSET>,
             SetRootURL: SetRootURL::<Identity, Impl, OFFSET>,
@@ -5948,7 +5948,7 @@ impl ISearchScopeRule_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             PatternOrURL: PatternOrURL::<Identity, Impl, OFFSET>,
             IsIncluded: IsIncluded::<Identity, Impl, OFFSET>,
             IsDefault: IsDefault::<Identity, Impl, OFFSET>,
@@ -5973,7 +5973,7 @@ impl ISearchViewChangedSink_Vtbl {
             let this = (*this).get_impl();
             this.OnChange(::core::mem::transmute_copy(&pdwdocid), ::core::mem::transmute_copy(&pchange), ::core::mem::transmute_copy(&pfinview)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnChange: OnChange::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnChange: OnChange::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ISearchViewChangedSink as ::windows::core::Interface>::IID
@@ -6006,7 +6006,7 @@ impl ISecurityInfo_Vtbl {
             this.GetPermissions(::core::mem::transmute(&objecttype), ::core::mem::transmute_copy(&ppermissions)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCurrentTrustee: GetCurrentTrustee::<Identity, Impl, OFFSET>,
             GetObjectTypes: GetObjectTypes::<Identity, Impl, OFFSET>,
             GetPermissions: GetPermissions::<Identity, Impl, OFFSET>,
@@ -6027,7 +6027,7 @@ impl IService_Vtbl {
             let this = (*this).get_impl();
             this.InvokeService(::core::mem::transmute(&punkinner)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), InvokeService: InvokeService::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), InvokeService: InvokeService::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IService as ::windows::core::Interface>::IID
@@ -6054,7 +6054,7 @@ impl ISessionProperties_Vtbl {
             this.SetProperties(::core::mem::transmute_copy(&cpropertysets), ::core::mem::transmute_copy(&rgpropertysets)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetProperties: GetProperties::<Identity, Impl, OFFSET>,
             SetProperties: SetProperties::<Identity, Impl, OFFSET>,
         }
@@ -6087,7 +6087,7 @@ impl ISimpleCommandCreator_Vtbl {
             this.GetDefaultCatalog(::core::mem::transmute(&pwszcatalogname), ::core::mem::transmute_copy(&cwcin), ::core::mem::transmute_copy(&pcwcout)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateICommand: CreateICommand::<Identity, Impl, OFFSET>,
             VerifyCatalog: VerifyCatalog::<Identity, Impl, OFFSET>,
             GetDefaultCatalog: GetDefaultCatalog::<Identity, Impl, OFFSET>,
@@ -6111,7 +6111,7 @@ impl ISourcesRowset_Vtbl {
             let this = (*this).get_impl();
             this.GetSourcesRowset(::core::mem::transmute(&punkouter), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&cpropertysets), ::core::mem::transmute_copy(&rgproperties), ::core::mem::transmute_copy(&ppsourcesrowset)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetSourcesRowset: GetSourcesRowset::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetSourcesRowset: GetSourcesRowset::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ISourcesRowset as ::windows::core::Interface>::IID
@@ -6144,7 +6144,7 @@ impl IStemmer_Vtbl {
             this.GetLicenseToUse(::core::mem::transmute_copy(&ppwcslicense)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Init: Init::<Identity, Impl, OFFSET>,
             GenerateWordForms: GenerateWordForms::<Identity, Impl, OFFSET>,
             GetLicenseToUse: GetLicenseToUse::<Identity, Impl, OFFSET>,
@@ -6229,7 +6229,7 @@ impl ISubscriptionItem_Vtbl {
             this.NotifyChanged().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCookie: GetCookie::<Identity, Impl, OFFSET>,
             GetSubscriptionItemInfo: GetSubscriptionItemInfo::<Identity, Impl, OFFSET>,
             SetSubscriptionItemInfo: SetSubscriptionItemInfo::<Identity, Impl, OFFSET>,
@@ -6318,7 +6318,7 @@ impl ISubscriptionMgr_Vtbl {
             this.CreateSubscription(::core::mem::transmute_copy(&hwnd), ::core::mem::transmute(&pwszurl), ::core::mem::transmute(&pwszfriendlyname), ::core::mem::transmute_copy(&dwflags), ::core::mem::transmute_copy(&substype), ::core::mem::transmute_copy(&pinfo)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             DeleteSubscription: DeleteSubscription::<Identity, Impl, OFFSET>,
             UpdateSubscription: UpdateSubscription::<Identity, Impl, OFFSET>,
             UpdateAll: UpdateAll::<Identity, Impl, OFFSET>,
@@ -6481,7 +6481,7 @@ impl ITableDefinition_Vtbl {
             this.DropColumn(::core::mem::transmute_copy(&ptableid), ::core::mem::transmute_copy(&pcolumnid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateTable: CreateTable::<Identity, Impl, OFFSET>,
             DropTable: DropTable::<Identity, Impl, OFFSET>,
             AddColumn: AddColumn::<Identity, Impl, OFFSET>,
@@ -6551,7 +6551,7 @@ impl ITableRename_Vtbl {
             this.RenameTable(::core::mem::transmute_copy(&poldtableid), ::core::mem::transmute_copy(&poldindexid), ::core::mem::transmute_copy(&pnewtableid), ::core::mem::transmute_copy(&pnewindexid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RenameColumn: RenameColumn::<Identity, Impl, OFFSET>,
             RenameTable: RenameTable::<Identity, Impl, OFFSET>,
         }
@@ -6578,7 +6578,7 @@ impl ITokenCollection_Vtbl {
             this.GetToken(::core::mem::transmute_copy(&i), ::core::mem::transmute_copy(&pbegin), ::core::mem::transmute_copy(&plength), ::core::mem::transmute_copy(&ppsz)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             NumberOfTokens: NumberOfTokens::<Identity, Impl, OFFSET>,
             GetToken: GetToken::<Identity, Impl, OFFSET>,
         }
@@ -6614,7 +6614,7 @@ impl ITransactionJoin_Vtbl {
             this.JoinTransaction(::core::mem::transmute(&punktransactioncoord), ::core::mem::transmute_copy(&isolevel), ::core::mem::transmute_copy(&isoflags), ::core::mem::transmute(&potheroptions)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetOptionsObject: GetOptionsObject::<Identity, Impl, OFFSET>,
             JoinTransaction: JoinTransaction::<Identity, Impl, OFFSET>,
         }
@@ -6685,7 +6685,7 @@ impl ITransactionObject_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetTransactionObject: GetTransactionObject::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetTransactionObject: GetTransactionObject::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ITransactionObject as ::windows::core::Interface>::IID
@@ -6730,7 +6730,7 @@ impl ITrusteeAdmin_Vtbl {
             this.GetTrusteeProperties(::core::mem::transmute_copy(&ptrustee), ::core::mem::transmute_copy(&cpropertyidsets), ::core::mem::transmute_copy(&rgpropertyidsets), ::core::mem::transmute_copy(&pcpropertysets), ::core::mem::transmute_copy(&prgpropertysets)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CompareTrustees: CompareTrustees::<Identity, Impl, OFFSET>,
             CreateTrustee: CreateTrustee::<Identity, Impl, OFFSET>,
             DeleteTrustee: DeleteTrustee::<Identity, Impl, OFFSET>,
@@ -6781,7 +6781,7 @@ impl ITrusteeGroupAdmin_Vtbl {
             this.GetMemberships(::core::mem::transmute_copy(&ptrustee), ::core::mem::transmute_copy(&pcmemberships), ::core::mem::transmute_copy(&prgmemberships)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddMember: AddMember::<Identity, Impl, OFFSET>,
             DeleteMember: DeleteMember::<Identity, Impl, OFFSET>,
             IsMember: IsMember::<Identity, Impl, OFFSET>,
@@ -6854,7 +6854,7 @@ impl IUMSInitialize_Vtbl {
             let this = (*this).get_impl();
             this.Initialize(::core::mem::transmute_copy(&pums)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Initialize: Initialize::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Initialize: Initialize::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IUMSInitialize as ::windows::core::Interface>::IID
@@ -6983,7 +6983,7 @@ impl IUrlAccessor_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddRequestParameter: AddRequestParameter::<Identity, Impl, OFFSET>,
             GetDocFormat: GetDocFormat::<Identity, Impl, OFFSET>,
             GetCLSID: GetCLSID::<Identity, Impl, OFFSET>,
@@ -7132,7 +7132,7 @@ impl IViewChapter_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSpecification: GetSpecification::<Identity, Impl, OFFSET>,
             OpenViewChapter: OpenViewChapter::<Identity, Impl, OFFSET>,
         }
@@ -7168,7 +7168,7 @@ impl IViewFilter_Vtbl {
             this.SetFilter(::core::mem::transmute_copy(&haccessor), ::core::mem::transmute_copy(&crows), ::core::mem::transmute_copy(&compareops), ::core::mem::transmute_copy(&pcriteriadata)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetFilter: GetFilter::<Identity, Impl, OFFSET>,
             GetFilterBindings: GetFilterBindings::<Identity, Impl, OFFSET>,
             SetFilter: SetFilter::<Identity, Impl, OFFSET>,
@@ -7208,7 +7208,7 @@ impl IViewRowset_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSpecification: GetSpecification::<Identity, Impl, OFFSET>,
             OpenViewRowset: OpenViewRowset::<Identity, Impl, OFFSET>,
         }
@@ -7235,7 +7235,7 @@ impl IViewSort_Vtbl {
             this.SetSortOrder(::core::mem::transmute_copy(&cvalues), ::core::mem::transmute_copy(&rgcolumns), ::core::mem::transmute_copy(&rgorders)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSortOrder: GetSortOrder::<Identity, Impl, OFFSET>,
             SetSortOrder: SetSortOrder::<Identity, Impl, OFFSET>,
         }
@@ -7277,7 +7277,7 @@ impl IWordBreaker_Vtbl {
             this.GetLicenseToUse(::core::mem::transmute_copy(&ppwcslicense)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Init: Init::<Identity, Impl, OFFSET>,
             BreakText: BreakText::<Identity, Impl, OFFSET>,
             ComposePhrase: ComposePhrase::<Identity, Impl, OFFSET>,
@@ -7306,7 +7306,7 @@ impl IWordFormSink_Vtbl {
             this.PutWord(::core::mem::transmute(&pwcinbuf), ::core::mem::transmute_copy(&cwc)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             PutAltWord: PutAltWord::<Identity, Impl, OFFSET>,
             PutWord: PutWord::<Identity, Impl, OFFSET>,
         }
@@ -7354,7 +7354,7 @@ impl IWordSink_Vtbl {
             this.PutBreak(::core::mem::transmute_copy(&breaktype)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             PutWord: PutWord::<Identity, Impl, OFFSET>,
             PutAltWord: PutAltWord::<Identity, Impl, OFFSET>,
             StartAltPhrase: StartAltPhrase::<Identity, Impl, OFFSET>,
@@ -7519,7 +7519,7 @@ impl OLEDBSimpleProvider_Vtbl {
             this.stopTransfer().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             getRowCount: getRowCount::<Identity, Impl, OFFSET>,
             getColumnCount: getColumnCount::<Identity, Impl, OFFSET>,
             getRWStatus: getRWStatus::<Identity, Impl, OFFSET>,
@@ -7594,7 +7594,7 @@ impl OLEDBSimpleProviderListener_Vtbl {
             this.transferComplete(::core::mem::transmute_copy(&xfer)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             aboutToChangeCell: aboutToChangeCell::<Identity, Impl, OFFSET>,
             cellChanged: cellChanged::<Identity, Impl, OFFSET>,
             aboutToDeleteRows: aboutToDeleteRows::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/System/Search/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Search/mod.rs
@@ -2542,7 +2542,7 @@ unsafe impl ::windows::core::Interface for DataSource {
 #[repr(C)]
 #[doc(hidden)]
 pub struct DataSource_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub getDataMember: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrdm: *const u16, riid: *const ::windows::core::GUID, ppunk: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub getDataMemberName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lindex: i32, pbstrdm: *mut *mut u16) -> ::windows::core::HRESULT,
     pub getDataMemberCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, plcount: *mut i32) -> ::windows::core::HRESULT,
@@ -2601,7 +2601,7 @@ unsafe impl ::windows::core::Interface for DataSourceListener {
 #[repr(C)]
 #[doc(hidden)]
 pub struct DataSourceListener_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub dataMemberChanged: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrdm: *const u16) -> ::windows::core::HRESULT,
     pub dataMemberAdded: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrdm: *const u16) -> ::windows::core::HRESULT,
     pub dataMemberRemoved: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrdm: *const u16) -> ::windows::core::HRESULT,
@@ -2749,7 +2749,7 @@ unsafe impl ::windows::core::Interface for IAccessor {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAccessor_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddRefAccessor: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, haccessor: HACCESSOR, pcrefcount: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
     pub CreateAccessor: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwaccessorflags: u32, cbindings: usize, rgbindings: *const DBBINDING, cbrowsize: usize, phaccessor: *mut HACCESSOR, rgstatus: *mut u32) -> ::windows::core::HRESULT,
@@ -2809,7 +2809,7 @@ unsafe impl ::windows::core::Interface for IAlterIndex {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAlterIndex_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub AlterIndex: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptableid: *mut super::super::Storage::IndexServer::DBID, pindexid: *mut super::super::Storage::IndexServer::DBID, pnewindexid: *mut super::super::Storage::IndexServer::DBID, cpropertysets: u32, rgpropertysets: *mut DBPROPSET) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole")))]
@@ -2868,7 +2868,7 @@ unsafe impl ::windows::core::Interface for IAlterTable {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAlterTable_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub AlterColumn: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptableid: *mut super::super::Storage::IndexServer::DBID, pcolumnid: *mut super::super::Storage::IndexServer::DBID, dwcolumndescflags: u32, pcolumndesc: *mut DBCOLUMNDESC) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole")))]
@@ -2931,7 +2931,7 @@ unsafe impl ::windows::core::Interface for IBindResource {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IBindResource_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub Bind: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punkouter: *mut ::core::ffi::c_void, pwszurl: ::windows::core::PCWSTR, dwbindurlflags: u32, rguid: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, pauthenticate: *mut ::core::ffi::c_void, pimplsession: *mut DBIMPLICITSESSION, pdwbindstatus: *mut u32, ppunk: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -2988,7 +2988,7 @@ unsafe impl ::windows::core::Interface for IChapteredRowset {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IChapteredRowset_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddRefChapter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hchapter: usize, pcrefcount: *mut u32) -> ::windows::core::HRESULT,
     pub ReleaseChapter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hchapter: usize, pcrefcount: *mut u32) -> ::windows::core::HRESULT,
 }
@@ -3056,7 +3056,7 @@ unsafe impl ::windows::core::Interface for IColumnMapper {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IColumnMapper_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Storage_IndexServer")]
     pub GetPropInfoFromName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wcspropname: ::windows::core::PCWSTR, pppropid: *mut *mut super::super::Storage::IndexServer::DBID, pproptype: *mut u16, puiwidth: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Storage_IndexServer"))]
@@ -3122,7 +3122,7 @@ unsafe impl ::windows::core::Interface for IColumnMapperCreator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IColumnMapperCreator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetColumnMapper: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wcsmachinename: ::windows::core::PCWSTR, wcscatalogname: ::windows::core::PCWSTR, ppcolumnmapper: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Search\"`*"]
@@ -3179,7 +3179,7 @@ unsafe impl ::windows::core::Interface for IColumnsInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IColumnsInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com"))]
     pub GetColumnInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pccolumns: *mut usize, prginfo: *mut *mut DBCOLUMNINFO, ppstringsbuffer: *mut *mut u16) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com")))]
@@ -3325,7 +3325,7 @@ unsafe impl ::windows::core::Interface for IColumnsRowset {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IColumnsRowset_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Storage_IndexServer")]
     pub GetAvailableColumns: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcoptcolumns: *mut usize, prgoptcolumns: *mut *mut super::super::Storage::IndexServer::DBID) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Storage_IndexServer"))]
@@ -3391,7 +3391,7 @@ unsafe impl ::windows::core::Interface for ICommand {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICommand_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Cancel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Execute: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punkouter: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, pparams: *mut DBPARAMS, pcrowsaffected: *mut isize, pprowset: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetDBSession: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppsession: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -3475,7 +3475,7 @@ unsafe impl ::windows::core::Interface for ICommandCost {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICommandCost_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetAccumulatedCost: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszrowsetname: ::windows::core::PCWSTR, pccostlimits: *mut u32, prgcostlimits: *mut *mut DBCOST) -> ::windows::core::HRESULT,
     pub GetCostEstimate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszrowsetname: ::windows::core::PCWSTR, pccostestimates: *mut u32, prgcostestimates: *mut DBCOST) -> ::windows::core::HRESULT,
     pub GetCostGoals: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszrowsetname: ::windows::core::PCWSTR, pccostgoals: *mut u32, prgcostgoals: *mut DBCOST) -> ::windows::core::HRESULT,
@@ -3546,7 +3546,7 @@ unsafe impl ::windows::core::Interface for ICommandPersist {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICommandPersist_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Storage_IndexServer")]
     pub DeleteCommand: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcommandid: *mut super::super::Storage::IndexServer::DBID) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Storage_IndexServer"))]
@@ -3613,7 +3613,7 @@ unsafe impl ::windows::core::Interface for ICommandPrepare {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICommandPrepare_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Prepare: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cexpectedruns: u32) -> ::windows::core::HRESULT,
     pub Unprepare: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -3670,7 +3670,7 @@ unsafe impl ::windows::core::Interface for ICommandProperties {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICommandProperties_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub GetProperties: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cpropertyidsets: u32, rgpropertyidsets: *const DBPROPIDSET, pcpropertysets: *mut u32, prgpropertysets: *mut *mut DBPROPSET) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole")))]
@@ -3732,7 +3732,7 @@ unsafe impl ::windows::core::Interface for ICommandStream {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICommandStream_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCommandStream: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, piid: *mut ::windows::core::GUID, pguiddialect: *mut ::windows::core::GUID, ppcommandstream: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetCommandStream: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, rguiddialect: *const ::windows::core::GUID, pcommandstream: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -3869,7 +3869,7 @@ unsafe impl ::windows::core::Interface for ICommandValidate {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICommandValidate_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ValidateCompletely: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub ValidateSyntax: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -3928,7 +3928,7 @@ unsafe impl ::windows::core::Interface for ICommandWithParameters {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICommandWithParameters_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub GetParameterInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcparams: *mut usize, prgparaminfo: *mut *mut DBPARAMINFO, ppnamesbuffer: *mut *mut u16) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -4392,7 +4392,7 @@ unsafe impl ::windows::core::Interface for IConditionFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IConditionFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
     pub MakeNot: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcsub: *mut ::core::ffi::c_void, fsimplify: super::super::Foundation::BOOL, ppcresult: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com")))]
@@ -4725,7 +4725,7 @@ unsafe impl ::windows::core::Interface for IConditionGenerator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IConditionGenerator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pschemaprovider: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub RecognizeNamedEntities: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszinputstring: ::windows::core::PCWSTR, lciduserlocale: u32, ptokencollection: *mut ::core::ffi::c_void, pnamedentities: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Search_Common"))]
@@ -4783,7 +4783,7 @@ unsafe impl ::windows::core::Interface for IConvertType {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IConvertType_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CanConvert: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wfromtype: u16, wtotype: u16, dwconvertflags: u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Search\"`*"]
@@ -4839,7 +4839,7 @@ unsafe impl ::windows::core::Interface for ICreateRow {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICreateRow_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub CreateRow: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punkouter: *mut ::core::ffi::c_void, pwszurl: ::windows::core::PCWSTR, dwbindurlflags: u32, rguid: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, pauthenticate: *mut ::core::ffi::c_void, pimplsession: *mut DBIMPLICITSESSION, pdwbindstatus: *mut u32, ppwsznewurl: *mut ::windows::core::PWSTR, ppunk: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -4903,7 +4903,7 @@ unsafe impl ::windows::core::Interface for IDBAsynchNotify {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDBAsynchNotify_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnLowResource: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwreserved: usize) -> ::windows::core::HRESULT,
     pub OnProgress: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hchapter: usize, eoperation: u32, ulprogress: usize, ulprogressmax: usize, easynchphase: u32, pwszstatustext: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub OnStop: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hchapter: usize, eoperation: u32, hrstatus: ::windows::core::HRESULT, pwszstatustext: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
@@ -4957,7 +4957,7 @@ unsafe impl ::windows::core::Interface for IDBAsynchStatus {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDBAsynchStatus_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Abort: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hchapter: usize, eoperation: u32) -> ::windows::core::HRESULT,
     pub GetStatus: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hchapter: usize, eoperation: u32, pulprogress: *mut usize, pulprogressmax: *mut usize, peasynchphase: *mut u32, ppwszstatustext: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
 }
@@ -5090,7 +5090,7 @@ unsafe impl ::windows::core::Interface for IDBCreateCommand {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDBCreateCommand_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateCommand: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punkouter: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppcommand: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Search\"`*"]
@@ -5143,7 +5143,7 @@ unsafe impl ::windows::core::Interface for IDBCreateSession {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDBCreateSession_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateSession: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punkouter: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppdbsession: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Search\"`*"]
@@ -5210,7 +5210,7 @@ unsafe impl ::windows::core::Interface for IDBDataSourceAdmin {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDBDataSourceAdmin_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub CreateDataSource: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cpropertysets: u32, rgpropertysets: *mut DBPROPSET, punkouter: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppdbsession: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole")))]
@@ -5277,7 +5277,7 @@ unsafe impl ::windows::core::Interface for IDBInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDBInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetKeywords: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppwszkeywords: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub GetLiteralInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cliterals: u32, rgliterals: *const u32, pcliteralinfo: *mut u32, prgliteralinfo: *mut *mut DBLITERALINFO, ppcharbuffer: *mut *mut u16) -> ::windows::core::HRESULT,
@@ -5333,7 +5333,7 @@ unsafe impl ::windows::core::Interface for IDBInitialize {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDBInitialize_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Uninitialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -5401,7 +5401,7 @@ unsafe impl ::windows::core::Interface for IDBPromptInitialize {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDBPromptInitialize_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub PromptDataSource: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punkouter: *mut ::core::ffi::c_void, hwndparent: super::super::Foundation::HWND, dwpromptoptions: u32, csourcetypefilter: u32, rgsourcetypefilter: *const u32, pwszszzproviderfilter: ::windows::core::PCWSTR, riid: *const ::windows::core::GUID, ppdatasource: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -5469,7 +5469,7 @@ unsafe impl ::windows::core::Interface for IDBProperties {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDBProperties_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub GetProperties: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cpropertyidsets: u32, rgpropertyidsets: *const DBPROPIDSET, pcpropertysets: *mut u32, prgpropertysets: *mut *mut DBPROPSET) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole")))]
@@ -5536,7 +5536,7 @@ unsafe impl ::windows::core::Interface for IDBSchemaCommand {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDBSchemaCommand_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCommand: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punkouter: *mut ::core::ffi::c_void, rguidschema: *const ::windows::core::GUID, ppcommand: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetSchemas: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcschemas: *mut u32, prgschemas: *mut *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
 }
@@ -5605,7 +5605,7 @@ unsafe impl ::windows::core::Interface for IDBSchemaRowset {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDBSchemaRowset_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub GetRowset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punkouter: *mut ::core::ffi::c_void, rguidschema: *const ::windows::core::GUID, crestrictions: u32, rgrestrictions: *const super::Com::VARIANT, riid: *const ::windows::core::GUID, cpropertysets: u32, rgpropertysets: *mut DBPROPSET, pprowset: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole")))]
@@ -5666,7 +5666,7 @@ unsafe impl ::windows::core::Interface for IDCInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDCInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub GetInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cinfo: u32, rgeinfotype: *const u32, prginfo: *mut *mut DCINFO) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole")))]
@@ -5728,7 +5728,7 @@ unsafe impl ::windows::core::Interface for IDataConvert {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDataConvert_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub DataConvert: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wsrctype: u16, wdsttype: u16, cbsrclength: usize, pcbdstlength: *mut usize, psrc: *const ::core::ffi::c_void, pdst: *mut ::core::ffi::c_void, cbdstmaxlength: usize, dbssrcstatus: u32, pdbsstatus: *mut u32, bprecision: u8, bscale: u8, dwflags: u32) -> ::windows::core::HRESULT,
     pub CanConvert: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wsrctype: u16, wdsttype: u16) -> ::windows::core::HRESULT,
     pub GetConversionSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wsrctype: u16, wdsttype: u16, pcbsrclength: *const usize, pcbdstlength: *mut usize, psrc: *const ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -5821,7 +5821,7 @@ unsafe impl ::windows::core::Interface for IDataInitialize {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDataInitialize_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDataSource: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punkouter: *mut ::core::ffi::c_void, dwclsctx: u32, pwszinitializationstring: ::windows::core::PCWSTR, riid: *const ::windows::core::GUID, ppdatasource: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetInitializationString: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdatasource: *mut ::core::ffi::c_void, fincludepassword: u8, ppwszinitstring: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub CreateDBInstance: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, clsidprovider: *const ::windows::core::GUID, punkouter: *mut ::core::ffi::c_void, dwclsctx: u32, pwszreserved: ::windows::core::PCWSTR, riid: *const ::windows::core::GUID, ppdatasource: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -6037,7 +6037,7 @@ unsafe impl ::windows::core::Interface for IEntity {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEntity_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Name: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppszname: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub Base: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbaseentity: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Relationships: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, prelationships: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -6109,7 +6109,7 @@ unsafe impl ::windows::core::Interface for IEnumItemProperties {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumItemProperties_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut ITEMPROP, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole")))]
@@ -6175,7 +6175,7 @@ unsafe impl ::windows::core::Interface for IEnumSearchRoots {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumSearchRoots_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -6237,7 +6237,7 @@ unsafe impl ::windows::core::Interface for IEnumSearchScopeRules {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumSearchScopeRules_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, pprgelt: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -6303,7 +6303,7 @@ unsafe impl ::windows::core::Interface for IEnumSubscription {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumSubscription_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut ::windows::core::GUID, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -6364,7 +6364,7 @@ unsafe impl ::windows::core::Interface for IErrorLookup {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IErrorLookup_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub GetErrorDescription: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hrerror: ::windows::core::HRESULT, dwlookupid: u32, pdispparams: *const super::Com::DISPPARAMS, lcid: u32, pbstrsource: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>, pbstrdescription: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole")))]
@@ -6447,7 +6447,7 @@ unsafe impl ::windows::core::Interface for IErrorRecords {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IErrorRecords_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub AddErrorRecord: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, perrorinfo: *const ERRORINFO, dwlookupid: u32, pdispparams: *const super::Com::DISPPARAMS, punkcustomerror: *mut ::core::ffi::c_void, dwdynamicerrorid: u32) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole")))]
@@ -6511,7 +6511,7 @@ unsafe impl ::windows::core::Interface for IGetDataSource {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IGetDataSource_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDataSource: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppdatasource: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Search\"`*"]
@@ -6568,7 +6568,7 @@ unsafe impl ::windows::core::Interface for IGetRow {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IGetRow_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetRowFromHROW: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punkouter: *mut ::core::ffi::c_void, hrow: usize, riid: *const ::windows::core::GUID, ppunk: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetURLFromHROW: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hrow: usize, ppwszurl: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
 }
@@ -6619,7 +6619,7 @@ unsafe impl ::windows::core::Interface for IGetSession {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IGetSession_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetSession: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppsession: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Search\"`*"]
@@ -6669,7 +6669,7 @@ unsafe impl ::windows::core::Interface for IGetSourceRow {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IGetSourceRow_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetSourceRow: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, pprow: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Search\"`*"]
@@ -6725,7 +6725,7 @@ unsafe impl ::windows::core::Interface for IIndexDefinition {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IIndexDefinition_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub CreateIndex: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptableid: *const super::super::Storage::IndexServer::DBID, pindexid: *const super::super::Storage::IndexServer::DBID, cindexcolumndescs: usize, rgindexcolumndescs: *const DBINDEXCOLUMNDESC, cpropertysets: u32, rgpropertysets: *mut DBPROPSET, ppindexid: *mut *mut super::super::Storage::IndexServer::DBID) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole")))]
@@ -6783,7 +6783,7 @@ unsafe impl ::windows::core::Interface for IInterval {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IInterval_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
     pub GetLimits: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pilklower: *mut INTERVAL_LIMIT_KIND, ppropvarlower: *mut super::Com::StructuredStorage::PROPVARIANT, pilkupper: *mut INTERVAL_LIMIT_KIND, ppropvarupper: *mut super::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage")))]
@@ -6863,7 +6863,7 @@ unsafe impl ::windows::core::Interface for ILoadFilter {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ILoadFilter_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer"))]
     pub LoadIFilter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwcspath: ::windows::core::PCWSTR, pfilteredsources: *const FILTERED_DATA_SOURCES, punkouter: *mut ::core::ffi::c_void, fusedefault: super::super::Foundation::BOOL, pfilterclsid: *mut ::windows::core::GUID, searchdecsize: *mut i32, pwcssearchdesc: *mut *mut u16, ppifilt: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer")))]
@@ -7047,7 +7047,7 @@ unsafe impl ::windows::core::Interface for IMDDataset {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMDDataset_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub FreeAxisInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, caxes: usize, rgaxisinfo: *mut MDAXISINFO) -> ::windows::core::HRESULT,
     pub GetAxisInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcaxes: *mut usize, prgaxisinfo: *mut *mut MDAXISINFO) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -7106,7 +7106,7 @@ unsafe impl ::windows::core::Interface for IMDFind {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMDFind_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub FindCell: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ulstartingordinal: usize, cmembers: usize, rgpwszmember: *mut ::windows::core::PWSTR, pulcellordinal: *mut usize) -> ::windows::core::HRESULT,
     pub FindTuple: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ulaxisidentifier: u32, ulstartingordinal: usize, cmembers: usize, rgpwszmember: *mut ::windows::core::PWSTR, pultupleordinal: *mut u32) -> ::windows::core::HRESULT,
 }
@@ -7161,7 +7161,7 @@ unsafe impl ::windows::core::Interface for IMDRangeRowset {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMDRangeRowset_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub GetRangeRowset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punkouter: *mut ::core::ffi::c_void, ulstartcell: usize, ulendcell: usize, riid: *const ::windows::core::GUID, cpropertysets: u32, rgpropertysets: *mut DBPROPSET, pprowset: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole")))]
@@ -7213,7 +7213,7 @@ unsafe impl ::windows::core::Interface for IMetaData {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMetaData_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppszkey: *mut ::windows::core::PWSTR, ppszvalue: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Search\"`*"]
@@ -7265,7 +7265,7 @@ unsafe impl ::windows::core::Interface for IMultipleResults {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMultipleResults_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetResult: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punkouter: *mut ::core::ffi::c_void, lresultflag: isize, riid: *const ::windows::core::GUID, pcrowsaffected: *mut isize, pprowset: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Search\"`*"]
@@ -7319,7 +7319,7 @@ unsafe impl ::windows::core::Interface for INamedEntity {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INamedEntity_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetValue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppszvalue: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub DefaultPhrase: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppszphrase: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
 }
@@ -7373,7 +7373,7 @@ unsafe impl ::windows::core::Interface for INamedEntityCollector {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INamedEntityCollector_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Add: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, beginspan: u32, endspan: u32, beginactual: u32, endactual: u32, ptype: *mut ::core::ffi::c_void, pszvalue: ::windows::core::PCWSTR, certainty: NAMED_ENTITY_CERTAINTY) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Search\"`*"]
@@ -7444,7 +7444,7 @@ unsafe impl ::windows::core::Interface for IObjectAccessControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IObjectAccessControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Security_Authorization", feature = "Win32_Storage_IndexServer"))]
     pub GetObjectAccessRights: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pobject: *mut SEC_OBJECT, pcaccessentries: *mut u32, prgaccessentries: *mut *mut super::super::Security::Authorization::EXPLICIT_ACCESS_W) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Security_Authorization", feature = "Win32_Storage_IndexServer")))]
@@ -7527,7 +7527,7 @@ unsafe impl ::windows::core::Interface for IOpLockStatus {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOpLockStatus_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub IsOplockValid: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfisoplockvalid: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -7592,7 +7592,7 @@ unsafe impl ::windows::core::Interface for IOpenRowset {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOpenRowset_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub OpenRowset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punkouter: *mut ::core::ffi::c_void, ptableid: *const super::super::Storage::IndexServer::DBID, pindexid: *const super::super::Storage::IndexServer::DBID, riid: *const ::windows::core::GUID, cpropertysets: u32, rgpropertysets: *mut DBPROPSET, pprowset: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole")))]
@@ -7648,7 +7648,7 @@ unsafe impl ::windows::core::Interface for IParentRowset {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IParentRowset_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetChildRowset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punkouter: *mut ::core::ffi::c_void, iordinal: usize, riid: *const ::windows::core::GUID, pprowset: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Search\"`*"]
@@ -7703,7 +7703,7 @@ unsafe impl ::windows::core::Interface for IProtocolHandlerSite {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IProtocolHandlerSite_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Storage_IndexServer")]
     pub GetFilter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pclsidobj: *mut ::windows::core::GUID, pcwszcontenttype: ::windows::core::PCWSTR, pcwszextension: ::windows::core::PCWSTR, ppfilter: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Storage_IndexServer"))]
@@ -7758,7 +7758,7 @@ unsafe impl ::windows::core::Interface for IProvideMoniker {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IProvideMoniker_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub GetMoniker: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppimoniker: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -7867,7 +7867,7 @@ unsafe impl ::windows::core::Interface for IQueryParser {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IQueryParser_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub Parse: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszinputstring: ::windows::core::PCWSTR, pcustomproperties: *mut ::core::ffi::c_void, ppsolution: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -7961,7 +7961,7 @@ unsafe impl ::windows::core::Interface for IQueryParserManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IQueryParserManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateLoadedParser: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszcatalog: ::windows::core::PCWSTR, langidforkeywords: u16, riid: *const ::windows::core::GUID, ppqueryparser: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub InitializeOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, funderstandnqs: super::super::Foundation::BOOL, fautowildcard: super::super::Foundation::BOOL, pqueryparser: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -8148,7 +8148,7 @@ unsafe impl ::windows::core::Interface for IReadData {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IReadData_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ReadData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hchapter: usize, cbbookmark: usize, pbookmark: *const u8, lrowsoffset: isize, haccessor: HACCESSOR, crows: isize, pcrowsobtained: *mut usize, ppfixeddata: *mut *mut u8, pcbvariabletotal: *mut usize, ppvariabledata: *mut *mut u8) -> ::windows::core::HRESULT,
     pub ReleaseChapter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hchapter: usize) -> ::windows::core::HRESULT,
 }
@@ -8214,7 +8214,7 @@ unsafe impl ::windows::core::Interface for IRegisterProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRegisterProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetURLMapping: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszurl: ::windows::core::PCWSTR, dwreserved: usize, pclsidprovider: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub SetURLMapping: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszurl: ::windows::core::PCWSTR, dwreserved: usize, rclsidprovider: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub UnregisterProvider: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszurl: ::windows::core::PCWSTR, dwreserved: usize, rclsidprovider: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
@@ -8287,7 +8287,7 @@ unsafe impl ::windows::core::Interface for IRelationship {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRelationship_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Name: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppszname: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub IsReal: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pisreal: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -8345,7 +8345,7 @@ unsafe impl ::windows::core::Interface for IRichChunk {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRichChunk_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
     pub GetData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfirstpos: *mut u32, plength: *mut u32, ppsz: *mut ::windows::core::PWSTR, pvalue: *mut super::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage")))]
@@ -8411,7 +8411,7 @@ unsafe impl ::windows::core::Interface for IRow {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRow_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Storage_IndexServer")]
     pub GetColumns: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ccolumns: usize, rgcolumns: *mut DBCOLUMNACCESS) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Storage_IndexServer"))]
@@ -8470,7 +8470,7 @@ unsafe impl ::windows::core::Interface for IRowChange {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRowChange_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Storage_IndexServer")]
     pub SetColumns: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ccolumns: usize, rgcolumns: *const DBCOLUMNACCESS) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Storage_IndexServer"))]
@@ -8538,7 +8538,7 @@ unsafe impl ::windows::core::Interface for IRowPosition {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRowPosition_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ClearRowPosition: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetRowPosition: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, phchapter: *mut usize, phrow: *mut usize, pdwpositionflags: *mut u32) -> ::windows::core::HRESULT,
     pub GetRowset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, pprowset: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -8596,7 +8596,7 @@ unsafe impl ::windows::core::Interface for IRowPositionChange {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRowPositionChange_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub OnRowPositionChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ereason: u32, ephase: u32, fcantdeny: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -8746,7 +8746,7 @@ unsafe impl ::windows::core::Interface for IRowset {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRowset_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddRefRows: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, crows: usize, rghrows: *const usize, rgrefcounts: *mut u32, rgrowstatus: *mut u32) -> ::windows::core::HRESULT,
     pub GetData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hrow: usize, haccessor: HACCESSOR, pdata: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetNextRows: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hreserved: usize, lrowsoffset: isize, crows: isize, pcrowsobtained: *mut usize, prghrows: *mut *mut usize) -> ::windows::core::HRESULT,
@@ -8804,7 +8804,7 @@ unsafe impl ::windows::core::Interface for IRowsetAsynch {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRowsetAsynch_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub RatioFinished: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, puldenominator: *mut usize, pulnumerator: *mut usize, pcrows: *mut usize, pfnewrows: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -8857,7 +8857,7 @@ unsafe impl ::windows::core::Interface for IRowsetBookmark {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRowsetBookmark_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub PositionOnBookmark: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hchapter: usize, cbbookmark: usize, pbookmark: *const u8) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Search\"`*"]
@@ -8918,7 +8918,7 @@ unsafe impl ::windows::core::Interface for IRowsetChange {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRowsetChange_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub DeleteRows: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hreserved: usize, crows: usize, rghrows: *const usize, rgrowstatus: *mut u32) -> ::windows::core::HRESULT,
     pub SetData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hrow: usize, haccessor: HACCESSOR, pdata: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub InsertRow: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hreserved: usize, haccessor: HACCESSOR, pdata: *mut ::core::ffi::c_void, phrow: *mut usize) -> ::windows::core::HRESULT,
@@ -8972,7 +8972,7 @@ unsafe impl ::windows::core::Interface for IRowsetChangeExtInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRowsetChangeExtInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetOriginalRow: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hreserved: usize, hrow: usize, phroworiginal: *mut usize) -> ::windows::core::HRESULT,
     pub GetPendingColumns: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hreserved: usize, hrow: usize, ccolumnordinals: u32, rgiordinals: *const u32, rgcolumnstatus: *mut u32) -> ::windows::core::HRESULT,
 }
@@ -9022,7 +9022,7 @@ unsafe impl ::windows::core::Interface for IRowsetChapterMember {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRowsetChapterMember_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub IsRowInChapter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hchapter: usize, hrow: usize) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Search\"`*"]
@@ -9083,7 +9083,7 @@ unsafe impl ::windows::core::Interface for IRowsetCopyRows {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRowsetCopyRows_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CloseSource: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hsourceid: u16) -> ::windows::core::HRESULT,
     pub CopyByHROWS: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hsourceid: u16, hreserved: usize, crows: isize, rghrows: *const usize, bflags: u32) -> ::windows::core::HRESULT,
     pub CopyRows: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hsourceid: u16, hreserved: usize, crows: isize, bflags: u32, pcrowscopied: *mut usize) -> ::windows::core::HRESULT,
@@ -9247,7 +9247,7 @@ unsafe impl ::windows::core::Interface for IRowsetEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRowsetEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
     pub OnNewItem: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, itemid: *const super::Com::StructuredStorage::PROPVARIANT, newitemstate: ROWSETEVENT_ITEMSTATE) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage")))]
@@ -9322,7 +9322,7 @@ unsafe impl ::windows::core::Interface for IRowsetFastLoad {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRowsetFastLoad_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub InsertRow: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, haccessor: HACCESSOR, pdata: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub Commit: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fdone: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -9378,7 +9378,7 @@ unsafe impl ::windows::core::Interface for IRowsetFind {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRowsetFind_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub FindNextRow: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hchapter: usize, haccessor: HACCESSOR, pfindvalue: *mut ::core::ffi::c_void, compareop: u32, cbbookmark: usize, pbookmark: *const u8, lrowsoffset: isize, crows: isize, pcrowsobtained: *mut usize, prghrows: *mut *mut usize) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Search\"`*"]
@@ -9427,7 +9427,7 @@ unsafe impl ::windows::core::Interface for IRowsetIdentity {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRowsetIdentity_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub IsSameRow: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hthisrow: usize, hthatrow: usize) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Search\"`*"]
@@ -9490,7 +9490,7 @@ unsafe impl ::windows::core::Interface for IRowsetIndex {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRowsetIndex_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub GetIndexInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pckeycolumns: *mut usize, prgindexcolumndesc: *mut *mut DBINDEXCOLUMNDESC, pcindexpropertysets: *mut u32, prgindexpropertysets: *mut *mut DBPROPSET) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole")))]
@@ -9554,7 +9554,7 @@ unsafe impl ::windows::core::Interface for IRowsetInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRowsetInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub GetProperties: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cpropertyidsets: u32, rgpropertyidsets: *const DBPROPIDSET, pcpropertysets: *mut u32, prgpropertysets: *mut *mut DBPROPSET) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole")))]
@@ -9608,7 +9608,7 @@ unsafe impl ::windows::core::Interface for IRowsetKeys {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRowsetKeys_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ListKeys: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pccolumns: *mut usize, prgcolumns: *mut *mut usize) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Search\"`*"]
@@ -9754,7 +9754,7 @@ unsafe impl ::windows::core::Interface for IRowsetNewRowAfter {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRowsetNewRowAfter_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetNewDataAfter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hchapter: usize, cbbmprevious: u32, pbmprevious: *const u8, haccessor: HACCESSOR, pdata: *mut u8, phrow: *mut usize) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Search\"`*"]
@@ -9807,7 +9807,7 @@ unsafe impl ::windows::core::Interface for IRowsetNextRowset {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRowsetNextRowset_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetNextRowset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punkouter: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppnextrowset: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Search\"`*"]
@@ -9880,7 +9880,7 @@ unsafe impl ::windows::core::Interface for IRowsetNotify {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRowsetNotify_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub OnFieldChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, prowset: *mut ::core::ffi::c_void, hrow: usize, ccolumns: usize, rgcolumns: *const usize, ereason: u32, ephase: u32, fcantdeny: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -9946,7 +9946,7 @@ unsafe impl ::windows::core::Interface for IRowsetPrioritization {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRowsetPrioritization_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetScopePriority: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, priority: PRIORITY_LEVEL, scopestatisticseventfrequency: u32) -> ::windows::core::HRESULT,
     pub GetScopePriority: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, priority: *mut PRIORITY_LEVEL, scopestatisticseventfrequency: *mut u32) -> ::windows::core::HRESULT,
     pub GetScopeStatistics: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, indexeddocumentcount: *mut u32, oustandingaddcount: *mut u32, oustandingmodifycount: *mut u32) -> ::windows::core::HRESULT,
@@ -10000,7 +10000,7 @@ unsafe impl ::windows::core::Interface for IRowsetQueryStatus {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRowsetQueryStatus_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetStatus: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwstatus: *mut u32) -> ::windows::core::HRESULT,
     pub GetStatusEx: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwstatus: *mut u32, pcfiltereddocuments: *mut u32, pcdocumentstofilter: *mut u32, pdwratiofinisheddenominator: *mut usize, pdwratiofinishednumerator: *mut usize, cbbmk: usize, pbmk: *const u8, pirowbmk: *mut usize, pcrowstotal: *mut usize) -> ::windows::core::HRESULT,
 }
@@ -10061,7 +10061,7 @@ unsafe impl ::windows::core::Interface for IRowsetRefresh {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRowsetRefresh_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub RefreshVisibleData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hchapter: usize, crows: usize, rghrows: *const usize, foverwrite: super::super::Foundation::BOOL, pcrowsrefreshed: *mut usize, prghrowsrefreshed: *mut *mut usize, prgrowstatus: *mut *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -10120,7 +10120,7 @@ unsafe impl ::windows::core::Interface for IRowsetResynch {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRowsetResynch_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetVisibleData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hrow: usize, haccessor: HACCESSOR, pdata: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub ResynchRows: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, crows: usize, rghrows: *const usize, pcrowsresynched: *mut usize, prghrowsresynched: *mut *mut usize, prgrowstatus: *mut *mut u32) -> ::windows::core::HRESULT,
 }
@@ -10388,7 +10388,7 @@ unsafe impl ::windows::core::Interface for IRowsetView {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRowsetView_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateView: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punkouter: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppview: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetView: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hchapter: usize, riid: *const ::windows::core::GUID, phchaptersource: *mut usize, ppview: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -10444,7 +10444,7 @@ unsafe impl ::windows::core::Interface for IRowsetWatchAll {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRowsetWatchAll_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Acknowledge: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Start: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub StopWatching: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -10498,7 +10498,7 @@ unsafe impl ::windows::core::Interface for IRowsetWatchNotify {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRowsetWatchNotify_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, prowset: *mut ::core::ffi::c_void, echangereason: u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Search\"`*"]
@@ -10645,7 +10645,7 @@ unsafe impl ::windows::core::Interface for IRowsetWithParameters {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRowsetWithParameters_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub GetParameterInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcparams: *mut usize, prgparaminfo: *mut *mut DBPARAMINFO, ppnamesbuffer: *mut *mut u16) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -10698,7 +10698,7 @@ unsafe impl ::windows::core::Interface for ISQLErrorInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISQLErrorInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetSQLInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstrsqlstate: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>, plnativeerror: *mut i32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Search\"`*"]
@@ -10749,7 +10749,7 @@ unsafe impl ::windows::core::Interface for ISQLGetDiagField {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISQLGetDiagField_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub GetDiagField: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdiaginfo: *mut KAGGETDIAG) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole")))]
@@ -10803,7 +10803,7 @@ unsafe impl ::windows::core::Interface for ISQLRequestDiagFields {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISQLRequestDiagFields_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub RequestDiagFields: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cdiagfields: u32, rgdiagfields: *const KAGREQDIAG) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -10855,7 +10855,7 @@ unsafe impl ::windows::core::Interface for ISQLServerErrorInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISQLServerErrorInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetErrorInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pperrorinfo: *mut *mut SSERRORINFO, ppstringsbuffer: *mut *mut u16) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Search\"`*"]
@@ -10908,7 +10908,7 @@ unsafe impl ::windows::core::Interface for ISchemaLocalizerSupport {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISchemaLocalizerSupport_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Localize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszglobalstring: ::windows::core::PCWSTR, ppszlocalstring: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Search\"`*"]
@@ -10967,7 +10967,7 @@ unsafe impl ::windows::core::Interface for ISchemaLock {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISchemaLock_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer"))]
     pub GetSchemaLock: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptableid: *mut super::super::Storage::IndexServer::DBID, lmmode: u32, phlockhandle: *mut super::super::Foundation::HANDLE, ptableversion: *mut u64) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer")))]
@@ -11065,7 +11065,7 @@ unsafe impl ::windows::core::Interface for ISchemaProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISchemaProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Entities: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, pentities: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub RootEntity: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, prootentity: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetEntity: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszentityname: ::windows::core::PCWSTR, pentity: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -11360,7 +11360,7 @@ unsafe impl ::windows::core::Interface for ISearchCatalogManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISearchCatalogManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Name: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszname: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
     pub GetParameter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszname: ::windows::core::PCWSTR, ppvalue: *mut *mut super::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::HRESULT,
@@ -11758,7 +11758,7 @@ unsafe impl ::windows::core::Interface for ISearchCrawlScopeManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISearchCrawlScopeManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub AddDefaultScopeRule: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszurl: ::windows::core::PCWSTR, finclude: super::super::Foundation::BOOL, ffollowflags: u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -12036,7 +12036,7 @@ unsafe impl ::windows::core::Interface for ISearchItemsChangedSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISearchItemsChangedSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub StartedMonitoringScope: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszurl: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub StoppedMonitoringScope: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszurl: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
@@ -12111,7 +12111,7 @@ unsafe impl ::windows::core::Interface for ISearchLanguageSupport {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISearchLanguageSupport_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub SetDiacriticSensitivity: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fdiacriticsensitive: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -12240,7 +12240,7 @@ unsafe impl ::windows::core::Interface for ISearchManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISearchManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetIndexerVersionStr: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppszversionstring: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetIndexerVersion: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwmajor: *mut u32, pdwminor: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
@@ -12464,7 +12464,7 @@ unsafe impl ::windows::core::Interface for ISearchNotifyInlineSite {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISearchNotifyInlineSite_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnItemIndexedStatusChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sipstatus: SEARCH_INDEXING_PHASE, dwnumentries: u32, rgitemstatusentries: *const SEARCH_ITEM_INDEXING_STATUS) -> ::windows::core::HRESULT,
     pub OnCatalogStatusChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, guidcatalogresetsignature: *const ::windows::core::GUID, guidcheckpointsignature: *const ::windows::core::GUID, dwlastcheckpointnumber: u32) -> ::windows::core::HRESULT,
 }
@@ -12527,7 +12527,7 @@ unsafe impl ::windows::core::Interface for ISearchPersistentItemsChangedSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISearchPersistentItemsChangedSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub StartedMonitoringScope: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszurl: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub StoppedMonitoringScope: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszurl: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub OnItemsChanged: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwnumberofchanges: u32, datachangeentries: *const SEARCH_ITEM_PERSISTENT_CHANGE, hrcompletioncodes: *mut ::windows::core::HRESULT) -> ::windows::core::HRESULT,
@@ -12600,7 +12600,7 @@ unsafe impl ::windows::core::Interface for ISearchProtocol {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISearchProtocol_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Init: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptimeoutinfo: *mut TIMEOUT_INFO, pprotocolhandlersite: *mut ::core::ffi::c_void, pproxyinfo: *mut PROXY_INFO) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -12761,7 +12761,7 @@ unsafe impl ::windows::core::Interface for ISearchProtocolThreadContext {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISearchProtocolThreadContext_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ThreadInit: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub ThreadShutdown: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub ThreadIdle: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwtimeelaspedsincelastcallinms: u32) -> ::windows::core::HRESULT,
@@ -12900,7 +12900,7 @@ unsafe impl ::windows::core::Interface for ISearchQueryHelper {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISearchQueryHelper_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ConnectionString: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszconnectionstring: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub SetQueryContentLocale: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lcid: u32) -> ::windows::core::HRESULT,
     pub QueryContentLocale: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, plcid: *mut u32) -> ::windows::core::HRESULT,
@@ -12987,7 +12987,7 @@ unsafe impl ::windows::core::Interface for ISearchQueryHits {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISearchQueryHits_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Storage_IndexServer")]
     pub Init: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pflt: *mut ::core::ffi::c_void, ulflags: u32) -> i32,
     #[cfg(not(feature = "Win32_Storage_IndexServer"))]
@@ -13161,7 +13161,7 @@ unsafe impl ::windows::core::Interface for ISearchRoot {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISearchRoot_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetSchedule: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psztaskarg: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub Schedule: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppsztaskarg: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub SetRootURL: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszurl: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
@@ -13272,7 +13272,7 @@ unsafe impl ::windows::core::Interface for ISearchScopeRule {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISearchScopeRule_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub PatternOrURL: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppszpatternorurl: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub IsIncluded: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfisincluded: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -13332,7 +13332,7 @@ unsafe impl ::windows::core::Interface for ISearchViewChangedSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISearchViewChangedSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
     pub OnChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwdocid: *const i32, pchange: *const SEARCH_ITEM_CHANGE, pfinview: *const super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com")))]
@@ -13392,7 +13392,7 @@ unsafe impl ::windows::core::Interface for ISecurityInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISecurityInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Security_Authorization")]
     pub GetCurrentTrustee: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pptrustee: *mut *mut super::super::Security::Authorization::TRUSTEE_W) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Security_Authorization"))]
@@ -13449,7 +13449,7 @@ unsafe impl ::windows::core::Interface for IService {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IService_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub InvokeService: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punkinner: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Search\"`*"]
@@ -13505,7 +13505,7 @@ unsafe impl ::windows::core::Interface for ISessionProperties {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISessionProperties_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub GetProperties: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cpropertyidsets: u32, rgpropertyidsets: *const DBPROPIDSET, pcpropertysets: *mut u32, prgpropertysets: *mut *mut DBPROPSET) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole")))]
@@ -13577,7 +13577,7 @@ unsafe impl ::windows::core::Interface for ISimpleCommandCreator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISimpleCommandCreator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateICommand: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppiunknown: *mut *mut ::core::ffi::c_void, pouterunk: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub VerifyCatalog: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszmachine: ::windows::core::PCWSTR, pwszcatalogname: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub GetDefaultCatalog: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszcatalogname: ::windows::core::PCWSTR, cwcin: u32, pcwcout: *mut u32) -> ::windows::core::HRESULT,
@@ -13633,7 +13633,7 @@ unsafe impl ::windows::core::Interface for ISourcesRowset {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISourcesRowset_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub GetSourcesRowset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punkouter: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, cpropertysets: u32, rgproperties: *mut DBPROPSET, ppsourcesrowset: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole")))]
@@ -13697,7 +13697,7 @@ unsafe impl ::windows::core::Interface for IStemmer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IStemmer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Init: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ulmaxtokensize: u32, pflicense: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -13777,7 +13777,7 @@ unsafe impl ::windows::core::Interface for ISubscriptionItem {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISubscriptionItem_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCookie: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcookie: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub GetSubscriptionItemInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psubscriptioniteminfo: *mut SUBSCRIPTIONITEMINFO) -> ::windows::core::HRESULT,
     pub SetSubscriptionItemInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psubscriptioniteminfo: *const SUBSCRIPTIONITEMINFO) -> ::windows::core::HRESULT,
@@ -13896,7 +13896,7 @@ unsafe impl ::windows::core::Interface for ISubscriptionMgr {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISubscriptionMgr_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub DeleteSubscription: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszurl: ::windows::core::PCWSTR, hwnd: super::super::Foundation::HWND) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -14275,7 +14275,7 @@ unsafe impl ::windows::core::Interface for ITableDefinition {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITableDefinition_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub CreateTable: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punkouter: *mut ::core::ffi::c_void, ptableid: *const super::super::Storage::IndexServer::DBID, ccolumndescs: usize, rgcolumndescs: *const DBCOLUMNDESC, riid: *const ::windows::core::GUID, cpropertysets: u32, rgpropertysets: *mut DBPROPSET, pptableid: *mut *mut super::super::Storage::IndexServer::DBID, pprowset: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole")))]
@@ -14503,7 +14503,7 @@ unsafe impl ::windows::core::Interface for ITableRename {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITableRename_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Storage_IndexServer")]
     pub RenameColumn: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptableid: *mut super::super::Storage::IndexServer::DBID, poldcolumnid: *mut super::super::Storage::IndexServer::DBID, pnewcolumnid: *mut super::super::Storage::IndexServer::DBID) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Storage_IndexServer"))]
@@ -14562,7 +14562,7 @@ unsafe impl ::windows::core::Interface for ITokenCollection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITokenCollection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub NumberOfTokens: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcount: *const u32) -> ::windows::core::HRESULT,
     pub GetToken: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, i: u32, pbegin: *mut u32, plength: *mut u32, ppsz: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
 }
@@ -14624,7 +14624,7 @@ unsafe impl ::windows::core::Interface for ITransactionJoin {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITransactionJoin_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_DistributedTransactionCoordinator")]
     pub GetOptionsObject: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppoptions: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_DistributedTransactionCoordinator"))]
@@ -14803,7 +14803,7 @@ unsafe impl ::windows::core::Interface for ITransactionObject {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITransactionObject_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_DistributedTransactionCoordinator")]
     pub GetTransactionObject: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ultransactionlevel: u32, pptransactionobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_DistributedTransactionCoordinator"))]
@@ -14877,7 +14877,7 @@ unsafe impl ::windows::core::Interface for ITrusteeAdmin {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITrusteeAdmin_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Security_Authorization")]
     pub CompareTrustees: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptrustee1: *mut super::super::Security::Authorization::TRUSTEE_W, ptrustee2: *mut super::super::Security::Authorization::TRUSTEE_W) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Security_Authorization"))]
@@ -14967,7 +14967,7 @@ unsafe impl ::windows::core::Interface for ITrusteeGroupAdmin {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITrusteeGroupAdmin_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Security_Authorization")]
     pub AddMember: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pmembershiptrustee: *mut super::super::Security::Authorization::TRUSTEE_W, pmembertrustee: *mut super::super::Security::Authorization::TRUSTEE_W) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Security_Authorization"))]
@@ -15089,7 +15089,7 @@ unsafe impl ::windows::core::Interface for IUMSInitialize {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUMSInitialize_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pums: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Search\"`*"]
@@ -15188,7 +15188,7 @@ unsafe impl ::windows::core::Interface for IUrlAccessor {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUrlAccessor_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
     pub AddRequestParameter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pspec: *const super::Com::StructuredStorage::PROPSPEC, pvar: *const super::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage")))]
@@ -15720,7 +15720,7 @@ unsafe impl ::windows::core::Interface for IViewChapter {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IViewChapter_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetSpecification: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, pprowset: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub OpenViewChapter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hsource: usize, phviewchapter: *mut usize) -> ::windows::core::HRESULT,
 }
@@ -15784,7 +15784,7 @@ unsafe impl ::windows::core::Interface for IViewFilter {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IViewFilter_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetFilter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, haccessor: HACCESSOR, pcrows: *mut usize, pcompareops: *mut *mut u32, pcriteriadata: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
     pub GetFilterBindings: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcbindings: *mut usize, prgbindings: *mut *mut DBBINDING) -> ::windows::core::HRESULT,
@@ -15846,7 +15846,7 @@ unsafe impl ::windows::core::Interface for IViewRowset {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IViewRowset_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetSpecification: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub OpenViewRowset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punkouter: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, pprowset: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -15899,7 +15899,7 @@ unsafe impl ::windows::core::Interface for IViewSort {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IViewSort_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetSortOrder: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcvalues: *mut usize, prgcolumns: *mut *mut usize, prgorders: *mut *mut u32) -> ::windows::core::HRESULT,
     pub SetSortOrder: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cvalues: usize, rgcolumns: *const usize, rgorders: *const u32) -> ::windows::core::HRESULT,
 }
@@ -15974,7 +15974,7 @@ unsafe impl ::windows::core::Interface for IWordBreaker {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWordBreaker_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Init: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fquery: super::super::Foundation::BOOL, ulmaxtokensize: u32, pflicense: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -16041,7 +16041,7 @@ unsafe impl ::windows::core::Interface for IWordFormSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWordFormSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub PutAltWord: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwcinbuf: ::windows::core::PCWSTR, cwc: u32) -> ::windows::core::HRESULT,
     pub PutWord: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwcinbuf: ::windows::core::PCWSTR, cwc: u32) -> ::windows::core::HRESULT,
 }
@@ -16111,7 +16111,7 @@ unsafe impl ::windows::core::Interface for IWordSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWordSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub PutWord: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cwc: u32, pwcinbuf: ::windows::core::PCWSTR, cwcsrclen: u32, cwcsrcpos: u32) -> ::windows::core::HRESULT,
     pub PutAltWord: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cwc: u32, pwcinbuf: ::windows::core::PCWSTR, cwcsrclen: u32, cwcsrcpos: u32) -> ::windows::core::HRESULT,
     pub StartAltPhrase: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -16236,7 +16236,7 @@ unsafe impl ::windows::core::Interface for OLEDBSimpleProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct OLEDBSimpleProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub getRowCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcrows: *mut isize) -> ::windows::core::HRESULT,
     pub getColumnCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pccolumns: *mut isize) -> ::windows::core::HRESULT,
     pub getRWStatus: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, irow: isize, icolumn: isize, prwstatus: *mut OSPRW) -> ::windows::core::HRESULT,
@@ -16331,7 +16331,7 @@ unsafe impl ::windows::core::Interface for OLEDBSimpleProviderListener {
 #[repr(C)]
 #[doc(hidden)]
 pub struct OLEDBSimpleProviderListener_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub aboutToChangeCell: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, irow: isize, icolumn: isize) -> ::windows::core::HRESULT,
     pub cellChanged: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, irow: isize, icolumn: isize) -> ::windows::core::HRESULT,
     pub aboutToDeleteRows: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, irow: isize, crows: isize) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/System/ServerBackup/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/ServerBackup/impl.rs
@@ -22,7 +22,7 @@ impl IWsbApplicationAsync_Vtbl {
             this.Abort().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             QueryStatus: QueryStatus::<Identity, Impl, OFFSET>,
             Abort: Abort::<Identity, Impl, OFFSET>,
         }
@@ -48,7 +48,7 @@ impl IWsbApplicationBackupSupport_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CheckConsistency: CheckConsistency::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CheckConsistency: CheckConsistency::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWsbApplicationBackupSupport as ::windows::core::Interface>::IID
@@ -93,7 +93,7 @@ impl IWsbApplicationRestoreSupport_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             PreRestore: PreRestore::<Identity, Impl, OFFSET>,
             PostRestore: PostRestore::<Identity, Impl, OFFSET>,
             OrderComponents: OrderComponents::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/System/ServerBackup/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/ServerBackup/mod.rs
@@ -48,7 +48,7 @@ unsafe impl ::windows::core::Interface for IWsbApplicationAsync {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWsbApplicationAsync_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub QueryStatus: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, phrresult: *mut ::windows::core::HRESULT) -> ::windows::core::HRESULT,
     pub Abort: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -104,7 +104,7 @@ unsafe impl ::windows::core::Interface for IWsbApplicationBackupSupport {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWsbApplicationBackupSupport_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CheckConsistency: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wszwritermetadata: ::windows::core::PCWSTR, wszcomponentname: ::windows::core::PCWSTR, wszcomponentlogicalpath: ::windows::core::PCWSTR, cvolumes: u32, rgwszsourcevolumepath: *const ::windows::core::PWSTR, rgwszsnapshotvolumepath: *const ::windows::core::PWSTR, ppasync: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_ServerBackup\"`*"]
@@ -179,7 +179,7 @@ unsafe impl ::windows::core::Interface for IWsbApplicationRestoreSupport {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWsbApplicationRestoreSupport_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub PreRestore: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wszwritermetadata: ::windows::core::PCWSTR, wszcomponentname: ::windows::core::PCWSTR, wszcomponentlogicalpath: ::windows::core::PCWSTR, bnorollforward: super::super::Foundation::BOOLEAN) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]

--- a/crates/libs/windows/src/Windows/Win32/System/SettingsManagementInfrastructure/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/SettingsManagementInfrastructure/impl.rs
@@ -37,7 +37,7 @@ impl IItemEnumerator_Vtbl {
             this.Reset().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Current: Current::<Identity, Impl, OFFSET>,
             MoveNext: MoveNext::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -110,7 +110,7 @@ impl ISettingsContext_Vtbl {
             this.RevertSetting(::core::mem::transmute(&pidentity), ::core::mem::transmute(&pwzsetting)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Serialize: Serialize::<Identity, Impl, OFFSET>,
             Deserialize: Deserialize::<Identity, Impl, OFFSET>,
             SetUserData: SetUserData::<Identity, Impl, OFFSET>,
@@ -289,7 +289,7 @@ impl ISettingsEngine_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetNamespaces: GetNamespaces::<Identity, Impl, OFFSET>,
             GetNamespace: GetNamespace::<Identity, Impl, OFFSET>,
             GetErrorDescription: GetErrorDescription::<Identity, Impl, OFFSET>,
@@ -354,7 +354,7 @@ impl ISettingsIdentity_Vtbl {
             this.SetFlags(::core::mem::transmute_copy(&flags)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetAttribute: GetAttribute::<Identity, Impl, OFFSET>,
             SetAttribute: SetAttribute::<Identity, Impl, OFFSET>,
             GetFlags: GetFlags::<Identity, Impl, OFFSET>,
@@ -602,7 +602,7 @@ impl ISettingsItem_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetName: GetName::<Identity, Impl, OFFSET>,
             GetValue: GetValue::<Identity, Impl, OFFSET>,
             SetValue: SetValue::<Identity, Impl, OFFSET>,
@@ -718,7 +718,7 @@ impl ISettingsNamespace_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetIdentity: GetIdentity::<Identity, Impl, OFFSET>,
             Settings: Settings::<Identity, Impl, OFFSET>,
             Save: Save::<Identity, Impl, OFFSET>,
@@ -810,7 +810,7 @@ impl ISettingsResult_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDescription: GetDescription::<Identity, Impl, OFFSET>,
             GetErrorCode: GetErrorCode::<Identity, Impl, OFFSET>,
             GetContextDescription: GetContextDescription::<Identity, Impl, OFFSET>,
@@ -1030,7 +1030,7 @@ impl ITargetInfo_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTargetMode: GetTargetMode::<Identity, Impl, OFFSET>,
             SetTargetMode: SetTargetMode::<Identity, Impl, OFFSET>,
             GetTemporaryStoreLocation: GetTemporaryStoreLocation::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/System/SettingsManagementInfrastructure/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/SettingsManagementInfrastructure/mod.rs
@@ -56,7 +56,7 @@ unsafe impl ::windows::core::Interface for IItemEnumerator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IItemEnumerator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub Current: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, item: *mut super::Com::VARIANT) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole")))]
@@ -152,7 +152,7 @@ unsafe impl ::windows::core::Interface for ISettingsContext {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISettingsContext_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub Serialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pstream: *mut ::core::ffi::c_void, ptarget: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -293,7 +293,7 @@ unsafe impl ::windows::core::Interface for ISettingsEngine {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISettingsEngine_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetNamespaces: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, flags: WcmNamespaceEnumerationFlags, reserved: *const ::core::ffi::c_void, namespaces: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetNamespace: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, settingsid: *mut ::core::ffi::c_void, access: WcmNamespaceAccess, reserved: *const ::core::ffi::c_void, namespaceitem: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetErrorDescription: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hresult: i32, message: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
@@ -381,7 +381,7 @@ unsafe impl ::windows::core::Interface for ISettingsIdentity {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISettingsIdentity_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetAttribute: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, reserved: *const ::core::ffi::c_void, name: ::windows::core::PCWSTR, value: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub SetAttribute: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, reserved: *const ::core::ffi::c_void, name: ::windows::core::PCWSTR, value: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub GetFlags: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, flags: *mut u32) -> ::windows::core::HRESULT,
@@ -544,7 +544,7 @@ unsafe impl ::windows::core::Interface for ISettingsItem {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISettingsItem_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, name: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub GetValue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: *mut super::Com::VARIANT) -> ::windows::core::HRESULT,
@@ -678,7 +678,7 @@ unsafe impl ::windows::core::Interface for ISettingsNamespace {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISettingsNamespace_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetIdentity: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, settingsid: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Settings: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, settings: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -760,7 +760,7 @@ unsafe impl ::windows::core::Interface for ISettingsResult {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISettingsResult_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDescription: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, description: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub GetErrorCode: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hrout: *mut ::windows::core::HRESULT) -> ::windows::core::HRESULT,
     pub GetContextDescription: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, description: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
@@ -939,7 +939,7 @@ unsafe impl ::windows::core::Interface for ITargetInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITargetInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetTargetMode: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, targetmode: *mut WcmTargetMode) -> ::windows::core::HRESULT,
     pub SetTargetMode: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, targetmode: WcmTargetMode) -> ::windows::core::HRESULT,
     pub GetTemporaryStoreLocation: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, temporarystorelocation: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/System/SideShow/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/SideShow/impl.rs
@@ -32,7 +32,7 @@ impl ISideShowCapabilities_Vtbl {
             let this = (*this).get_impl();
             this.GetCapability(::core::mem::transmute_copy(&in_keycapability), ::core::mem::transmute_copy(&inout_pvalue)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetCapability: GetCapability::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetCapability: GetCapability::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ISideShowCapabilities as ::windows::core::Interface>::IID
@@ -68,7 +68,7 @@ impl ISideShowCapabilitiesCollection_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCount: GetCount::<Identity, Impl, OFFSET>,
             GetAt: GetAt::<Identity, Impl, OFFSET>,
         }
@@ -116,7 +116,7 @@ impl ISideShowContent_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetContent: GetContent::<Identity, Impl, OFFSET>,
             ContentId: ContentId::<Identity, Impl, OFFSET>,
             DifferentiateContent: DifferentiateContent::<Identity, Impl, OFFSET>,
@@ -168,7 +168,7 @@ impl ISideShowContentManager_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Add: Add::<Identity, Impl, OFFSET>,
             Remove: Remove::<Identity, Impl, OFFSET>,
             RemoveAll: RemoveAll::<Identity, Impl, OFFSET>,
@@ -216,7 +216,7 @@ impl ISideShowEvents_Vtbl {
             this.DeviceRemoved(::core::mem::transmute(&in_pidevice)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ContentMissing: ContentMissing::<Identity, Impl, OFFSET>,
             ApplicationEvent: ApplicationEvent::<Identity, Impl, OFFSET>,
             DeviceAdded: DeviceAdded::<Identity, Impl, OFFSET>,
@@ -266,7 +266,7 @@ impl ISideShowKeyCollection_Vtbl {
             this.RemoveAt(::core::mem::transmute_copy(&dwindex)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Add: Add::<Identity, Impl, OFFSET>,
             Clear: Clear::<Identity, Impl, OFFSET>,
             GetAt: GetAt::<Identity, Impl, OFFSET>,
@@ -377,7 +377,7 @@ impl ISideShowNotification_Vtbl {
             this.SetExpirationTime(::core::mem::transmute_copy(&in_ptime)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             NotificationId: NotificationId::<Identity, Impl, OFFSET>,
             SetNotificationId: SetNotificationId::<Identity, Impl, OFFSET>,
             Title: Title::<Identity, Impl, OFFSET>,
@@ -418,7 +418,7 @@ impl ISideShowNotificationManager_Vtbl {
             this.RevokeAll().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Show: Show::<Identity, Impl, OFFSET>,
             Revoke: Revoke::<Identity, Impl, OFFSET>,
             RevokeAll: RevokeAll::<Identity, Impl, OFFSET>,
@@ -467,7 +467,7 @@ impl ISideShowPropVariantCollection_Vtbl {
             this.RemoveAt(::core::mem::transmute_copy(&dwindex)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Add: Add::<Identity, Impl, OFFSET>,
             Clear: Clear::<Identity, Impl, OFFSET>,
             GetAt: GetAt::<Identity, Impl, OFFSET>,
@@ -509,7 +509,7 @@ impl ISideShowSession_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RegisterContent: RegisterContent::<Identity, Impl, OFFSET>,
             RegisterNotifications: RegisterNotifications::<Identity, Impl, OFFSET>,
         }

--- a/crates/libs/windows/src/Windows/Win32/System/SideShow/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/SideShow/mod.rs
@@ -118,7 +118,7 @@ unsafe impl ::windows::core::Interface for ISideShowCapabilities {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISideShowCapabilities_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
     pub GetCapability: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, in_keycapability: *const super::super::UI::Shell::PropertiesSystem::PROPERTYKEY, inout_pvalue: *mut super::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem")))]
@@ -175,7 +175,7 @@ unsafe impl ::windows::core::Interface for ISideShowCapabilitiesCollection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISideShowCapabilitiesCollection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, out_pdwcount: *mut u32) -> ::windows::core::HRESULT,
     pub GetAt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, in_dwindex: u32, out_ppcapabilities: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -238,7 +238,7 @@ unsafe impl ::windows::core::Interface for ISideShowContent {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISideShowContent_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetContent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, in_picapabilities: *mut ::core::ffi::c_void, out_pdwsize: *mut u32, out_ppbdata: *mut *mut u8) -> ::windows::core::HRESULT,
     pub ContentId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, out_pcontentid: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -311,7 +311,7 @@ unsafe impl ::windows::core::Interface for ISideShowContentManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISideShowContentManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Add: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, in_picontent: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Remove: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, in_contentid: u32) -> ::windows::core::HRESULT,
     pub RemoveAll: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -383,7 +383,7 @@ unsafe impl ::windows::core::Interface for ISideShowEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISideShowEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ContentMissing: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, in_contentid: u32, out_ppicontent: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub ApplicationEvent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, in_picapabilities: *mut ::core::ffi::c_void, in_dweventid: u32, in_dweventsize: u32, in_pbeventdata: *const u8) -> ::windows::core::HRESULT,
     pub DeviceAdded: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, in_pidevice: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -451,7 +451,7 @@ unsafe impl ::windows::core::Interface for ISideShowKeyCollection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISideShowKeyCollection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
     pub Add: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, key: *const super::super::UI::Shell::PropertiesSystem::PROPERTYKEY) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_UI_Shell_PropertiesSystem"))]
@@ -559,7 +559,7 @@ unsafe impl ::windows::core::Interface for ISideShowNotification {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISideShowNotification_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub NotificationId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, out_pnotificationid: *mut u32) -> ::windows::core::HRESULT,
     pub SetNotificationId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, in_notificationid: u32) -> ::windows::core::HRESULT,
     pub Title: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, out_ppwsztitle: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
@@ -638,7 +638,7 @@ unsafe impl ::windows::core::Interface for ISideShowNotificationManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISideShowNotificationManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Show: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, in_pinotification: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Revoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, in_notificationid: u32) -> ::windows::core::HRESULT,
     pub RevokeAll: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -705,7 +705,7 @@ unsafe impl ::windows::core::Interface for ISideShowPropVariantCollection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISideShowPropVariantCollection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
     pub Add: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pvalue: *const super::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage")))]
@@ -769,7 +769,7 @@ unsafe impl ::windows::core::Interface for ISideShowSession {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISideShowSession_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub RegisterContent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, in_applicationid: *const ::windows::core::GUID, in_endpointid: *const ::windows::core::GUID, out_ppicontent: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub RegisterNotifications: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, in_applicationid: *const ::windows::core::GUID, out_ppinotification: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }

--- a/crates/libs/windows/src/Windows/Win32/System/TaskScheduler/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/TaskScheduler/impl.rs
@@ -451,7 +451,7 @@ impl IEnumWorkItems_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -1174,7 +1174,7 @@ impl IProvideTaskPage_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetPage: GetPage::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetPage: GetPage::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IProvideTaskPage as ::windows::core::Interface>::IID
@@ -2105,7 +2105,7 @@ impl IScheduledWorkItem_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateTrigger: CreateTrigger::<Identity, Impl, OFFSET>,
             DeleteTrigger: DeleteTrigger::<Identity, Impl, OFFSET>,
             GetTriggerCount: GetTriggerCount::<Identity, Impl, OFFSET>,
@@ -2781,7 +2781,7 @@ impl ITaskHandler_Vtbl {
             this.Resume().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Start: Start::<Identity, Impl, OFFSET>,
             Stop: Stop::<Identity, Impl, OFFSET>,
             Pause: Pause::<Identity, Impl, OFFSET>,
@@ -2810,7 +2810,7 @@ impl ITaskHandlerStatus_Vtbl {
             this.TaskCompleted(::core::mem::transmute_copy(&taskerrcode)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             UpdateStatus: UpdateStatus::<Identity, Impl, OFFSET>,
             TaskCompleted: TaskCompleted::<Identity, Impl, OFFSET>,
         }
@@ -3017,7 +3017,7 @@ impl ITaskScheduler_Vtbl {
             this.IsOfType(::core::mem::transmute(&pwszname), ::core::mem::transmute_copy(&riid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetTargetComputer: SetTargetComputer::<Identity, Impl, OFFSET>,
             GetTargetComputer: GetTargetComputer::<Identity, Impl, OFFSET>,
             Enum: Enum::<Identity, Impl, OFFSET>,
@@ -3638,7 +3638,7 @@ impl ITaskTrigger_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetTrigger: SetTrigger::<Identity, Impl, OFFSET>,
             GetTrigger: GetTrigger::<Identity, Impl, OFFSET>,
             GetTriggerString: GetTriggerString::<Identity, Impl, OFFSET>,
@@ -3684,7 +3684,7 @@ impl ITaskVariables_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetInput: GetInput::<Identity, Impl, OFFSET>,
             SetOutput: SetOutput::<Identity, Impl, OFFSET>,
             GetContext: GetContext::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/System/TaskScheduler/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/TaskScheduler/mod.rs
@@ -899,7 +899,7 @@ unsafe impl ::windows::core::Interface for IEnumWorkItems {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumWorkItems_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgpwsznames: *mut *mut ::windows::core::PWSTR, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -2558,7 +2558,7 @@ unsafe impl ::windows::core::Interface for IProvideTaskPage {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IProvideTaskPage_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Controls"))]
     pub GetPage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, tptype: TASKPAGE, fpersistchanges: super::super::Foundation::BOOL, phpage: *mut super::super::UI::Controls::HPROPSHEETPAGE) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_UI_Controls")))]
@@ -3628,7 +3628,7 @@ unsafe impl ::windows::core::Interface for IScheduledWorkItem {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IScheduledWorkItem_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateTrigger: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinewtrigger: *mut u16, pptrigger: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub DeleteTrigger: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, itrigger: u16) -> ::windows::core::HRESULT,
     pub GetTriggerCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwcount: *mut u16) -> ::windows::core::HRESULT,
@@ -4735,7 +4735,7 @@ unsafe impl ::windows::core::Interface for ITaskHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITaskHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Start: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, phandlerservices: *mut ::core::ffi::c_void, data: ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub Stop: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pretcode: *mut ::windows::core::HRESULT) -> ::windows::core::HRESULT,
     pub Pause: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -4790,7 +4790,7 @@ unsafe impl ::windows::core::Interface for ITaskHandlerStatus {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITaskHandlerStatus_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub UpdateStatus: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, percentcomplete: i16, statusmessage: ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub TaskCompleted: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, taskerrcode: ::windows::core::HRESULT) -> ::windows::core::HRESULT,
 }
@@ -5085,7 +5085,7 @@ unsafe impl ::windows::core::Interface for ITaskScheduler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITaskScheduler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetTargetComputer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszcomputer: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub GetTargetComputer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppwszcomputer: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub Enum: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppenumworkitems: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -5929,7 +5929,7 @@ unsafe impl ::windows::core::Interface for ITaskTrigger {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITaskTrigger_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetTrigger: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptrigger: *const TASK_TRIGGER) -> ::windows::core::HRESULT,
     pub GetTrigger: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptrigger: *mut TASK_TRIGGER) -> ::windows::core::HRESULT,
     pub GetTriggerString: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppwsztrigger: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
@@ -5988,7 +5988,7 @@ unsafe impl ::windows::core::Interface for ITaskVariables {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITaskVariables_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetInput: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinput: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub SetOutput: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, input: ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub GetContext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcontext: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/System/UpdateAgent/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/UpdateAgent/impl.rs
@@ -566,7 +566,7 @@ impl IDownloadCompletedCallback_Vtbl {
             let this = (*this).get_impl();
             this.Invoke(::core::mem::transmute(&downloadjob), ::core::mem::transmute(&callbackargs)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Invoke: Invoke::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Invoke: Invoke::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDownloadCompletedCallback as ::windows::core::Interface>::IID
@@ -814,7 +814,7 @@ impl IDownloadProgressChangedCallback_Vtbl {
             let this = (*this).get_impl();
             this.Invoke(::core::mem::transmute(&downloadjob), ::core::mem::transmute(&callbackargs)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Invoke: Invoke::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Invoke: Invoke::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDownloadProgressChangedCallback as ::windows::core::Interface>::IID
@@ -1074,7 +1074,7 @@ impl IInstallationCompletedCallback_Vtbl {
             let this = (*this).get_impl();
             this.Invoke(::core::mem::transmute(&installationjob), ::core::mem::transmute(&callbackargs)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Invoke: Invoke::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Invoke: Invoke::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IInstallationCompletedCallback as ::windows::core::Interface>::IID
@@ -1257,7 +1257,7 @@ impl IInstallationProgressChangedCallback_Vtbl {
             let this = (*this).get_impl();
             this.Invoke(::core::mem::transmute(&installationjob), ::core::mem::transmute(&callbackargs)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Invoke: Invoke::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Invoke: Invoke::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IInstallationProgressChangedCallback as ::windows::core::Interface>::IID
@@ -1397,7 +1397,7 @@ impl ISearchCompletedCallback_Vtbl {
             let this = (*this).get_impl();
             this.Invoke(::core::mem::transmute(&searchjob), ::core::mem::transmute(&callbackargs)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Invoke: Invoke::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Invoke: Invoke::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ISearchCompletedCallback as ::windows::core::Interface>::IID
@@ -3694,7 +3694,7 @@ impl IUpdateLockdown_Vtbl {
             let this = (*this).get_impl();
             this.LockDown(::core::mem::transmute_copy(&flags)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), LockDown: LockDown::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), LockDown: LockDown::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IUpdateLockdown as ::windows::core::Interface>::IID

--- a/crates/libs/windows/src/Windows/Win32/System/UpdateAgent/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/UpdateAgent/mod.rs
@@ -1047,7 +1047,7 @@ unsafe impl ::windows::core::Interface for IDownloadCompletedCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDownloadCompletedCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, downloadjob: *mut ::core::ffi::c_void, callbackargs: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -1439,7 +1439,7 @@ unsafe impl ::windows::core::Interface for IDownloadProgressChangedCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDownloadProgressChangedCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, downloadjob: *mut ::core::ffi::c_void, callbackargs: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -1949,7 +1949,7 @@ unsafe impl ::windows::core::Interface for IInstallationCompletedCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IInstallationCompletedCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, installationjob: *mut ::core::ffi::c_void, callbackargs: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -2296,7 +2296,7 @@ unsafe impl ::windows::core::Interface for IInstallationProgressChangedCallback 
 #[repr(C)]
 #[doc(hidden)]
 pub struct IInstallationProgressChangedCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, installationjob: *mut ::core::ffi::c_void, callbackargs: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -2646,7 +2646,7 @@ unsafe impl ::windows::core::Interface for ISearchCompletedCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISearchCompletedCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, searchjob: *mut ::core::ffi::c_void, callbackargs: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -7444,7 +7444,7 @@ unsafe impl ::windows::core::Interface for IUpdateLockdown {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUpdateLockdown_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub LockDown: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, flags: i32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_System_Com\"`*"]

--- a/crates/libs/windows/src/Windows/Win32/System/UpdateAssessment/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/UpdateAssessment/impl.rs
@@ -18,7 +18,7 @@ impl IWaaSAssessor_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetOSUpdateAssessment: GetOSUpdateAssessment::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetOSUpdateAssessment: GetOSUpdateAssessment::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWaaSAssessor as ::windows::core::Interface>::IID

--- a/crates/libs/windows/src/Windows/Win32/System/UpdateAssessment/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/UpdateAssessment/mod.rs
@@ -47,7 +47,7 @@ unsafe impl ::windows::core::Interface for IWaaSAssessor {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWaaSAssessor_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetOSUpdateAssessment: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, result: *mut OSUpdateAssessment) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Composition/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Composition/impl.rs
@@ -72,7 +72,7 @@ impl ICompositionDrawingSurfaceInterop_Vtbl {
             this.SuspendDraw().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             BeginDraw: BeginDraw::<Identity, Impl, OFFSET>,
             EndDraw: EndDraw::<Identity, Impl, OFFSET>,
             Resize: Resize::<Identity, Impl, OFFSET>,
@@ -129,7 +129,7 @@ impl ICompositionGraphicsDeviceInterop_Vtbl {
             this.SetRenderingDevice(::core::mem::transmute(&value)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetRenderingDevice: GetRenderingDevice::<Identity, Impl, OFFSET>,
             SetRenderingDevice: SetRenderingDevice::<Identity, Impl, OFFSET>,
         }
@@ -165,7 +165,7 @@ impl ICompositorDesktopInterop_Vtbl {
             this.EnsureOnThread(::core::mem::transmute_copy(&threadid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateDesktopWindowTarget: CreateDesktopWindowTarget::<Identity, Impl, OFFSET>,
             EnsureOnThread: EnsureOnThread::<Identity, Impl, OFFSET>,
         }
@@ -219,7 +219,7 @@ impl ICompositorInterop_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateCompositionSurfaceForHandle: CreateCompositionSurfaceForHandle::<Identity, Impl, OFFSET>,
             CreateCompositionSurfaceForSwapChain: CreateCompositionSurfaceForSwapChain::<Identity, Impl, OFFSET>,
             CreateGraphicsDevice: CreateGraphicsDevice::<Identity, Impl, OFFSET>,
@@ -249,7 +249,7 @@ impl IDesktopWindowTargetInterop_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Hwnd: Hwnd::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Hwnd: Hwnd::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDesktopWindowTargetInterop as ::windows::core::Interface>::IID
@@ -266,7 +266,7 @@ impl ISwapChainInterop_Vtbl {
             let this = (*this).get_impl();
             this.SetSwapChain(::core::mem::transmute(&swapchain)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SetSwapChain: SetSwapChain::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SetSwapChain: SetSwapChain::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ISwapChainInterop as ::windows::core::Interface>::IID
@@ -287,7 +287,7 @@ impl IVisualInteractionSourceInterop_Vtbl {
             this.TryRedirectForManipulation(::core::mem::transmute_copy(&pointerinfo)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             TryRedirectForManipulation: TryRedirectForManipulation::<Identity, Impl, OFFSET>,
         }
     }

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Composition/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Composition/mod.rs
@@ -142,7 +142,7 @@ unsafe impl ::windows::core::Interface for ICompositionDrawingSurfaceInterop {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICompositionDrawingSurfaceInterop_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub BeginDraw: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, updaterect: *const super::super::super::Foundation::RECT, iid: *const ::windows::core::GUID, updateobject: *mut *mut ::core::ffi::c_void, updateoffset: *mut super::super::super::Foundation::POINT) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -312,7 +312,7 @@ unsafe impl ::windows::core::Interface for ICompositionGraphicsDeviceInterop {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICompositionGraphicsDeviceInterop_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetRenderingDevice: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetRenderingDevice: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -372,7 +372,7 @@ unsafe impl ::windows::core::Interface for ICompositorDesktopInterop {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICompositorDesktopInterop_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "UI_Composition_Desktop", feature = "Win32_Foundation"))]
     pub CreateDesktopWindowTarget: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hwndtarget: super::super::super::Foundation::HWND, istopmost: super::super::super::Foundation::BOOL, result: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "UI_Composition_Desktop", feature = "Win32_Foundation")))]
@@ -449,7 +449,7 @@ unsafe impl ::windows::core::Interface for ICompositorInterop {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICompositorInterop_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "UI_Composition", feature = "Win32_Foundation"))]
     pub CreateCompositionSurfaceForHandle: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, swapchain: super::super::super::Foundation::HANDLE, result: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "UI_Composition", feature = "Win32_Foundation")))]
@@ -512,7 +512,7 @@ unsafe impl ::windows::core::Interface for IDesktopWindowTargetInterop {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDesktopWindowTargetInterop_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Hwnd: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: *mut super::super::super::Foundation::HWND) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -567,7 +567,7 @@ unsafe impl ::windows::core::Interface for ISwapChainInterop {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISwapChainInterop_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetSwapChain: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, swapchain: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_WinRT_Composition\"`*"]
@@ -618,7 +618,7 @@ unsafe impl ::windows::core::Interface for IVisualInteractionSourceInterop {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVisualInteractionSourceInterop_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Input_Pointer", feature = "Win32_UI_WindowsAndMessaging"))]
     pub TryRedirectForManipulation: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pointerinfo: *const super::super::super::UI::Input::Pointer::POINTER_INFO) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_UI_Input_Pointer", feature = "Win32_UI_WindowsAndMessaging")))]

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Direct3D11/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Direct3D11/impl.rs
@@ -9,7 +9,7 @@ impl IDirect3DDxgiInterfaceAccess_Vtbl {
             let this = (*this).get_impl();
             this.GetInterface(::core::mem::transmute_copy(&iid), ::core::mem::transmute_copy(&p)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetInterface: GetInterface::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetInterface: GetInterface::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDirect3DDxgiInterfaceAccess as ::windows::core::Interface>::IID

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Direct3D11/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Direct3D11/mod.rs
@@ -76,7 +76,7 @@ unsafe impl ::windows::core::Interface for IDirect3DDxgiInterfaceAccess {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDirect3DDxgiInterfaceAccess_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetInterface: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, iid: *const ::windows::core::GUID, p: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Display/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Display/impl.rs
@@ -31,7 +31,7 @@ impl IDisplayDeviceInterop_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateSharedHandle: CreateSharedHandle::<Identity, Impl, OFFSET>,
             OpenSharedHandle: OpenSharedHandle::<Identity, Impl, OFFSET>,
         }
@@ -73,7 +73,7 @@ impl IDisplayPathInterop_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateSourcePresentationHandle: CreateSourcePresentationHandle::<Identity, Impl, OFFSET>,
             GetSourceId: GetSourceId::<Identity, Impl, OFFSET>,
         }

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Display/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Display/mod.rs
@@ -59,7 +59,7 @@ unsafe impl ::windows::core::Interface for IDisplayDeviceInterop {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDisplayDeviceInterop_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
     pub CreateSharedHandle: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pobject: *mut ::core::ffi::c_void, psecurityattributes: *const super::super::super::Security::SECURITY_ATTRIBUTES, access: u32, name: ::core::mem::ManuallyDrop<::windows::core::HSTRING>, phandle: *mut super::super::super::Foundation::HANDLE) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_Security")))]
@@ -122,7 +122,7 @@ unsafe impl ::windows::core::Interface for IDisplayPathInterop {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDisplayPathInterop_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub CreateSourcePresentationHandle: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pvalue: *mut super::super::super::Foundation::HANDLE) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Graphics/Capture/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Graphics/Capture/impl.rs
@@ -19,7 +19,7 @@ impl IGraphicsCaptureItemInterop_Vtbl {
             this.CreateForMonitor(::core::mem::transmute_copy(&monitor), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&result)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateForWindow: CreateForWindow::<Identity, Impl, OFFSET>,
             CreateForMonitor: CreateForMonitor::<Identity, Impl, OFFSET>,
         }

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Graphics/Capture/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Graphics/Capture/mod.rs
@@ -61,7 +61,7 @@ unsafe impl ::windows::core::Interface for IGraphicsCaptureItemInterop {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IGraphicsCaptureItemInterop_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub CreateForWindow: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, window: super::super::super::super::Foundation::HWND, riid: *const ::windows::core::GUID, result: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Graphics/Direct2D/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Graphics/Direct2D/impl.rs
@@ -31,7 +31,7 @@ impl IGeometrySource2DInterop_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetGeometry: GetGeometry::<Identity, Impl, OFFSET>,
             TryGetGeometryUsingFactory: TryGetGeometryUsingFactory::<Identity, Impl, OFFSET>,
         }
@@ -115,7 +115,7 @@ impl IGraphicsEffectD2D1Interop_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetEffectId: GetEffectId::<Identity, Impl, OFFSET>,
             GetNamedPropertyMapping: GetNamedPropertyMapping::<Identity, Impl, OFFSET>,
             GetPropertyCount: GetPropertyCount::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Graphics/Direct2D/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Graphics/Direct2D/mod.rs
@@ -56,7 +56,7 @@ unsafe impl ::windows::core::Interface for IGeometrySource2DInterop {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IGeometrySource2DInterop_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Graphics_Direct2D")]
     pub GetGeometry: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Graphics_Direct2D"))]
@@ -139,7 +139,7 @@ unsafe impl ::windows::core::Interface for IGraphicsEffectD2D1Interop {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IGraphicsEffectD2D1Interop_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetEffectId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, id: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub GetNamedPropertyMapping: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, name: ::windows::core::PCWSTR, index: *mut u32, mapping: *mut GRAPHICS_EFFECT_PROPERTY_MAPPING) -> ::windows::core::HRESULT,
     pub GetPropertyCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, count: *mut u32) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Isolation/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Isolation/impl.rs
@@ -18,7 +18,7 @@ impl IIsolatedEnvironmentInterop_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetHostHwndInterop: GetHostHwndInterop::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetHostHwndInterop: GetHostHwndInterop::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IIsolatedEnvironmentInterop as ::windows::core::Interface>::IID

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Isolation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Isolation/mod.rs
@@ -50,7 +50,7 @@ unsafe impl ::windows::core::Interface for IIsolatedEnvironmentInterop {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IIsolatedEnvironmentInterop_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetHostHwndInterop: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, containerhwnd: super::super::super::Foundation::HWND, hosthwnd: *mut super::super::super::Foundation::HWND) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/ML/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/ML/impl.rs
@@ -19,7 +19,7 @@ impl ILearningModelDeviceFactoryNative_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateFromD3D12CommandQueue: CreateFromD3D12CommandQueue::<Identity, Impl, OFFSET>,
         }
     }
@@ -47,7 +47,7 @@ impl ILearningModelOperatorProviderNative_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetRegistry: GetRegistry::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetRegistry: GetRegistry::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ILearningModelOperatorProviderNative as ::windows::core::Interface>::IID
@@ -65,7 +65,7 @@ impl ILearningModelSessionOptionsNative_Vtbl {
             this.SetIntraOpNumThreadsOverride(::core::mem::transmute_copy(&intraopnumthreads)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetIntraOpNumThreadsOverride: SetIntraOpNumThreadsOverride::<Identity, Impl, OFFSET>,
         }
     }
@@ -100,7 +100,7 @@ impl ITensorNative_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetBuffer: GetBuffer::<Identity, Impl, OFFSET>,
             GetD3D12Resource: GetD3D12Resource::<Identity, Impl, OFFSET>,
         }
@@ -123,7 +123,7 @@ impl ITensorStaticsNative_Vtbl {
             let this = (*this).get_impl();
             this.CreateFromD3D12Resource(::core::mem::transmute(&value), ::core::mem::transmute_copy(&shape), ::core::mem::transmute_copy(&shapecount), ::core::mem::transmute_copy(&result)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CreateFromD3D12Resource: CreateFromD3D12Resource::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CreateFromD3D12Resource: CreateFromD3D12Resource::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ITensorStaticsNative as ::windows::core::Interface>::IID

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/ML/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/ML/mod.rs
@@ -50,7 +50,7 @@ unsafe impl ::windows::core::Interface for ILearningModelDeviceFactoryNative {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ILearningModelDeviceFactoryNative_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Graphics_Direct3D12")]
     pub CreateFromD3D12CommandQueue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: *mut ::core::ffi::c_void, result: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Graphics_Direct3D12"))]
@@ -105,7 +105,7 @@ unsafe impl ::windows::core::Interface for ILearningModelOperatorProviderNative 
 #[repr(C)]
 #[doc(hidden)]
 pub struct ILearningModelOperatorProviderNative_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_AI_MachineLearning_WinML")]
     pub GetRegistry: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppoperatorregistry: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_AI_MachineLearning_WinML"))]
@@ -157,7 +157,7 @@ unsafe impl ::windows::core::Interface for ILearningModelSessionOptionsNative {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ILearningModelSessionOptionsNative_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetIntraOpNumThreadsOverride: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, intraopnumthreads: u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_WinRT_ML\"`*"]
@@ -212,7 +212,7 @@ unsafe impl ::windows::core::Interface for ITensorNative {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITensorNative_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetBuffer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: *mut *mut u8, capacity: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Graphics_Direct3D12")]
     pub GetD3D12Resource: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, result: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -270,7 +270,7 @@ unsafe impl ::windows::core::Interface for ITensorStaticsNative {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITensorStaticsNative_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Graphics_Direct3D12")]
     pub CreateFromD3D12Resource: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: *mut ::core::ffi::c_void, shape: *mut i64, shapecount: i32, result: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Graphics_Direct3D12"))]

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Pdf/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Pdf/impl.rs
@@ -19,7 +19,7 @@ impl IPdfRendererNative_Vtbl {
             this.RenderPageToDeviceContext(::core::mem::transmute(&pdfpage), ::core::mem::transmute(&pd2ddevicecontext), ::core::mem::transmute_copy(&prenderparams)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RenderPageToSurface: RenderPageToSurface::<Identity, Impl, OFFSET>,
             RenderPageToDeviceContext: RenderPageToDeviceContext::<Identity, Impl, OFFSET>,
         }

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Pdf/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Pdf/mod.rs
@@ -73,7 +73,7 @@ unsafe impl ::windows::core::Interface for IPdfRendererNative {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPdfRendererNative_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Dxgi"))]
     pub RenderPageToSurface: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdfpage: *mut ::core::ffi::c_void, psurface: *mut ::core::ffi::c_void, offset: super::super::super::Foundation::POINT, prenderparams: *const PDF_RENDER_PARAMS) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Dxgi")))]

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Printing/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Printing/impl.rs
@@ -73,7 +73,7 @@ impl IPrintWorkflowConfigurationNative_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             PrinterQueue: PrinterQueue::<Identity, Impl, OFFSET>,
             DriverProperties: DriverProperties::<Identity, Impl, OFFSET>,
             UserProperties: UserProperties::<Identity, Impl, OFFSET>,
@@ -110,7 +110,7 @@ impl IPrintWorkflowObjectModelSourceFileContentNative_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             StartXpsOMGeneration: StartXpsOMGeneration::<Identity, Impl, OFFSET>,
             ObjectFactory: ObjectFactory::<Identity, Impl, OFFSET>,
         }
@@ -139,7 +139,7 @@ impl IPrintWorkflowXpsObjectModelTargetPackageNative_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), DocumentPackageTarget: DocumentPackageTarget::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), DocumentPackageTarget: DocumentPackageTarget::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IPrintWorkflowXpsObjectModelTargetPackageNative as ::windows::core::Interface>::IID
@@ -184,7 +184,7 @@ impl IPrintWorkflowXpsReceiver_Vtbl {
             this.Close().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetDocumentSequencePrintTicket: SetDocumentSequencePrintTicket::<Identity, Impl, OFFSET>,
             SetDocumentSequenceUri: SetDocumentSequenceUri::<Identity, Impl, OFFSET>,
             AddDocumentData: AddDocumentData::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Printing/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Printing/mod.rs
@@ -147,7 +147,7 @@ unsafe impl ::windows::core::Interface for IPrintWorkflowConfigurationNative {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPrintWorkflowConfigurationNative_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Graphics_Printing", feature = "Win32_System_Com"))]
     pub PrinterQueue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Graphics_Printing", feature = "Win32_System_Com")))]
@@ -216,7 +216,7 @@ unsafe impl ::windows::core::Interface for IPrintWorkflowObjectModelSourceFileCo
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPrintWorkflowObjectModelSourceFileContentNative_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub StartXpsOMGeneration: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, receiver: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Storage_Xps")]
     pub ObjectFactory: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -272,7 +272,7 @@ unsafe impl ::windows::core::Interface for IPrintWorkflowXpsObjectModelTargetPac
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPrintWorkflowXpsObjectModelTargetPackageNative_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Storage_Xps")]
     pub DocumentPackageTarget: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Storage_Xps"))]
@@ -356,7 +356,7 @@ unsafe impl ::windows::core::Interface for IPrintWorkflowXpsReceiver {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPrintWorkflowXpsReceiver_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub SetDocumentSequencePrintTicket: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, documentsequenceprintticket: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Shell/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Shell/impl.rs
@@ -12,7 +12,7 @@ impl IDDEInitializer_Vtbl {
             let this = (*this).get_impl();
             this.Initialize(::core::mem::transmute(&fileextensionorprotocol), ::core::mem::transmute_copy(&method), ::core::mem::transmute(&currentdirectory), ::core::mem::transmute(&exectarget), ::core::mem::transmute(&site), ::core::mem::transmute(&application), ::core::mem::transmute(&targetfile), ::core::mem::transmute(&arguments), ::core::mem::transmute(&verb)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Initialize: Initialize::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Initialize: Initialize::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDDEInitializer as ::windows::core::Interface>::IID

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Shell/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Shell/mod.rs
@@ -56,7 +56,7 @@ unsafe impl ::windows::core::Interface for IDDEInitializer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDDEInitializer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_UI_Shell")]
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fileextensionorprotocol: ::windows::core::PCWSTR, method: CreateProcessMethod, currentdirectory: ::windows::core::PCWSTR, exectarget: *mut ::core::ffi::c_void, site: *mut ::core::ffi::c_void, application: ::windows::core::PCWSTR, targetfile: ::windows::core::PCWSTR, arguments: ::windows::core::PCWSTR, verb: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_UI_Shell"))]

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Storage/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Storage/impl.rs
@@ -9,7 +9,7 @@ impl IOplockBreakingHandler_Vtbl {
             let this = (*this).get_impl();
             this.OplockBreaking().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OplockBreaking: OplockBreaking::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OplockBreaking: OplockBreaking::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IOplockBreakingHandler as ::windows::core::Interface>::IID
@@ -32,7 +32,7 @@ impl IRandomAccessStreamFileAccessMode_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetMode: GetMode::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetMode: GetMode::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IRandomAccessStreamFileAccessMode as ::windows::core::Interface>::IID
@@ -58,7 +58,7 @@ impl IStorageFolderHandleAccess_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Create: Create::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Create: Create::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IStorageFolderHandleAccess as ::windows::core::Interface>::IID
@@ -84,7 +84,7 @@ impl IStorageItemHandleAccess_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Create: Create::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Create: Create::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IStorageItemHandleAccess as ::windows::core::Interface>::IID
@@ -101,7 +101,7 @@ impl IUnbufferedFileHandleOplockCallback_Vtbl {
             let this = (*this).get_impl();
             this.OnBrokenCallback().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnBrokenCallback: OnBrokenCallback::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnBrokenCallback: OnBrokenCallback::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IUnbufferedFileHandleOplockCallback as ::windows::core::Interface>::IID
@@ -131,7 +131,7 @@ impl IUnbufferedFileHandleProvider_Vtbl {
             this.CloseUnbufferedFileHandle().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OpenUnbufferedFileHandle: OpenUnbufferedFileHandle::<Identity, Impl, OFFSET>,
             CloseUnbufferedFileHandle: CloseUnbufferedFileHandle::<Identity, Impl, OFFSET>,
         }

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Storage/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Storage/mod.rs
@@ -44,7 +44,7 @@ unsafe impl ::windows::core::Interface for IOplockBreakingHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOplockBreakingHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OplockBreaking: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_WinRT_Storage\"`*"]
@@ -94,7 +94,7 @@ unsafe impl ::windows::core::Interface for IRandomAccessStreamFileAccessMode {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRandomAccessStreamFileAccessMode_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetMode: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fileaccessmode: *mut u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_WinRT_Storage\"`*"]
@@ -150,7 +150,7 @@ unsafe impl ::windows::core::Interface for IStorageFolderHandleAccess {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IStorageFolderHandleAccess_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Create: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, filename: ::windows::core::PCWSTR, creationoptions: HANDLE_CREATION_OPTIONS, accessoptions: HANDLE_ACCESS_OPTIONS, sharingoptions: HANDLE_SHARING_OPTIONS, options: HANDLE_OPTIONS, oplockbreakinghandler: *mut ::core::ffi::c_void, interophandle: *mut super::super::super::Foundation::HANDLE) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -208,7 +208,7 @@ unsafe impl ::windows::core::Interface for IStorageItemHandleAccess {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IStorageItemHandleAccess_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Create: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, accessoptions: HANDLE_ACCESS_OPTIONS, sharingoptions: HANDLE_SHARING_OPTIONS, options: HANDLE_OPTIONS, oplockbreakinghandler: *mut ::core::ffi::c_void, interophandle: *mut super::super::super::Foundation::HANDLE) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -260,7 +260,7 @@ unsafe impl ::windows::core::Interface for IUnbufferedFileHandleOplockCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUnbufferedFileHandleOplockCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnBrokenCallback: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_WinRT_Storage\"`*"]
@@ -316,7 +316,7 @@ unsafe impl ::windows::core::Interface for IUnbufferedFileHandleProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUnbufferedFileHandleProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OpenUnbufferedFileHandle: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, oplockbreakcallback: *mut ::core::ffi::c_void, filehandle: *mut usize) -> ::windows::core::HRESULT,
     pub CloseUnbufferedFileHandle: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/impl.rs
@@ -72,7 +72,7 @@ impl IAgileReference_Vtbl {
             let this = (*this).get_impl();
             this.Resolve(::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppvobjectreference)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Resolve: Resolve::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Resolve: Resolve::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IAgileReference as ::windows::core::Interface>::IID
@@ -89,7 +89,7 @@ impl IApartmentShutdown_Vtbl {
             let this = (*this).get_impl();
             this.OnUninitialize(::core::mem::transmute_copy(&ui64apartmentidentifier))
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnUninitialize: OnUninitialize::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnUninitialize: OnUninitialize::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IApartmentShutdown as ::windows::core::Interface>::IID
@@ -107,7 +107,7 @@ impl IAppServiceConnectionExtendedExecution_Vtbl {
             this.OpenForExtendedExecutionAsync(::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&operation)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OpenForExtendedExecutionAsync: OpenForExtendedExecutionAsync::<Identity, Impl, OFFSET>,
         }
     }
@@ -132,7 +132,7 @@ impl IBufferByteAccess_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Buffer: Buffer::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Buffer: Buffer::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IBufferByteAccess as ::windows::core::Interface>::IID
@@ -180,7 +180,7 @@ impl ICastingController_Vtbl {
             this.UnAdvise(::core::mem::transmute_copy(&cookie)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             Connect: Connect::<Identity, Impl, OFFSET>,
             Disconnect: Disconnect::<Identity, Impl, OFFSET>,
@@ -210,7 +210,7 @@ impl ICastingEventHandler_Vtbl {
             this.OnError(::core::mem::transmute_copy(&errorstatus), ::core::mem::transmute(&errormessage)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnStateChanged: OnStateChanged::<Identity, Impl, OFFSET>,
             OnError: OnError::<Identity, Impl, OFFSET>,
         }
@@ -252,7 +252,7 @@ impl ICastingSourceInfo_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetController: GetController::<Identity, Impl, OFFSET>,
             GetProperties: GetProperties::<Identity, Impl, OFFSET>,
         }
@@ -279,7 +279,7 @@ impl ICoreInputInterop_Vtbl {
             this.SetMessageHandled(::core::mem::transmute_copy(&value)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetInputSource: SetInputSource::<Identity, Impl, OFFSET>,
             SetMessageHandled: SetMessageHandled::<Identity, Impl, OFFSET>,
         }
@@ -426,7 +426,7 @@ impl ICoreWindowComponentInterop_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ConfigureComponentInput: ConfigureComponentInput::<Identity, Impl, OFFSET>,
             GetViewInstanceId: GetViewInstanceId::<Identity, Impl, OFFSET>,
         }
@@ -462,7 +462,7 @@ impl ICoreWindowInterop_Vtbl {
             this.SetMessageHandled(::core::mem::transmute_copy(&value)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             WindowHandle: WindowHandle::<Identity, Impl, OFFSET>,
             SetMessageHandled: SetMessageHandled::<Identity, Impl, OFFSET>,
         }
@@ -534,7 +534,7 @@ impl ICorrelationVectorSource_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CorrelationVector: CorrelationVector::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CorrelationVector: CorrelationVector::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ICorrelationVectorSource as ::windows::core::Interface>::IID
@@ -623,7 +623,7 @@ impl ILanguageExceptionErrorInfo_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetLanguageException: GetLanguageException::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetLanguageException: GetLanguageException::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ILanguageExceptionErrorInfo as ::windows::core::Interface>::IID
@@ -686,7 +686,7 @@ impl ILanguageExceptionStackBackTrace_Vtbl {
             let this = (*this).get_impl();
             this.GetStackBackTrace(::core::mem::transmute_copy(&maxframestocapture), ::core::mem::transmute_copy(&stackbacktrace), ::core::mem::transmute_copy(&framescaptured)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetStackBackTrace: GetStackBackTrace::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetStackBackTrace: GetStackBackTrace::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ILanguageExceptionStackBackTrace as ::windows::core::Interface>::IID
@@ -710,7 +710,7 @@ impl ILanguageExceptionTransform_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTransformedRestrictedErrorInfo: GetTransformedRestrictedErrorInfo::<Identity, Impl, OFFSET>,
         }
     }
@@ -729,7 +729,7 @@ impl IMemoryBufferByteAccess_Vtbl {
             let this = (*this).get_impl();
             this.GetBuffer(::core::mem::transmute_copy(&value), ::core::mem::transmute_copy(&capacity)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetBuffer: GetBuffer::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetBuffer: GetBuffer::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMemoryBufferByteAccess as ::windows::core::Interface>::IID
@@ -806,7 +806,7 @@ impl IRestrictedErrorInfo_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetErrorDetails: GetErrorDetails::<Identity, Impl, OFFSET>,
             GetReference: GetReference::<Identity, Impl, OFFSET>,
         }
@@ -934,7 +934,7 @@ impl IShareWindowCommandEventArgsInterop_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetWindow: GetWindow::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetWindow: GetWindow::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IShareWindowCommandEventArgsInterop as ::windows::core::Interface>::IID
@@ -954,7 +954,7 @@ impl IShareWindowCommandSourceInterop_Vtbl {
             let this = (*this).get_impl();
             this.GetForWindow(::core::mem::transmute_copy(&appwindow), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&sharewindowcommandsource)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetForWindow: GetForWindow::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetForWindow: GetForWindow::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IShareWindowCommandSourceInterop as ::windows::core::Interface>::IID
@@ -1129,7 +1129,7 @@ impl IWeakReference_Vtbl {
             let this = (*this).get_impl();
             this.Resolve(::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&objectreference)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Resolve: Resolve::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Resolve: Resolve::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWeakReference as ::windows::core::Interface>::IID
@@ -1152,7 +1152,7 @@ impl IWeakReferenceSource_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetWeakReference: GetWeakReference::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetWeakReference: GetWeakReference::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWeakReferenceSource as ::windows::core::Interface>::IID

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/mod.rs
@@ -978,7 +978,7 @@ unsafe impl ::windows::core::Interface for IAgileReference {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAgileReference_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Resolve: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppvobjectreference: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_WinRT\"`*"]
@@ -1027,7 +1027,7 @@ unsafe impl ::windows::core::Interface for IApartmentShutdown {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IApartmentShutdown_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnUninitialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ui64apartmentidentifier: u64),
 }
 #[doc = "*Required features: `\"Win32_System_WinRT\"`*"]
@@ -1080,7 +1080,7 @@ unsafe impl ::windows::core::Interface for IAppServiceConnectionExtendedExecutio
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppServiceConnectionExtendedExecution_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OpenForExtendedExecutionAsync: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, operation: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_WinRT\"`*"]
@@ -1130,7 +1130,7 @@ unsafe impl ::windows::core::Interface for IBufferByteAccess {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IBufferByteAccess_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Buffer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: *mut *mut u8) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_WinRT\"`*"]
@@ -1199,7 +1199,7 @@ unsafe impl ::windows::core::Interface for ICastingController {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICastingController_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, castingengine: *mut ::core::ffi::c_void, castingsource: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Connect: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Disconnect: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1258,7 +1258,7 @@ unsafe impl ::windows::core::Interface for ICastingEventHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICastingEventHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnStateChanged: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, newstate: CASTING_CONNECTION_STATE) -> ::windows::core::HRESULT,
     pub OnError: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, errorstatus: CASTING_CONNECTION_ERROR_STATUS, errormessage: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
 }
@@ -1315,7 +1315,7 @@ unsafe impl ::windows::core::Interface for ICastingSourceInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICastingSourceInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetController: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, controller: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
     pub GetProperties: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, props: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1374,7 +1374,7 @@ unsafe impl ::windows::core::Interface for ICoreInputInterop {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICoreInputInterop_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetInputSource: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetMessageHandled: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: u8) -> ::windows::core::HRESULT,
 }
@@ -1536,7 +1536,7 @@ unsafe impl ::windows::core::Interface for ICoreWindowComponentInterop {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICoreWindowComponentInterop_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub ConfigureComponentInput: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hostviewinstanceid: u32, hwndhost: super::super::Foundation::HWND, inputsourcevisual: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -1595,7 +1595,7 @@ unsafe impl ::windows::core::Interface for ICoreWindowInterop {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICoreWindowInterop_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub WindowHandle: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hwnd: *mut super::super::Foundation::HWND) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -1723,7 +1723,7 @@ unsafe impl ::windows::core::Interface for ICorrelationVectorSource {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICorrelationVectorSource_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CorrelationVector: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cv: *mut ::core::mem::ManuallyDrop<::windows::core::HSTRING>) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_WinRT\"`*"]
@@ -1995,7 +1995,7 @@ unsafe impl ::windows::core::Interface for ILanguageExceptionErrorInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ILanguageExceptionErrorInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetLanguageException: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, languageexception: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_WinRT\"`*"]
@@ -2125,7 +2125,7 @@ unsafe impl ::windows::core::Interface for ILanguageExceptionStackBackTrace {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ILanguageExceptionStackBackTrace_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetStackBackTrace: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, maxframestocapture: u32, stackbacktrace: *mut usize, framescaptured: *mut u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_WinRT\"`*"]
@@ -2175,7 +2175,7 @@ unsafe impl ::windows::core::Interface for ILanguageExceptionTransform {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ILanguageExceptionTransform_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetTransformedRestrictedErrorInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, restrictederrorinfo: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_WinRT\"`*"]
@@ -2224,7 +2224,7 @@ unsafe impl ::windows::core::Interface for IMemoryBufferByteAccess {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMemoryBufferByteAccess_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetBuffer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: *mut *mut u8, capacity: *mut u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_WinRT\"`*"]
@@ -2429,7 +2429,7 @@ unsafe impl ::windows::core::Interface for IRestrictedErrorInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRestrictedErrorInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetErrorDetails: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, description: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>, error: *mut ::windows::core::HRESULT, restricteddescription: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>, capabilitysid: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub GetReference: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, reference: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
 }
@@ -2609,7 +2609,7 @@ unsafe impl ::windows::core::Interface for IShareWindowCommandEventArgsInterop {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IShareWindowCommandEventArgsInterop_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetWindow: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: *mut super::super::Foundation::HWND) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -2668,7 +2668,7 @@ unsafe impl ::windows::core::Interface for IShareWindowCommandSourceInterop {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IShareWindowCommandSourceInterop_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetForWindow: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, appwindow: super::super::Foundation::HWND, riid: *const ::windows::core::GUID, sharewindowcommandsource: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -3232,7 +3232,7 @@ unsafe impl ::windows::core::Interface for IWeakReference {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWeakReference_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Resolve: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, objectreference: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_WinRT\"`*"]
@@ -3282,7 +3282,7 @@ unsafe impl ::windows::core::Interface for IWeakReferenceSource {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWeakReferenceSource_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetWeakReference: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, weakreference: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_WinRT\"`*"]

--- a/crates/libs/windows/src/Windows/Win32/System/WindowsProgramming/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WindowsProgramming/impl.rs
@@ -79,7 +79,7 @@ impl ICameraUIControl_Vtbl {
             this.RemoveCapturedItem(::core::mem::transmute(&pszpath)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Show: Show::<Identity, Impl, OFFSET>,
             Close: Close::<Identity, Impl, OFFSET>,
             Suspend: Suspend::<Identity, Impl, OFFSET>,
@@ -130,7 +130,7 @@ impl ICameraUIControlEventCallback_Vtbl {
             this.OnClosed()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnStartupComplete: OnStartupComplete::<Identity, Impl, OFFSET>,
             OnSuspendComplete: OnSuspendComplete::<Identity, Impl, OFFSET>,
             OnItemCaptured: OnItemCaptured::<Identity, Impl, OFFSET>,
@@ -153,7 +153,7 @@ impl IClipServiceNotificationHelper_Vtbl {
             let this = (*this).get_impl();
             this.ShowToast(::core::mem::transmute(&titletext), ::core::mem::transmute(&bodytext), ::core::mem::transmute(&packagename), ::core::mem::transmute(&appid), ::core::mem::transmute(&launchcommand)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), ShowToast: ShowToast::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), ShowToast: ShowToast::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IClipServiceNotificationHelper as ::windows::core::Interface>::IID
@@ -176,7 +176,7 @@ impl IContainerActivationHelper_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CanActivateClientVM: CanActivateClientVM::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CanActivateClientVM: CanActivateClientVM::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IContainerActivationHelper as ::windows::core::Interface>::IID
@@ -196,7 +196,7 @@ impl IDefaultBrowserSyncSettings_Vtbl {
             let this = (*this).get_impl();
             this.IsEnabled()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), IsEnabled: IsEnabled::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), IsEnabled: IsEnabled::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDefaultBrowserSyncSettings as ::windows::core::Interface>::IID
@@ -213,7 +213,7 @@ impl IDeleteBrowsingHistory_Vtbl {
             let this = (*this).get_impl();
             this.DeleteBrowsingHistory(::core::mem::transmute_copy(&dwflags)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), DeleteBrowsingHistory: DeleteBrowsingHistory::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), DeleteBrowsingHistory: DeleteBrowsingHistory::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDeleteBrowsingHistory as ::windows::core::Interface>::IID
@@ -249,7 +249,7 @@ impl IEditionUpgradeBroker_Vtbl {
             this.CanUpgrade().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             InitializeParentWindow: InitializeParentWindow::<Identity, Impl, OFFSET>,
             UpdateOperatingSystem: UpdateOperatingSystem::<Identity, Impl, OFFSET>,
             ShowProductKeyUI: ShowProductKeyUI::<Identity, Impl, OFFSET>,
@@ -317,7 +317,7 @@ impl IEditionUpgradeHelper_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CanUpgrade: CanUpgrade::<Identity, Impl, OFFSET>,
             UpdateOperatingSystem: UpdateOperatingSystem::<Identity, Impl, OFFSET>,
             ShowProductKeyUI: ShowProductKeyUI::<Identity, Impl, OFFSET>,
@@ -349,7 +349,7 @@ impl IWindowsLockModeHelper_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetSMode: GetSMode::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetSMode: GetSMode::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWindowsLockModeHelper as ::windows::core::Interface>::IID

--- a/crates/libs/windows/src/Windows/Win32/System/WindowsProgramming/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WindowsProgramming/mod.rs
@@ -2875,7 +2875,7 @@ unsafe impl ::windows::core::Interface for ICameraUIControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICameraUIControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Show: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwindow: *mut ::core::ffi::c_void, mode: CameraUIControlMode, selectionmode: CameraUIControlLinearSelectionMode, capturemode: CameraUIControlCaptureMode, photoformat: CameraUIControlPhotoFormat, videoformat: CameraUIControlVideoFormat, bhasclosebutton: super::super::Foundation::BOOL, peventcallback: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -2958,7 +2958,7 @@ unsafe impl ::windows::core::Interface for ICameraUIControlEventCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICameraUIControlEventCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnStartupComplete: unsafe extern "system" fn(this: *mut ::core::ffi::c_void),
     pub OnSuspendComplete: unsafe extern "system" fn(this: *mut ::core::ffi::c_void),
     pub OnItemCaptured: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszpath: ::windows::core::PCWSTR),
@@ -3011,7 +3011,7 @@ unsafe impl ::windows::core::Interface for IClipServiceNotificationHelper {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IClipServiceNotificationHelper_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ShowToast: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, titletext: ::core::mem::ManuallyDrop<::windows::core::BSTR>, bodytext: ::core::mem::ManuallyDrop<::windows::core::BSTR>, packagename: ::core::mem::ManuallyDrop<::windows::core::BSTR>, appid: ::core::mem::ManuallyDrop<::windows::core::BSTR>, launchcommand: ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_WindowsProgramming\"`*"]
@@ -3061,7 +3061,7 @@ unsafe impl ::windows::core::Interface for IContainerActivationHelper {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IContainerActivationHelper_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CanActivateClientVM: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, isallowed: *mut i16) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_WindowsProgramming\"`*"]
@@ -3112,7 +3112,7 @@ unsafe impl ::windows::core::Interface for IDefaultBrowserSyncSettings {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDefaultBrowserSyncSettings_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub IsEnabled: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> super::super::Foundation::BOOL,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -3164,7 +3164,7 @@ unsafe impl ::windows::core::Interface for IDeleteBrowsingHistory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDeleteBrowsingHistory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub DeleteBrowsingHistory: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwflags: u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_WindowsProgramming\"`*"]
@@ -3222,7 +3222,7 @@ unsafe impl ::windows::core::Interface for IEditionUpgradeBroker {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEditionUpgradeBroker_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub InitializeParentWindow: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, parenthandle: u32) -> ::windows::core::HRESULT,
     pub UpdateOperatingSystem: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, parameter: ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub ShowProductKeyUI: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -3296,7 +3296,7 @@ unsafe impl ::windows::core::Interface for IEditionUpgradeHelper {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEditionUpgradeHelper_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub CanUpgrade: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, isallowed: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -3358,7 +3358,7 @@ unsafe impl ::windows::core::Interface for IWindowsLockModeHelper {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWindowsLockModeHelper_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetSMode: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, issmode: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]

--- a/crates/libs/windows/src/Windows/Win32/System/WindowsSync/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WindowsSync/impl.rs
@@ -31,7 +31,7 @@ impl IAsynchronousDataRetriever_Vtbl {
             this.LoadChangeData(::core::mem::transmute(&ploadchangecontext)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetIdParameters: GetIdParameters::<Identity, Impl, OFFSET>,
             RegisterCallback: RegisterCallback::<Identity, Impl, OFFSET>,
             RevokeCallback: RevokeCallback::<Identity, Impl, OFFSET>,
@@ -120,7 +120,7 @@ impl IChangeConflict_Vtbl {
             this.SetResolveActionForChangeUnit(::core::mem::transmute(&pchangeunit), ::core::mem::transmute_copy(&resolveaction)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDestinationProviderConflictingChange: GetDestinationProviderConflictingChange::<Identity, Impl, OFFSET>,
             GetSourceProviderConflictingChange: GetSourceProviderConflictingChange::<Identity, Impl, OFFSET>,
             GetDestinationProviderConflictingData: GetDestinationProviderConflictingData::<Identity, Impl, OFFSET>,
@@ -159,7 +159,7 @@ impl IChangeUnitException_Vtbl {
             this.GetClockVector(::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppunk)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetItemId: GetItemId::<Identity, Impl, OFFSET>,
             GetChangeUnitId: GetChangeUnitId::<Identity, Impl, OFFSET>,
             GetClockVector: GetClockVector::<Identity, Impl, OFFSET>,
@@ -221,7 +221,7 @@ impl IClockVector_Vtbl {
             this.GetClockVectorElementCount(::core::mem::transmute_copy(&pdwcount)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetClockVectorElements: GetClockVectorElements::<Identity, Impl, OFFSET>,
             GetClockVectorElementCount: GetClockVectorElementCount::<Identity, Impl, OFFSET>,
         }
@@ -248,7 +248,7 @@ impl IClockVectorElement_Vtbl {
             this.GetTickCount(::core::mem::transmute_copy(&pulltickcount)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetReplicaKey: GetReplicaKey::<Identity, Impl, OFFSET>,
             GetTickCount: GetTickCount::<Identity, Impl, OFFSET>,
         }
@@ -411,7 +411,7 @@ impl IConstraintConflict_Vtbl {
             this.IsTemporary().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDestinationProviderConflictingChange: GetDestinationProviderConflictingChange::<Identity, Impl, OFFSET>,
             GetSourceProviderConflictingChange: GetSourceProviderConflictingChange::<Identity, Impl, OFFSET>,
             GetDestinationProviderOriginalChange: GetDestinationProviderOriginalChange::<Identity, Impl, OFFSET>,
@@ -441,7 +441,7 @@ impl IConstructReplicaKeyMap_Vtbl {
             let this = (*this).get_impl();
             this.FindOrAddReplica(::core::mem::transmute_copy(&pbreplicaid), ::core::mem::transmute_copy(&pdwreplicakey)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), FindOrAddReplica: FindOrAddReplica::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), FindOrAddReplica: FindOrAddReplica::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IConstructReplicaKeyMap as ::windows::core::Interface>::IID
@@ -483,7 +483,7 @@ impl ICoreFragment_Vtbl {
             this.GetRangeCount(::core::mem::transmute_copy(&prangecount)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             NextColumn: NextColumn::<Identity, Impl, OFFSET>,
             NextRange: NextRange::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -513,7 +513,7 @@ impl ICoreFragmentInspector_Vtbl {
             this.Reset().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             NextCoreFragments: NextCoreFragments::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
         }
@@ -563,7 +563,7 @@ impl IDataRetrieverCallback_Vtbl {
             this.LoadChangeDataError(::core::mem::transmute_copy(&hrerror)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             LoadChangeDataComplete: LoadChangeDataComplete::<Identity, Impl, OFFSET>,
             LoadChangeDataError: LoadChangeDataError::<Identity, Impl, OFFSET>,
         }
@@ -608,7 +608,7 @@ impl IEnumChangeUnitExceptions_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -655,7 +655,7 @@ impl IEnumClockVector_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -702,7 +702,7 @@ impl IEnumFeedClockVector_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -724,7 +724,7 @@ impl IEnumItemIds_Vtbl {
             let this = (*this).get_impl();
             this.Next(::core::mem::transmute_copy(&pbitemid), ::core::mem::transmute_copy(&pcbitemidsize)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Next: Next::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Next: Next::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IEnumItemIds as ::windows::core::Interface>::IID
@@ -766,7 +766,7 @@ impl IEnumRangeExceptions_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -813,7 +813,7 @@ impl IEnumSingleItemExceptions_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -860,7 +860,7 @@ impl IEnumSyncChangeUnits_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -907,7 +907,7 @@ impl IEnumSyncChanges_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -957,7 +957,7 @@ impl IEnumSyncProviderConfigUIInfos_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -1007,7 +1007,7 @@ impl IEnumSyncProviderInfos_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -1111,7 +1111,7 @@ impl IFilterKeyMap_Vtbl {
             this.Serialize(::core::mem::transmute_copy(&pbfilterkeymap), ::core::mem::transmute_copy(&pcbfilterkeymap)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCount: GetCount::<Identity, Impl, OFFSET>,
             AddFilter: AddFilter::<Identity, Impl, OFFSET>,
             GetFilter: GetFilter::<Identity, Impl, OFFSET>,
@@ -1133,7 +1133,7 @@ impl IFilterRequestCallback_Vtbl {
             let this = (*this).get_impl();
             this.RequestFilter(::core::mem::transmute(&pfilter), ::core::mem::transmute_copy(&filteringtype)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), RequestFilter: RequestFilter::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), RequestFilter: RequestFilter::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IFilterRequestCallback as ::windows::core::Interface>::IID
@@ -1157,7 +1157,7 @@ impl IFilterTrackingProvider_Vtbl {
             this.AddTrackedFilter(::core::mem::transmute(&pfilter)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SpecifyTrackedFilters: SpecifyTrackedFilters::<Identity, Impl, OFFSET>,
             AddTrackedFilter: AddTrackedFilter::<Identity, Impl, OFFSET>,
         }
@@ -1177,7 +1177,7 @@ impl IFilterTrackingRequestCallback_Vtbl {
             let this = (*this).get_impl();
             this.RequestTrackedFilter(::core::mem::transmute(&pfilter)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), RequestTrackedFilter: RequestTrackedFilter::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), RequestTrackedFilter: RequestTrackedFilter::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IFilterTrackingRequestCallback as ::windows::core::Interface>::IID
@@ -1204,7 +1204,7 @@ impl IFilterTrackingSyncChangeBuilder_Vtbl {
             this.SetAllChangeUnitsPresentFlag().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddFilterChange: AddFilterChange::<Identity, Impl, OFFSET>,
             SetAllChangeUnitsPresentFlag: SetAllChangeUnitsPresentFlag::<Identity, Impl, OFFSET>,
         }
@@ -1328,7 +1328,7 @@ impl ILoadChangeContext_Vtbl {
             this.SetRecoverableErrorOnChangeUnit(::core::mem::transmute_copy(&hrerror), ::core::mem::transmute(&pchangeunit), ::core::mem::transmute(&perrordata)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSyncChange: GetSyncChange::<Identity, Impl, OFFSET>,
             SetRecoverableErrorOnChange: SetRecoverableErrorOnChange::<Identity, Impl, OFFSET>,
             SetRecoverableErrorOnChangeUnit: SetRecoverableErrorOnChangeUnit::<Identity, Impl, OFFSET>,
@@ -1349,7 +1349,7 @@ impl IProviderConverter_Vtbl {
             let this = (*this).get_impl();
             this.Initialize(::core::mem::transmute(&pisyncprovider)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Initialize: Initialize::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Initialize: Initialize::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IProviderConverter as ::windows::core::Interface>::IID
@@ -1379,7 +1379,7 @@ impl IRangeException_Vtbl {
             this.GetClockVector(::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppunk)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetClosedRangeStart: GetClosedRangeStart::<Identity, Impl, OFFSET>,
             GetClosedRangeEnd: GetClosedRangeEnd::<Identity, Impl, OFFSET>,
             GetClockVector: GetClockVector::<Identity, Impl, OFFSET>,
@@ -1431,7 +1431,7 @@ impl IRecoverableError_Vtbl {
             this.GetRecoverableErrorDataForChangeUnit(::core::mem::transmute(&pchangeunit), ::core::mem::transmute_copy(&phrerror), ::core::mem::transmute_copy(&pperrordata)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetStage: GetStage::<Identity, Impl, OFFSET>,
             GetProvider: GetProvider::<Identity, Impl, OFFSET>,
             GetChangeWithRecoverableError: GetChangeWithRecoverableError::<Identity, Impl, OFFSET>,
@@ -1467,7 +1467,7 @@ impl IRecoverableErrorData_Vtbl {
             this.GetErrorDescription(::core::mem::transmute(&pszerrordescription), ::core::mem::transmute_copy(&pccherrordescription)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             GetItemDisplayName: GetItemDisplayName::<Identity, Impl, OFFSET>,
             GetErrorDescription: GetErrorDescription::<Identity, Impl, OFFSET>,
@@ -1510,7 +1510,7 @@ impl IRegisteredSyncProvider_Vtbl {
             this.Reset().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Init: Init::<Identity, Impl, OFFSET>,
             GetInstanceId: GetInstanceId::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -1544,7 +1544,7 @@ impl IReplicaKeyMap_Vtbl {
             this.Serialize(::core::mem::transmute_copy(&pbreplicakeymap), ::core::mem::transmute_copy(&pcbreplicakeymap)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             LookupReplicaKey: LookupReplicaKey::<Identity, Impl, OFFSET>,
             LookupReplicaId: LookupReplicaId::<Identity, Impl, OFFSET>,
             Serialize: Serialize::<Identity, Impl, OFFSET>,
@@ -1565,7 +1565,7 @@ impl IRequestFilteredSync_Vtbl {
             let this = (*this).get_impl();
             this.SpecifyFilter(::core::mem::transmute(&pcallback)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SpecifyFilter: SpecifyFilter::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SpecifyFilter: SpecifyFilter::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IRequestFilteredSync as ::windows::core::Interface>::IID
@@ -1589,7 +1589,7 @@ impl ISingleItemException_Vtbl {
             this.GetClockVector(::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppunk)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetItemId: GetItemId::<Identity, Impl, OFFSET>,
             GetClockVector: GetClockVector::<Identity, Impl, OFFSET>,
         }
@@ -1609,7 +1609,7 @@ impl ISupportFilteredSync_Vtbl {
             let this = (*this).get_impl();
             this.AddFilter(::core::mem::transmute(&pfilter), ::core::mem::transmute_copy(&filteringtype)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), AddFilter: AddFilter::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), AddFilter: AddFilter::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ISupportFilteredSync as ::windows::core::Interface>::IID
@@ -1633,7 +1633,7 @@ impl ISupportLastWriteTime_Vtbl {
             this.GetChangeUnitChangeTime(::core::mem::transmute_copy(&pbitemid), ::core::mem::transmute_copy(&pbchangeunitid), ::core::mem::transmute_copy(&pulltimestamp)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetItemChangeTime: GetItemChangeTime::<Identity, Impl, OFFSET>,
             GetChangeUnitChangeTime: GetChangeUnitChangeTime::<Identity, Impl, OFFSET>,
         }
@@ -1678,7 +1678,7 @@ impl ISyncCallback_Vtbl {
             this.OnRecoverableError(::core::mem::transmute(&precoverableerror)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnProgress: OnProgress::<Identity, Impl, OFFSET>,
             OnChange: OnChange::<Identity, Impl, OFFSET>,
             OnConflict: OnConflict::<Identity, Impl, OFFSET>,
@@ -1801,7 +1801,7 @@ impl ISyncChange_Vtbl {
             this.SetWorkEstimate(::core::mem::transmute_copy(&dwwork)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetOwnerReplicaId: GetOwnerReplicaId::<Identity, Impl, OFFSET>,
             GetRootItemId: GetRootItemId::<Identity, Impl, OFFSET>,
             GetChangeVersion: GetChangeVersion::<Identity, Impl, OFFSET>,
@@ -1948,7 +1948,7 @@ impl ISyncChangeBatchAdvanced_Vtbl {
             this.GetBatchLevelKnowledgeShouldBeApplied(::core::mem::transmute_copy(&pfbatchknowledgeshouldbeapplied)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetFilterInfo: GetFilterInfo::<Identity, Impl, OFFSET>,
             ConvertFullEnumerationChangeBatchToRegularChangeBatch: ConvertFullEnumerationChangeBatchToRegularChangeBatch::<Identity, Impl, OFFSET>,
             GetUpperBoundItemId: GetUpperBoundItemId::<Identity, Impl, OFFSET>,
@@ -2082,7 +2082,7 @@ impl ISyncChangeBatchBase_Vtbl {
             this.Serialize(::core::mem::transmute_copy(&pbchangebatch), ::core::mem::transmute_copy(&pcbchangebatch)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetChangeEnumerator: GetChangeEnumerator::<Identity, Impl, OFFSET>,
             GetIsLastBatch: GetIsLastBatch::<Identity, Impl, OFFSET>,
             GetWorkEstimateForBatch: GetWorkEstimateForBatch::<Identity, Impl, OFFSET>,
@@ -2213,7 +2213,7 @@ impl ISyncChangeBatchWithFilterKeyMap_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetFilterKeyMap: GetFilterKeyMap::<Identity, Impl, OFFSET>,
             SetFilterKeyMap: SetFilterKeyMap::<Identity, Impl, OFFSET>,
             SetFilterForgottenKnowledge: SetFilterForgottenKnowledge::<Identity, Impl, OFFSET>,
@@ -2288,7 +2288,7 @@ impl ISyncChangeBuilder_Vtbl {
             let this = (*this).get_impl();
             this.AddChangeUnitMetadata(::core::mem::transmute_copy(&pbchangeunitid), ::core::mem::transmute_copy(&pchangeunitversion)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), AddChangeUnitMetadata: AddChangeUnitMetadata::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), AddChangeUnitMetadata: AddChangeUnitMetadata::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ISyncChangeBuilder as ::windows::core::Interface>::IID
@@ -2324,7 +2324,7 @@ impl ISyncChangeUnit_Vtbl {
             this.GetChangeUnitVersion(::core::mem::transmute_copy(&pbcurrentreplicaid), ::core::mem::transmute_copy(&pversion)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetItemChange: GetItemChange::<Identity, Impl, OFFSET>,
             GetChangeUnitId: GetChangeUnitId::<Identity, Impl, OFFSET>,
             GetChangeUnitVersion: GetChangeUnitVersion::<Identity, Impl, OFFSET>,
@@ -2433,7 +2433,7 @@ impl ISyncChangeWithFilterKeyMap_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetFilterCount: GetFilterCount::<Identity, Impl, OFFSET>,
             GetFilterChange: GetFilterChange::<Identity, Impl, OFFSET>,
             GetAllChangeUnitsPresentFlag: GetAllChangeUnitsPresentFlag::<Identity, Impl, OFFSET>,
@@ -2479,7 +2479,7 @@ impl ISyncChangeWithPrerequisite_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetPrerequisiteKnowledge: GetPrerequisiteKnowledge::<Identity, Impl, OFFSET>,
             GetLearnedKnowledgeWithPrerequisite: GetLearnedKnowledgeWithPrerequisite::<Identity, Impl, OFFSET>,
         }
@@ -2499,7 +2499,7 @@ impl ISyncConstraintCallback_Vtbl {
             let this = (*this).get_impl();
             this.OnConstraintConflict(::core::mem::transmute(&pconflict)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnConstraintConflict: OnConstraintConflict::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnConstraintConflict: OnConstraintConflict::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ISyncConstraintCallback as ::windows::core::Interface>::IID
@@ -2559,7 +2559,7 @@ impl ISyncDataConverter_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ConvertDataRetrieverFromProviderFormat: ConvertDataRetrieverFromProviderFormat::<Identity, Impl, OFFSET>,
             ConvertDataRetrieverToProviderFormat: ConvertDataRetrieverToProviderFormat::<Identity, Impl, OFFSET>,
             ConvertDataFromProviderFormat: ConvertDataFromProviderFormat::<Identity, Impl, OFFSET>,
@@ -2588,7 +2588,7 @@ impl ISyncFilter_Vtbl {
             this.Serialize(::core::mem::transmute_copy(&pbsyncfilter), ::core::mem::transmute_copy(&pcbsyncfilter)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             IsIdentical: IsIdentical::<Identity, Impl, OFFSET>,
             Serialize: Serialize::<Identity, Impl, OFFSET>,
         }
@@ -2614,7 +2614,7 @@ impl ISyncFilterDeserializer_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), DeserializeSyncFilter: DeserializeSyncFilter::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), DeserializeSyncFilter: DeserializeSyncFilter::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ISyncFilterDeserializer as ::windows::core::Interface>::IID
@@ -2631,7 +2631,7 @@ impl ISyncFilterInfo_Vtbl {
             let this = (*this).get_impl();
             this.Serialize(::core::mem::transmute_copy(&pbbuffer), ::core::mem::transmute_copy(&pcbbuffer)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Serialize: Serialize::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Serialize: Serialize::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ISyncFilterInfo as ::windows::core::Interface>::IID
@@ -2684,7 +2684,7 @@ impl ISyncFullEnumerationChange_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetLearnedKnowledgeAfterRecoveryComplete: GetLearnedKnowledgeAfterRecoveryComplete::<Identity, Impl, OFFSET>,
             GetLearnedForgottenKnowledge: GetLearnedForgottenKnowledge::<Identity, Impl, OFFSET>,
         }
@@ -2954,7 +2954,7 @@ impl ISyncKnowledge_Vtbl {
             this.GetVersion(::core::mem::transmute_copy(&pdwversion)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetOwnerReplicaId: GetOwnerReplicaId::<Identity, Impl, OFFSET>,
             Serialize: Serialize::<Identity, Impl, OFFSET>,
             SetLocalTickCount: SetLocalTickCount::<Identity, Impl, OFFSET>,
@@ -3134,7 +3134,7 @@ impl ISyncMergeTombstoneChange_Vtbl {
             let this = (*this).get_impl();
             this.GetWinnerItemId(::core::mem::transmute_copy(&pbwinneritemid), ::core::mem::transmute_copy(&pcbidsize)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetWinnerItemId: GetWinnerItemId::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetWinnerItemId: GetWinnerItemId::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ISyncMergeTombstoneChange as ::windows::core::Interface>::IID
@@ -3154,7 +3154,7 @@ impl ISyncProvider_Vtbl {
             let this = (*this).get_impl();
             this.GetIdParameters(::core::mem::transmute_copy(&pidparameters)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetIdParameters: GetIdParameters::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetIdParameters: GetIdParameters::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ISyncProvider as ::windows::core::Interface>::IID
@@ -3205,7 +3205,7 @@ impl ISyncProviderConfigUI_Vtbl {
             this.ModifySyncProvider(::core::mem::transmute_copy(&hwndparent), ::core::mem::transmute(&punkcontext), ::core::mem::transmute(&pproviderinfo)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Init: Init::<Identity, Impl, OFFSET>,
             GetRegisteredProperties: GetRegisteredProperties::<Identity, Impl, OFFSET>,
             CreateAndRegisterNewSyncProvider: CreateAndRegisterNewSyncProvider::<Identity, Impl, OFFSET>,
@@ -3445,7 +3445,7 @@ impl ISyncProviderRegistration_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateSyncProviderConfigUIRegistrationInstance: CreateSyncProviderConfigUIRegistrationInstance::<Identity, Impl, OFFSET>,
             UnregisterSyncProviderConfigUI: UnregisterSyncProviderConfigUI::<Identity, Impl, OFFSET>,
             EnumerateSyncProviderConfigUIs: EnumerateSyncProviderConfigUIs::<Identity, Impl, OFFSET>,
@@ -3498,7 +3498,7 @@ impl ISyncRegistrationChange_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetEvent: GetEvent::<Identity, Impl, OFFSET>,
             GetInstanceId: GetInstanceId::<Identity, Impl, OFFSET>,
         }
@@ -3524,7 +3524,7 @@ impl ISyncSessionExtendedErrorInfo_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetSyncProviderWithError: GetSyncProviderWithError::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetSyncProviderWithError: GetSyncProviderWithError::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ISyncSessionExtendedErrorInfo as ::windows::core::Interface>::IID
@@ -3581,7 +3581,7 @@ impl ISyncSessionState_Vtbl {
             this.OnProgress(::core::mem::transmute_copy(&provider), ::core::mem::transmute_copy(&syncstage), ::core::mem::transmute_copy(&dwcompletedwork), ::core::mem::transmute_copy(&dwtotalwork)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             IsCanceled: IsCanceled::<Identity, Impl, OFFSET>,
             GetInfoForChangeApplication: GetInfoForChangeApplication::<Identity, Impl, OFFSET>,
             LoadInfoFromChangeApplication: LoadInfoFromChangeApplication::<Identity, Impl, OFFSET>,
@@ -3652,7 +3652,7 @@ impl ISynchronousDataRetriever_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetIdParameters: GetIdParameters::<Identity, Impl, OFFSET>,
             LoadChangeData: LoadChangeData::<Identity, Impl, OFFSET>,
         }

--- a/crates/libs/windows/src/Windows/Win32/System/WindowsSync/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WindowsSync/mod.rs
@@ -64,7 +64,7 @@ unsafe impl ::windows::core::Interface for IAsynchronousDataRetriever {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAsynchronousDataRetriever_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetIdParameters: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pidparameters: *mut ID_PARAMETERS) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -150,7 +150,7 @@ unsafe impl ::windows::core::Interface for IChangeConflict {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IChangeConflict_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDestinationProviderConflictingChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppconflictingchange: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetSourceProviderConflictingChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppconflictingchange: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetDestinationProviderConflictingData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppconflictingdata: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -212,7 +212,7 @@ unsafe impl ::windows::core::Interface for IChangeUnitException {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IChangeUnitException_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetItemId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbitemid: *mut u8, pcbidsize: *mut u32) -> ::windows::core::HRESULT,
     pub GetChangeUnitId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbchangeunitid: *mut u8, pcbidsize: *mut u32) -> ::windows::core::HRESULT,
     pub GetClockVector: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppunk: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -341,7 +341,7 @@ unsafe impl ::windows::core::Interface for IClockVector {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IClockVector_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetClockVectorElements: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppienumclockvector: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetClockVectorElementCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwcount: *mut u32) -> ::windows::core::HRESULT,
 }
@@ -394,7 +394,7 @@ unsafe impl ::windows::core::Interface for IClockVectorElement {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IClockVectorElement_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetReplicaKey: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwreplicakey: *mut u32) -> ::windows::core::HRESULT,
     pub GetTickCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pulltickcount: *mut u64) -> ::windows::core::HRESULT,
 }
@@ -565,7 +565,7 @@ unsafe impl ::windows::core::Interface for IConstraintConflict {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IConstraintConflict_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDestinationProviderConflictingChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppconflictingchange: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetSourceProviderConflictingChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppconflictingchange: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetDestinationProviderOriginalChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pporiginalchange: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -625,7 +625,7 @@ unsafe impl ::windows::core::Interface for IConstructReplicaKeyMap {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IConstructReplicaKeyMap_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub FindOrAddReplica: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbreplicaid: *const u8, pdwreplicakey: *mut u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_WindowsSync\"`*"]
@@ -686,7 +686,7 @@ unsafe impl ::windows::core::Interface for ICoreFragment {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICoreFragment_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub NextColumn: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pchangeunitid: *mut u8, pchangeunitidsize: *mut u32) -> ::windows::core::HRESULT,
     pub NextRange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pitemid: *mut u8, pitemidsize: *mut u32, piclockvector: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -742,7 +742,7 @@ unsafe impl ::windows::core::Interface for ICoreFragmentInspector {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICoreFragmentInspector_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub NextCoreFragments: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, requestedcount: u32, ppicorefragments: *mut *mut ::core::ffi::c_void, pfetchedcount: *mut u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -866,7 +866,7 @@ unsafe impl ::windows::core::Interface for IDataRetrieverCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDataRetrieverCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub LoadChangeDataComplete: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punkdata: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub LoadChangeDataError: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hrerror: ::windows::core::HRESULT) -> ::windows::core::HRESULT,
 }
@@ -926,7 +926,7 @@ unsafe impl ::windows::core::Interface for IEnumChangeUnitExceptions {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumChangeUnitExceptions_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cexceptions: u32, ppchangeunitexception: *mut *mut ::core::ffi::c_void, pcfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cexceptions: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -988,7 +988,7 @@ unsafe impl ::windows::core::Interface for IEnumClockVector {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumClockVector_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cclockvectorelements: u32, ppiclockvectorelements: *mut *mut ::core::ffi::c_void, pcfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, csyncversions: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1050,7 +1050,7 @@ unsafe impl ::windows::core::Interface for IEnumFeedClockVector {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumFeedClockVector_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cclockvectorelements: u32, ppiclockvectorelements: *mut *mut ::core::ffi::c_void, pcfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, csyncversions: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1102,7 +1102,7 @@ unsafe impl ::windows::core::Interface for IEnumItemIds {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumItemIds_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbitemid: *mut u8, pcbitemidsize: *mut u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_WindowsSync\"`*"]
@@ -1161,7 +1161,7 @@ unsafe impl ::windows::core::Interface for IEnumRangeExceptions {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumRangeExceptions_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cexceptions: u32, pprangeexception: *mut *mut ::core::ffi::c_void, pcfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cexceptions: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1223,7 +1223,7 @@ unsafe impl ::windows::core::Interface for IEnumSingleItemExceptions {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumSingleItemExceptions_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cexceptions: u32, ppsingleitemexception: *mut *mut ::core::ffi::c_void, pcfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cexceptions: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1285,7 +1285,7 @@ unsafe impl ::windows::core::Interface for IEnumSyncChangeUnits {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumSyncChangeUnits_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cchanges: u32, ppchangeunit: *mut *mut ::core::ffi::c_void, pcfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cchanges: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1347,7 +1347,7 @@ unsafe impl ::windows::core::Interface for IEnumSyncChanges {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumSyncChanges_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cchanges: u32, ppchange: *mut *mut ::core::ffi::c_void, pcfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cchanges: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1411,7 +1411,7 @@ unsafe impl ::windows::core::Interface for IEnumSyncProviderConfigUIInfos {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumSyncProviderConfigUIInfos_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cfactories: u32, ppsyncproviderconfiguiinfo: *mut *mut ::core::ffi::c_void, pcfetched: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_UI_Shell_PropertiesSystem"))]
@@ -1478,7 +1478,7 @@ unsafe impl ::windows::core::Interface for IEnumSyncProviderInfos {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumSyncProviderInfos_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cinstances: u32, ppsyncproviderinfo: *mut *mut ::core::ffi::c_void, pcfetched: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_UI_Shell_PropertiesSystem"))]
@@ -1699,7 +1699,7 @@ unsafe impl ::windows::core::Interface for IFilterKeyMap {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IFilterKeyMap_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwcount: *mut u32) -> ::windows::core::HRESULT,
     pub AddFilter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pisyncfilter: *mut ::core::ffi::c_void, pdwfilterkey: *mut u32) -> ::windows::core::HRESULT,
     pub GetFilter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwfilterkey: u32, ppisyncfilter: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1754,7 +1754,7 @@ unsafe impl ::windows::core::Interface for IFilterRequestCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IFilterRequestCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub RequestFilter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfilter: *mut ::core::ffi::c_void, filteringtype: FILTERING_TYPE) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_WindowsSync\"`*"]
@@ -1812,7 +1812,7 @@ unsafe impl ::windows::core::Interface for IFilterTrackingProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IFilterTrackingProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SpecifyTrackedFilters: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcallback: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub AddTrackedFilter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfilter: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -1865,7 +1865,7 @@ unsafe impl ::windows::core::Interface for IFilterTrackingRequestCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IFilterTrackingRequestCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub RequestTrackedFilter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfilter: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_WindowsSync\"`*"]
@@ -1919,7 +1919,7 @@ unsafe impl ::windows::core::Interface for IFilterTrackingSyncChangeBuilder {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IFilterTrackingSyncChangeBuilder_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub AddFilterChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwfilterkey: u32, pfilterchange: *const SYNC_FILTER_CHANGE) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -2263,7 +2263,7 @@ unsafe impl ::windows::core::Interface for ILoadChangeContext {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ILoadChangeContext_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetSyncChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppsyncchange: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetRecoverableErrorOnChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hrerror: ::windows::core::HRESULT, perrordata: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetRecoverableErrorOnChangeUnit: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hrerror: ::windows::core::HRESULT, pchangeunit: *mut ::core::ffi::c_void, perrordata: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -2317,7 +2317,7 @@ unsafe impl ::windows::core::Interface for IProviderConverter {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IProviderConverter_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pisyncprovider: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_WindowsSync\"`*"]
@@ -2372,7 +2372,7 @@ unsafe impl ::windows::core::Interface for IRangeException {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRangeException_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetClosedRangeStart: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbclosedrangestart: *mut u8, pcbidsize: *mut u32) -> ::windows::core::HRESULT,
     pub GetClosedRangeEnd: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbclosedrangeend: *mut u8, pcbidsize: *mut u32) -> ::windows::core::HRESULT,
     pub GetClockVector: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppunk: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -2439,7 +2439,7 @@ unsafe impl ::windows::core::Interface for IRecoverableError {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRecoverableError_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetStage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pstage: *mut SYNC_PROGRESS_STAGE) -> ::windows::core::HRESULT,
     pub GetProvider: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pproviderrole: *mut SYNC_PROVIDER_ROLE) -> ::windows::core::HRESULT,
     pub GetChangeWithRecoverableError: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppchangewithrecoverableerror: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -2508,7 +2508,7 @@ unsafe impl ::windows::core::Interface for IRecoverableErrorData {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRecoverableErrorData_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcszitemdisplayname: ::windows::core::PCWSTR, pcszerrordescription: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub GetItemDisplayName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszitemdisplayname: ::windows::core::PCWSTR, pcchitemdisplayname: *mut u32) -> ::windows::core::HRESULT,
     pub GetErrorDescription: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszerrordescription: ::windows::core::PCWSTR, pccherrordescription: *mut u32) -> ::windows::core::HRESULT,
@@ -2571,7 +2571,7 @@ unsafe impl ::windows::core::Interface for IRegisteredSyncProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRegisteredSyncProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
     pub Init: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pguidinstanceid: *const ::windows::core::GUID, pguidcontenttype: *const ::windows::core::GUID, pcontextpropertystore: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_UI_Shell_PropertiesSystem"))]
@@ -2631,7 +2631,7 @@ unsafe impl ::windows::core::Interface for IReplicaKeyMap {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IReplicaKeyMap_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub LookupReplicaKey: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbreplicaid: *const u8, pdwreplicakey: *mut u32) -> ::windows::core::HRESULT,
     pub LookupReplicaId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwreplicakey: u32, pbreplicaid: *mut u8, pcbidsize: *mut u32) -> ::windows::core::HRESULT,
     pub Serialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbreplicakeymap: *mut u8, pcbreplicakeymap: *mut u32) -> ::windows::core::HRESULT,
@@ -2685,7 +2685,7 @@ unsafe impl ::windows::core::Interface for IRequestFilteredSync {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRequestFilteredSync_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SpecifyFilter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcallback: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_WindowsSync\"`*"]
@@ -2737,7 +2737,7 @@ unsafe impl ::windows::core::Interface for ISingleItemException {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISingleItemException_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetItemId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbitemid: *mut u8, pcbidsize: *mut u32) -> ::windows::core::HRESULT,
     pub GetClockVector: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppunk: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -2790,7 +2790,7 @@ unsafe impl ::windows::core::Interface for ISupportFilteredSync {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISupportFilteredSync_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddFilter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfilter: *mut ::core::ffi::c_void, filteringtype: FILTERING_TYPE) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_WindowsSync\"`*"]
@@ -2842,7 +2842,7 @@ unsafe impl ::windows::core::Interface for ISupportLastWriteTime {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISupportLastWriteTime_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetItemChangeTime: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbitemid: *const u8, pulltimestamp: *mut u64) -> ::windows::core::HRESULT,
     pub GetChangeUnitChangeTime: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbitemid: *const u8, pbchangeunitid: *const u8, pulltimestamp: *mut u64) -> ::windows::core::HRESULT,
 }
@@ -2913,7 +2913,7 @@ unsafe impl ::windows::core::Interface for ISyncCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISyncCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnProgress: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, provider: SYNC_PROVIDER_ROLE, syncstage: SYNC_PROGRESS_STAGE, dwcompletedwork: u32, dwtotalwork: u32) -> ::windows::core::HRESULT,
     pub OnChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psyncchange: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub OnConflict: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pconflict: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -3088,7 +3088,7 @@ unsafe impl ::windows::core::Interface for ISyncChange {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISyncChange_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetOwnerReplicaId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbreplicaid: *mut u8, pcbidsize: *mut u32) -> ::windows::core::HRESULT,
     pub GetRootItemId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbrootitemid: *mut u8, pcbidsize: *mut u32) -> ::windows::core::HRESULT,
     pub GetChangeVersion: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbcurrentreplicaid: *const u8, pversion: *mut SYNC_VERSION) -> ::windows::core::HRESULT,
@@ -3455,7 +3455,7 @@ unsafe impl ::windows::core::Interface for ISyncChangeBatchAdvanced {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISyncChangeBatchAdvanced_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetFilterInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppfilterinfo: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub ConvertFullEnumerationChangeBatchToRegularChangeBatch: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppchangebatch: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetUpperBoundItemId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbitemid: *mut u8, pcbidsize: *mut u32) -> ::windows::core::HRESULT,
@@ -3559,7 +3559,7 @@ unsafe impl ::windows::core::Interface for ISyncChangeBatchBase {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISyncChangeBatchBase_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetChangeEnumerator: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub GetIsLastBatch: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pflastbatch: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -3793,7 +3793,7 @@ unsafe impl ::windows::core::Interface for ISyncChangeBatchWithFilterKeyMap {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISyncChangeBatchWithFilterKeyMap_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetFilterKeyMap: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppifilterkeymap: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetFilterKeyMap: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pifilterkeymap: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetFilterForgottenKnowledge: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwfilterkey: u32, pfilterforgottenknowledge: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -3981,7 +3981,7 @@ unsafe impl ::windows::core::Interface for ISyncChangeBuilder {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISyncChangeBuilder_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddChangeUnitMetadata: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbchangeunitid: *const u8, pchangeunitversion: *const SYNC_VERSION) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_WindowsSync\"`*"]
@@ -4037,7 +4037,7 @@ unsafe impl ::windows::core::Interface for ISyncChangeUnit {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISyncChangeUnit_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetItemChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppsyncchange: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetChangeUnitId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbchangeunitid: *mut u8, pcbidsize: *mut u32) -> ::windows::core::HRESULT,
     pub GetChangeUnitVersion: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbcurrentreplicaid: *const u8, pversion: *mut SYNC_VERSION) -> ::windows::core::HRESULT,
@@ -4142,7 +4142,7 @@ unsafe impl ::windows::core::Interface for ISyncChangeWithFilterKeyMap {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISyncChangeWithFilterKeyMap_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetFilterCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwfiltercount: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub GetFilterChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwfilterkey: u32, pfilterchange: *mut SYNC_FILTER_CHANGE) -> ::windows::core::HRESULT,
@@ -4213,7 +4213,7 @@ unsafe impl ::windows::core::Interface for ISyncChangeWithPrerequisite {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISyncChangeWithPrerequisite_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetPrerequisiteKnowledge: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppprerequisiteknowledge: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetLearnedKnowledgeWithPrerequisite: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdestinationknowledge: *mut ::core::ffi::c_void, pplearnedknowledgewithprerequisite: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -4266,7 +4266,7 @@ unsafe impl ::windows::core::Interface for ISyncConstraintCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISyncConstraintCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnConstraintConflict: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pconflict: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_WindowsSync\"`*"]
@@ -4344,7 +4344,7 @@ unsafe impl ::windows::core::Interface for ISyncDataConverter {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISyncDataConverter_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ConvertDataRetrieverFromProviderFormat: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punkdataretrieverin: *mut ::core::ffi::c_void, penumsyncchanges: *mut ::core::ffi::c_void, ppunkdataout: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub ConvertDataRetrieverToProviderFormat: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punkdataretrieverin: *mut ::core::ffi::c_void, penumsyncchanges: *mut ::core::ffi::c_void, ppunkdataout: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub ConvertDataFromProviderFormat: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdatacontext: *mut ::core::ffi::c_void, punkdatain: *mut ::core::ffi::c_void, ppunkdataout: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -4402,7 +4402,7 @@ unsafe impl ::windows::core::Interface for ISyncFilter {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISyncFilter_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub IsIdentical: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psyncfilter: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Serialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbsyncfilter: *mut u8, pcbsyncfilter: *mut u32) -> ::windows::core::HRESULT,
 }
@@ -4453,7 +4453,7 @@ unsafe impl ::windows::core::Interface for ISyncFilterDeserializer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISyncFilterDeserializer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub DeserializeSyncFilter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbsyncfilter: *const u8, dwcbsyncfilter: u32, ppisyncfilter: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_WindowsSync\"`*"]
@@ -4502,7 +4502,7 @@ unsafe impl ::windows::core::Interface for ISyncFilterInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISyncFilterInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Serialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbbuffer: *mut u8, pcbbuffer: *mut u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_WindowsSync\"`*"]
@@ -4623,7 +4623,7 @@ unsafe impl ::windows::core::Interface for ISyncFullEnumerationChange {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISyncFullEnumerationChange_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetLearnedKnowledgeAfterRecoveryComplete: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pplearnedknowledge: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetLearnedForgottenKnowledge: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pplearnedforgottenknowledge: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -5032,7 +5032,7 @@ unsafe impl ::windows::core::Interface for ISyncKnowledge {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISyncKnowledge_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetOwnerReplicaId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbreplicaid: *mut u8, pcbidsize: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub Serialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fserializereplicakeymap: super::super::Foundation::BOOL, pbknowledge: *mut u8, pcbknowledge: *mut u32) -> ::windows::core::HRESULT,
@@ -5349,7 +5349,7 @@ unsafe impl ::windows::core::Interface for ISyncMergeTombstoneChange {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISyncMergeTombstoneChange_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetWinnerItemId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbwinneritemid: *mut u8, pcbidsize: *mut u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_WindowsSync\"`*"]
@@ -5400,7 +5400,7 @@ unsafe impl ::windows::core::Interface for ISyncProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISyncProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetIdParameters: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pidparameters: *mut ID_PARAMETERS) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -5483,7 +5483,7 @@ unsafe impl ::windows::core::Interface for ISyncProviderConfigUI {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISyncProviderConfigUI_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
     pub Init: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pguidinstanceid: *const ::windows::core::GUID, pguidcontenttype: *const ::windows::core::GUID, pconfigurationproperties: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_UI_Shell_PropertiesSystem"))]
@@ -5839,7 +5839,7 @@ unsafe impl ::windows::core::Interface for ISyncProviderRegistration {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISyncProviderRegistration_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_PropertiesSystem"))]
     pub CreateSyncProviderConfigUIRegistrationInstance: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pconfiguiconfig: *const SyncProviderConfigUIConfiguration, ppconfiguiinfo: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_PropertiesSystem")))]
@@ -5932,7 +5932,7 @@ unsafe impl ::windows::core::Interface for ISyncRegistrationChange {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISyncRegistrationChange_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetEvent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psreevent: *mut SYNC_REGISTRATION_EVENT) -> ::windows::core::HRESULT,
     pub GetInstanceId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pguidinstanceid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
 }
@@ -5983,7 +5983,7 @@ unsafe impl ::windows::core::Interface for ISyncSessionExtendedErrorInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISyncSessionExtendedErrorInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetSyncProviderWithError: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppproviderwitherror: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_WindowsSync\"`*"]
@@ -6052,7 +6052,7 @@ unsafe impl ::windows::core::Interface for ISyncSessionState {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISyncSessionState_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub IsCanceled: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfiscanceled: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -6218,7 +6218,7 @@ unsafe impl ::windows::core::Interface for ISynchronousDataRetriever {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISynchronousDataRetriever_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetIdParameters: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pidparameters: *mut ID_PARAMETERS) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]

--- a/crates/libs/windows/src/Windows/Win32/System/Wmi/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Wmi/impl.rs
@@ -40,7 +40,7 @@ impl IEnumWbemClassObject_Vtbl {
             this.Skip(::core::mem::transmute_copy(&ltimeout), ::core::mem::transmute_copy(&ncount))
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Reset: Reset::<Identity, Impl, OFFSET>,
             Next: Next::<Identity, Impl, OFFSET>,
             NextAsync: NextAsync::<Identity, Impl, OFFSET>,
@@ -76,7 +76,7 @@ impl IMofCompiler_Vtbl {
             this.CreateBMOF(::core::mem::transmute(&textfilename), ::core::mem::transmute(&bmoffilename), ::core::mem::transmute(&serverandnamespace), ::core::mem::transmute_copy(&loptionflags), ::core::mem::transmute_copy(&lclassflags), ::core::mem::transmute_copy(&linstanceflags), ::core::mem::transmute_copy(&pinfo)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CompileFile: CompileFile::<Identity, Impl, OFFSET>,
             CompileBuffer: CompileBuffer::<Identity, Impl, OFFSET>,
             CreateBMOF: CreateBMOF::<Identity, Impl, OFFSET>,
@@ -2769,7 +2769,7 @@ impl IUnsecuredApartment_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CreateObjectStub: CreateObjectStub::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CreateObjectStub: CreateObjectStub::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IUnsecuredApartment as ::windows::core::Interface>::IID
@@ -2841,7 +2841,7 @@ impl IWbemAddressResolution_Vtbl {
             let this = (*this).get_impl();
             this.Resolve(::core::mem::transmute(&wsznamespacepath), ::core::mem::transmute_copy(&wszaddresstype), ::core::mem::transmute_copy(&pdwaddresslength), ::core::mem::transmute_copy(&pabbinaryaddress)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Resolve: Resolve::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Resolve: Resolve::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWbemAddressResolution as ::windows::core::Interface>::IID
@@ -2865,7 +2865,7 @@ impl IWbemBackupRestore_Vtbl {
             this.Restore(::core::mem::transmute(&strrestorefromfile), ::core::mem::transmute_copy(&lflags)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Backup: Backup::<Identity, Impl, OFFSET>,
             Restore: Restore::<Identity, Impl, OFFSET>,
         }
@@ -2955,7 +2955,7 @@ impl IWbemCallResult_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetResultObject: GetResultObject::<Identity, Impl, OFFSET>,
             GetResultString: GetResultString::<Identity, Impl, OFFSET>,
             GetResultServices: GetResultServices::<Identity, Impl, OFFSET>,
@@ -3179,7 +3179,7 @@ impl IWbemClassObject_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetQualifierSet: GetQualifierSet::<Identity, Impl, OFFSET>,
             Get: Get::<Identity, Impl, OFFSET>,
             Put: Put::<Identity, Impl, OFFSET>,
@@ -3235,7 +3235,7 @@ impl IWbemClientConnectionTransport_Vtbl {
             this.Cancel(::core::mem::transmute_copy(&lflags), ::core::mem::transmute(&phandler)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Open: Open::<Identity, Impl, OFFSET>,
             OpenAsync: OpenAsync::<Identity, Impl, OFFSET>,
             Cancel: Cancel::<Identity, Impl, OFFSET>,
@@ -3262,7 +3262,7 @@ impl IWbemClientTransport_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), ConnectServer: ConnectServer::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), ConnectServer: ConnectServer::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWbemClientTransport as ::windows::core::Interface>::IID
@@ -3304,7 +3304,7 @@ impl IWbemConfigureRefresher_Vtbl {
             this.AddEnum(::core::mem::transmute(&pnamespace), ::core::mem::transmute(&wszclassname), ::core::mem::transmute_copy(&lflags), ::core::mem::transmute(&pcontext), ::core::mem::transmute_copy(&ppenum), ::core::mem::transmute_copy(&plid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddObjectByPath: AddObjectByPath::<Identity, Impl, OFFSET>,
             AddObjectByTemplate: AddObjectByTemplate::<Identity, Impl, OFFSET>,
             AddRefresher: AddRefresher::<Identity, Impl, OFFSET>,
@@ -3327,7 +3327,7 @@ impl IWbemConnectorLogin_Vtbl {
             let this = (*this).get_impl();
             this.ConnectorLogin(::core::mem::transmute(&wsznetworkresource), ::core::mem::transmute(&wszpreferredlocale), ::core::mem::transmute_copy(&lflags), ::core::mem::transmute(&pctx), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&pinterface)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), ConnectorLogin: ConnectorLogin::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), ConnectorLogin: ConnectorLogin::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWbemConnectorLogin as ::windows::core::Interface>::IID
@@ -3363,7 +3363,7 @@ impl IWbemConstructClassObject_Vtbl {
             this.SetServerNamespace(::core::mem::transmute(&wszserver), ::core::mem::transmute(&wsznamespace)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetInheritanceChain: SetInheritanceChain::<Identity, Impl, OFFSET>,
             SetPropertyOrigin: SetPropertyOrigin::<Identity, Impl, OFFSET>,
             SetMethodOrigin: SetMethodOrigin::<Identity, Impl, OFFSET>,
@@ -3455,7 +3455,7 @@ impl IWbemContext_Vtbl {
             this.DeleteAll().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Clone: Clone::<Identity, Impl, OFFSET>,
             GetNames: GetNames::<Identity, Impl, OFFSET>,
             BeginEnumeration: BeginEnumeration::<Identity, Impl, OFFSET>,
@@ -3528,7 +3528,7 @@ impl IWbemDecoupledRegistrar_Vtbl {
             this.UnRegister().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Register: Register::<Identity, Impl, OFFSET>,
             UnRegister: UnRegister::<Identity, Impl, OFFSET>,
         }
@@ -3554,7 +3554,7 @@ impl IWbemEventConsumerProvider_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), FindConsumer: FindConsumer::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), FindConsumer: FindConsumer::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWbemEventConsumerProvider as ::windows::core::Interface>::IID
@@ -3571,7 +3571,7 @@ impl IWbemEventProvider_Vtbl {
             let this = (*this).get_impl();
             this.ProvideEvents(::core::mem::transmute(&psink), ::core::mem::transmute_copy(&lflags)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), ProvideEvents: ProvideEvents::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), ProvideEvents: ProvideEvents::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWbemEventProvider as ::windows::core::Interface>::IID
@@ -3595,7 +3595,7 @@ impl IWbemEventProviderQuerySink_Vtbl {
             this.CancelQuery(::core::mem::transmute_copy(&dwid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             NewQuery: NewQuery::<Identity, Impl, OFFSET>,
             CancelQuery: CancelQuery::<Identity, Impl, OFFSET>,
         }
@@ -3615,7 +3615,7 @@ impl IWbemEventProviderSecurity_Vtbl {
             let this = (*this).get_impl();
             this.AccessCheck(::core::mem::transmute_copy(&wszquerylanguage), ::core::mem::transmute_copy(&wszquery), ::core::mem::transmute_copy(&lsidlength), ::core::mem::transmute_copy(&psid)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), AccessCheck: AccessCheck::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), AccessCheck: AccessCheck::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWbemEventProviderSecurity as ::windows::core::Interface>::IID
@@ -3698,7 +3698,7 @@ impl IWbemHiPerfEnum_Vtbl {
             this.RemoveAll(::core::mem::transmute_copy(&lflags)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddObjects: AddObjects::<Identity, Impl, OFFSET>,
             RemoveObjects: RemoveObjects::<Identity, Impl, OFFSET>,
             GetObjects: GetObjects::<Identity, Impl, OFFSET>,
@@ -3763,7 +3763,7 @@ impl IWbemHiPerfProvider_Vtbl {
             this.GetObjects(::core::mem::transmute(&pnamespace), ::core::mem::transmute_copy(&lnumobjects), ::core::mem::transmute_copy(&apobj), ::core::mem::transmute_copy(&lflags), ::core::mem::transmute(&pcontext)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             QueryInstances: QueryInstances::<Identity, Impl, OFFSET>,
             CreateRefresher: CreateRefresher::<Identity, Impl, OFFSET>,
             CreateRefreshableObject: CreateRefreshableObject::<Identity, Impl, OFFSET>,
@@ -3830,7 +3830,7 @@ impl IWbemLevel1Login_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             EstablishPosition: EstablishPosition::<Identity, Impl, OFFSET>,
             RequestChallenge: RequestChallenge::<Identity, Impl, OFFSET>,
             WBEMLogin: WBEMLogin::<Identity, Impl, OFFSET>,
@@ -3858,7 +3858,7 @@ impl IWbemLocator_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), ConnectServer: ConnectServer::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), ConnectServer: ConnectServer::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWbemLocator as ::windows::core::Interface>::IID
@@ -3980,7 +3980,7 @@ impl IWbemObjectSink_Vtbl {
             this.SetStatus(::core::mem::transmute_copy(&lflags), ::core::mem::transmute_copy(&hresult), ::core::mem::transmute(&strparam), ::core::mem::transmute(&pobjparam)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Indicate: Indicate::<Identity, Impl, OFFSET>,
             SetStatus: SetStatus::<Identity, Impl, OFFSET>,
         }
@@ -4082,7 +4082,7 @@ impl IWbemObjectTextSrc_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetText: GetText::<Identity, Impl, OFFSET>,
             CreateFromText: CreateFromText::<Identity, Impl, OFFSET>,
         }
@@ -4280,7 +4280,7 @@ impl IWbemPath_Vtbl {
             this.IsSameClassName(::core::mem::transmute(&wszclass))
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetText: SetText::<Identity, Impl, OFFSET>,
             GetText: GetText::<Identity, Impl, OFFSET>,
             GetInfo: GetInfo::<Identity, Impl, OFFSET>,
@@ -4394,7 +4394,7 @@ impl IWbemPathKeyList_Vtbl {
             this.GetText(::core::mem::transmute_copy(&lflags), ::core::mem::transmute_copy(&pubufflength), ::core::mem::transmute_copy(&psztext)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCount: GetCount::<Identity, Impl, OFFSET>,
             SetKey: SetKey::<Identity, Impl, OFFSET>,
             SetKey2: SetKey2::<Identity, Impl, OFFSET>,
@@ -4438,7 +4438,7 @@ impl IWbemPropertyProvider_Vtbl {
             this.PutProperty(::core::mem::transmute_copy(&lflags), ::core::mem::transmute(&strlocale), ::core::mem::transmute(&strclassmapping), ::core::mem::transmute(&strinstmapping), ::core::mem::transmute(&strpropmapping), ::core::mem::transmute_copy(&pvvalue)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetProperty: GetProperty::<Identity, Impl, OFFSET>,
             PutProperty: PutProperty::<Identity, Impl, OFFSET>,
         }
@@ -4458,7 +4458,7 @@ impl IWbemProviderIdentity_Vtbl {
             let this = (*this).get_impl();
             this.SetRegistrationObject(::core::mem::transmute_copy(&lflags), ::core::mem::transmute(&pprovreg)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SetRegistrationObject: SetRegistrationObject::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SetRegistrationObject: SetRegistrationObject::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWbemProviderIdentity as ::windows::core::Interface>::IID
@@ -4475,7 +4475,7 @@ impl IWbemProviderInit_Vtbl {
             let this = (*this).get_impl();
             this.Initialize(::core::mem::transmute(&wszuser), ::core::mem::transmute_copy(&lflags), ::core::mem::transmute(&wsznamespace), ::core::mem::transmute(&wszlocale), ::core::mem::transmute(&pnamespace), ::core::mem::transmute(&pctx), ::core::mem::transmute(&pinitsink)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Initialize: Initialize::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Initialize: Initialize::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWbemProviderInit as ::windows::core::Interface>::IID
@@ -4492,7 +4492,7 @@ impl IWbemProviderInitSink_Vtbl {
             let this = (*this).get_impl();
             this.SetStatus(::core::mem::transmute_copy(&lstatus), ::core::mem::transmute_copy(&lflags)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SetStatus: SetStatus::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SetStatus: SetStatus::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWbemProviderInitSink as ::windows::core::Interface>::IID
@@ -4555,7 +4555,7 @@ impl IWbemQualifierSet_Vtbl {
             this.EndEnumeration().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Get: Get::<Identity, Impl, OFFSET>,
             Put: Put::<Identity, Impl, OFFSET>,
             Delete: Delete::<Identity, Impl, OFFSET>,
@@ -4617,7 +4617,7 @@ impl IWbemQuery_Vtbl {
             this.GetQueryInfo(::core::mem::transmute_copy(&uanalysistype), ::core::mem::transmute_copy(&uinfoid), ::core::mem::transmute_copy(&ubufsize), ::core::mem::transmute_copy(&pdestbuf)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Empty: Empty::<Identity, Impl, OFFSET>,
             SetLanguageFeatures: SetLanguageFeatures::<Identity, Impl, OFFSET>,
             TestLanguageFeatures: TestLanguageFeatures::<Identity, Impl, OFFSET>,
@@ -4642,7 +4642,7 @@ impl IWbemRefresher_Vtbl {
             let this = (*this).get_impl();
             this.Refresh(::core::mem::transmute_copy(&lflags)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Refresh: Refresh::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Refresh: Refresh::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWbemRefresher as ::windows::core::Interface>::IID
@@ -4822,7 +4822,7 @@ impl IWbemServices_Vtbl {
             this.ExecMethodAsync(::core::mem::transmute(&strobjectpath), ::core::mem::transmute(&strmethodname), ::core::mem::transmute_copy(&lflags), ::core::mem::transmute(&pctx), ::core::mem::transmute(&pinparams), ::core::mem::transmute(&presponsehandler)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OpenNamespace: OpenNamespace::<Identity, Impl, OFFSET>,
             CancelAsyncCall: CancelAsyncCall::<Identity, Impl, OFFSET>,
             QueryObjectSink: QueryObjectSink::<Identity, Impl, OFFSET>,
@@ -4863,7 +4863,7 @@ impl IWbemShutdown_Vtbl {
             let this = (*this).get_impl();
             this.Shutdown(::core::mem::transmute_copy(&ureason), ::core::mem::transmute_copy(&umaxmilliseconds), ::core::mem::transmute(&pctx)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Shutdown: Shutdown::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Shutdown: Shutdown::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWbemShutdown as ::windows::core::Interface>::IID
@@ -4899,7 +4899,7 @@ impl IWbemStatusCodeText_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetErrorCodeText: GetErrorCodeText::<Identity, Impl, OFFSET>,
             GetFacilityCodeText: GetFacilityCodeText::<Identity, Impl, OFFSET>,
         }
@@ -4919,7 +4919,7 @@ impl IWbemTransport_Vtbl {
             let this = (*this).get_impl();
             this.Initialize().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Initialize: Initialize::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Initialize: Initialize::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWbemTransport as ::windows::core::Interface>::IID
@@ -4936,7 +4936,7 @@ impl IWbemUnboundObjectSink_Vtbl {
             let this = (*this).get_impl();
             this.IndicateToConsumer(::core::mem::transmute(&plogicalconsumer), ::core::mem::transmute_copy(&lnumobjects), ::core::mem::transmute_copy(&apobjects)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), IndicateToConsumer: IndicateToConsumer::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), IndicateToConsumer: IndicateToConsumer::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IWbemUnboundObjectSink as ::windows::core::Interface>::IID

--- a/crates/libs/windows/src/Windows/Win32/System/Wmi/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Wmi/mod.rs
@@ -69,7 +69,7 @@ unsafe impl ::windows::core::Interface for IEnumWbemClassObject {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumWbemClassObject_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ltimeout: i32, ucount: u32, apobjects: *mut *mut ::core::ffi::c_void, pureturned: *mut u32) -> ::windows::core::HRESULT,
     pub NextAsync: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ucount: u32, psink: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -146,7 +146,7 @@ unsafe impl ::windows::core::Interface for IMofCompiler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMofCompiler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CompileFile: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, filename: ::windows::core::PCWSTR, serverandnamespace: ::windows::core::PCWSTR, user: ::windows::core::PCWSTR, authority: ::windows::core::PCWSTR, password: ::windows::core::PCWSTR, loptionflags: i32, lclassflags: i32, linstanceflags: i32, pinfo: *mut WBEM_COMPILE_STATUS_INFO) -> ::windows::core::HRESULT,
     pub CompileBuffer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, buffsize: i32, pbuffer: *const u8, serverandnamespace: ::windows::core::PCWSTR, user: ::windows::core::PCWSTR, authority: ::windows::core::PCWSTR, password: ::windows::core::PCWSTR, loptionflags: i32, lclassflags: i32, linstanceflags: i32, pinfo: *mut WBEM_COMPILE_STATUS_INFO) -> ::windows::core::HRESULT,
     pub CreateBMOF: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, textfilename: ::windows::core::PCWSTR, bmoffilename: ::windows::core::PCWSTR, serverandnamespace: ::windows::core::PCWSTR, loptionflags: i32, lclassflags: i32, linstanceflags: i32, pinfo: *mut WBEM_COMPILE_STATUS_INFO) -> ::windows::core::HRESULT,
@@ -4254,7 +4254,7 @@ unsafe impl ::windows::core::Interface for IUnsecuredApartment {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUnsecuredApartment_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateObjectStub: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pobject: *mut ::core::ffi::c_void, ppstub: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"Win32_System_Com\"`*"]
@@ -4405,7 +4405,7 @@ unsafe impl ::windows::core::Interface for IWbemAddressResolution {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWbemAddressResolution_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Resolve: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wsznamespacepath: ::windows::core::PCWSTR, wszaddresstype: ::windows::core::PWSTR, pdwaddresslength: *mut u32, pabbinaryaddress: *mut *mut u8) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Wmi\"`*"]
@@ -4463,7 +4463,7 @@ unsafe impl ::windows::core::Interface for IWbemBackupRestore {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWbemBackupRestore_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Backup: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, strbackuptofile: ::windows::core::PCWSTR, lflags: i32) -> ::windows::core::HRESULT,
     pub Restore: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, strrestorefromfile: ::windows::core::PCWSTR, lflags: i32) -> ::windows::core::HRESULT,
 }
@@ -4606,7 +4606,7 @@ unsafe impl ::windows::core::Interface for IWbemCallResult {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWbemCallResult_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetResultObject: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ltimeout: i32, ppresultobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetResultString: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ltimeout: i32, pstrresultstring: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub GetResultServices: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ltimeout: i32, ppservices: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -4786,7 +4786,7 @@ unsafe impl ::windows::core::Interface for IWbemClassObject {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWbemClassObject_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetQualifierSet: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppqualset: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub Get: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wszname: ::windows::core::PCWSTR, lflags: i32, pval: *mut super::Com::VARIANT, ptype: *mut i32, plflavor: *mut i32) -> ::windows::core::HRESULT,
@@ -4888,7 +4888,7 @@ unsafe impl ::windows::core::Interface for IWbemClientConnectionTransport {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWbemClientConnectionTransport_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Open: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, straddresstype: ::core::mem::ManuallyDrop<::windows::core::BSTR>, dwbinaryaddresslength: u32, abbinaryaddress: *const u8, strobject: ::core::mem::ManuallyDrop<::windows::core::BSTR>, struser: ::core::mem::ManuallyDrop<::windows::core::BSTR>, strpassword: ::core::mem::ManuallyDrop<::windows::core::BSTR>, strlocale: ::core::mem::ManuallyDrop<::windows::core::BSTR>, lflags: i32, pctx: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, pinterface: *mut *mut ::core::ffi::c_void, pcallres: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub OpenAsync: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, straddresstype: ::core::mem::ManuallyDrop<::windows::core::BSTR>, dwbinaryaddresslength: u32, abbinaryaddress: *const u8, strobject: ::core::mem::ManuallyDrop<::windows::core::BSTR>, struser: ::core::mem::ManuallyDrop<::windows::core::BSTR>, strpassword: ::core::mem::ManuallyDrop<::windows::core::BSTR>, strlocale: ::core::mem::ManuallyDrop<::windows::core::BSTR>, lflags: i32, pctx: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, presponsehandler: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Cancel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lflags: i32, phandler: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -4943,7 +4943,7 @@ unsafe impl ::windows::core::Interface for IWbemClientTransport {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWbemClientTransport_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ConnectServer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, straddresstype: ::core::mem::ManuallyDrop<::windows::core::BSTR>, dwbinaryaddresslength: u32, abbinaryaddress: *const u8, strnetworkresource: ::core::mem::ManuallyDrop<::windows::core::BSTR>, struser: ::core::mem::ManuallyDrop<::windows::core::BSTR>, strpassword: ::core::mem::ManuallyDrop<::windows::core::BSTR>, strlocale: ::core::mem::ManuallyDrop<::windows::core::BSTR>, lsecurityflags: i32, strauthority: ::core::mem::ManuallyDrop<::windows::core::BSTR>, pctx: *mut ::core::ffi::c_void, ppnamespace: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Wmi\"`*"]
@@ -5022,7 +5022,7 @@ unsafe impl ::windows::core::Interface for IWbemConfigureRefresher {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWbemConfigureRefresher_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddObjectByPath: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pnamespace: *mut ::core::ffi::c_void, wszpath: ::windows::core::PCWSTR, lflags: i32, pcontext: *mut ::core::ffi::c_void, pprefreshable: *mut *mut ::core::ffi::c_void, plid: *mut i32) -> ::windows::core::HRESULT,
     pub AddObjectByTemplate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pnamespace: *mut ::core::ffi::c_void, ptemplate: *mut ::core::ffi::c_void, lflags: i32, pcontext: *mut ::core::ffi::c_void, pprefreshable: *mut *mut ::core::ffi::c_void, plid: *mut i32) -> ::windows::core::HRESULT,
     pub AddRefresher: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, prefresher: *mut ::core::ffi::c_void, lflags: i32, plid: *mut i32) -> ::windows::core::HRESULT,
@@ -5082,7 +5082,7 @@ unsafe impl ::windows::core::Interface for IWbemConnectorLogin {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWbemConnectorLogin_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ConnectorLogin: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wsznetworkresource: ::windows::core::PCWSTR, wszpreferredlocale: ::windows::core::PCWSTR, lflags: i32, pctx: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, pinterface: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Wmi\"`*"]
@@ -5150,7 +5150,7 @@ unsafe impl ::windows::core::Interface for IWbemConstructClassObject {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWbemConstructClassObject_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetInheritanceChain: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lnumantecedents: i32, awszantecedents: *const ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub SetPropertyOrigin: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wszpropertyname: ::windows::core::PCWSTR, loriginindex: i32) -> ::windows::core::HRESULT,
     pub SetMethodOrigin: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wszmethodname: ::windows::core::PCWSTR, loriginindex: i32) -> ::windows::core::HRESULT,
@@ -5246,7 +5246,7 @@ unsafe impl ::windows::core::Interface for IWbemContext {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWbemContext_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Clone: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppnewcopy: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
     pub GetNames: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lflags: i32, pnames: *mut *mut super::Com::SAFEARRAY) -> ::windows::core::HRESULT,
@@ -5416,7 +5416,7 @@ unsafe impl ::windows::core::Interface for IWbemDecoupledRegistrar {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWbemDecoupledRegistrar_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Register: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, a_flags: i32, a_context: *mut ::core::ffi::c_void, a_user: ::windows::core::PCWSTR, a_locale: ::windows::core::PCWSTR, a_scope: ::windows::core::PCWSTR, a_registration: ::windows::core::PCWSTR, piunknown: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub UnRegister: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -5470,7 +5470,7 @@ unsafe impl ::windows::core::Interface for IWbemEventConsumerProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWbemEventConsumerProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub FindConsumer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, plogicalconsumer: *mut ::core::ffi::c_void, ppconsumer: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Wmi\"`*"]
@@ -5522,7 +5522,7 @@ unsafe impl ::windows::core::Interface for IWbemEventProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWbemEventProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ProvideEvents: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psink: *mut ::core::ffi::c_void, lflags: i32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Wmi\"`*"]
@@ -5574,7 +5574,7 @@ unsafe impl ::windows::core::Interface for IWbemEventProviderQuerySink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWbemEventProviderQuerySink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub NewQuery: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwid: u32, wszquerylanguage: *const u16, wszquery: *const u16) -> ::windows::core::HRESULT,
     pub CancelQuery: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwid: u32) -> ::windows::core::HRESULT,
 }
@@ -5624,7 +5624,7 @@ unsafe impl ::windows::core::Interface for IWbemEventProviderSecurity {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWbemEventProviderSecurity_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AccessCheck: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wszquerylanguage: *const u16, wszquery: *const u16, lsidlength: i32, psid: *const u8) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Wmi\"`*"]
@@ -5771,7 +5771,7 @@ unsafe impl ::windows::core::Interface for IWbemHiPerfEnum {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWbemHiPerfEnum_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddObjects: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lflags: i32, unumobjects: u32, apids: *const i32, apobj: *const *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub RemoveObjects: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lflags: i32, unumobjects: u32, apids: *const i32) -> ::windows::core::HRESULT,
     pub GetObjects: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lflags: i32, unumobjects: u32, apobj: *mut *mut ::core::ffi::c_void, pureturned: *mut u32) -> ::windows::core::HRESULT,
@@ -5869,7 +5869,7 @@ unsafe impl ::windows::core::Interface for IWbemHiPerfProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWbemHiPerfProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub QueryInstances: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pnamespace: *mut ::core::ffi::c_void, wszclass: ::windows::core::PCWSTR, lflags: i32, pctx: *mut ::core::ffi::c_void, psink: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CreateRefresher: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pnamespace: *mut ::core::ffi::c_void, lflags: i32, pprefresher: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CreateRefreshableObject: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pnamespace: *mut ::core::ffi::c_void, ptemplate: *mut ::core::ffi::c_void, prefresher: *mut ::core::ffi::c_void, lflags: i32, pcontext: *mut ::core::ffi::c_void, pprefreshable: *mut *mut ::core::ffi::c_void, plid: *mut i32) -> ::windows::core::HRESULT,
@@ -5952,7 +5952,7 @@ unsafe impl ::windows::core::Interface for IWbemLevel1Login {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWbemLevel1Login_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub EstablishPosition: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wszlocalelist: ::windows::core::PCWSTR, dwnumlocales: u32, reserved: *mut u32) -> ::windows::core::HRESULT,
     pub RequestChallenge: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wsznetworkresource: ::windows::core::PCWSTR, wszuser: ::windows::core::PCWSTR, nonce: *mut u8) -> ::windows::core::HRESULT,
     pub WBEMLogin: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wszpreferredlocale: ::windows::core::PCWSTR, accesstoken: *const u8, lflags: i32, pctx: *mut ::core::ffi::c_void, ppnamespace: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -6008,7 +6008,7 @@ unsafe impl ::windows::core::Interface for IWbemLocator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWbemLocator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ConnectServer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, strnetworkresource: ::core::mem::ManuallyDrop<::windows::core::BSTR>, struser: ::core::mem::ManuallyDrop<::windows::core::BSTR>, strpassword: ::core::mem::ManuallyDrop<::windows::core::BSTR>, strlocale: ::core::mem::ManuallyDrop<::windows::core::BSTR>, lsecurityflags: i32, strauthority: ::core::mem::ManuallyDrop<::windows::core::BSTR>, pctx: *mut ::core::ffi::c_void, ppnamespace: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Wmi\"`*"]
@@ -6299,7 +6299,7 @@ unsafe impl ::windows::core::Interface for IWbemObjectSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWbemObjectSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Indicate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lobjectcount: i32, apobjarray: *const *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetStatus: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lflags: i32, hresult: ::windows::core::HRESULT, strparam: ::core::mem::ManuallyDrop<::windows::core::BSTR>, pobjparam: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -6460,7 +6460,7 @@ unsafe impl ::windows::core::Interface for IWbemObjectTextSrc {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWbemObjectTextSrc_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetText: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lflags: i32, pobj: *mut ::core::ffi::c_void, uobjtextformat: u32, pctx: *mut ::core::ffi::c_void, strtext: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub CreateFromText: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lflags: i32, strtext: ::core::mem::ManuallyDrop<::windows::core::BSTR>, uobjtextformat: u32, pctx: *mut ::core::ffi::c_void, pnewobj: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -6632,7 +6632,7 @@ unsafe impl ::windows::core::Interface for IWbemPath {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWbemPath_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetText: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, umode: u32, pszpath: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub GetText: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lflags: i32, pubufflength: *mut u32, psztext: ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, urequestedinfo: u32, puresponse: *mut u64) -> ::windows::core::HRESULT,
@@ -6760,7 +6760,7 @@ unsafe impl ::windows::core::Interface for IWbemPathKeyList {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWbemPathKeyList_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pukeycount: *mut u32) -> ::windows::core::HRESULT,
     pub SetKey: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wszname: ::windows::core::PCWSTR, uflags: u32, ucimtype: u32, pkeyval: *const ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -6832,7 +6832,7 @@ unsafe impl ::windows::core::Interface for IWbemPropertyProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWbemPropertyProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub GetProperty: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lflags: i32, strlocale: ::core::mem::ManuallyDrop<::windows::core::BSTR>, strclassmapping: ::core::mem::ManuallyDrop<::windows::core::BSTR>, strinstmapping: ::core::mem::ManuallyDrop<::windows::core::BSTR>, strpropmapping: ::core::mem::ManuallyDrop<::windows::core::BSTR>, pvvalue: *mut super::Com::VARIANT) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole")))]
@@ -6891,7 +6891,7 @@ unsafe impl ::windows::core::Interface for IWbemProviderIdentity {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWbemProviderIdentity_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetRegistrationObject: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lflags: i32, pprovreg: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Wmi\"`*"]
@@ -6948,7 +6948,7 @@ unsafe impl ::windows::core::Interface for IWbemProviderInit {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWbemProviderInit_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wszuser: ::windows::core::PCWSTR, lflags: i32, wsznamespace: ::windows::core::PCWSTR, wszlocale: ::windows::core::PCWSTR, pnamespace: *mut ::core::ffi::c_void, pctx: *mut ::core::ffi::c_void, pinitsink: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Wmi\"`*"]
@@ -6997,7 +6997,7 @@ unsafe impl ::windows::core::Interface for IWbemProviderInitSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWbemProviderInitSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetStatus: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lstatus: i32, lflags: i32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Wmi\"`*"]
@@ -7082,7 +7082,7 @@ unsafe impl ::windows::core::Interface for IWbemQualifierSet {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWbemQualifierSet_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub Get: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wszname: ::windows::core::PCWSTR, lflags: i32, pval: *mut super::Com::VARIANT, plflavor: *mut i32) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole")))]
@@ -7171,7 +7171,7 @@ unsafe impl ::windows::core::Interface for IWbemQuery {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWbemQuery_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Empty: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetLanguageFeatures: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, uflags: u32, uarraysize: u32, pufeatures: *const u32) -> ::windows::core::HRESULT,
     pub TestLanguageFeatures: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, uflags: u32, uarraysize: *mut u32, pufeatures: *mut u32) -> ::windows::core::HRESULT,
@@ -7226,7 +7226,7 @@ unsafe impl ::windows::core::Interface for IWbemRefresher {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWbemRefresher_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Refresh: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lflags: i32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Wmi\"`*"]
@@ -7428,7 +7428,7 @@ unsafe impl ::windows::core::Interface for IWbemServices {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWbemServices_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OpenNamespace: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, strnamespace: ::core::mem::ManuallyDrop<::windows::core::BSTR>, lflags: i32, pctx: *mut ::core::ffi::c_void, ppworkingnamespace: *mut *mut ::core::ffi::c_void, ppresult: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CancelAsyncCall: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psink: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub QueryObjectSink: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lflags: i32, ppresponsehandler: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -7502,7 +7502,7 @@ unsafe impl ::windows::core::Interface for IWbemShutdown {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWbemShutdown_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Shutdown: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ureason: i32, umaxmilliseconds: u32, pctx: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Wmi\"`*"]
@@ -7556,7 +7556,7 @@ unsafe impl ::windows::core::Interface for IWbemStatusCodeText {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWbemStatusCodeText_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetErrorCodeText: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hres: ::windows::core::HRESULT, localeid: u32, lflags: i32, messagetext: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub GetFacilityCodeText: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hres: ::windows::core::HRESULT, localeid: u32, lflags: i32, messagetext: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
 }
@@ -7606,7 +7606,7 @@ unsafe impl ::windows::core::Interface for IWbemTransport {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWbemTransport_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Wmi\"`*"]
@@ -7658,7 +7658,7 @@ unsafe impl ::windows::core::Interface for IWbemUnboundObjectSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWbemUnboundObjectSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub IndicateToConsumer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, plogicalconsumer: *mut ::core::ffi::c_void, lnumobjects: i32, apobjects: *const *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_System_Wmi\"`*"]

--- a/crates/libs/windows/src/Windows/Win32/UI/Accessibility/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Accessibility/impl.rs
@@ -9,7 +9,7 @@ impl IAccIdentity_Vtbl {
             let this = (*this).get_impl();
             this.GetIdentityString(::core::mem::transmute_copy(&dwidchild), ::core::mem::transmute_copy(&ppidstring), ::core::mem::transmute_copy(&pdwidstringlen)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetIdentityString: GetIdentityString::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetIdentityString: GetIdentityString::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IAccIdentity as ::windows::core::Interface>::IID
@@ -29,7 +29,7 @@ impl IAccPropServer_Vtbl {
             let this = (*this).get_impl();
             this.GetPropValue(::core::mem::transmute_copy(&pidstring), ::core::mem::transmute_copy(&dwidstringlen), ::core::mem::transmute(&idprop), ::core::mem::transmute_copy(&pvarvalue), ::core::mem::transmute_copy(&pfhasprop)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetPropValue: GetPropValue::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetPropValue: GetPropValue::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IAccPropServer as ::windows::core::Interface>::IID
@@ -134,7 +134,7 @@ impl IAccPropServices_Vtbl {
             this.DecomposeHmenuIdentityString(::core::mem::transmute_copy(&pidstring), ::core::mem::transmute_copy(&dwidstringlen), ::core::mem::transmute_copy(&phmenu), ::core::mem::transmute_copy(&pidchild)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetPropValue: SetPropValue::<Identity, Impl, OFFSET>,
             SetPropServer: SetPropServer::<Identity, Impl, OFFSET>,
             ClearProps: ClearProps::<Identity, Impl, OFFSET>,
@@ -460,7 +460,7 @@ impl IAccessibleEx_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetObjectForChild: GetObjectForChild::<Identity, Impl, OFFSET>,
             GetIAccessiblePair: GetIAccessiblePair::<Identity, Impl, OFFSET>,
             GetRuntimeId: GetRuntimeId::<Identity, Impl, OFFSET>,
@@ -491,7 +491,7 @@ impl IAccessibleHandler_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), AccessibleObjectFromID: AccessibleObjectFromID::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), AccessibleObjectFromID: AccessibleObjectFromID::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IAccessibleHandler as ::windows::core::Interface>::IID
@@ -530,7 +530,7 @@ impl IAccessibleHostingElementProviders_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetEmbeddedFragmentRoots: GetEmbeddedFragmentRoots::<Identity, Impl, OFFSET>,
             GetObjectIdForProvider: GetObjectIdForProvider::<Identity, Impl, OFFSET>,
         }
@@ -590,7 +590,7 @@ impl IAccessibleWindowlessSite_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AcquireObjectIdRange: AcquireObjectIdRange::<Identity, Impl, OFFSET>,
             ReleaseObjectIdRange: ReleaseObjectIdRange::<Identity, Impl, OFFSET>,
             QueryObjectIdRanges: QueryObjectIdRanges::<Identity, Impl, OFFSET>,
@@ -667,7 +667,7 @@ impl IAnnotationProvider_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AnnotationTypeId: AnnotationTypeId::<Identity, Impl, OFFSET>,
             AnnotationTypeName: AnnotationTypeName::<Identity, Impl, OFFSET>,
             Author: Author::<Identity, Impl, OFFSET>,
@@ -696,7 +696,7 @@ impl ICustomNavigationProvider_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Navigate: Navigate::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Navigate: Navigate::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ICustomNavigationProvider as ::windows::core::Interface>::IID
@@ -726,7 +726,7 @@ impl IDockProvider_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetDockPosition: SetDockPosition::<Identity, Impl, OFFSET>,
             DockPosition: DockPosition::<Identity, Impl, OFFSET>,
         }
@@ -792,7 +792,7 @@ impl IDragProvider_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             IsGrabbed: IsGrabbed::<Identity, Impl, OFFSET>,
             DropEffect: DropEffect::<Identity, Impl, OFFSET>,
             DropEffects: DropEffects::<Identity, Impl, OFFSET>,
@@ -836,7 +836,7 @@ impl IDropTargetProvider_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             DropTargetEffect: DropTargetEffect::<Identity, Impl, OFFSET>,
             DropTargetEffects: DropTargetEffects::<Identity, Impl, OFFSET>,
         }
@@ -875,7 +875,7 @@ impl IExpandCollapseProvider_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Expand: Expand::<Identity, Impl, OFFSET>,
             Collapse: Collapse::<Identity, Impl, OFFSET>,
             ExpandCollapseState: ExpandCollapseState::<Identity, Impl, OFFSET>,
@@ -951,7 +951,7 @@ impl IGridItemProvider_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Row: Row::<Identity, Impl, OFFSET>,
             Column: Column::<Identity, Impl, OFFSET>,
             RowSpan: RowSpan::<Identity, Impl, OFFSET>,
@@ -1005,7 +1005,7 @@ impl IGridProvider_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetItem: GetItem::<Identity, Impl, OFFSET>,
             RowCount: RowCount::<Identity, Impl, OFFSET>,
             ColumnCount: ColumnCount::<Identity, Impl, OFFSET>,
@@ -1026,7 +1026,7 @@ impl IInvokeProvider_Vtbl {
             let this = (*this).get_impl();
             this.Invoke().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Invoke: Invoke::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Invoke: Invoke::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IInvokeProvider as ::windows::core::Interface>::IID
@@ -1052,7 +1052,7 @@ impl IItemContainerProvider_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), FindItemByProperty: FindItemByProperty::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), FindItemByProperty: FindItemByProperty::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IItemContainerProvider as ::windows::core::Interface>::IID
@@ -1217,7 +1217,7 @@ impl ILegacyIAccessibleProvider_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Select: Select::<Identity, Impl, OFFSET>,
             DoDefaultAction: DoDefaultAction::<Identity, Impl, OFFSET>,
             SetValue: SetValue::<Identity, Impl, OFFSET>,
@@ -1289,7 +1289,7 @@ impl IMultipleViewProvider_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetViewName: GetViewName::<Identity, Impl, OFFSET>,
             SetCurrentView: SetCurrentView::<Identity, Impl, OFFSET>,
             CurrentView: CurrentView::<Identity, Impl, OFFSET>,
@@ -1317,7 +1317,7 @@ impl IObjectModelProvider_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetUnderlyingObjectModel: GetUnderlyingObjectModel::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetUnderlyingObjectModel: GetUnderlyingObjectModel::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IObjectModelProvider as ::windows::core::Interface>::IID
@@ -1337,7 +1337,7 @@ impl IProxyProviderWinEventHandler_Vtbl {
             let this = (*this).get_impl();
             this.RespondToWinEvent(::core::mem::transmute_copy(&idwinevent), ::core::mem::transmute_copy(&hwnd), ::core::mem::transmute_copy(&idobject), ::core::mem::transmute_copy(&idchild), ::core::mem::transmute(&psink)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), RespondToWinEvent: RespondToWinEvent::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), RespondToWinEvent: RespondToWinEvent::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IProxyProviderWinEventHandler as ::windows::core::Interface>::IID
@@ -1370,7 +1370,7 @@ impl IProxyProviderWinEventSink_Vtbl {
             this.AddStructureChangedEvent(::core::mem::transmute(&pprovider), ::core::mem::transmute_copy(&structurechangetype), ::core::mem::transmute_copy(&runtimeid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddAutomationPropertyChangedEvent: AddAutomationPropertyChangedEvent::<Identity, Impl, OFFSET>,
             AddAutomationEvent: AddAutomationEvent::<Identity, Impl, OFFSET>,
             AddStructureChangedEvent: AddStructureChangedEvent::<Identity, Impl, OFFSET>,
@@ -1467,7 +1467,7 @@ impl IRangeValueProvider_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetValue: SetValue::<Identity, Impl, OFFSET>,
             Value: Value::<Identity, Impl, OFFSET>,
             IsReadOnly: IsReadOnly::<Identity, Impl, OFFSET>,
@@ -1502,7 +1502,7 @@ impl IRawElementProviderAdviseEvents_Vtbl {
             this.AdviseEventRemoved(::core::mem::transmute_copy(&eventid), ::core::mem::transmute_copy(&propertyids)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AdviseEventAdded: AdviseEventAdded::<Identity, Impl, OFFSET>,
             AdviseEventRemoved: AdviseEventRemoved::<Identity, Impl, OFFSET>,
         }
@@ -1586,7 +1586,7 @@ impl IRawElementProviderFragment_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Navigate: Navigate::<Identity, Impl, OFFSET>,
             GetRuntimeId: GetRuntimeId::<Identity, Impl, OFFSET>,
             BoundingRectangle: BoundingRectangle::<Identity, Impl, OFFSET>,
@@ -1629,7 +1629,7 @@ impl IRawElementProviderFragmentRoot_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ElementProviderFromPoint: ElementProviderFromPoint::<Identity, Impl, OFFSET>,
             GetFocus: GetFocus::<Identity, Impl, OFFSET>,
         }
@@ -1658,7 +1658,7 @@ impl IRawElementProviderHostingAccessibles_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetEmbeddedAccessibles: GetEmbeddedAccessibles::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetEmbeddedAccessibles: GetEmbeddedAccessibles::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IRawElementProviderHostingAccessibles as ::windows::core::Interface>::IID
@@ -1685,7 +1685,7 @@ impl IRawElementProviderHwndOverride_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetOverrideProviderForHwnd: GetOverrideProviderForHwnd::<Identity, Impl, OFFSET>,
         }
     }
@@ -1750,7 +1750,7 @@ impl IRawElementProviderSimple_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ProviderOptions: ProviderOptions::<Identity, Impl, OFFSET>,
             GetPatternProvider: GetPatternProvider::<Identity, Impl, OFFSET>,
             GetPropertyValue: GetPropertyValue::<Identity, Impl, OFFSET>,
@@ -1840,7 +1840,7 @@ impl IRawElementProviderWindowlessSite_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetAdjacentFragment: GetAdjacentFragment::<Identity, Impl, OFFSET>,
             GetRuntimeIdPrefix: GetRuntimeIdPrefix::<Identity, Impl, OFFSET>,
         }
@@ -1867,7 +1867,7 @@ impl IRichEditUiaInformation_Vtbl {
             this.IsVisible().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetBoundaryRectangle: GetBoundaryRectangle::<Identity, Impl, OFFSET>,
             IsVisible: IsVisible::<Identity, Impl, OFFSET>,
         }
@@ -1893,7 +1893,7 @@ impl IRicheditWindowlessAccessibility_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CreateProvider: CreateProvider::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CreateProvider: CreateProvider::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IRicheditWindowlessAccessibility as ::windows::core::Interface>::IID
@@ -1910,7 +1910,7 @@ impl IScrollItemProvider_Vtbl {
             let this = (*this).get_impl();
             this.ScrollIntoView().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), ScrollIntoView: ScrollIntoView::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), ScrollIntoView: ScrollIntoView::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IScrollItemProvider as ::windows::core::Interface>::IID
@@ -2009,7 +2009,7 @@ impl IScrollProvider_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Scroll: Scroll::<Identity, Impl, OFFSET>,
             SetScrollPercent: SetScrollPercent::<Identity, Impl, OFFSET>,
             HorizontalScrollPercent: HorizontalScrollPercent::<Identity, Impl, OFFSET>,
@@ -2075,7 +2075,7 @@ impl ISelectionItemProvider_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Select: Select::<Identity, Impl, OFFSET>,
             AddToSelection: AddToSelection::<Identity, Impl, OFFSET>,
             RemoveFromSelection: RemoveFromSelection::<Identity, Impl, OFFSET>,
@@ -2132,7 +2132,7 @@ impl ISelectionProvider_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSelection: GetSelection::<Identity, Impl, OFFSET>,
             CanSelectMultiple: CanSelectMultiple::<Identity, Impl, OFFSET>,
             IsSelectionRequired: IsSelectionRequired::<Identity, Impl, OFFSET>,
@@ -2255,7 +2255,7 @@ impl ISpreadsheetItemProvider_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Formula: Formula::<Identity, Impl, OFFSET>,
             GetAnnotationObjects: GetAnnotationObjects::<Identity, Impl, OFFSET>,
             GetAnnotationTypes: GetAnnotationTypes::<Identity, Impl, OFFSET>,
@@ -2282,7 +2282,7 @@ impl ISpreadsheetProvider_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetItemByName: GetItemByName::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetItemByName: GetItemByName::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ISpreadsheetProvider as ::windows::core::Interface>::IID
@@ -2378,7 +2378,7 @@ impl IStylesProvider_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             StyleId: StyleId::<Identity, Impl, OFFSET>,
             StyleName: StyleName::<Identity, Impl, OFFSET>,
             FillColor: FillColor::<Identity, Impl, OFFSET>,
@@ -2410,7 +2410,7 @@ impl ISynchronizedInputProvider_Vtbl {
             this.Cancel().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             StartListening: StartListening::<Identity, Impl, OFFSET>,
             Cancel: Cancel::<Identity, Impl, OFFSET>,
         }
@@ -2452,7 +2452,7 @@ impl ITableItemProvider_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetRowHeaderItems: GetRowHeaderItems::<Identity, Impl, OFFSET>,
             GetColumnHeaderItems: GetColumnHeaderItems::<Identity, Impl, OFFSET>,
         }
@@ -2506,7 +2506,7 @@ impl ITableProvider_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetRowHeaders: GetRowHeaders::<Identity, Impl, OFFSET>,
             GetColumnHeaders: GetColumnHeaders::<Identity, Impl, OFFSET>,
             RowOrColumnMajor: RowOrColumnMajor::<Identity, Impl, OFFSET>,
@@ -2546,7 +2546,7 @@ impl ITextChildProvider_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             TextContainer: TextContainer::<Identity, Impl, OFFSET>,
             TextRange: TextRange::<Identity, Impl, OFFSET>,
         }
@@ -2678,7 +2678,7 @@ impl ITextProvider_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSelection: GetSelection::<Identity, Impl, OFFSET>,
             GetVisibleRanges: GetVisibleRanges::<Identity, Impl, OFFSET>,
             RangeFromChild: RangeFromChild::<Identity, Impl, OFFSET>,
@@ -2916,7 +2916,7 @@ impl ITextRangeProvider_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Clone: Clone::<Identity, Impl, OFFSET>,
             Compare: Compare::<Identity, Impl, OFFSET>,
             CompareEndpoints: CompareEndpoints::<Identity, Impl, OFFSET>,
@@ -2985,7 +2985,7 @@ impl IToggleProvider_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Toggle: Toggle::<Identity, Impl, OFFSET>,
             ToggleState: ToggleState::<Identity, Impl, OFFSET>,
         }
@@ -3057,7 +3057,7 @@ impl ITransformProvider_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Move: Move::<Identity, Impl, OFFSET>,
             Resize: Resize::<Identity, Impl, OFFSET>,
             Rotate: Rotate::<Identity, Impl, OFFSET>,
@@ -3737,7 +3737,7 @@ impl IUIAutomation_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CompareElements: CompareElements::<Identity, Impl, OFFSET>,
             CompareRuntimeIds: CompareRuntimeIds::<Identity, Impl, OFFSET>,
             GetRootElement: GetRootElement::<Identity, Impl, OFFSET>,
@@ -4074,7 +4074,7 @@ impl IUIAutomationActiveTextPositionChangedEventHandler_Vtbl {
             this.HandleActiveTextPositionChangedEvent(::core::mem::transmute(&sender), ::core::mem::transmute(&range)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             HandleActiveTextPositionChangedEvent: HandleActiveTextPositionChangedEvent::<Identity, Impl, OFFSET>,
         }
     }
@@ -4257,7 +4257,7 @@ impl IUIAutomationAnnotationPattern_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CurrentAnnotationTypeId: CurrentAnnotationTypeId::<Identity, Impl, OFFSET>,
             CurrentAnnotationTypeName: CurrentAnnotationTypeName::<Identity, Impl, OFFSET>,
             CurrentAuthor: CurrentAuthor::<Identity, Impl, OFFSET>,
@@ -4384,7 +4384,7 @@ impl IUIAutomationCacheRequest_Vtbl {
             this.SetAutomationElementMode(::core::mem::transmute_copy(&mode)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddProperty: AddProperty::<Identity, Impl, OFFSET>,
             AddPattern: AddPattern::<Identity, Impl, OFFSET>,
             Clone: Clone::<Identity, Impl, OFFSET>,
@@ -4414,7 +4414,7 @@ impl IUIAutomationChangesEventHandler_Vtbl {
             let this = (*this).get_impl();
             this.HandleChangesEvent(::core::mem::transmute(&sender), ::core::mem::transmute_copy(&uiachanges), ::core::mem::transmute_copy(&changescount)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), HandleChangesEvent: HandleChangesEvent::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), HandleChangesEvent: HandleChangesEvent::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IUIAutomationChangesEventHandler as ::windows::core::Interface>::IID
@@ -4424,7 +4424,7 @@ pub trait IUIAutomationCondition_Impl: Sized {}
 impl ::windows::core::RuntimeName for IUIAutomationCondition {}
 impl IUIAutomationCondition_Vtbl {
     pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IUIAutomationCondition_Impl, const OFFSET: isize>() -> IUIAutomationCondition_Vtbl {
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>() }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>() }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IUIAutomationCondition as ::windows::core::Interface>::IID
@@ -4447,7 +4447,7 @@ impl IUIAutomationCustomNavigationPattern_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Navigate: Navigate::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Navigate: Navigate::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IUIAutomationCustomNavigationPattern as ::windows::core::Interface>::IID
@@ -4489,7 +4489,7 @@ impl IUIAutomationDockPattern_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetDockPosition: SetDockPosition::<Identity, Impl, OFFSET>,
             CurrentDockPosition: CurrentDockPosition::<Identity, Impl, OFFSET>,
             CachedDockPosition: CachedDockPosition::<Identity, Impl, OFFSET>,
@@ -4604,7 +4604,7 @@ impl IUIAutomationDragPattern_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CurrentIsGrabbed: CurrentIsGrabbed::<Identity, Impl, OFFSET>,
             CachedIsGrabbed: CachedIsGrabbed::<Identity, Impl, OFFSET>,
             CurrentDropEffect: CurrentDropEffect::<Identity, Impl, OFFSET>,
@@ -4676,7 +4676,7 @@ impl IUIAutomationDropTargetPattern_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CurrentDropTargetEffect: CurrentDropTargetEffect::<Identity, Impl, OFFSET>,
             CachedDropTargetEffect: CachedDropTargetEffect::<Identity, Impl, OFFSET>,
             CurrentDropTargetEffects: CurrentDropTargetEffects::<Identity, Impl, OFFSET>,
@@ -5656,7 +5656,7 @@ impl IUIAutomationElement_Vtbl {
             this.GetClickablePoint(::core::mem::transmute_copy(&clickable), ::core::mem::transmute_copy(&gotclickable)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetFocus: SetFocus::<Identity, Impl, OFFSET>,
             GetRuntimeId: GetRuntimeId::<Identity, Impl, OFFSET>,
             FindFirst: FindFirst::<Identity, Impl, OFFSET>,
@@ -6339,7 +6339,7 @@ impl IUIAutomationElementArray_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Length: Length::<Identity, Impl, OFFSET>,
             GetElement: GetElement::<Identity, Impl, OFFSET>,
         }
@@ -6359,7 +6359,7 @@ impl IUIAutomationEventHandler_Vtbl {
             let this = (*this).get_impl();
             this.HandleAutomationEvent(::core::mem::transmute(&sender), ::core::mem::transmute_copy(&eventid)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), HandleAutomationEvent: HandleAutomationEvent::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), HandleAutomationEvent: HandleAutomationEvent::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IUIAutomationEventHandler as ::windows::core::Interface>::IID
@@ -6413,7 +6413,7 @@ impl IUIAutomationEventHandlerGroup_Vtbl {
             this.AddTextEditTextChangedEventHandler(::core::mem::transmute_copy(&scope), ::core::mem::transmute_copy(&texteditchangetype), ::core::mem::transmute(&cacherequest), ::core::mem::transmute(&handler)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddActiveTextPositionChangedEventHandler: AddActiveTextPositionChangedEventHandler::<Identity, Impl, OFFSET>,
             AddAutomationEventHandler: AddAutomationEventHandler::<Identity, Impl, OFFSET>,
             AddChangesEventHandler: AddChangesEventHandler::<Identity, Impl, OFFSET>,
@@ -6469,7 +6469,7 @@ impl IUIAutomationExpandCollapsePattern_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Expand: Expand::<Identity, Impl, OFFSET>,
             Collapse: Collapse::<Identity, Impl, OFFSET>,
             CurrentExpandCollapseState: CurrentExpandCollapseState::<Identity, Impl, OFFSET>,
@@ -6491,7 +6491,7 @@ impl IUIAutomationFocusChangedEventHandler_Vtbl {
             let this = (*this).get_impl();
             this.HandleFocusChangedEvent(::core::mem::transmute(&sender)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), HandleFocusChangedEvent: HandleFocusChangedEvent::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), HandleFocusChangedEvent: HandleFocusChangedEvent::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IUIAutomationFocusChangedEventHandler as ::windows::core::Interface>::IID
@@ -6623,7 +6623,7 @@ impl IUIAutomationGridItemPattern_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CurrentContainingGrid: CurrentContainingGrid::<Identity, Impl, OFFSET>,
             CurrentRow: CurrentRow::<Identity, Impl, OFFSET>,
             CurrentColumn: CurrentColumn::<Identity, Impl, OFFSET>,
@@ -6706,7 +6706,7 @@ impl IUIAutomationGridPattern_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetItem: GetItem::<Identity, Impl, OFFSET>,
             CurrentRowCount: CurrentRowCount::<Identity, Impl, OFFSET>,
             CurrentColumnCount: CurrentColumnCount::<Identity, Impl, OFFSET>,
@@ -6729,7 +6729,7 @@ impl IUIAutomationInvokePattern_Vtbl {
             let this = (*this).get_impl();
             this.Invoke().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Invoke: Invoke::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Invoke: Invoke::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IUIAutomationInvokePattern as ::windows::core::Interface>::IID
@@ -6755,7 +6755,7 @@ impl IUIAutomationItemContainerPattern_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), FindItemByProperty: FindItemByProperty::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), FindItemByProperty: FindItemByProperty::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IUIAutomationItemContainerPattern as ::windows::core::Interface>::IID
@@ -7040,7 +7040,7 @@ impl IUIAutomationLegacyIAccessiblePattern_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Select: Select::<Identity, Impl, OFFSET>,
             DoDefaultAction: DoDefaultAction::<Identity, Impl, OFFSET>,
             SetValue: SetValue::<Identity, Impl, OFFSET>,
@@ -7146,7 +7146,7 @@ impl IUIAutomationMultipleViewPattern_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetViewName: GetViewName::<Identity, Impl, OFFSET>,
             SetCurrentView: SetCurrentView::<Identity, Impl, OFFSET>,
             CurrentCurrentView: CurrentCurrentView::<Identity, Impl, OFFSET>,
@@ -7193,7 +7193,7 @@ impl IUIAutomationNotificationEventHandler_Vtbl {
             let this = (*this).get_impl();
             this.HandleNotificationEvent(::core::mem::transmute(&sender), ::core::mem::transmute_copy(&notificationkind), ::core::mem::transmute_copy(&notificationprocessing), ::core::mem::transmute(&displaystring), ::core::mem::transmute(&activityid)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), HandleNotificationEvent: HandleNotificationEvent::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), HandleNotificationEvent: HandleNotificationEvent::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IUIAutomationNotificationEventHandler as ::windows::core::Interface>::IID
@@ -7216,7 +7216,7 @@ impl IUIAutomationObjectModelPattern_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetUnderlyingObjectModel: GetUnderlyingObjectModel::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetUnderlyingObjectModel: GetUnderlyingObjectModel::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IUIAutomationObjectModelPattern as ::windows::core::Interface>::IID
@@ -7295,7 +7295,7 @@ impl IUIAutomationPatternHandler_Vtbl {
             this.Dispatch(::core::mem::transmute(&ptarget), ::core::mem::transmute_copy(&index), ::core::mem::transmute_copy(&pparams), ::core::mem::transmute_copy(&cparams)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateClientWrapper: CreateClientWrapper::<Identity, Impl, OFFSET>,
             Dispatch: Dispatch::<Identity, Impl, OFFSET>,
         }
@@ -7325,7 +7325,7 @@ impl IUIAutomationPatternInstance_Vtbl {
             this.CallMethod(::core::mem::transmute_copy(&index), ::core::mem::transmute_copy(&pparams), ::core::mem::transmute_copy(&cparams)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetProperty: GetProperty::<Identity, Impl, OFFSET>,
             CallMethod: CallMethod::<Identity, Impl, OFFSET>,
         }
@@ -7349,7 +7349,7 @@ impl IUIAutomationPropertyChangedEventHandler_Vtbl {
             this.HandlePropertyChangedEvent(::core::mem::transmute(&sender), ::core::mem::transmute_copy(&propertyid), ::core::mem::transmute(&newvalue)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             HandlePropertyChangedEvent: HandlePropertyChangedEvent::<Identity, Impl, OFFSET>,
         }
     }
@@ -7445,7 +7445,7 @@ impl IUIAutomationProxyFactory_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateProvider: CreateProvider::<Identity, Impl, OFFSET>,
             ProxyFactoryId: ProxyFactoryId::<Identity, Impl, OFFSET>,
         }
@@ -7583,7 +7583,7 @@ impl IUIAutomationProxyFactoryEntry_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ProxyFactory: ProxyFactory::<Identity, Impl, OFFSET>,
             ClassName: ClassName::<Identity, Impl, OFFSET>,
             ImageName: ImageName::<Identity, Impl, OFFSET>,
@@ -7684,7 +7684,7 @@ impl IUIAutomationProxyFactoryMapping_Vtbl {
             this.RestoreDefaultTable().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Count: Count::<Identity, Impl, OFFSET>,
             GetTable: GetTable::<Identity, Impl, OFFSET>,
             GetEntry: GetEntry::<Identity, Impl, OFFSET>,
@@ -7859,7 +7859,7 @@ impl IUIAutomationRangeValuePattern_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetValue: SetValue::<Identity, Impl, OFFSET>,
             CurrentValue: CurrentValue::<Identity, Impl, OFFSET>,
             CurrentIsReadOnly: CurrentIsReadOnly::<Identity, Impl, OFFSET>,
@@ -7918,7 +7918,7 @@ impl IUIAutomationRegistrar_Vtbl {
             this.RegisterPattern(::core::mem::transmute_copy(&pattern), ::core::mem::transmute_copy(&ppatternid), ::core::mem::transmute_copy(&ppatternavailablepropertyid), ::core::mem::transmute_copy(&propertyidcount), ::core::mem::transmute_copy(&ppropertyids), ::core::mem::transmute_copy(&eventidcount), ::core::mem::transmute_copy(&peventids)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RegisterProperty: RegisterProperty::<Identity, Impl, OFFSET>,
             RegisterEvent: RegisterEvent::<Identity, Impl, OFFSET>,
             RegisterPattern: RegisterPattern::<Identity, Impl, OFFSET>,
@@ -7939,7 +7939,7 @@ impl IUIAutomationScrollItemPattern_Vtbl {
             let this = (*this).get_impl();
             this.ScrollIntoView().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), ScrollIntoView: ScrollIntoView::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), ScrollIntoView: ScrollIntoView::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IUIAutomationScrollItemPattern as ::windows::core::Interface>::IID
@@ -8110,7 +8110,7 @@ impl IUIAutomationScrollPattern_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Scroll: Scroll::<Identity, Impl, OFFSET>,
             SetScrollPercent: SetScrollPercent::<Identity, Impl, OFFSET>,
             CurrentHorizontalScrollPercent: CurrentHorizontalScrollPercent::<Identity, Impl, OFFSET>,
@@ -8206,7 +8206,7 @@ impl IUIAutomationSelectionItemPattern_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Select: Select::<Identity, Impl, OFFSET>,
             AddToSelection: AddToSelection::<Identity, Impl, OFFSET>,
             RemoveFromSelection: RemoveFromSelection::<Identity, Impl, OFFSET>,
@@ -8301,7 +8301,7 @@ impl IUIAutomationSelectionPattern_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCurrentSelection: GetCurrentSelection::<Identity, Impl, OFFSET>,
             CurrentCanSelectMultiple: CurrentCanSelectMultiple::<Identity, Impl, OFFSET>,
             CurrentIsSelectionRequired: CurrentIsSelectionRequired::<Identity, Impl, OFFSET>,
@@ -8515,7 +8515,7 @@ impl IUIAutomationSpreadsheetItemPattern_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CurrentFormula: CurrentFormula::<Identity, Impl, OFFSET>,
             GetCurrentAnnotationObjects: GetCurrentAnnotationObjects::<Identity, Impl, OFFSET>,
             GetCurrentAnnotationTypes: GetCurrentAnnotationTypes::<Identity, Impl, OFFSET>,
@@ -8545,7 +8545,7 @@ impl IUIAutomationSpreadsheetPattern_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetItemByName: GetItemByName::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetItemByName: GetItemByName::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IUIAutomationSpreadsheetPattern as ::windows::core::Interface>::IID
@@ -8566,7 +8566,7 @@ impl IUIAutomationStructureChangedEventHandler_Vtbl {
             this.HandleStructureChangedEvent(::core::mem::transmute(&sender), ::core::mem::transmute_copy(&changetype), ::core::mem::transmute_copy(&runtimeid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             HandleStructureChangedEvent: HandleStructureChangedEvent::<Identity, Impl, OFFSET>,
         }
     }
@@ -8760,7 +8760,7 @@ impl IUIAutomationStylesPattern_Vtbl {
             this.GetCachedExtendedPropertiesAsArray(::core::mem::transmute_copy(&propertyarray), ::core::mem::transmute_copy(&propertycount)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CurrentStyleId: CurrentStyleId::<Identity, Impl, OFFSET>,
             CurrentStyleName: CurrentStyleName::<Identity, Impl, OFFSET>,
             CurrentFillColor: CurrentFillColor::<Identity, Impl, OFFSET>,
@@ -8801,7 +8801,7 @@ impl IUIAutomationSynchronizedInputPattern_Vtbl {
             this.Cancel().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             StartListening: StartListening::<Identity, Impl, OFFSET>,
             Cancel: Cancel::<Identity, Impl, OFFSET>,
         }
@@ -8864,7 +8864,7 @@ impl IUIAutomationTableItemPattern_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCurrentRowHeaderItems: GetCurrentRowHeaderItems::<Identity, Impl, OFFSET>,
             GetCurrentColumnHeaderItems: GetCurrentColumnHeaderItems::<Identity, Impl, OFFSET>,
             GetCachedRowHeaderItems: GetCachedRowHeaderItems::<Identity, Impl, OFFSET>,
@@ -8953,7 +8953,7 @@ impl IUIAutomationTablePattern_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCurrentRowHeaders: GetCurrentRowHeaders::<Identity, Impl, OFFSET>,
             GetCurrentColumnHeaders: GetCurrentColumnHeaders::<Identity, Impl, OFFSET>,
             CurrentRowOrColumnMajor: CurrentRowOrColumnMajor::<Identity, Impl, OFFSET>,
@@ -8996,7 +8996,7 @@ impl IUIAutomationTextChildPattern_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             TextContainer: TextContainer::<Identity, Impl, OFFSET>,
             TextRange: TextRange::<Identity, Impl, OFFSET>,
         }
@@ -9062,7 +9062,7 @@ impl IUIAutomationTextEditTextChangedEventHandler_Vtbl {
             this.HandleTextEditTextChangedEvent(::core::mem::transmute(&sender), ::core::mem::transmute_copy(&texteditchangetype), ::core::mem::transmute_copy(&eventstrings)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             HandleTextEditTextChangedEvent: HandleTextEditTextChangedEvent::<Identity, Impl, OFFSET>,
         }
     }
@@ -9151,7 +9151,7 @@ impl IUIAutomationTextPattern_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RangeFromPoint: RangeFromPoint::<Identity, Impl, OFFSET>,
             RangeFromChild: RangeFromChild::<Identity, Impl, OFFSET>,
             GetSelection: GetSelection::<Identity, Impl, OFFSET>,
@@ -9389,7 +9389,7 @@ impl IUIAutomationTextRange_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Clone: Clone::<Identity, Impl, OFFSET>,
             Compare: Compare::<Identity, Impl, OFFSET>,
             CompareEndpoints: CompareEndpoints::<Identity, Impl, OFFSET>,
@@ -9519,7 +9519,7 @@ impl IUIAutomationTextRangeArray_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Length: Length::<Identity, Impl, OFFSET>,
             GetElement: GetElement::<Identity, Impl, OFFSET>,
         }
@@ -9564,7 +9564,7 @@ impl IUIAutomationTogglePattern_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Toggle: Toggle::<Identity, Impl, OFFSET>,
             CurrentToggleState: CurrentToggleState::<Identity, Impl, OFFSET>,
             CachedToggleState: CachedToggleState::<Identity, Impl, OFFSET>,
@@ -9673,7 +9673,7 @@ impl IUIAutomationTransformPattern_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Move: Move::<Identity, Impl, OFFSET>,
             Resize: Resize::<Identity, Impl, OFFSET>,
             Rotate: Rotate::<Identity, Impl, OFFSET>,
@@ -9985,7 +9985,7 @@ impl IUIAutomationTreeWalker_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetParentElement: GetParentElement::<Identity, Impl, OFFSET>,
             GetFirstChildElement: GetFirstChildElement::<Identity, Impl, OFFSET>,
             GetLastChildElement: GetLastChildElement::<Identity, Impl, OFFSET>,
@@ -10068,7 +10068,7 @@ impl IUIAutomationValuePattern_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetValue: SetValue::<Identity, Impl, OFFSET>,
             CurrentValue: CurrentValue::<Identity, Impl, OFFSET>,
             CurrentIsReadOnly: CurrentIsReadOnly::<Identity, Impl, OFFSET>,
@@ -10091,7 +10091,7 @@ impl IUIAutomationVirtualizedItemPattern_Vtbl {
             let this = (*this).get_impl();
             this.Realize().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Realize: Realize::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Realize: Realize::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IUIAutomationVirtualizedItemPattern as ::windows::core::Interface>::IID
@@ -10274,7 +10274,7 @@ impl IUIAutomationWindowPattern_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Close: Close::<Identity, Impl, OFFSET>,
             WaitForInputIdle: WaitForInputIdle::<Identity, Impl, OFFSET>,
             SetWindowVisualState: SetWindowVisualState::<Identity, Impl, OFFSET>,
@@ -10335,7 +10335,7 @@ impl IValueProvider_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetValue: SetValue::<Identity, Impl, OFFSET>,
             Value: Value::<Identity, Impl, OFFSET>,
             IsReadOnly: IsReadOnly::<Identity, Impl, OFFSET>,
@@ -10356,7 +10356,7 @@ impl IVirtualizedItemProvider_Vtbl {
             let this = (*this).get_impl();
             this.Realize().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Realize: Realize::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Realize: Realize::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IVirtualizedItemProvider as ::windows::core::Interface>::IID
@@ -10467,7 +10467,7 @@ impl IWindowProvider_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetVisualState: SetVisualState::<Identity, Impl, OFFSET>,
             Close: Close::<Identity, Impl, OFFSET>,
             WaitForInputIdle: WaitForInputIdle::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/UI/Accessibility/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Accessibility/mod.rs
@@ -1555,7 +1555,7 @@ unsafe impl ::windows::core::Interface for IAccIdentity {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAccIdentity_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetIdentityString: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwidchild: u32, ppidstring: *mut *mut u8, pdwidstringlen: *mut u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Accessibility\"`*"]
@@ -1606,7 +1606,7 @@ unsafe impl ::windows::core::Interface for IAccPropServer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAccPropServer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub GetPropValue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pidstring: *const u8, dwidstringlen: u32, idprop: ::windows::core::GUID, pvarvalue: *mut super::super::System::Com::VARIANT, pfhasprop: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole")))]
@@ -1768,7 +1768,7 @@ unsafe impl ::windows::core::Interface for IAccPropServices {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAccPropServices_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub SetPropValue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pidstring: *const u8, dwidstringlen: u32, idprop: ::windows::core::GUID, var: ::core::mem::ManuallyDrop<super::super::System::Com::VARIANT>) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole")))]
@@ -2210,7 +2210,7 @@ unsafe impl ::windows::core::Interface for IAccessibleEx {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAccessibleEx_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetObjectForChild: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, idchild: i32, pretval: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
     pub GetIAccessiblePair: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppacc: *mut *mut ::core::ffi::c_void, pidchild: *mut i32) -> ::windows::core::HRESULT,
@@ -2271,7 +2271,7 @@ unsafe impl ::windows::core::Interface for IAccessibleHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAccessibleHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub AccessibleObjectFromID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hwnd: i32, lobjectid: i32, piaccessible: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -2333,7 +2333,7 @@ unsafe impl ::windows::core::Interface for IAccessibleHostingElementProviders {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAccessibleHostingElementProviders_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub GetEmbeddedFragmentRoots: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pretval: *mut *mut super::super::System::Com::SAFEARRAY) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -2411,7 +2411,7 @@ unsafe impl ::windows::core::Interface for IAccessibleWindowlessSite {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAccessibleWindowlessSite_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AcquireObjectIdRange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, rangesize: i32, prangeowner: *mut ::core::ffi::c_void, prangebase: *mut i32) -> ::windows::core::HRESULT,
     pub ReleaseObjectIdRange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, rangebase: i32, prangeowner: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
@@ -2486,7 +2486,7 @@ unsafe impl ::windows::core::Interface for IAnnotationProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAnnotationProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AnnotationTypeId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, retval: *mut i32) -> ::windows::core::HRESULT,
     pub AnnotationTypeName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, retval: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub Author: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, retval: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
@@ -2540,7 +2540,7 @@ unsafe impl ::windows::core::Interface for ICustomNavigationProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICustomNavigationProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Navigate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, direction: NavigateDirection, pretval: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Accessibility\"`*"]
@@ -2593,7 +2593,7 @@ unsafe impl ::windows::core::Interface for IDockProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDockProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetDockPosition: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dockposition: DockPosition) -> ::windows::core::HRESULT,
     pub DockPosition: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pretval: *mut DockPosition) -> ::windows::core::HRESULT,
 }
@@ -2662,7 +2662,7 @@ unsafe impl ::windows::core::Interface for IDragProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDragProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub IsGrabbed: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pretval: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -2730,7 +2730,7 @@ unsafe impl ::windows::core::Interface for IDropTargetProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDropTargetProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub DropTargetEffect: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pretval: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
     pub DropTargetEffects: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pretval: *mut *mut super::super::System::Com::SAFEARRAY) -> ::windows::core::HRESULT,
@@ -2790,7 +2790,7 @@ unsafe impl ::windows::core::Interface for IExpandCollapseProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IExpandCollapseProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Expand: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Collapse: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub ExpandCollapseState: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pretval: *mut ExpandCollapseState) -> ::windows::core::HRESULT,
@@ -2858,7 +2858,7 @@ unsafe impl ::windows::core::Interface for IGridItemProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IGridItemProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Row: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pretval: *mut i32) -> ::windows::core::HRESULT,
     pub Column: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pretval: *mut i32) -> ::windows::core::HRESULT,
     pub RowSpan: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pretval: *mut i32) -> ::windows::core::HRESULT,
@@ -2920,7 +2920,7 @@ unsafe impl ::windows::core::Interface for IGridProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IGridProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetItem: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, row: i32, column: i32, pretval: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub RowCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pretval: *mut i32) -> ::windows::core::HRESULT,
     pub ColumnCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pretval: *mut i32) -> ::windows::core::HRESULT,
@@ -2971,7 +2971,7 @@ unsafe impl ::windows::core::Interface for IInvokeProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IInvokeProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Accessibility\"`*"]
@@ -3027,7 +3027,7 @@ unsafe impl ::windows::core::Interface for IItemContainerProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IItemContainerProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub FindItemByProperty: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pstartafter: *mut ::core::ffi::c_void, propertyid: i32, value: ::core::mem::ManuallyDrop<super::super::System::Com::VARIANT>, pfound: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole")))]
@@ -3136,7 +3136,7 @@ unsafe impl ::windows::core::Interface for ILegacyIAccessibleProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ILegacyIAccessibleProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Select: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, flagsselect: i32) -> ::windows::core::HRESULT,
     pub DoDefaultAction: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetValue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, szvalue: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
@@ -3218,7 +3218,7 @@ unsafe impl ::windows::core::Interface for IMultipleViewProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMultipleViewProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetViewName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, viewid: i32, pretval: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub SetCurrentView: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, viewid: i32) -> ::windows::core::HRESULT,
     pub CurrentView: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pretval: *mut i32) -> ::windows::core::HRESULT,
@@ -3274,7 +3274,7 @@ unsafe impl ::windows::core::Interface for IObjectModelProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IObjectModelProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetUnderlyingObjectModel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppunknown: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Accessibility\"`*"]
@@ -3329,7 +3329,7 @@ unsafe impl ::windows::core::Interface for IProxyProviderWinEventHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IProxyProviderWinEventHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub RespondToWinEvent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, idwinevent: u32, hwnd: super::super::Foundation::HWND, idobject: i32, idchild: i32, psink: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -3401,7 +3401,7 @@ unsafe impl ::windows::core::Interface for IProxyProviderWinEventSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IProxyProviderWinEventSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub AddAutomationPropertyChangedEvent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pprovider: *mut ::core::ffi::c_void, id: i32, newvalue: ::core::mem::ManuallyDrop<super::super::System::Com::VARIANT>) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole")))]
@@ -3484,7 +3484,7 @@ unsafe impl ::windows::core::Interface for IRangeValueProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRangeValueProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetValue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, val: f64) -> ::windows::core::HRESULT,
     pub Value: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pretval: *mut f64) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -3549,7 +3549,7 @@ unsafe impl ::windows::core::Interface for IRawElementProviderAdviseEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRawElementProviderAdviseEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub AdviseEventAdded: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, eventid: i32, propertyids: *const super::super::System::Com::SAFEARRAY) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -3629,7 +3629,7 @@ unsafe impl ::windows::core::Interface for IRawElementProviderFragment {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRawElementProviderFragment_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Navigate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, direction: NavigateDirection, pretval: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
     pub GetRuntimeId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pretval: *mut *mut super::super::System::Com::SAFEARRAY) -> ::windows::core::HRESULT,
@@ -3694,7 +3694,7 @@ unsafe impl ::windows::core::Interface for IRawElementProviderFragmentRoot {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRawElementProviderFragmentRoot_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ElementProviderFromPoint: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, x: f64, y: f64, pretval: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetFocus: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pretval: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -3747,7 +3747,7 @@ unsafe impl ::windows::core::Interface for IRawElementProviderHostingAccessibles
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRawElementProviderHostingAccessibles_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub GetEmbeddedAccessibles: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pretval: *mut *mut super::super::System::Com::SAFEARRAY) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -3805,7 +3805,7 @@ unsafe impl ::windows::core::Interface for IRawElementProviderHwndOverride {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRawElementProviderHwndOverride_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetOverrideProviderForHwnd: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hwnd: super::super::Foundation::HWND, pretval: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -3872,7 +3872,7 @@ unsafe impl ::windows::core::Interface for IRawElementProviderSimple {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRawElementProviderSimple_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ProviderOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pretval: *mut ProviderOptions) -> ::windows::core::HRESULT,
     pub GetPatternProvider: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, patternid: i32, pretval: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -4122,7 +4122,7 @@ unsafe impl ::windows::core::Interface for IRawElementProviderWindowlessSite {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRawElementProviderWindowlessSite_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetAdjacentFragment: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, direction: NavigateDirection, ppparent: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
     pub GetRuntimeIdPrefix: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pretval: *mut *mut super::super::System::Com::SAFEARRAY) -> ::windows::core::HRESULT,
@@ -4178,7 +4178,7 @@ unsafe impl ::windows::core::Interface for IRichEditUiaInformation {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRichEditUiaInformation_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetBoundaryRectangle: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, puiarect: *mut UiaRect) -> ::windows::core::HRESULT,
     pub IsVisible: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -4232,7 +4232,7 @@ unsafe impl ::windows::core::Interface for IRicheditWindowlessAccessibility {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRicheditWindowlessAccessibility_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateProvider: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psite: *mut ::core::ffi::c_void, ppprovider: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Accessibility\"`*"]
@@ -4281,7 +4281,7 @@ unsafe impl ::windows::core::Interface for IScrollItemProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IScrollItemProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ScrollIntoView: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Accessibility\"`*"]
@@ -4361,7 +4361,7 @@ unsafe impl ::windows::core::Interface for IScrollProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IScrollProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Scroll: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, horizontalamount: ScrollAmount, verticalamount: ScrollAmount) -> ::windows::core::HRESULT,
     pub SetScrollPercent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, horizontalpercent: f64, verticalpercent: f64) -> ::windows::core::HRESULT,
     pub HorizontalScrollPercent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pretval: *mut f64) -> ::windows::core::HRESULT,
@@ -4439,7 +4439,7 @@ unsafe impl ::windows::core::Interface for ISelectionItemProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISelectionItemProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Select: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub AddToSelection: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub RemoveFromSelection: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -4510,7 +4510,7 @@ unsafe impl ::windows::core::Interface for ISelectionProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISelectionProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub GetSelection: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pretval: *mut *mut super::super::System::Com::SAFEARRAY) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -4681,7 +4681,7 @@ unsafe impl ::windows::core::Interface for ISpreadsheetItemProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISpreadsheetItemProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Formula: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pretval: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
     pub GetAnnotationObjects: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pretval: *mut *mut super::super::System::Com::SAFEARRAY) -> ::windows::core::HRESULT,
@@ -4742,7 +4742,7 @@ unsafe impl ::windows::core::Interface for ISpreadsheetProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISpreadsheetProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetItemByName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, name: ::windows::core::PCWSTR, pretval: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Accessibility\"`*"]
@@ -4816,7 +4816,7 @@ unsafe impl ::windows::core::Interface for IStylesProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IStylesProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub StyleId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, retval: *mut i32) -> ::windows::core::HRESULT,
     pub StyleName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, retval: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub FillColor: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, retval: *mut i32) -> ::windows::core::HRESULT,
@@ -4874,7 +4874,7 @@ unsafe impl ::windows::core::Interface for ISynchronizedInputProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISynchronizedInputProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub StartListening: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, inputtype: SynchronizedInputType) -> ::windows::core::HRESULT,
     pub Cancel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -4933,7 +4933,7 @@ unsafe impl ::windows::core::Interface for ITableItemProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITableItemProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub GetRowHeaderItems: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pretval: *mut *mut super::super::System::Com::SAFEARRAY) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -5002,7 +5002,7 @@ unsafe impl ::windows::core::Interface for ITableProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITableProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub GetRowHeaders: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pretval: *mut *mut super::super::System::Com::SAFEARRAY) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -5064,7 +5064,7 @@ unsafe impl ::windows::core::Interface for ITextChildProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITextChildProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub TextContainer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pretval: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub TextRange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pretval: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -5243,7 +5243,7 @@ unsafe impl ::windows::core::Interface for ITextProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITextProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub GetSelection: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pretval: *mut *mut super::super::System::Com::SAFEARRAY) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -5508,7 +5508,7 @@ unsafe impl ::windows::core::Interface for ITextRangeProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITextRangeProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Clone: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pretval: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub Compare: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, range: *mut ::core::ffi::c_void, pretval: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -5763,7 +5763,7 @@ unsafe impl ::windows::core::Interface for IToggleProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IToggleProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Toggle: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub ToggleState: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pretval: *mut ToggleState) -> ::windows::core::HRESULT,
 }
@@ -5837,7 +5837,7 @@ unsafe impl ::windows::core::Interface for ITransformProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITransformProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Move: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, x: f64, y: f64) -> ::windows::core::HRESULT,
     pub Resize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, width: f64, height: f64) -> ::windows::core::HRESULT,
     pub Rotate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, degrees: f64) -> ::windows::core::HRESULT,
@@ -6366,7 +6366,7 @@ unsafe impl ::windows::core::Interface for IUIAutomation {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAutomation_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub CompareElements: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, el1: *mut ::core::ffi::c_void, el2: *mut ::core::ffi::c_void, aresame: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -9080,7 +9080,7 @@ unsafe impl ::windows::core::Interface for IUIAutomationActiveTextPositionChange
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAutomationActiveTextPositionChangedEventHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub HandleActiveTextPositionChangedEvent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sender: *mut ::core::ffi::c_void, range: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Accessibility\"`*"]
@@ -9245,7 +9245,7 @@ unsafe impl ::windows::core::Interface for IUIAutomationAnnotationPattern {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAutomationAnnotationPattern_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CurrentAnnotationTypeId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, retval: *mut i32) -> ::windows::core::HRESULT,
     pub CurrentAnnotationTypeName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, retval: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub CurrentAuthor: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, retval: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
@@ -9404,7 +9404,7 @@ unsafe impl ::windows::core::Interface for IUIAutomationCacheRequest {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAutomationCacheRequest_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddProperty: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, propertyid: i32) -> ::windows::core::HRESULT,
     pub AddPattern: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, patternid: i32) -> ::windows::core::HRESULT,
     pub Clone: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, clonedrequest: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -9466,7 +9466,7 @@ unsafe impl ::windows::core::Interface for IUIAutomationChangesEventHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAutomationChangesEventHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub HandleChangesEvent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sender: *mut ::core::ffi::c_void, uiachanges: *const UiaChangeInfo, changescount: i32) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole")))]
@@ -9514,7 +9514,7 @@ unsafe impl ::windows::core::Interface for IUIAutomationCondition {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAutomationCondition_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
 }
 #[doc = "*Required features: `\"Win32_UI_Accessibility\"`*"]
 #[repr(transparent)]
@@ -9563,7 +9563,7 @@ unsafe impl ::windows::core::Interface for IUIAutomationCustomNavigationPattern 
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAutomationCustomNavigationPattern_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Navigate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, direction: NavigateDirection, pretval: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Accessibility\"`*"]
@@ -9620,7 +9620,7 @@ unsafe impl ::windows::core::Interface for IUIAutomationDockPattern {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAutomationDockPattern_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetDockPosition: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dockpos: DockPosition) -> ::windows::core::HRESULT,
     pub CurrentDockPosition: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, retval: *mut DockPosition) -> ::windows::core::HRESULT,
     pub CachedDockPosition: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, retval: *mut DockPosition) -> ::windows::core::HRESULT,
@@ -9708,7 +9708,7 @@ unsafe impl ::windows::core::Interface for IUIAutomationDragPattern {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAutomationDragPattern_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub CurrentIsGrabbed: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, retval: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -9793,7 +9793,7 @@ unsafe impl ::windows::core::Interface for IUIAutomationDropTargetPattern {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAutomationDropTargetPattern_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CurrentDropTargetEffect: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, retval: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub CachedDropTargetEffect: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, retval: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
@@ -10259,7 +10259,7 @@ unsafe impl ::windows::core::Interface for IUIAutomationElement {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAutomationElement_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetFocus: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
     pub GetRuntimeId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, runtimeid: *mut *mut super::super::System::Com::SAFEARRAY) -> ::windows::core::HRESULT,
@@ -15580,7 +15580,7 @@ unsafe impl ::windows::core::Interface for IUIAutomationElementArray {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAutomationElementArray_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Length: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, length: *mut i32) -> ::windows::core::HRESULT,
     pub GetElement: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: i32, element: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -15633,7 +15633,7 @@ unsafe impl ::windows::core::Interface for IUIAutomationEventHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAutomationEventHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub HandleAutomationEvent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sender: *mut ::core::ffi::c_void, eventid: i32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Accessibility\"`*"]
@@ -15728,7 +15728,7 @@ unsafe impl ::windows::core::Interface for IUIAutomationEventHandlerGroup {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAutomationEventHandlerGroup_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddActiveTextPositionChangedEventHandler: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, scope: TreeScope, cacherequest: *mut ::core::ffi::c_void, handler: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub AddAutomationEventHandler: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, eventid: i32, scope: TreeScope, cacherequest: *mut ::core::ffi::c_void, handler: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub AddChangesEventHandler: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, scope: TreeScope, changetypes: *const i32, changescount: i32, cacherequest: *mut ::core::ffi::c_void, handler: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -15794,7 +15794,7 @@ unsafe impl ::windows::core::Interface for IUIAutomationExpandCollapsePattern {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAutomationExpandCollapsePattern_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Expand: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Collapse: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CurrentExpandCollapseState: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, retval: *mut ExpandCollapseState) -> ::windows::core::HRESULT,
@@ -15849,7 +15849,7 @@ unsafe impl ::windows::core::Interface for IUIAutomationFocusChangedEventHandler
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAutomationFocusChangedEventHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub HandleFocusChangedEvent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sender: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Accessibility\"`*"]
@@ -15935,7 +15935,7 @@ unsafe impl ::windows::core::Interface for IUIAutomationGridItemPattern {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAutomationGridItemPattern_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CurrentContainingGrid: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, retval: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CurrentRow: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, retval: *mut i32) -> ::windows::core::HRESULT,
     pub CurrentColumn: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, retval: *mut i32) -> ::windows::core::HRESULT,
@@ -16010,7 +16010,7 @@ unsafe impl ::windows::core::Interface for IUIAutomationGridPattern {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAutomationGridPattern_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetItem: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, row: i32, column: i32, element: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CurrentRowCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, retval: *mut i32) -> ::windows::core::HRESULT,
     pub CurrentColumnCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, retval: *mut i32) -> ::windows::core::HRESULT,
@@ -16063,7 +16063,7 @@ unsafe impl ::windows::core::Interface for IUIAutomationInvokePattern {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAutomationInvokePattern_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Accessibility\"`*"]
@@ -16119,7 +16119,7 @@ unsafe impl ::windows::core::Interface for IUIAutomationItemContainerPattern {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAutomationItemContainerPattern_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub FindItemByProperty: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pstartafter: *mut ::core::ffi::c_void, propertyid: i32, value: ::core::mem::ManuallyDrop<super::super::System::Com::VARIANT>, pfound: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole")))]
@@ -16266,7 +16266,7 @@ unsafe impl ::windows::core::Interface for IUIAutomationLegacyIAccessiblePattern
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAutomationLegacyIAccessiblePattern_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Select: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, flagsselect: i32) -> ::windows::core::HRESULT,
     pub DoDefaultAction: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetValue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, szvalue: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
@@ -16365,7 +16365,7 @@ unsafe impl ::windows::core::Interface for IUIAutomationMultipleViewPattern {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAutomationMultipleViewPattern_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetViewName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, view: i32, name: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub SetCurrentView: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, view: i32) -> ::windows::core::HRESULT,
     pub CurrentCurrentView: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, retval: *mut i32) -> ::windows::core::HRESULT,
@@ -16493,7 +16493,7 @@ unsafe impl ::windows::core::Interface for IUIAutomationNotificationEventHandler
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAutomationNotificationEventHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub HandleNotificationEvent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sender: *mut ::core::ffi::c_void, notificationkind: NotificationKind, notificationprocessing: NotificationProcessing, displaystring: ::core::mem::ManuallyDrop<::windows::core::BSTR>, activityid: ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Accessibility\"`*"]
@@ -16543,7 +16543,7 @@ unsafe impl ::windows::core::Interface for IUIAutomationObjectModelPattern {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAutomationObjectModelPattern_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetUnderlyingObjectModel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, retval: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Accessibility\"`*"]
@@ -16681,7 +16681,7 @@ unsafe impl ::windows::core::Interface for IUIAutomationPatternHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAutomationPatternHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateClientWrapper: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppatterninstance: *mut ::core::ffi::c_void, pclientwrapper: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Dispatch: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptarget: *mut ::core::ffi::c_void, index: u32, pparams: *const UIAutomationParameter, cparams: u32) -> ::windows::core::HRESULT,
 }
@@ -16739,7 +16739,7 @@ unsafe impl ::windows::core::Interface for IUIAutomationPatternInstance {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAutomationPatternInstance_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetProperty: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: u32, cached: super::super::Foundation::BOOL, r#type: UIAutomationType, pptr: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -16798,7 +16798,7 @@ unsafe impl ::windows::core::Interface for IUIAutomationPropertyChangedEventHand
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAutomationPropertyChangedEventHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub HandlePropertyChangedEvent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sender: *mut ::core::ffi::c_void, propertyid: i32, newvalue: ::core::mem::ManuallyDrop<super::super::System::Com::VARIANT>) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole")))]
@@ -16940,7 +16940,7 @@ unsafe impl ::windows::core::Interface for IUIAutomationProxyFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAutomationProxyFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub CreateProvider: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hwnd: super::super::Foundation::HWND, idobject: i32, idchild: i32, provider: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -17067,7 +17067,7 @@ unsafe impl ::windows::core::Interface for IUIAutomationProxyFactoryEntry {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAutomationProxyFactoryEntry_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ProxyFactory: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, factory: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub ClassName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, classname: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub ImageName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, imagename: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
@@ -17188,7 +17188,7 @@ unsafe impl ::windows::core::Interface for IUIAutomationProxyFactoryMapping {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAutomationProxyFactoryMapping_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Count: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, count: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
     pub GetTable: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, table: *mut *mut super::super::System::Com::SAFEARRAY) -> ::windows::core::HRESULT,
@@ -17306,7 +17306,7 @@ unsafe impl ::windows::core::Interface for IUIAutomationRangeValuePattern {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAutomationRangeValuePattern_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetValue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, val: f64) -> ::windows::core::HRESULT,
     pub CurrentValue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, retval: *mut f64) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -17383,7 +17383,7 @@ unsafe impl ::windows::core::Interface for IUIAutomationRegistrar {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAutomationRegistrar_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub RegisterProperty: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, property: *const UIAutomationPropertyInfo, propertyid: *mut i32) -> ::windows::core::HRESULT,
     pub RegisterEvent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, event: *const UIAutomationEventInfo, eventid: *mut i32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -17437,7 +17437,7 @@ unsafe impl ::windows::core::Interface for IUIAutomationScrollItemPattern {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAutomationScrollItemPattern_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ScrollIntoView: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Accessibility\"`*"]
@@ -17545,7 +17545,7 @@ unsafe impl ::windows::core::Interface for IUIAutomationScrollPattern {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAutomationScrollPattern_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Scroll: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, horizontalamount: ScrollAmount, verticalamount: ScrollAmount) -> ::windows::core::HRESULT,
     pub SetScrollPercent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, horizontalpercent: f64, verticalpercent: f64) -> ::windows::core::HRESULT,
     pub CurrentHorizontalScrollPercent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, retval: *mut f64) -> ::windows::core::HRESULT,
@@ -17645,7 +17645,7 @@ unsafe impl ::windows::core::Interface for IUIAutomationSelectionItemPattern {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAutomationSelectionItemPattern_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Select: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub AddToSelection: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub RemoveFromSelection: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -17735,7 +17735,7 @@ unsafe impl ::windows::core::Interface for IUIAutomationSelectionPattern {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAutomationSelectionPattern_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCurrentSelection: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, retval: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub CurrentCanSelectMultiple: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, retval: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -17958,7 +17958,7 @@ unsafe impl ::windows::core::Interface for IUIAutomationSpreadsheetItemPattern {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAutomationSpreadsheetItemPattern_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CurrentFormula: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, retval: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub GetCurrentAnnotationObjects: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, retval: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
@@ -18019,7 +18019,7 @@ unsafe impl ::windows::core::Interface for IUIAutomationSpreadsheetPattern {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAutomationSpreadsheetPattern_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetItemByName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, name: ::core::mem::ManuallyDrop<::windows::core::BSTR>, element: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Accessibility\"`*"]
@@ -18073,7 +18073,7 @@ unsafe impl ::windows::core::Interface for IUIAutomationStructureChangedEventHan
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAutomationStructureChangedEventHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub HandleStructureChangedEvent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sender: *mut ::core::ffi::c_void, changetype: StructureChangeType, runtimeid: *const super::super::System::Com::SAFEARRAY) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -18184,7 +18184,7 @@ unsafe impl ::windows::core::Interface for IUIAutomationStylesPattern {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAutomationStylesPattern_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CurrentStyleId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, retval: *mut i32) -> ::windows::core::HRESULT,
     pub CurrentStyleName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, retval: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub CurrentFillColor: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, retval: *mut i32) -> ::windows::core::HRESULT,
@@ -18251,7 +18251,7 @@ unsafe impl ::windows::core::Interface for IUIAutomationSynchronizedInputPattern
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAutomationSynchronizedInputPattern_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub StartListening: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, inputtype: SynchronizedInputType) -> ::windows::core::HRESULT,
     pub Cancel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -18314,7 +18314,7 @@ unsafe impl ::windows::core::Interface for IUIAutomationTableItemPattern {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAutomationTableItemPattern_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCurrentRowHeaderItems: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, retval: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetCurrentColumnHeaderItems: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, retval: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetCachedRowHeaderItems: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, retval: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -18387,7 +18387,7 @@ unsafe impl ::windows::core::Interface for IUIAutomationTablePattern {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAutomationTablePattern_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCurrentRowHeaders: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, retval: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetCurrentColumnHeaders: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, retval: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CurrentRowOrColumnMajor: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, retval: *mut RowOrColumnMajor) -> ::windows::core::HRESULT,
@@ -18446,7 +18446,7 @@ unsafe impl ::windows::core::Interface for IUIAutomationTextChildPattern {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAutomationTextChildPattern_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub TextContainer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, container: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub TextRange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, range: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -18600,7 +18600,7 @@ unsafe impl ::windows::core::Interface for IUIAutomationTextEditTextChangedEvent
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAutomationTextEditTextChangedEventHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub HandleTextEditTextChangedEvent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sender: *mut ::core::ffi::c_void, texteditchangetype: TextEditChangeType, eventstrings: *const super::super::System::Com::SAFEARRAY) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -18678,7 +18678,7 @@ unsafe impl ::windows::core::Interface for IUIAutomationTextPattern {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAutomationTextPattern_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub RangeFromPoint: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pt: super::super::Foundation::POINT, range: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -18936,7 +18936,7 @@ unsafe impl ::windows::core::Interface for IUIAutomationTextRange {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAutomationTextRange_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Clone: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, clonedrange: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub Compare: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, range: *mut ::core::ffi::c_void, aresame: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -19389,7 +19389,7 @@ unsafe impl ::windows::core::Interface for IUIAutomationTextRangeArray {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAutomationTextRangeArray_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Length: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, length: *mut i32) -> ::windows::core::HRESULT,
     pub GetElement: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: i32, element: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -19447,7 +19447,7 @@ unsafe impl ::windows::core::Interface for IUIAutomationTogglePattern {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAutomationTogglePattern_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Toggle: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CurrentToggleState: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, retval: *mut ToggleState) -> ::windows::core::HRESULT,
     pub CachedToggleState: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, retval: *mut ToggleState) -> ::windows::core::HRESULT,
@@ -19540,7 +19540,7 @@ unsafe impl ::windows::core::Interface for IUIAutomationTransformPattern {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAutomationTransformPattern_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Move: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, x: f64, y: f64) -> ::windows::core::HRESULT,
     pub Resize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, width: f64, height: f64) -> ::windows::core::HRESULT,
     pub Rotate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, degrees: f64) -> ::windows::core::HRESULT,
@@ -19869,7 +19869,7 @@ unsafe impl ::windows::core::Interface for IUIAutomationTreeWalker {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAutomationTreeWalker_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetParentElement: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, element: *mut ::core::ffi::c_void, parent: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetFirstChildElement: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, element: *mut ::core::ffi::c_void, first: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetLastChildElement: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, element: *mut ::core::ffi::c_void, last: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -19950,7 +19950,7 @@ unsafe impl ::windows::core::Interface for IUIAutomationValuePattern {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAutomationValuePattern_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetValue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, val: ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub CurrentValue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, retval: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -20009,7 +20009,7 @@ unsafe impl ::windows::core::Interface for IUIAutomationVirtualizedItemPattern {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAutomationVirtualizedItemPattern_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Realize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Accessibility\"`*"]
@@ -20131,7 +20131,7 @@ unsafe impl ::windows::core::Interface for IUIAutomationWindowPattern {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAutomationWindowPattern_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Close: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub WaitForInputIdle: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, milliseconds: i32, success: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -20234,7 +20234,7 @@ unsafe impl ::windows::core::Interface for IValueProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IValueProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetValue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, val: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub Value: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pretval: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -20288,7 +20288,7 @@ unsafe impl ::windows::core::Interface for IVirtualizedItemProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVirtualizedItemProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Realize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Accessibility\"`*"]
@@ -20378,7 +20378,7 @@ unsafe impl ::windows::core::Interface for IWindowProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWindowProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetVisualState: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, state: WindowVisualState) -> ::windows::core::HRESULT,
     pub Close: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]

--- a/crates/libs/windows/src/Windows/Win32/UI/Animation/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Animation/impl.rs
@@ -70,7 +70,7 @@ impl IUIAnimationInterpolator_Vtbl {
             this.GetDependencies(::core::mem::transmute_copy(&initialvaluedependencies), ::core::mem::transmute_copy(&initialvelocitydependencies), ::core::mem::transmute_copy(&durationdependencies)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetInitialValueAndVelocity: SetInitialValueAndVelocity::<Identity, Impl, OFFSET>,
             SetDuration: SetDuration::<Identity, Impl, OFFSET>,
             GetDuration: GetDuration::<Identity, Impl, OFFSET>,
@@ -156,7 +156,7 @@ impl IUIAnimationInterpolator2_Vtbl {
             this.GetDependencies(::core::mem::transmute_copy(&initialvaluedependencies), ::core::mem::transmute_copy(&initialvelocitydependencies), ::core::mem::transmute_copy(&durationdependencies)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDimension: GetDimension::<Identity, Impl, OFFSET>,
             SetInitialValueAndVelocity: SetInitialValueAndVelocity::<Identity, Impl, OFFSET>,
             SetDuration: SetDuration::<Identity, Impl, OFFSET>,
@@ -183,7 +183,7 @@ impl IUIAnimationLoopIterationChangeHandler2_Vtbl {
             let this = (*this).get_impl();
             this.OnLoopIterationChanged(::core::mem::transmute(&storyboard), ::core::mem::transmute_copy(&id), ::core::mem::transmute_copy(&newiterationcount), ::core::mem::transmute_copy(&olditerationcount)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnLoopIterationChanged: OnLoopIterationChanged::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnLoopIterationChanged: OnLoopIterationChanged::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IUIAnimationLoopIterationChangeHandler2 as ::windows::core::Interface>::IID
@@ -345,7 +345,7 @@ impl IUIAnimationManager_Vtbl {
             this.Shutdown().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateAnimationVariable: CreateAnimationVariable::<Identity, Impl, OFFSET>,
             ScheduleTransition: ScheduleTransition::<Identity, Impl, OFFSET>,
             CreateStoryboard: CreateStoryboard::<Identity, Impl, OFFSET>,
@@ -554,7 +554,7 @@ impl IUIAnimationManager2_Vtbl {
             this.Shutdown().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateAnimationVectorVariable: CreateAnimationVectorVariable::<Identity, Impl, OFFSET>,
             CreateAnimationVariable: CreateAnimationVariable::<Identity, Impl, OFFSET>,
             ScheduleTransition: ScheduleTransition::<Identity, Impl, OFFSET>,
@@ -593,7 +593,7 @@ impl IUIAnimationManagerEventHandler_Vtbl {
             let this = (*this).get_impl();
             this.OnManagerStatusChanged(::core::mem::transmute_copy(&newstatus), ::core::mem::transmute_copy(&previousstatus)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnManagerStatusChanged: OnManagerStatusChanged::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnManagerStatusChanged: OnManagerStatusChanged::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IUIAnimationManagerEventHandler as ::windows::core::Interface>::IID
@@ -610,7 +610,7 @@ impl IUIAnimationManagerEventHandler2_Vtbl {
             let this = (*this).get_impl();
             this.OnManagerStatusChanged(::core::mem::transmute_copy(&newstatus), ::core::mem::transmute_copy(&previousstatus)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnManagerStatusChanged: OnManagerStatusChanged::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnManagerStatusChanged: OnManagerStatusChanged::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IUIAnimationManagerEventHandler2 as ::windows::core::Interface>::IID
@@ -634,7 +634,7 @@ impl IUIAnimationPrimitiveInterpolation_Vtbl {
             this.AddSinusoidal(::core::mem::transmute_copy(&dimension), ::core::mem::transmute_copy(&beginoffset), ::core::mem::transmute_copy(&bias), ::core::mem::transmute_copy(&amplitude), ::core::mem::transmute_copy(&frequency), ::core::mem::transmute_copy(&phase)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddCubic: AddCubic::<Identity, Impl, OFFSET>,
             AddSinusoidal: AddSinusoidal::<Identity, Impl, OFFSET>,
         }
@@ -654,7 +654,7 @@ impl IUIAnimationPriorityComparison_Vtbl {
             let this = (*this).get_impl();
             this.HasPriority(::core::mem::transmute(&scheduledstoryboard), ::core::mem::transmute(&newstoryboard), ::core::mem::transmute_copy(&priorityeffect)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), HasPriority: HasPriority::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), HasPriority: HasPriority::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IUIAnimationPriorityComparison as ::windows::core::Interface>::IID
@@ -671,7 +671,7 @@ impl IUIAnimationPriorityComparison2_Vtbl {
             let this = (*this).get_impl();
             this.HasPriority(::core::mem::transmute(&scheduledstoryboard), ::core::mem::transmute(&newstoryboard), ::core::mem::transmute_copy(&priorityeffect)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), HasPriority: HasPriority::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), HasPriority: HasPriority::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IUIAnimationPriorityComparison2 as ::windows::core::Interface>::IID
@@ -815,7 +815,7 @@ impl IUIAnimationStoryboard_Vtbl {
             this.SetStoryboardEventHandler(::core::mem::transmute(&handler)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddTransition: AddTransition::<Identity, Impl, OFFSET>,
             AddKeyframeAtOffset: AddKeyframeAtOffset::<Identity, Impl, OFFSET>,
             AddKeyframeAfterTransition: AddKeyframeAfterTransition::<Identity, Impl, OFFSET>,
@@ -986,7 +986,7 @@ impl IUIAnimationStoryboard2_Vtbl {
             this.SetStoryboardEventHandler(::core::mem::transmute(&handler), ::core::mem::transmute_copy(&fregisterstatuschangefornextanimationevent), ::core::mem::transmute_copy(&fregisterupdatefornextanimationevent)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddTransition: AddTransition::<Identity, Impl, OFFSET>,
             AddKeyframeAtOffset: AddKeyframeAtOffset::<Identity, Impl, OFFSET>,
             AddKeyframeAfterTransition: AddKeyframeAfterTransition::<Identity, Impl, OFFSET>,
@@ -1029,7 +1029,7 @@ impl IUIAnimationStoryboardEventHandler_Vtbl {
             this.OnStoryboardUpdated(::core::mem::transmute(&storyboard)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnStoryboardStatusChanged: OnStoryboardStatusChanged::<Identity, Impl, OFFSET>,
             OnStoryboardUpdated: OnStoryboardUpdated::<Identity, Impl, OFFSET>,
         }
@@ -1056,7 +1056,7 @@ impl IUIAnimationStoryboardEventHandler2_Vtbl {
             this.OnStoryboardUpdated(::core::mem::transmute(&storyboard)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnStoryboardStatusChanged: OnStoryboardStatusChanged::<Identity, Impl, OFFSET>,
             OnStoryboardUpdated: OnStoryboardUpdated::<Identity, Impl, OFFSET>,
         }
@@ -1119,7 +1119,7 @@ impl IUIAnimationTimer_Vtbl {
             this.SetFrameRateThreshold(::core::mem::transmute_copy(&framespersecond)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetTimerUpdateHandler: SetTimerUpdateHandler::<Identity, Impl, OFFSET>,
             SetTimerEventHandler: SetTimerEventHandler::<Identity, Impl, OFFSET>,
             Enable: Enable::<Identity, Impl, OFFSET>,
@@ -1145,7 +1145,7 @@ impl IUIAnimationTimerClientEventHandler_Vtbl {
             this.OnTimerClientStatusChanged(::core::mem::transmute_copy(&newstatus), ::core::mem::transmute_copy(&previousstatus)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnTimerClientStatusChanged: OnTimerClientStatusChanged::<Identity, Impl, OFFSET>,
         }
     }
@@ -1177,7 +1177,7 @@ impl IUIAnimationTimerEventHandler_Vtbl {
             this.OnRenderingTooSlow(::core::mem::transmute_copy(&framespersecond)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnPreUpdate: OnPreUpdate::<Identity, Impl, OFFSET>,
             OnPostUpdate: OnPostUpdate::<Identity, Impl, OFFSET>,
             OnRenderingTooSlow: OnRenderingTooSlow::<Identity, Impl, OFFSET>,
@@ -1217,7 +1217,7 @@ impl IUIAnimationTimerUpdateHandler_Vtbl {
             this.ClearTimerClientEventHandler().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnUpdate: OnUpdate::<Identity, Impl, OFFSET>,
             SetTimerClientEventHandler: SetTimerClientEventHandler::<Identity, Impl, OFFSET>,
             ClearTimerClientEventHandler: ClearTimerClientEventHandler::<Identity, Impl, OFFSET>,
@@ -1263,7 +1263,7 @@ impl IUIAnimationTransition_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetInitialValue: SetInitialValue::<Identity, Impl, OFFSET>,
             SetInitialVelocity: SetInitialVelocity::<Identity, Impl, OFFSET>,
             IsDurationKnown: IsDurationKnown::<Identity, Impl, OFFSET>,
@@ -1334,7 +1334,7 @@ impl IUIAnimationTransition2_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDimension: GetDimension::<Identity, Impl, OFFSET>,
             SetInitialValue: SetInitialValue::<Identity, Impl, OFFSET>,
             SetInitialVectorValue: SetInitialVectorValue::<Identity, Impl, OFFSET>,
@@ -1365,7 +1365,7 @@ impl IUIAnimationTransitionFactory_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CreateTransition: CreateTransition::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CreateTransition: CreateTransition::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IUIAnimationTransitionFactory as ::windows::core::Interface>::IID
@@ -1388,7 +1388,7 @@ impl IUIAnimationTransitionFactory2_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CreateTransition: CreateTransition::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CreateTransition: CreateTransition::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IUIAnimationTransitionFactory2 as ::windows::core::Interface>::IID
@@ -1544,7 +1544,7 @@ impl IUIAnimationTransitionLibrary_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateInstantaneousTransition: CreateInstantaneousTransition::<Identity, Impl, OFFSET>,
             CreateConstantTransition: CreateConstantTransition::<Identity, Impl, OFFSET>,
             CreateDiscreteTransition: CreateDiscreteTransition::<Identity, Impl, OFFSET>,
@@ -1797,7 +1797,7 @@ impl IUIAnimationTransitionLibrary2_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateInstantaneousTransition: CreateInstantaneousTransition::<Identity, Impl, OFFSET>,
             CreateInstantaneousVectorTransition: CreateInstantaneousVectorTransition::<Identity, Impl, OFFSET>,
             CreateConstantTransition: CreateConstantTransition::<Identity, Impl, OFFSET>,
@@ -1955,7 +1955,7 @@ impl IUIAnimationVariable_Vtbl {
             this.SetVariableIntegerChangeHandler(::core::mem::transmute(&handler)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetValue: GetValue::<Identity, Impl, OFFSET>,
             GetFinalValue: GetFinalValue::<Identity, Impl, OFFSET>,
             GetPreviousValue: GetPreviousValue::<Identity, Impl, OFFSET>,
@@ -2189,7 +2189,7 @@ impl IUIAnimationVariable2_Vtbl {
             this.SetVariableCurveChangeHandler(::core::mem::transmute(&handler)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDimension: GetDimension::<Identity, Impl, OFFSET>,
             GetValue: GetValue::<Identity, Impl, OFFSET>,
             GetVectorValue: GetVectorValue::<Identity, Impl, OFFSET>,
@@ -2233,7 +2233,7 @@ impl IUIAnimationVariableChangeHandler_Vtbl {
             let this = (*this).get_impl();
             this.OnValueChanged(::core::mem::transmute(&storyboard), ::core::mem::transmute(&variable), ::core::mem::transmute_copy(&newvalue), ::core::mem::transmute_copy(&previousvalue)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnValueChanged: OnValueChanged::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnValueChanged: OnValueChanged::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IUIAnimationVariableChangeHandler as ::windows::core::Interface>::IID
@@ -2250,7 +2250,7 @@ impl IUIAnimationVariableChangeHandler2_Vtbl {
             let this = (*this).get_impl();
             this.OnValueChanged(::core::mem::transmute(&storyboard), ::core::mem::transmute(&variable), ::core::mem::transmute_copy(&newvalue), ::core::mem::transmute_copy(&previousvalue), ::core::mem::transmute_copy(&cdimension)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnValueChanged: OnValueChanged::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnValueChanged: OnValueChanged::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IUIAnimationVariableChangeHandler2 as ::windows::core::Interface>::IID
@@ -2267,7 +2267,7 @@ impl IUIAnimationVariableCurveChangeHandler2_Vtbl {
             let this = (*this).get_impl();
             this.OnCurveChanged(::core::mem::transmute(&variable)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnCurveChanged: OnCurveChanged::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnCurveChanged: OnCurveChanged::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IUIAnimationVariableCurveChangeHandler2 as ::windows::core::Interface>::IID
@@ -2284,7 +2284,7 @@ impl IUIAnimationVariableIntegerChangeHandler_Vtbl {
             let this = (*this).get_impl();
             this.OnIntegerValueChanged(::core::mem::transmute(&storyboard), ::core::mem::transmute(&variable), ::core::mem::transmute_copy(&newvalue), ::core::mem::transmute_copy(&previousvalue)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnIntegerValueChanged: OnIntegerValueChanged::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnIntegerValueChanged: OnIntegerValueChanged::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IUIAnimationVariableIntegerChangeHandler as ::windows::core::Interface>::IID
@@ -2301,7 +2301,7 @@ impl IUIAnimationVariableIntegerChangeHandler2_Vtbl {
             let this = (*this).get_impl();
             this.OnIntegerValueChanged(::core::mem::transmute(&storyboard), ::core::mem::transmute(&variable), ::core::mem::transmute_copy(&newvalue), ::core::mem::transmute_copy(&previousvalue), ::core::mem::transmute_copy(&cdimension)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnIntegerValueChanged: OnIntegerValueChanged::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnIntegerValueChanged: OnIntegerValueChanged::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IUIAnimationVariableIntegerChangeHandler2 as ::windows::core::Interface>::IID

--- a/crates/libs/windows/src/Windows/Win32/UI/Animation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Animation/mod.rs
@@ -66,7 +66,7 @@ unsafe impl ::windows::core::Interface for IUIAnimationInterpolator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAnimationInterpolator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetInitialValueAndVelocity: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, initialvalue: f64, initialvelocity: f64) -> ::windows::core::HRESULT,
     pub SetDuration: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, duration: f64) -> ::windows::core::HRESULT,
     pub GetDuration: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, duration: *mut f64) -> ::windows::core::HRESULT,
@@ -150,7 +150,7 @@ unsafe impl ::windows::core::Interface for IUIAnimationInterpolator2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAnimationInterpolator2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDimension: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dimension: *mut u32) -> ::windows::core::HRESULT,
     pub SetInitialValueAndVelocity: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, initialvalue: *const f64, initialvelocity: *const f64, cdimension: u32) -> ::windows::core::HRESULT,
     pub SetDuration: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, duration: f64) -> ::windows::core::HRESULT,
@@ -210,7 +210,7 @@ unsafe impl ::windows::core::Interface for IUIAnimationLoopIterationChangeHandle
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAnimationLoopIterationChangeHandler2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnLoopIterationChanged: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, storyboard: *mut ::core::ffi::c_void, id: usize, newiterationcount: u32, olditerationcount: u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Animation\"`*"]
@@ -344,7 +344,7 @@ unsafe impl ::windows::core::Interface for IUIAnimationManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAnimationManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateAnimationVariable: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, initialvalue: f64, variable: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub ScheduleTransition: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, variable: *mut ::core::ffi::c_void, transition: *mut ::core::ffi::c_void, timenow: f64) -> ::windows::core::HRESULT,
     pub CreateStoryboard: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, storyboard: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -507,7 +507,7 @@ unsafe impl ::windows::core::Interface for IUIAnimationManager2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAnimationManager2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateAnimationVectorVariable: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, initialvalue: *const f64, cdimension: u32, variable: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CreateAnimationVariable: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, initialvalue: f64, variable: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub ScheduleTransition: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, variable: *mut ::core::ffi::c_void, transition: *mut ::core::ffi::c_void, timenow: f64) -> ::windows::core::HRESULT,
@@ -579,7 +579,7 @@ unsafe impl ::windows::core::Interface for IUIAnimationManagerEventHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAnimationManagerEventHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnManagerStatusChanged: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, newstatus: UI_ANIMATION_MANAGER_STATUS, previousstatus: UI_ANIMATION_MANAGER_STATUS) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Animation\"`*"]
@@ -628,7 +628,7 @@ unsafe impl ::windows::core::Interface for IUIAnimationManagerEventHandler2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAnimationManagerEventHandler2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnManagerStatusChanged: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, newstatus: UI_ANIMATION_MANAGER_STATUS, previousstatus: UI_ANIMATION_MANAGER_STATUS) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Animation\"`*"]
@@ -680,7 +680,7 @@ unsafe impl ::windows::core::Interface for IUIAnimationPrimitiveInterpolation {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAnimationPrimitiveInterpolation_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddCubic: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dimension: u32, beginoffset: f64, constantcoefficient: f32, linearcoefficient: f32, quadraticcoefficient: f32, cubiccoefficient: f32) -> ::windows::core::HRESULT,
     pub AddSinusoidal: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dimension: u32, beginoffset: f64, bias: f32, amplitude: f32, frequency: f32, phase: f32) -> ::windows::core::HRESULT,
 }
@@ -734,7 +734,7 @@ unsafe impl ::windows::core::Interface for IUIAnimationPriorityComparison {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAnimationPriorityComparison_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub HasPriority: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, scheduledstoryboard: *mut ::core::ffi::c_void, newstoryboard: *mut ::core::ffi::c_void, priorityeffect: UI_ANIMATION_PRIORITY_EFFECT) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Animation\"`*"]
@@ -787,7 +787,7 @@ unsafe impl ::windows::core::Interface for IUIAnimationPriorityComparison2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAnimationPriorityComparison2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub HasPriority: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, scheduledstoryboard: *mut ::core::ffi::c_void, newstoryboard: *mut ::core::ffi::c_void, priorityeffect: UI_ANIMATION_PRIORITY_EFFECT) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Animation\"`*"]
@@ -923,7 +923,7 @@ unsafe impl ::windows::core::Interface for IUIAnimationStoryboard {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAnimationStoryboard_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddTransition: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, variable: *mut ::core::ffi::c_void, transition: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub AddKeyframeAtOffset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, existingkeyframe: UI_ANIMATION_KEYFRAME, offset: f64, keyframe: *mut UI_ANIMATION_KEYFRAME) -> ::windows::core::HRESULT,
     pub AddKeyframeAfterTransition: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, transition: *mut ::core::ffi::c_void, keyframe: *mut UI_ANIMATION_KEYFRAME) -> ::windows::core::HRESULT,
@@ -1086,7 +1086,7 @@ unsafe impl ::windows::core::Interface for IUIAnimationStoryboard2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAnimationStoryboard2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddTransition: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, variable: *mut ::core::ffi::c_void, transition: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub AddKeyframeAtOffset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, existingkeyframe: UI_ANIMATION_KEYFRAME, offset: f64, keyframe: *mut UI_ANIMATION_KEYFRAME) -> ::windows::core::HRESULT,
     pub AddKeyframeAfterTransition: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, transition: *mut ::core::ffi::c_void, keyframe: *mut UI_ANIMATION_KEYFRAME) -> ::windows::core::HRESULT,
@@ -1167,7 +1167,7 @@ unsafe impl ::windows::core::Interface for IUIAnimationStoryboardEventHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAnimationStoryboardEventHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnStoryboardStatusChanged: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, storyboard: *mut ::core::ffi::c_void, newstatus: UI_ANIMATION_STORYBOARD_STATUS, previousstatus: UI_ANIMATION_STORYBOARD_STATUS) -> ::windows::core::HRESULT,
     pub OnStoryboardUpdated: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, storyboard: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -1226,7 +1226,7 @@ unsafe impl ::windows::core::Interface for IUIAnimationStoryboardEventHandler2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAnimationStoryboardEventHandler2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnStoryboardStatusChanged: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, storyboard: *mut ::core::ffi::c_void, newstatus: UI_ANIMATION_STORYBOARD_STATUS, previousstatus: UI_ANIMATION_STORYBOARD_STATUS) -> ::windows::core::HRESULT,
     pub OnStoryboardUpdated: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, storyboard: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -1301,7 +1301,7 @@ unsafe impl ::windows::core::Interface for IUIAnimationTimer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAnimationTimer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetTimerUpdateHandler: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, updatehandler: *mut ::core::ffi::c_void, idlebehavior: UI_ANIMATION_IDLE_BEHAVIOR) -> ::windows::core::HRESULT,
     pub SetTimerEventHandler: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, handler: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Enable: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1356,7 +1356,7 @@ unsafe impl ::windows::core::Interface for IUIAnimationTimerClientEventHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAnimationTimerClientEventHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnTimerClientStatusChanged: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, newstatus: UI_ANIMATION_TIMER_CLIENT_STATUS, previousstatus: UI_ANIMATION_TIMER_CLIENT_STATUS) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Animation\"`*"]
@@ -1411,7 +1411,7 @@ unsafe impl ::windows::core::Interface for IUIAnimationTimerEventHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAnimationTimerEventHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnPreUpdate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub OnPostUpdate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub OnRenderingTooSlow: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, framespersecond: u32) -> ::windows::core::HRESULT,
@@ -1472,7 +1472,7 @@ unsafe impl ::windows::core::Interface for IUIAnimationTimerUpdateHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAnimationTimerUpdateHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnUpdate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, timenow: f64, result: *mut UI_ANIMATION_UPDATE_RESULT) -> ::windows::core::HRESULT,
     pub SetTimerClientEventHandler: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, handler: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub ClearTimerClientEventHandler: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1533,7 +1533,7 @@ unsafe impl ::windows::core::Interface for IUIAnimationTransition {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAnimationTransition_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetInitialValue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: f64) -> ::windows::core::HRESULT,
     pub SetInitialVelocity: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, velocity: f64) -> ::windows::core::HRESULT,
     pub IsDurationKnown: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1605,7 +1605,7 @@ unsafe impl ::windows::core::Interface for IUIAnimationTransition2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAnimationTransition2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDimension: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dimension: *mut u32) -> ::windows::core::HRESULT,
     pub SetInitialValue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: f64) -> ::windows::core::HRESULT,
     pub SetInitialVectorValue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: *const f64, cdimension: u32) -> ::windows::core::HRESULT,
@@ -1664,7 +1664,7 @@ unsafe impl ::windows::core::Interface for IUIAnimationTransitionFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAnimationTransitionFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateTransition: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, interpolator: *mut ::core::ffi::c_void, transition: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Animation\"`*"]
@@ -1717,7 +1717,7 @@ unsafe impl ::windows::core::Interface for IUIAnimationTransitionFactory2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAnimationTransitionFactory2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateTransition: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, interpolator: *mut ::core::ffi::c_void, transition: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Animation\"`*"]
@@ -1811,7 +1811,7 @@ unsafe impl ::windows::core::Interface for IUIAnimationTransitionLibrary {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAnimationTransitionLibrary_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateInstantaneousTransition: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, finalvalue: f64, transition: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CreateConstantTransition: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, duration: f64, transition: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CreateDiscreteTransition: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, delay: f64, finalvalue: f64, hold: f64, transition: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1944,7 +1944,7 @@ unsafe impl ::windows::core::Interface for IUIAnimationTransitionLibrary2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAnimationTransitionLibrary2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateInstantaneousTransition: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, finalvalue: f64, transition: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CreateInstantaneousVectorTransition: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, finalvalue: *const f64, cdimension: u32, transition: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CreateConstantTransition: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, duration: f64, transition: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -2066,7 +2066,7 @@ unsafe impl ::windows::core::Interface for IUIAnimationVariable {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAnimationVariable_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetValue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: *mut f64) -> ::windows::core::HRESULT,
     pub GetFinalValue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, finalvalue: *mut f64) -> ::windows::core::HRESULT,
     pub GetPreviousValue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, previousvalue: *mut f64) -> ::windows::core::HRESULT,
@@ -2236,7 +2236,7 @@ unsafe impl ::windows::core::Interface for IUIAnimationVariable2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAnimationVariable2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDimension: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dimension: *mut u32) -> ::windows::core::HRESULT,
     pub GetValue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: *mut f64) -> ::windows::core::HRESULT,
     pub GetVectorValue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: *mut f64, cdimension: u32) -> ::windows::core::HRESULT,
@@ -2326,7 +2326,7 @@ unsafe impl ::windows::core::Interface for IUIAnimationVariableChangeHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAnimationVariableChangeHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnValueChanged: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, storyboard: *mut ::core::ffi::c_void, variable: *mut ::core::ffi::c_void, newvalue: f64, previousvalue: f64) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Animation\"`*"]
@@ -2379,7 +2379,7 @@ unsafe impl ::windows::core::Interface for IUIAnimationVariableChangeHandler2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAnimationVariableChangeHandler2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnValueChanged: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, storyboard: *mut ::core::ffi::c_void, variable: *mut ::core::ffi::c_void, newvalue: *const f64, previousvalue: *const f64, cdimension: u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Animation\"`*"]
@@ -2431,7 +2431,7 @@ unsafe impl ::windows::core::Interface for IUIAnimationVariableCurveChangeHandle
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAnimationVariableCurveChangeHandler2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnCurveChanged: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, variable: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Animation\"`*"]
@@ -2484,7 +2484,7 @@ unsafe impl ::windows::core::Interface for IUIAnimationVariableIntegerChangeHand
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAnimationVariableIntegerChangeHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnIntegerValueChanged: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, storyboard: *mut ::core::ffi::c_void, variable: *mut ::core::ffi::c_void, newvalue: i32, previousvalue: i32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Animation\"`*"]
@@ -2537,7 +2537,7 @@ unsafe impl ::windows::core::Interface for IUIAnimationVariableIntegerChangeHand
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIAnimationVariableIntegerChangeHandler2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnIntegerValueChanged: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, storyboard: *mut ::core::ffi::c_void, variable: *mut ::core::ffi::c_void, newvalue: *const i32, previousvalue: *const i32, cdimension: u32) -> ::windows::core::HRESULT,
 }
 pub const UIAnimationManager: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4c1fc63a_695c_47e8_a339_1a194be3d0b8);

--- a/crates/libs/windows/src/Windows/Win32/UI/ColorSystem/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/ColorSystem/impl.rs
@@ -103,7 +103,7 @@ impl IDeviceModelPlugIn_Vtbl {
             this.GetNeutralAxis(::core::mem::transmute_copy(&ccolors), ::core::mem::transmute_copy(&pxyzcolors)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             GetNumChannels: GetNumChannels::<Identity, Impl, OFFSET>,
             DeviceToColorimetricColors: DeviceToColorimetricColors::<Identity, Impl, OFFSET>,
@@ -145,7 +145,7 @@ impl IGamutMapModelPlugIn_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             SourceToDestinationAppearanceColors: SourceToDestinationAppearanceColors::<Identity, Impl, OFFSET>,
         }

--- a/crates/libs/windows/src/Windows/Win32/UI/ColorSystem/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/ColorSystem/mod.rs
@@ -1486,7 +1486,7 @@ unsafe impl ::windows::core::Interface for IDeviceModelPlugIn {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDeviceModelPlugIn_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrxml: ::core::mem::ManuallyDrop<::windows::core::BSTR>, cnummodels: u32, imodelposition: u32) -> ::windows::core::HRESULT,
     pub GetNumChannels: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pnumchannels: *mut u32) -> ::windows::core::HRESULT,
     pub DeviceToColorimetricColors: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ccolors: u32, cchannels: u32, pdevicevalues: *const f32, pxyzcolors: *mut XYZColorF) -> ::windows::core::HRESULT,
@@ -1556,7 +1556,7 @@ unsafe impl ::windows::core::Interface for IGamutMapModelPlugIn {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IGamutMapModelPlugIn_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrxml: ::core::mem::ManuallyDrop<::windows::core::BSTR>, psrcplugin: *mut ::core::ffi::c_void, pdestplugin: *mut ::core::ffi::c_void, psrcgbd: *const GamutBoundaryDescription, pdestgbd: *const GamutBoundaryDescription) -> ::windows::core::HRESULT,
     pub SourceToDestinationAppearanceColors: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ccolors: u32, pinputcolors: *const JChColorF, poutputcolors: *mut JChColorF) -> ::windows::core::HRESULT,
 }

--- a/crates/libs/windows/src/Windows/Win32/UI/Controls/Dialogs/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Controls/Dialogs/impl.rs
@@ -25,7 +25,7 @@ impl IPrintDialogCallback_Vtbl {
             this.HandleMessage(::core::mem::transmute_copy(&hdlg), ::core::mem::transmute_copy(&umsg), ::core::mem::transmute_copy(&wparam), ::core::mem::transmute_copy(&lparam), ::core::mem::transmute_copy(&presult)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             InitDone: InitDone::<Identity, Impl, OFFSET>,
             SelectionChange: SelectionChange::<Identity, Impl, OFFSET>,
             HandleMessage: HandleMessage::<Identity, Impl, OFFSET>,
@@ -62,7 +62,7 @@ impl IPrintDialogServices_Vtbl {
             this.GetCurrentPortName(::core::mem::transmute_copy(&pportname), ::core::mem::transmute_copy(&pcchsize)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCurrentDevMode: GetCurrentDevMode::<Identity, Impl, OFFSET>,
             GetCurrentPrinterName: GetCurrentPrinterName::<Identity, Impl, OFFSET>,
             GetCurrentPortName: GetCurrentPortName::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/UI/Controls/Dialogs/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Controls/Dialogs/mod.rs
@@ -270,7 +270,7 @@ unsafe impl ::windows::core::Interface for IPrintDialogCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPrintDialogCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub InitDone: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SelectionChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -332,7 +332,7 @@ unsafe impl ::windows::core::Interface for IPrintDialogServices {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPrintDialogServices_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
     pub GetCurrentDevMode: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdevmode: *mut super::super::super::Graphics::Gdi::DEVMODEA, pcbsize: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi")))]

--- a/crates/libs/windows/src/Windows/Win32/UI/Controls/RichEdit/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Controls/RichEdit/impl.rs
@@ -109,7 +109,7 @@ impl IRichEditOle_Vtbl {
             this.ImportDataObject(::core::mem::transmute(&lpdataobj), ::core::mem::transmute_copy(&cf), ::core::mem::transmute_copy(&hmetapict)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetClientSite: GetClientSite::<Identity, Impl, OFFSET>,
             GetObjectCount: GetObjectCount::<Identity, Impl, OFFSET>,
             GetLinkCount: GetLinkCount::<Identity, Impl, OFFSET>,
@@ -207,7 +207,7 @@ impl IRichEditOleCallback_Vtbl {
             this.GetContextMenu(::core::mem::transmute_copy(&seltype), ::core::mem::transmute(&lpoleobj), ::core::mem::transmute_copy(&lpchrg), ::core::mem::transmute_copy(&lphmenu)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetNewStorage: GetNewStorage::<Identity, Impl, OFFSET>,
             GetInPlaceContext: GetInPlaceContext::<Identity, Impl, OFFSET>,
             ShowContainerUI: ShowContainerUI::<Identity, Impl, OFFSET>,
@@ -238,7 +238,7 @@ impl IRicheditUiaOverrides_Vtbl {
             let this = (*this).get_impl();
             this.GetPropertyOverrideValue(::core::mem::transmute_copy(&propertyid), ::core::mem::transmute_copy(&pretvalue)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetPropertyOverrideValue: GetPropertyOverrideValue::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetPropertyOverrideValue: GetPropertyOverrideValue::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IRicheditUiaOverrides as ::windows::core::Interface>::IID
@@ -2478,7 +2478,7 @@ impl ITextHost_Vtbl {
             this.TxGetSelectionBarWidth(::core::mem::transmute_copy(&lselbarwidth)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             TxGetDC: TxGetDC::<Identity, Impl, OFFSET>,
             TxReleaseDC: TxReleaseDC::<Identity, Impl, OFFSET>,
             TxShowScrollBar: TxShowScrollBar::<Identity, Impl, OFFSET>,
@@ -5025,7 +5025,7 @@ impl ITextServices_Vtbl {
             this.TxGetCachedSize(::core::mem::transmute_copy(&pdwwidth), ::core::mem::transmute_copy(&pdwheight)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             TxSendMessage: TxSendMessage::<Identity, Impl, OFFSET>,
             TxDraw: TxDraw::<Identity, Impl, OFFSET>,
             TxGetHScroll: TxGetHScroll::<Identity, Impl, OFFSET>,
@@ -5203,7 +5203,7 @@ impl ITextStory_Vtbl {
             this.SetText(::core::mem::transmute_copy(&flags), ::core::mem::transmute(&bstr)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetActive: GetActive::<Identity, Impl, OFFSET>,
             SetActive: SetActive::<Identity, Impl, OFFSET>,
             GetDisplay: GetDisplay::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/UI/Controls/RichEdit/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Controls/RichEdit/mod.rs
@@ -125,7 +125,7 @@ unsafe impl ::windows::core::Interface for IRichEditOle {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRichEditOle_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Ole")]
     pub GetClientSite: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lplpolesite: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Ole"))]
@@ -283,7 +283,7 @@ unsafe impl ::windows::core::Interface for IRichEditOleCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRichEditOleCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com_StructuredStorage")]
     pub GetNewStorage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lplpstg: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com_StructuredStorage"))]
@@ -373,7 +373,7 @@ unsafe impl ::windows::core::Interface for IRicheditUiaOverrides {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRicheditUiaOverrides_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub GetPropertyOverrideValue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, propertyid: i32, pretvalue: *mut super::super::super::System::Com::VARIANT) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole")))]
@@ -2510,7 +2510,7 @@ unsafe impl ::windows::core::Interface for ITextHost {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITextHost_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Graphics_Gdi")]
     pub TxGetDC: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> super::super::super::Graphics::Gdi::HDC,
     #[cfg(not(feature = "Win32_Graphics_Gdi"))]
@@ -6111,7 +6111,7 @@ unsafe impl ::windows::core::Interface for ITextServices {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITextServices_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub TxSendMessage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, msg: u32, wparam: super::super::super::Foundation::WPARAM, lparam: super::super::super::Foundation::LPARAM, plresult: *mut super::super::super::Foundation::LRESULT) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -6430,7 +6430,7 @@ unsafe impl ::windows::core::Interface for ITextStory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITextStory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetActive: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pvalue: *mut i32) -> ::windows::core::HRESULT,
     pub SetActive: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: i32) -> ::windows::core::HRESULT,
     pub GetDisplay: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppdisplay: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/UI/Controls/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Controls/impl.rs
@@ -247,7 +247,7 @@ impl IImageList_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Add: Add::<Identity, Impl, OFFSET>,
             ReplaceIcon: ReplaceIcon::<Identity, Impl, OFFSET>,
             SetOverlayImage: SetOverlayImage::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/UI/Controls/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Controls/mod.rs
@@ -2865,7 +2865,7 @@ unsafe impl ::windows::core::Interface for IImageList {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IImageList_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Graphics_Gdi")]
     pub Add: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hbmimage: super::super::Graphics::Gdi::HBITMAP, hbmmask: super::super::Graphics::Gdi::HBITMAP, pi: *mut i32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Graphics_Gdi"))]

--- a/crates/libs/windows/src/Windows/Win32/UI/Input/Ime/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Input/Ime/impl.rs
@@ -127,7 +127,7 @@ impl IActiveIME_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Inquire: Inquire::<Identity, Impl, OFFSET>,
             ConversionList: ConversionList::<Identity, Impl, OFFSET>,
             Configure: Configure::<Identity, Impl, OFFSET>,
@@ -708,7 +708,7 @@ impl IActiveIMMApp_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AssociateContext: AssociateContext::<Identity, Impl, OFFSET>,
             ConfigureIMEA: ConfigureIMEA::<Identity, Impl, OFFSET>,
             ConfigureIMEW: ConfigureIMEW::<Identity, Impl, OFFSET>,
@@ -1494,7 +1494,7 @@ impl IActiveIMMIME_Vtbl {
             this.IsSleeping().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AssociateContext: AssociateContext::<Identity, Impl, OFFSET>,
             ConfigureIMEA: ConfigureIMEA::<Identity, Impl, OFFSET>,
             ConfigureIMEW: ConfigureIMEW::<Identity, Impl, OFFSET>,
@@ -1634,7 +1634,7 @@ impl IActiveIMMMessagePumpOwner_Vtbl {
             this.Resume(::core::mem::transmute_copy(&dwcookie)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Start: Start::<Identity, Impl, OFFSET>,
             End: End::<Identity, Impl, OFFSET>,
             OnTranslateMessage: OnTranslateMessage::<Identity, Impl, OFFSET>,
@@ -1664,7 +1664,7 @@ impl IActiveIMMRegistrar_Vtbl {
             this.UnregisterIME(::core::mem::transmute_copy(&rclsid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RegisterIME: RegisterIME::<Identity, Impl, OFFSET>,
             UnregisterIME: UnregisterIME::<Identity, Impl, OFFSET>,
         }
@@ -1712,7 +1712,7 @@ impl IEnumInputContext_Vtbl {
             this.Skip(::core::mem::transmute_copy(&ulcount)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Clone: Clone::<Identity, Impl, OFFSET>,
             Next: Next::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -1759,7 +1759,7 @@ impl IEnumRegisterWordA_Vtbl {
             this.Skip(::core::mem::transmute_copy(&ulcount)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Clone: Clone::<Identity, Impl, OFFSET>,
             Next: Next::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -1806,7 +1806,7 @@ impl IEnumRegisterWordW_Vtbl {
             this.Skip(::core::mem::transmute_copy(&ulcount)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Clone: Clone::<Identity, Impl, OFFSET>,
             Next: Next::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -1863,7 +1863,7 @@ impl IFECommon_Vtbl {
             this.InvokeDictToolDialog(::core::mem::transmute_copy(&pimedlg)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             IsDefaultIME: IsDefaultIME::<Identity, Impl, OFFSET>,
             SetDefaultIME: SetDefaultIME::<Identity, Impl, OFFSET>,
             InvokeWordRegDialog: InvokeWordRegDialog::<Identity, Impl, OFFSET>,
@@ -1985,7 +1985,7 @@ impl IFEDictionary_Vtbl {
             this.ConvertFromUserToSys().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Open: Open::<Identity, Impl, OFFSET>,
             Close: Close::<Identity, Impl, OFFSET>,
             GetHeader: GetHeader::<Identity, Impl, OFFSET>,
@@ -2051,7 +2051,7 @@ impl IFELanguage_Vtbl {
             this.GetConversion(::core::mem::transmute(&string), ::core::mem::transmute_copy(&start), ::core::mem::transmute_copy(&length), ::core::mem::transmute_copy(&result)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Open: Open::<Identity, Impl, OFFSET>,
             Close: Close::<Identity, Impl, OFFSET>,
             GetJMorphResult: GetJMorphResult::<Identity, Impl, OFFSET>,
@@ -2078,7 +2078,7 @@ impl IImePad_Vtbl {
             let this = (*this).get_impl();
             this.Request(::core::mem::transmute(&piimepadapplet), ::core::mem::transmute_copy(&reqid), ::core::mem::transmute_copy(&wparam), ::core::mem::transmute_copy(&lparam)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Request: Request::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Request: Request::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IImePad as ::windows::core::Interface>::IID
@@ -2123,7 +2123,7 @@ impl IImePadApplet_Vtbl {
             this.Notify(::core::mem::transmute(&lpimepad), ::core::mem::transmute_copy(&notify), ::core::mem::transmute_copy(&wparam), ::core::mem::transmute_copy(&lparam)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             Terminate: Terminate::<Identity, Impl, OFFSET>,
             GetAppletConfig: GetAppletConfig::<Identity, Impl, OFFSET>,
@@ -2156,7 +2156,7 @@ impl IImePlugInDictDictionaryList_Vtbl {
             this.DeleteDictionary(::core::mem::transmute(&bstrdictionaryguid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDictionariesInUse: GetDictionariesInUse::<Identity, Impl, OFFSET>,
             DeleteDictionary: DeleteDictionary::<Identity, Impl, OFFSET>,
         }
@@ -2176,7 +2176,7 @@ impl IImeSpecifyApplets_Vtbl {
             let this = (*this).get_impl();
             this.GetAppletIIDList(::core::mem::transmute_copy(&refiid), ::core::mem::transmute_copy(&lpiidlist)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetAppletIIDList: GetAppletIIDList::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetAppletIIDList: GetAppletIIDList::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IImeSpecifyApplets as ::windows::core::Interface>::IID

--- a/crates/libs/windows/src/Windows/Win32/UI/Input/Ime/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Input/Ime/mod.rs
@@ -1238,7 +1238,7 @@ unsafe impl ::windows::core::Interface for IActiveIME {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IActiveIME_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Inquire: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwsysteminfoflags: u32, pimeinfo: *mut IMEINFO, szwndclass: ::windows::core::PWSTR, pdwprivate: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Globalization")]
     pub ConversionList: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, himc: super::super::super::Globalization::HIMC, szsource: ::windows::core::PCWSTR, uflag: u32, ubuflen: u32, pdest: *mut CANDIDATELIST, pucopied: *mut u32) -> ::windows::core::HRESULT,
@@ -2090,7 +2090,7 @@ unsafe impl ::windows::core::Interface for IActiveIMMApp {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IActiveIMMApp_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Globalization"))]
     pub AssociateContext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hwnd: super::super::super::Foundation::HWND, hime: super::super::super::Globalization::HIMC, phprev: *mut super::super::super::Globalization::HIMC) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_Globalization")))]
@@ -3127,7 +3127,7 @@ unsafe impl ::windows::core::Interface for IActiveIMMIME {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IActiveIMMIME_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Globalization"))]
     pub AssociateContext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hwnd: super::super::super::Foundation::HWND, hime: super::super::super::Globalization::HIMC, phprev: *mut super::super::super::Globalization::HIMC) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_Globalization")))]
@@ -3524,7 +3524,7 @@ unsafe impl ::windows::core::Interface for IActiveIMMMessagePumpOwner {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IActiveIMMMessagePumpOwner_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Start: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub End: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
@@ -3587,7 +3587,7 @@ unsafe impl ::windows::core::Interface for IActiveIMMRegistrar {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IActiveIMMRegistrar_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub RegisterIME: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, rclsid: *const ::windows::core::GUID, lgid: u16, psziconfile: ::windows::core::PCWSTR, pszdesc: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub UnregisterIME: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, rclsid: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
 }
@@ -3649,7 +3649,7 @@ unsafe impl ::windows::core::Interface for IEnumInputContext {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumInputContext_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Clone: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Globalization")]
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ulcount: u32, rginputcontext: *mut super::super::super::Globalization::HIMC, pcfetched: *mut u32) -> ::windows::core::HRESULT,
@@ -3714,7 +3714,7 @@ unsafe impl ::windows::core::Interface for IEnumRegisterWordA {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumRegisterWordA_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Clone: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ulcount: u32, rgregisterword: *mut REGISTERWORDA, pcfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -3776,7 +3776,7 @@ unsafe impl ::windows::core::Interface for IEnumRegisterWordW {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumRegisterWordW_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Clone: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ulcount: u32, rgregisterword: *mut REGISTERWORDW, pcfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -3933,7 +3933,7 @@ unsafe impl ::windows::core::Interface for IFECommon {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IFECommon_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub IsDefaultIME: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, szname: ::windows::core::PCSTR, cszname: i32) -> ::windows::core::HRESULT,
     pub SetDefaultIME: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -4071,7 +4071,7 @@ unsafe impl ::windows::core::Interface for IFEDictionary {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IFEDictionary_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Open: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pchdictpath: ::windows::core::PSTR, pshf: *mut IMESHF) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -4172,7 +4172,7 @@ unsafe impl ::windows::core::Interface for IFELanguage {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IFELanguage_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Open: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Close: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetJMorphResult: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwrequest: u32, dwcmode: u32, cwchinput: i32, pwchinput: ::windows::core::PCWSTR, pfcinfo: *mut u32, ppresult: *mut *mut MORRSLT) -> ::windows::core::HRESULT,
@@ -4233,7 +4233,7 @@ unsafe impl ::windows::core::Interface for IImePad {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IImePad_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Request: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, piimepadapplet: *mut ::core::ffi::c_void, reqid: IME_PAD_REQUEST_FLAGS, wparam: super::super::super::Foundation::WPARAM, lparam: super::super::super::Foundation::LPARAM) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -4314,7 +4314,7 @@ unsafe impl ::windows::core::Interface for IImePadApplet {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IImePadApplet_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lpiimepad: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Terminate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
@@ -4381,7 +4381,7 @@ unsafe impl ::windows::core::Interface for IImePlugInDictDictionaryList {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IImePlugInDictDictionaryList_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub GetDictionariesInUse: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, prgdictionaryguid: *mut *mut super::super::super::System::Com::SAFEARRAY, prgdatecreated: *mut *mut super::super::super::System::Com::SAFEARRAY, prgfencrypted: *mut *mut super::super::super::System::Com::SAFEARRAY) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -4434,7 +4434,7 @@ unsafe impl ::windows::core::Interface for IImeSpecifyApplets {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IImeSpecifyApplets_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetAppletIIDList: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, refiid: *const ::windows::core::GUID, lpiidlist: *mut APPLETIDLIST) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Input_Ime\"`*"]

--- a/crates/libs/windows/src/Windows/Win32/UI/Input/Ink/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Input/Ink/impl.rs
@@ -9,7 +9,7 @@ impl IInkCommitRequestHandler_Vtbl {
             let this = (*this).get_impl();
             this.OnCommitRequested().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnCommitRequested: OnCommitRequested::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnCommitRequested: OnCommitRequested::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IInkCommitRequestHandler as ::windows::core::Interface>::IID
@@ -29,7 +29,7 @@ impl IInkD2DRenderer_Vtbl {
             let this = (*this).get_impl();
             this.Draw(::core::mem::transmute(&pd2d1devicecontext), ::core::mem::transmute(&pinkstrokeiterable), ::core::mem::transmute_copy(&fhighcontrast)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Draw: Draw::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Draw: Draw::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IInkD2DRenderer as ::windows::core::Interface>::IID
@@ -46,7 +46,7 @@ impl IInkD2DRenderer2_Vtbl {
             let this = (*this).get_impl();
             this.Draw(::core::mem::transmute(&pd2d1devicecontext), ::core::mem::transmute(&pinkstrokeiterable), ::core::mem::transmute_copy(&highcontrastadjustment)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Draw: Draw::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Draw: Draw::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IInkD2DRenderer2 as ::windows::core::Interface>::IID
@@ -76,7 +76,7 @@ impl IInkDesktopHost_Vtbl {
             this.CreateAndInitializeInkPresenter(::core::mem::transmute(&rootvisual), ::core::mem::transmute_copy(&width), ::core::mem::transmute_copy(&height), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppv)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             QueueWorkItem: QueueWorkItem::<Identity, Impl, OFFSET>,
             CreateInkPresenter: CreateInkPresenter::<Identity, Impl, OFFSET>,
             CreateAndInitializeInkPresenter: CreateAndInitializeInkPresenter::<Identity, Impl, OFFSET>,
@@ -97,7 +97,7 @@ impl IInkHostWorkItem_Vtbl {
             let this = (*this).get_impl();
             this.Invoke().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Invoke: Invoke::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Invoke: Invoke::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IInkHostWorkItem as ::windows::core::Interface>::IID
@@ -139,7 +139,7 @@ impl IInkPresenterDesktop_Vtbl {
             this.OnHighContrastChanged().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetRootVisual: SetRootVisual::<Identity, Impl, OFFSET>,
             SetCommitRequestHandler: SetCommitRequestHandler::<Identity, Impl, OFFSET>,
             GetSize: GetSize::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/UI/Input/Ink/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Input/Ink/mod.rs
@@ -44,7 +44,7 @@ unsafe impl ::windows::core::Interface for IInkCommitRequestHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IInkCommitRequestHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnCommitRequested: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Input_Ink\"`*"]
@@ -100,7 +100,7 @@ unsafe impl ::windows::core::Interface for IInkD2DRenderer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IInkD2DRenderer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Draw: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pd2d1devicecontext: *mut ::core::ffi::c_void, pinkstrokeiterable: *mut ::core::ffi::c_void, fhighcontrast: super::super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -156,7 +156,7 @@ unsafe impl ::windows::core::Interface for IInkD2DRenderer2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IInkD2DRenderer2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Draw: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pd2d1devicecontext: *mut ::core::ffi::c_void, pinkstrokeiterable: *mut ::core::ffi::c_void, highcontrastadjustment: INK_HIGH_CONTRAST_ADJUSTMENT) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Input_Ink\"`*"]
@@ -223,7 +223,7 @@ unsafe impl ::windows::core::Interface for IInkDesktopHost {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IInkDesktopHost_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub QueueWorkItem: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, workitem: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CreateInkPresenter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CreateAndInitializeInkPresenter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, rootvisual: *mut ::core::ffi::c_void, width: f32, height: f32, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -274,7 +274,7 @@ unsafe impl ::windows::core::Interface for IInkHostWorkItem {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IInkHostWorkItem_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Input_Ink\"`*"]
@@ -342,7 +342,7 @@ unsafe impl ::windows::core::Interface for IInkPresenterDesktop {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IInkPresenterDesktop_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetRootVisual: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, rootvisual: *mut ::core::ffi::c_void, device: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetCommitRequestHandler: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, handler: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, width: *mut f32, height: *mut f32) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/UI/Input/Touch/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Input/Touch/impl.rs
@@ -445,7 +445,7 @@ impl IInertiaProcessor_Vtbl {
             this.CompleteTime(::core::mem::transmute_copy(&timestamp)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             InitialOriginX: InitialOriginX::<Identity, Impl, OFFSET>,
             SetInitialOriginX: SetInitialOriginX::<Identity, Impl, OFFSET>,
             InitialOriginY: InitialOriginY::<Identity, Impl, OFFSET>,
@@ -687,7 +687,7 @@ impl IManipulationProcessor_Vtbl {
             this.SetMinimumScaleRotateRadius(::core::mem::transmute_copy(&minradius)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SupportedManipulations: SupportedManipulations::<Identity, Impl, OFFSET>,
             SetSupportedManipulations: SetSupportedManipulations::<Identity, Impl, OFFSET>,
             PivotPointX: PivotPointX::<Identity, Impl, OFFSET>,
@@ -753,7 +753,7 @@ impl _IManipulationEvents_Vtbl {
             this.ManipulationCompleted(::core::mem::transmute_copy(&x), ::core::mem::transmute_copy(&y), ::core::mem::transmute_copy(&cumulativetranslationx), ::core::mem::transmute_copy(&cumulativetranslationy), ::core::mem::transmute_copy(&cumulativescale), ::core::mem::transmute_copy(&cumulativeexpansion), ::core::mem::transmute_copy(&cumulativerotation)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ManipulationStarted: ManipulationStarted::<Identity, Impl, OFFSET>,
             ManipulationDelta: ManipulationDelta::<Identity, Impl, OFFSET>,
             ManipulationCompleted: ManipulationCompleted::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/UI/Input/Touch/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Input/Touch/mod.rs
@@ -346,7 +346,7 @@ unsafe impl ::windows::core::Interface for IInertiaProcessor {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IInertiaProcessor_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub InitialOriginX: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, x: *mut f32) -> ::windows::core::HRESULT,
     pub SetInitialOriginX: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, x: f32) -> ::windows::core::HRESULT,
     pub InitialOriginY: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, y: *mut f32) -> ::windows::core::HRESULT,
@@ -518,7 +518,7 @@ unsafe impl ::windows::core::Interface for IManipulationProcessor {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IManipulationProcessor_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SupportedManipulations: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, manipulations: *mut MANIPULATION_PROCESSOR_MANIPULATIONS) -> ::windows::core::HRESULT,
     pub SetSupportedManipulations: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, manipulations: MANIPULATION_PROCESSOR_MANIPULATIONS) -> ::windows::core::HRESULT,
     pub PivotPointX: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pivotpointx: *mut f32) -> ::windows::core::HRESULT,
@@ -593,7 +593,7 @@ unsafe impl ::windows::core::Interface for _IManipulationEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct _IManipulationEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ManipulationStarted: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, x: f32, y: f32) -> ::windows::core::HRESULT,
     pub ManipulationDelta: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, x: f32, y: f32, translationdeltax: f32, translationdeltay: f32, scaledelta: f32, expansiondelta: f32, rotationdelta: f32, cumulativetranslationx: f32, cumulativetranslationy: f32, cumulativescale: f32, cumulativeexpansion: f32, cumulativerotation: f32) -> ::windows::core::HRESULT,
     pub ManipulationCompleted: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, x: f32, y: f32, cumulativetranslationx: f32, cumulativetranslationy: f32, cumulativescale: f32, cumulativeexpansion: f32, cumulativerotation: f32) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/UI/LegacyWindowsEnvironmentFeatures/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/LegacyWindowsEnvironmentFeatures/impl.rs
@@ -31,7 +31,7 @@ impl IADesktopP2_Vtbl {
             this.MakeDynamicChanges(::core::mem::transmute(&poleobj)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ReReadWallpaper: ReReadWallpaper::<Identity, Impl, OFFSET>,
             GetADObjectFlags: GetADObjectFlags::<Identity, Impl, OFFSET>,
             UpdateAllDesktopSubscriptions: UpdateAllDesktopSubscriptions::<Identity, Impl, OFFSET>,
@@ -72,7 +72,7 @@ impl IActiveDesktopP_Vtbl {
             this.GetScheme(::core::mem::transmute_copy(&pwszschemename), ::core::mem::transmute_copy(&pdwcchbuffer), ::core::mem::transmute_copy(&dwflags)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetSafeMode: SetSafeMode::<Identity, Impl, OFFSET>,
             EnsureUpdateHTML: EnsureUpdateHTML::<Identity, Impl, OFFSET>,
             SetScheme: SetScheme::<Identity, Impl, OFFSET>,
@@ -97,7 +97,7 @@ impl IBriefcaseInitiator_Vtbl {
             let this = (*this).get_impl();
             this.IsMonikerInBriefcase(::core::mem::transmute(&pmk)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), IsMonikerInBriefcase: IsMonikerInBriefcase::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), IsMonikerInBriefcase: IsMonikerInBriefcase::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IBriefcaseInitiator as ::windows::core::Interface>::IID
@@ -148,7 +148,7 @@ impl IEmptyVolumeCache_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             GetSpaceUsed: GetSpaceUsed::<Identity, Impl, OFFSET>,
             Purge: Purge::<Identity, Impl, OFFSET>,
@@ -198,7 +198,7 @@ impl IEmptyVolumeCacheCallBack_Vtbl {
             this.PurgeProgress(::core::mem::transmute_copy(&dwlspacefreed), ::core::mem::transmute_copy(&dwlspacetofree), ::core::mem::transmute_copy(&dwflags), ::core::mem::transmute(&pcwszstatus)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ScanProgress: ScanProgress::<Identity, Impl, OFFSET>,
             PurgeProgress: PurgeProgress::<Identity, Impl, OFFSET>,
         }
@@ -234,7 +234,7 @@ impl IReconcilableObject_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Reconcile: Reconcile::<Identity, Impl, OFFSET>,
             GetProgressFeedbackMaxEstimate: GetProgressFeedbackMaxEstimate::<Identity, Impl, OFFSET>,
         }
@@ -261,7 +261,7 @@ impl IReconcileInitiator_Vtbl {
             this.SetProgressFeedback(::core::mem::transmute_copy(&ulprogress), ::core::mem::transmute_copy(&ulprogressmax)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetAbortCallback: SetAbortCallback::<Identity, Impl, OFFSET>,
             SetProgressFeedback: SetProgressFeedback::<Identity, Impl, OFFSET>,
         }

--- a/crates/libs/windows/src/Windows/Win32/UI/LegacyWindowsEnvironmentFeatures/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/LegacyWindowsEnvironmentFeatures/mod.rs
@@ -58,7 +58,7 @@ unsafe impl ::windows::core::Interface for IADesktopP2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IADesktopP2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ReReadWallpaper: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetADObjectFlags: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwflags: *mut u32, dwmask: u32) -> ::windows::core::HRESULT,
     pub UpdateAllDesktopSubscriptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -125,7 +125,7 @@ unsafe impl ::windows::core::Interface for IActiveDesktopP {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IActiveDesktopP_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetSafeMode: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwflags: u32) -> ::windows::core::HRESULT,
     pub EnsureUpdateHTML: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetScheme: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszschemename: ::windows::core::PCWSTR, dwflags: u32) -> ::windows::core::HRESULT,
@@ -182,7 +182,7 @@ unsafe impl ::windows::core::Interface for IBriefcaseInitiator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IBriefcaseInitiator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub IsMonikerInBriefcase: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pmk: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -264,7 +264,7 @@ unsafe impl ::windows::core::Interface for IEmptyVolumeCache {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEmptyVolumeCache_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Registry")]
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hkregkey: super::super::System::Registry::HKEY, pcwszvolume: ::windows::core::PCWSTR, ppwszdisplayname: *mut ::windows::core::PWSTR, ppwszdescription: *mut ::windows::core::PWSTR, pdwflags: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Registry"))]
@@ -439,7 +439,7 @@ unsafe impl ::windows::core::Interface for IEmptyVolumeCacheCallBack {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEmptyVolumeCacheCallBack_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ScanProgress: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwlspaceused: u64, dwflags: u32, pcwszstatus: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub PurgeProgress: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwlspacefreed: u64, dwlspacetofree: u64, dwflags: u32, pcwszstatus: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
 }
@@ -501,7 +501,7 @@ unsafe impl ::windows::core::Interface for IReconcilableObject {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IReconcilableObject_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
     pub Reconcile: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinitiator: *mut ::core::ffi::c_void, dwflags: u32, hwndowner: super::super::Foundation::HWND, hwndprogressfeedback: super::super::Foundation::HWND, ulcinput: u32, rgpmkotherinput: *mut *mut ::core::ffi::c_void, ploutindex: *mut i32, pstgnewresidues: *mut ::core::ffi::c_void, pvreserved: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage")))]
@@ -560,7 +560,7 @@ unsafe impl ::windows::core::Interface for IReconcileInitiator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IReconcileInitiator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetAbortCallback: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punkforabort: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SetProgressFeedback: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ulprogress: u32, ulprogressmax: u32) -> ::windows::core::HRESULT,
 }

--- a/crates/libs/windows/src/Windows/Win32/UI/Notifications/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Notifications/impl.rs
@@ -9,7 +9,7 @@ impl INotificationActivationCallback_Vtbl {
             let this = (*this).get_impl();
             this.Activate(::core::mem::transmute(&appusermodelid), ::core::mem::transmute(&invokedargs), ::core::mem::transmute_copy(&data), ::core::mem::transmute_copy(&count)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Activate: Activate::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Activate: Activate::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<INotificationActivationCallback as ::windows::core::Interface>::IID

--- a/crates/libs/windows/src/Windows/Win32/UI/Notifications/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Notifications/mod.rs
@@ -48,7 +48,7 @@ unsafe impl ::windows::core::Interface for INotificationActivationCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INotificationActivationCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Activate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, appusermodelid: ::windows::core::PCWSTR, invokedargs: ::windows::core::PCWSTR, data: *const NOTIFICATION_USER_INPUT_DATA, count: u32) -> ::windows::core::HRESULT,
 }
 #[repr(C)]

--- a/crates/libs/windows/src/Windows/Win32/UI/Ribbon/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Ribbon/impl.rs
@@ -28,7 +28,7 @@ impl IUIApplication_Vtbl {
             this.OnDestroyUICommand(::core::mem::transmute_copy(&commandid), ::core::mem::transmute_copy(&typeid), ::core::mem::transmute(&commandhandler)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnViewChanged: OnViewChanged::<Identity, Impl, OFFSET>,
             OnCreateUICommand: OnCreateUICommand::<Identity, Impl, OFFSET>,
             OnDestroyUICommand: OnDestroyUICommand::<Identity, Impl, OFFSET>,
@@ -98,7 +98,7 @@ impl IUICollection_Vtbl {
             this.Clear().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCount: GetCount::<Identity, Impl, OFFSET>,
             GetItem: GetItem::<Identity, Impl, OFFSET>,
             Add: Add::<Identity, Impl, OFFSET>,
@@ -123,7 +123,7 @@ impl IUICollectionChangedEvent_Vtbl {
             let this = (*this).get_impl();
             this.OnChanged(::core::mem::transmute_copy(&action), ::core::mem::transmute_copy(&oldindex), ::core::mem::transmute(&olditem), ::core::mem::transmute_copy(&newindex), ::core::mem::transmute(&newitem)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnChanged: OnChanged::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnChanged: OnChanged::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IUICollectionChangedEvent as ::windows::core::Interface>::IID
@@ -156,7 +156,7 @@ impl IUICommandHandler_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Execute: Execute::<Identity, Impl, OFFSET>,
             UpdateProperty: UpdateProperty::<Identity, Impl, OFFSET>,
         }
@@ -176,7 +176,7 @@ impl IUIContextualUI_Vtbl {
             let this = (*this).get_impl();
             this.ShowAtLocation(::core::mem::transmute_copy(&x), ::core::mem::transmute_copy(&y)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), ShowAtLocation: ShowAtLocation::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), ShowAtLocation: ShowAtLocation::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IUIContextualUI as ::windows::core::Interface>::IID
@@ -193,7 +193,7 @@ impl IUIEventLogger_Vtbl {
             let this = (*this).get_impl();
             this.OnUIEvent(::core::mem::transmute_copy(&peventparams))
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnUIEvent: OnUIEvent::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnUIEvent: OnUIEvent::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IUIEventLogger as ::windows::core::Interface>::IID
@@ -210,7 +210,7 @@ impl IUIEventingManager_Vtbl {
             let this = (*this).get_impl();
             this.SetEventLogger(::core::mem::transmute(&eventlogger)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SetEventLogger: SetEventLogger::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SetEventLogger: SetEventLogger::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IUIEventingManager as ::windows::core::Interface>::IID
@@ -285,7 +285,7 @@ impl IUIFramework_Vtbl {
             this.SetModes(::core::mem::transmute_copy(&imodes)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             Destroy: Destroy::<Identity, Impl, OFFSET>,
             LoadUI: LoadUI::<Identity, Impl, OFFSET>,
@@ -321,7 +321,7 @@ impl IUIImage_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetBitmap: GetBitmap::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetBitmap: GetBitmap::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IUIImage as ::windows::core::Interface>::IID
@@ -347,7 +347,7 @@ impl IUIImageFromBitmap_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CreateImage: CreateImage::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CreateImage: CreateImage::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IUIImageFromBitmap as ::windows::core::Interface>::IID
@@ -386,7 +386,7 @@ impl IUIRibbon_Vtbl {
             this.SaveSettingsToStream(::core::mem::transmute(&pstream)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetHeight: GetHeight::<Identity, Impl, OFFSET>,
             LoadSettingsFromStream: LoadSettingsFromStream::<Identity, Impl, OFFSET>,
             SaveSettingsToStream: SaveSettingsToStream::<Identity, Impl, OFFSET>,
@@ -416,7 +416,7 @@ impl IUISimplePropertySet_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetValue: GetValue::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetValue: GetValue::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IUISimplePropertySet as ::windows::core::Interface>::IID

--- a/crates/libs/windows/src/Windows/Win32/UI/Ribbon/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Ribbon/mod.rs
@@ -57,7 +57,7 @@ unsafe impl ::windows::core::Interface for IUIApplication {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIApplication_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnViewChanged: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, viewid: u32, typeid: UI_VIEWTYPE, view: *mut ::core::ffi::c_void, verb: UI_VIEWVERB, ureasoncode: i32) -> ::windows::core::HRESULT,
     pub OnCreateUICommand: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, commandid: u32, typeid: UI_COMMANDTYPE, commandhandler: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub OnDestroyUICommand: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, commandid: u32, typeid: UI_COMMANDTYPE, commandhandler: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -137,7 +137,7 @@ unsafe impl ::windows::core::Interface for IUICollection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUICollection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, count: *mut u32) -> ::windows::core::HRESULT,
     pub GetItem: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: u32, item: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Add: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, item: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -196,7 +196,7 @@ unsafe impl ::windows::core::Interface for IUICollectionChangedEvent {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUICollectionChangedEvent_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnChanged: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, action: UI_COLLECTIONCHANGE, oldindex: u32, olditem: *mut ::core::ffi::c_void, newindex: u32, newitem: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Ribbon\"`*"]
@@ -256,7 +256,7 @@ unsafe impl ::windows::core::Interface for IUICommandHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUICommandHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
     pub Execute: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, commandid: u32, verb: UI_EXECUTIONVERB, key: *const super::Shell::PropertiesSystem::PROPERTYKEY, currentvalue: *const super::super::System::Com::StructuredStorage::PROPVARIANT, commandexecutionproperties: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem")))]
@@ -312,7 +312,7 @@ unsafe impl ::windows::core::Interface for IUIContextualUI {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIContextualUI_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ShowAtLocation: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, x: i32, y: i32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Ribbon\"`*"]
@@ -361,7 +361,7 @@ unsafe impl ::windows::core::Interface for IUIEventLogger {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIEventLogger_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnUIEvent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, peventparams: *const UI_EVENTPARAMS),
 }
 #[doc = "*Required features: `\"Win32_UI_Ribbon\"`*"]
@@ -413,7 +413,7 @@ unsafe impl ::windows::core::Interface for IUIEventingManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIEventingManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetEventLogger: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, eventlogger: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Ribbon\"`*"]
@@ -505,7 +505,7 @@ unsafe impl ::windows::core::Interface for IUIFramework {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIFramework_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, framewnd: super::super::Foundation::HWND, application: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -580,7 +580,7 @@ unsafe impl ::windows::core::Interface for IUIImage {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIImage_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Graphics_Gdi")]
     pub GetBitmap: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bitmap: *mut super::super::Graphics::Gdi::HBITMAP) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Graphics_Gdi"))]
@@ -638,7 +638,7 @@ unsafe impl ::windows::core::Interface for IUIImageFromBitmap {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIImageFromBitmap_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Graphics_Gdi")]
     pub CreateImage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bitmap: super::super::Graphics::Gdi::HBITMAP, options: UI_OWNERSHIP, image: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Graphics_Gdi"))]
@@ -707,7 +707,7 @@ unsafe impl ::windows::core::Interface for IUIRibbon {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIRibbon_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetHeight: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cy: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
     pub LoadSettingsFromStream: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pstream: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -767,7 +767,7 @@ unsafe impl ::windows::core::Interface for IUISimplePropertySet {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUISimplePropertySet_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
     pub GetValue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, key: *const super::Shell::PropertiesSystem::PROPERTYKEY, value: *mut super::super::System::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem")))]

--- a/crates/libs/windows/src/Windows/Win32/UI/Shell/Common/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Shell/Common/impl.rs
@@ -22,7 +22,7 @@ impl IObjectArray_Vtbl {
             this.GetAt(::core::mem::transmute_copy(&uiindex), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppv)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCount: GetCount::<Identity, Impl, OFFSET>,
             GetAt: GetAt::<Identity, Impl, OFFSET>,
         }

--- a/crates/libs/windows/src/Windows/Win32/UI/Shell/Common/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Shell/Common/mod.rs
@@ -52,7 +52,7 @@ unsafe impl ::windows::core::Interface for IObjectArray {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IObjectArray_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcobjects: *mut u32) -> ::windows::core::HRESULT,
     pub GetAt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, uiindex: u32, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }

--- a/crates/libs/windows/src/Windows/Win32/UI/Shell/PropertiesSystem/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Shell/PropertiesSystem/impl.rs
@@ -9,7 +9,7 @@ impl ICreateObject_Vtbl {
             let this = (*this).get_impl();
             this.CreateObject(::core::mem::transmute_copy(&clsid), ::core::mem::transmute(&punkouter), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppv)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CreateObject: CreateObject::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CreateObject: CreateObject::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ICreateObject as ::windows::core::Interface>::IID
@@ -43,7 +43,7 @@ impl IInitializeWithFile_Vtbl {
             let this = (*this).get_impl();
             this.Initialize(::core::mem::transmute(&pszfilepath), ::core::mem::transmute_copy(&grfmode)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Initialize: Initialize::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Initialize: Initialize::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IInitializeWithFile as ::windows::core::Interface>::IID
@@ -63,7 +63,7 @@ impl IInitializeWithStream_Vtbl {
             let this = (*this).get_impl();
             this.Initialize(::core::mem::transmute(&pstream), ::core::mem::transmute_copy(&grfmode)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Initialize: Initialize::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Initialize: Initialize::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IInitializeWithStream as ::windows::core::Interface>::IID
@@ -120,7 +120,7 @@ impl INamedPropertyStore_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetNamedValue: GetNamedValue::<Identity, Impl, OFFSET>,
             SetNamedValue: SetNamedValue::<Identity, Impl, OFFSET>,
             GetNameCount: GetNameCount::<Identity, Impl, OFFSET>,
@@ -155,7 +155,7 @@ impl IObjectWithPropertyKey_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetPropertyKey: SetPropertyKey::<Identity, Impl, OFFSET>,
             GetPropertyKey: GetPropertyKey::<Identity, Impl, OFFSET>,
         }
@@ -188,7 +188,7 @@ impl IPersistSerializedPropStorage_Vtbl {
             this.GetPropertyStorage(::core::mem::transmute_copy(&ppsps), ::core::mem::transmute_copy(&pcb)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetFlags: SetFlags::<Identity, Impl, OFFSET>,
             SetPropertyStorage: SetPropertyStorage::<Identity, Impl, OFFSET>,
             GetPropertyStorage: GetPropertyStorage::<Identity, Impl, OFFSET>,
@@ -311,7 +311,7 @@ impl IPropertyChangeArray_Vtbl {
             this.IsKeyInArray(::core::mem::transmute_copy(&key)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCount: GetCount::<Identity, Impl, OFFSET>,
             GetAt: GetAt::<Identity, Impl, OFFSET>,
             InsertAt: InsertAt::<Identity, Impl, OFFSET>,
@@ -556,7 +556,7 @@ impl IPropertyDescription_Vtbl {
             this.IsValueCanonical(::core::mem::transmute_copy(&propvar)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetPropertyKey: GetPropertyKey::<Identity, Impl, OFFSET>,
             GetCanonicalName: GetCanonicalName::<Identity, Impl, OFFSET>,
             GetPropertyType: GetPropertyType::<Identity, Impl, OFFSET>,
@@ -667,7 +667,7 @@ impl IPropertyDescriptionList_Vtbl {
             this.GetAt(::core::mem::transmute_copy(&ielem), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppv)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCount: GetCount::<Identity, Impl, OFFSET>,
             GetAt: GetAt::<Identity, Impl, OFFSET>,
         }
@@ -833,7 +833,7 @@ impl IPropertyEnumType_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetEnumType: GetEnumType::<Identity, Impl, OFFSET>,
             GetValue: GetValue::<Identity, Impl, OFFSET>,
             GetRangeMinValue: GetRangeMinValue::<Identity, Impl, OFFSET>,
@@ -916,7 +916,7 @@ impl IPropertyEnumTypeList_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCount: GetCount::<Identity, Impl, OFFSET>,
             GetAt: GetAt::<Identity, Impl, OFFSET>,
             GetConditionAt: GetConditionAt::<Identity, Impl, OFFSET>,
@@ -984,7 +984,7 @@ impl IPropertyStore_Vtbl {
             this.Commit().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCount: GetCount::<Identity, Impl, OFFSET>,
             GetAt: GetAt::<Identity, Impl, OFFSET>,
             GetValue: GetValue::<Identity, Impl, OFFSET>,
@@ -1057,7 +1057,7 @@ impl IPropertyStoreCapabilities_Vtbl {
             let this = (*this).get_impl();
             this.IsPropertyWritable(::core::mem::transmute_copy(&key)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), IsPropertyWritable: IsPropertyWritable::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), IsPropertyWritable: IsPropertyWritable::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IPropertyStoreCapabilities as ::windows::core::Interface>::IID
@@ -1081,7 +1081,7 @@ impl IPropertyStoreFactory_Vtbl {
             this.GetPropertyStoreForKeys(::core::mem::transmute_copy(&rgkeys), ::core::mem::transmute_copy(&ckeys), ::core::mem::transmute_copy(&flags), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppv)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetPropertyStore: GetPropertyStore::<Identity, Impl, OFFSET>,
             GetPropertyStoreForKeys: GetPropertyStoreForKeys::<Identity, Impl, OFFSET>,
         }
@@ -1159,7 +1159,7 @@ impl IPropertySystem_Vtbl {
             this.RefreshPropertySchema().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetPropertyDescription: GetPropertyDescription::<Identity, Impl, OFFSET>,
             GetPropertyDescriptionByName: GetPropertyDescriptionByName::<Identity, Impl, OFFSET>,
             GetPropertyDescriptionListFromString: GetPropertyDescriptionListFromString::<Identity, Impl, OFFSET>,
@@ -1186,7 +1186,7 @@ impl IPropertySystemChangeNotify_Vtbl {
             let this = (*this).get_impl();
             this.SchemaRefreshed().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SchemaRefreshed: SchemaRefreshed::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SchemaRefreshed: SchemaRefreshed::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IPropertySystemChangeNotify as ::windows::core::Interface>::IID
@@ -1261,7 +1261,7 @@ impl IPropertyUI_Vtbl {
             this.GetHelpInfo(::core::mem::transmute_copy(&fmtid), ::core::mem::transmute_copy(&pid), ::core::mem::transmute_copy(&pwszhelpfile), ::core::mem::transmute_copy(&cch), ::core::mem::transmute_copy(&puhelpid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ParsePropertyName: ParsePropertyName::<Identity, Impl, OFFSET>,
             GetCannonicalName: GetCannonicalName::<Identity, Impl, OFFSET>,
             GetDisplayName: GetDisplayName::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/UI/Shell/PropertiesSystem/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Shell/PropertiesSystem/mod.rs
@@ -2660,7 +2660,7 @@ unsafe impl ::windows::core::Interface for ICreateObject {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICreateObject_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateObject: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, clsid: *const ::windows::core::GUID, punkouter: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Shell_PropertiesSystem\"`*"]
@@ -2795,7 +2795,7 @@ unsafe impl ::windows::core::Interface for IInitializeWithFile {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IInitializeWithFile_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszfilepath: ::windows::core::PCWSTR, grfmode: u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Shell_PropertiesSystem\"`*"]
@@ -2849,7 +2849,7 @@ unsafe impl ::windows::core::Interface for IInitializeWithStream {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IInitializeWithStream_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pstream: *mut ::core::ffi::c_void, grfmode: u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -2923,7 +2923,7 @@ unsafe impl ::windows::core::Interface for INamedPropertyStore {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INamedPropertyStore_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
     pub GetNamedValue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszname: ::windows::core::PCWSTR, ppropvar: *mut super::super::super::System::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage")))]
@@ -2985,7 +2985,7 @@ unsafe impl ::windows::core::Interface for IObjectWithPropertyKey {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IObjectWithPropertyKey_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetPropertyKey: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, key: *const PROPERTYKEY) -> ::windows::core::HRESULT,
     pub GetPropertyKey: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pkey: *mut PROPERTYKEY) -> ::windows::core::HRESULT,
 }
@@ -3041,7 +3041,7 @@ unsafe impl ::windows::core::Interface for IPersistSerializedPropStorage {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPersistSerializedPropStorage_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetFlags: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, flags: i32) -> ::windows::core::HRESULT,
     pub SetPropertyStorage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psps: *const SERIALIZEDPROPSTORAGE, cb: u32) -> ::windows::core::HRESULT,
     pub GetPropertyStorage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppsps: *mut *mut SERIALIZEDPROPSTORAGE, pcb: *mut u32) -> ::windows::core::HRESULT,
@@ -3279,7 +3279,7 @@ unsafe impl ::windows::core::Interface for IPropertyChangeArray {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPropertyChangeArray_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcoperations: *mut u32) -> ::windows::core::HRESULT,
     pub GetAt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, iindex: u32, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub InsertAt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, iindex: u32, ppropchange: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -3429,7 +3429,7 @@ unsafe impl ::windows::core::Interface for IPropertyDescription {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPropertyDescription_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetPropertyKey: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pkey: *mut PROPERTYKEY) -> ::windows::core::HRESULT,
     pub GetCanonicalName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppszname: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetPropertyType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pvartype: *mut u16) -> ::windows::core::HRESULT,
@@ -3866,7 +3866,7 @@ unsafe impl ::windows::core::Interface for IPropertyDescriptionList {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPropertyDescriptionList_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcelem: *mut u32) -> ::windows::core::HRESULT,
     pub GetAt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ielem: u32, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -4284,7 +4284,7 @@ unsafe impl ::windows::core::Interface for IPropertyEnumType {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPropertyEnumType_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetEnumType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, penumtype: *mut PROPENUMTYPE) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
     pub GetValue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppropvar: *mut super::super::super::System::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::HRESULT,
@@ -4458,7 +4458,7 @@ unsafe impl ::windows::core::Interface for IPropertyEnumTypeList {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPropertyEnumTypeList_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pctypes: *mut u32) -> ::windows::core::HRESULT,
     pub GetAt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, itype: u32, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetConditionAt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, nindex: u32, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -4532,7 +4532,7 @@ unsafe impl ::windows::core::Interface for IPropertyStore {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPropertyStore_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cprops: *mut u32) -> ::windows::core::HRESULT,
     pub GetAt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, iprop: u32, pkey: *mut PROPERTYKEY) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
@@ -4700,7 +4700,7 @@ unsafe impl ::windows::core::Interface for IPropertyStoreCapabilities {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPropertyStoreCapabilities_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub IsPropertyWritable: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, key: *const PROPERTYKEY) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Shell_PropertiesSystem\"`*"]
@@ -4761,7 +4761,7 @@ unsafe impl ::windows::core::Interface for IPropertyStoreFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPropertyStoreFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetPropertyStore: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, flags: GETPROPERTYSTOREFLAGS, punkfactory: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetPropertyStoreForKeys: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, rgkeys: *const PROPERTYKEY, ckeys: u32, flags: GETPROPERTYSTOREFLAGS, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -4864,7 +4864,7 @@ unsafe impl ::windows::core::Interface for IPropertySystem {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPropertySystem_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetPropertyDescription: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, propkey: *const PROPERTYKEY, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetPropertyDescriptionByName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszcanonicalname: ::windows::core::PCWSTR, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetPropertyDescriptionListFromString: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszproplist: ::windows::core::PCWSTR, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -4927,7 +4927,7 @@ unsafe impl ::windows::core::Interface for IPropertySystemChangeNotify {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPropertySystemChangeNotify_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SchemaRefreshed: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Shell_PropertiesSystem\"`*"]
@@ -5004,7 +5004,7 @@ unsafe impl ::windows::core::Interface for IPropertyUI {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPropertyUI_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ParsePropertyName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszname: ::windows::core::PCWSTR, pfmtid: *mut ::windows::core::GUID, ppid: *mut u32, pcheaten: *mut u32) -> ::windows::core::HRESULT,
     pub GetCannonicalName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fmtid: *const ::windows::core::GUID, pid: u32, pwsztext: ::windows::core::PWSTR, cchtext: u32) -> ::windows::core::HRESULT,
     pub GetDisplayName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fmtid: *const ::windows::core::GUID, pid: u32, flags: PROPERTYUI_NAME_FLAGS, pwsztext: ::windows::core::PWSTR, cchtext: u32) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/UI/Shell/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Shell/impl.rs
@@ -910,7 +910,7 @@ impl IACList_Vtbl {
             let this = (*this).get_impl();
             this.Expand(::core::mem::transmute(&pszexpand)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Expand: Expand::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Expand: Expand::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IACList as ::windows::core::Interface>::IID
@@ -976,7 +976,7 @@ impl IAccessibilityDockingService_Vtbl {
             this.UndockWindow(::core::mem::transmute_copy(&hwnd)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetAvailableSize: GetAvailableSize::<Identity, Impl, OFFSET>,
             DockWindow: DockWindow::<Identity, Impl, OFFSET>,
             UndockWindow: UndockWindow::<Identity, Impl, OFFSET>,
@@ -997,7 +997,7 @@ impl IAccessibilityDockingServiceCallback_Vtbl {
             let this = (*this).get_impl();
             this.Undocked(::core::mem::transmute_copy(&undockreason)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Undocked: Undocked::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Undocked: Undocked::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IAccessibilityDockingServiceCallback as ::windows::core::Interface>::IID
@@ -1014,7 +1014,7 @@ impl IAccessibleObject_Vtbl {
             let this = (*this).get_impl();
             this.SetAccessibleName(::core::mem::transmute(&pszname)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SetAccessibleName: SetAccessibleName::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SetAccessibleName: SetAccessibleName::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IAccessibleObject as ::windows::core::Interface>::IID
@@ -1071,7 +1071,7 @@ impl IActionProgress_Vtbl {
             this.End().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Begin: Begin::<Identity, Impl, OFFSET>,
             UpdateProgress: UpdateProgress::<Identity, Impl, OFFSET>,
             UpdateText: UpdateText::<Identity, Impl, OFFSET>,
@@ -1102,7 +1102,7 @@ impl IActionProgressDialog_Vtbl {
             this.Stop().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             Stop: Stop::<Identity, Impl, OFFSET>,
         }
@@ -1180,7 +1180,7 @@ impl IAppActivationUIInfo_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetMonitor: GetMonitor::<Identity, Impl, OFFSET>,
             GetInvokePoint: GetInvokePoint::<Identity, Impl, OFFSET>,
             GetShowCommand: GetShowCommand::<Identity, Impl, OFFSET>,
@@ -1246,7 +1246,7 @@ impl IAppPublisher_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetNumberOfCategories: GetNumberOfCategories::<Identity, Impl, OFFSET>,
             GetCategories: GetCategories::<Identity, Impl, OFFSET>,
             GetNumberOfApps: GetNumberOfApps::<Identity, Impl, OFFSET>,
@@ -1308,7 +1308,7 @@ impl IAppVisibility_Vtbl {
             this.Unadvise(::core::mem::transmute_copy(&dwcookie)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetAppVisibilityOnMonitor: GetAppVisibilityOnMonitor::<Identity, Impl, OFFSET>,
             IsLauncherVisible: IsLauncherVisible::<Identity, Impl, OFFSET>,
             Advise: Advise::<Identity, Impl, OFFSET>,
@@ -1340,7 +1340,7 @@ impl IAppVisibilityEvents_Vtbl {
             this.LauncherVisibilityChange(::core::mem::transmute_copy(&currentvisiblestate)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AppVisibilityOnMonitorChanged: AppVisibilityOnMonitorChanged::<Identity, Impl, OFFSET>,
             LauncherVisibilityChange: LauncherVisibilityChange::<Identity, Impl, OFFSET>,
         }
@@ -1391,7 +1391,7 @@ impl IApplicationActivationManager_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ActivateApplication: ActivateApplication::<Identity, Impl, OFFSET>,
             ActivateForFile: ActivateForFile::<Identity, Impl, OFFSET>,
             ActivateForProtocol: ActivateForProtocol::<Identity, Impl, OFFSET>,
@@ -1464,7 +1464,7 @@ impl IApplicationAssociationRegistration_Vtbl {
             this.ClearUserAssociations().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             QueryCurrentDefault: QueryCurrentDefault::<Identity, Impl, OFFSET>,
             QueryAppIsDefault: QueryAppIsDefault::<Identity, Impl, OFFSET>,
             QueryAppIsDefaultAll: QueryAppIsDefaultAll::<Identity, Impl, OFFSET>,
@@ -1489,7 +1489,7 @@ impl IApplicationAssociationRegistrationUI_Vtbl {
             this.LaunchAdvancedAssociationUI(::core::mem::transmute(&pszappregistryname)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             LaunchAdvancedAssociationUI: LaunchAdvancedAssociationUI::<Identity, Impl, OFFSET>,
         }
     }
@@ -1554,7 +1554,7 @@ impl IApplicationDesignModeSettings_Vtbl {
             this.TriggerEdgeGesture(::core::mem::transmute_copy(&edgegesturekind)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetNativeDisplaySize: SetNativeDisplaySize::<Identity, Impl, OFFSET>,
             SetScaleFactor: SetScaleFactor::<Identity, Impl, OFFSET>,
             SetApplicationViewState: SetApplicationViewState::<Identity, Impl, OFFSET>,
@@ -1662,7 +1662,7 @@ impl IApplicationDestinations_Vtbl {
             this.RemoveAllDestinations().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetAppID: SetAppID::<Identity, Impl, OFFSET>,
             RemoveDestination: RemoveDestination::<Identity, Impl, OFFSET>,
             RemoveAllDestinations: RemoveAllDestinations::<Identity, Impl, OFFSET>,
@@ -1690,7 +1690,7 @@ impl IApplicationDocumentLists_Vtbl {
             this.GetList(::core::mem::transmute_copy(&listtype), ::core::mem::transmute_copy(&citemsdesired), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppv)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetAppID: SetAppID::<Identity, Impl, OFFSET>,
             GetList: GetList::<Identity, Impl, OFFSET>,
         }
@@ -1768,7 +1768,7 @@ impl IAssocHandler_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetName: GetName::<Identity, Impl, OFFSET>,
             GetUIName: GetUIName::<Identity, Impl, OFFSET>,
             GetIconLocation: GetIconLocation::<Identity, Impl, OFFSET>,
@@ -1800,7 +1800,7 @@ impl IAssocHandlerInvoker_Vtbl {
             this.Invoke().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SupportsSelection: SupportsSelection::<Identity, Impl, OFFSET>,
             Invoke: Invoke::<Identity, Impl, OFFSET>,
         }
@@ -1902,7 +1902,7 @@ impl IAttachmentExecute_Vtbl {
             this.ClearClientState().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetClientTitle: SetClientTitle::<Identity, Impl, OFFSET>,
             SetClientGuid: SetClientGuid::<Identity, Impl, OFFSET>,
             SetLocalPath: SetLocalPath::<Identity, Impl, OFFSET>,
@@ -1941,7 +1941,11 @@ impl IAutoComplete_Vtbl {
             let this = (*this).get_impl();
             this.Enable(::core::mem::transmute_copy(&fenable)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Init: Init::<Identity, Impl, OFFSET>, Enable: Enable::<Identity, Impl, OFFSET> }
+        Self {
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
+            Init: Init::<Identity, Impl, OFFSET>,
+            Enable: Enable::<Identity, Impl, OFFSET>,
+        }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IAutoComplete as ::windows::core::Interface>::IID
@@ -2001,7 +2005,7 @@ impl IAutoCompleteDropDown_Vtbl {
             this.ResetEnumerator().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDropDownStatus: GetDropDownStatus::<Identity, Impl, OFFSET>,
             ResetEnumerator: ResetEnumerator::<Identity, Impl, OFFSET>,
         }
@@ -2037,7 +2041,7 @@ impl IBandHost_Vtbl {
             this.DestroyBand(::core::mem::transmute_copy(&rclsidband)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateBand: CreateBand::<Identity, Impl, OFFSET>,
             SetBandAvailability: SetBandAvailability::<Identity, Impl, OFFSET>,
             DestroyBand: DestroyBand::<Identity, Impl, OFFSET>,
@@ -2110,7 +2114,7 @@ impl IBandSite_Vtbl {
             this.GetBandSiteInfo(::core::mem::transmute_copy(&pbsinfo)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddBand: AddBand::<Identity, Impl, OFFSET>,
             EnumBands: EnumBands::<Identity, Impl, OFFSET>,
             QueryBand: QueryBand::<Identity, Impl, OFFSET>,
@@ -2136,7 +2140,7 @@ impl IBannerNotificationHandler_Vtbl {
             let this = (*this).get_impl();
             this.OnBannerEvent(::core::mem::transmute_copy(&notification)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnBannerEvent: OnBannerEvent::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnBannerEvent: OnBannerEvent::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IBannerNotificationHandler as ::windows::core::Interface>::IID
@@ -2187,7 +2191,7 @@ impl IBanneredBar_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetIconSize: SetIconSize::<Identity, Impl, OFFSET>,
             GetIconSize: GetIconSize::<Identity, Impl, OFFSET>,
             SetBitmap: SetBitmap::<Identity, Impl, OFFSET>,
@@ -2215,7 +2219,7 @@ impl IBrowserFrameOptions_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetFrameOptions: GetFrameOptions::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetFrameOptions: GetFrameOptions::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IBrowserFrameOptions as ::windows::core::Interface>::IID
@@ -2488,7 +2492,7 @@ impl IBrowserService_Vtbl {
             this.RegisterWindow(::core::mem::transmute_copy(&fforceregister), ::core::mem::transmute_copy(&swc)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetParentSite: GetParentSite::<Identity, Impl, OFFSET>,
             SetTitle: SetTitle::<Identity, Impl, OFFSET>,
             GetTitle: GetTitle::<Identity, Impl, OFFSET>,
@@ -3105,7 +3109,7 @@ impl ICDBurn_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetRecorderDriveLetter: GetRecorderDriveLetter::<Identity, Impl, OFFSET>,
             Burn: Burn::<Identity, Impl, OFFSET>,
             HasRecordableDrive: HasRecordableDrive::<Identity, Impl, OFFSET>,
@@ -3132,7 +3136,7 @@ impl ICDBurnExt_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetSupportedActionTypes: GetSupportedActionTypes::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetSupportedActionTypes: GetSupportedActionTypes::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ICDBurnExt as ::windows::core::Interface>::IID
@@ -3183,7 +3187,7 @@ impl ICategorizer_Vtbl {
             this.CompareCategory(::core::mem::transmute_copy(&csfflags), ::core::mem::transmute_copy(&dwcategoryid1), ::core::mem::transmute_copy(&dwcategoryid2)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDescription: GetDescription::<Identity, Impl, OFFSET>,
             GetCategory: GetCategory::<Identity, Impl, OFFSET>,
             GetCategoryInfo: GetCategoryInfo::<Identity, Impl, OFFSET>,
@@ -3251,7 +3255,7 @@ impl ICategoryProvider_Vtbl {
             this.CreateCategory(::core::mem::transmute_copy(&pguid), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppv)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CanCategorizeOnSCID: CanCategorizeOnSCID::<Identity, Impl, OFFSET>,
             GetDefaultCategory: GetDefaultCategory::<Identity, Impl, OFFSET>,
             GetCategoryForSCID: GetCategoryForSCID::<Identity, Impl, OFFSET>,
@@ -3309,7 +3313,7 @@ impl IColumnManager_Vtbl {
             this.SetColumns(::core::mem::transmute_copy(&rgkeyorder), ::core::mem::transmute_copy(&cvisible)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetColumnInfo: SetColumnInfo::<Identity, Impl, OFFSET>,
             GetColumnInfo: GetColumnInfo::<Identity, Impl, OFFSET>,
             GetColumnCount: GetColumnCount::<Identity, Impl, OFFSET>,
@@ -3360,7 +3364,7 @@ impl IColumnProvider_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             GetColumnInfo: GetColumnInfo::<Identity, Impl, OFFSET>,
             GetItemData: GetItemData::<Identity, Impl, OFFSET>,
@@ -3397,7 +3401,7 @@ impl ICommDlgBrowser_Vtbl {
             this.IncludeObject(::core::mem::transmute(&ppshv), ::core::mem::transmute_copy(&pidl)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnDefaultCommand: OnDefaultCommand::<Identity, Impl, OFFSET>,
             OnStateChange: OnStateChange::<Identity, Impl, OFFSET>,
             IncludeObject: IncludeObject::<Identity, Impl, OFFSET>,
@@ -3498,7 +3502,7 @@ impl IComputerInfoChangeNotify_Vtbl {
             let this = (*this).get_impl();
             this.ComputerInfoChanged().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), ComputerInfoChanged: ComputerInfoChanged::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), ComputerInfoChanged: ComputerInfoChanged::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IComputerInfoChangeNotify as ::windows::core::Interface>::IID
@@ -3548,7 +3552,7 @@ impl IContactManagerInterop_Vtbl {
             let this = (*this).get_impl();
             this.ShowContactCardForWindow(::core::mem::transmute_copy(&appwindow), ::core::mem::transmute(&contact), ::core::mem::transmute_copy(&selection), ::core::mem::transmute_copy(&preferredplacement)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), ShowContactCardForWindow: ShowContactCardForWindow::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), ShowContactCardForWindow: ShowContactCardForWindow::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IContactManagerInterop as ::windows::core::Interface>::IID
@@ -3581,7 +3585,7 @@ impl IContextMenu_Vtbl {
             this.GetCommandString(::core::mem::transmute_copy(&idcmd), ::core::mem::transmute_copy(&utype), ::core::mem::transmute_copy(&preserved), ::core::mem::transmute_copy(&pszname), ::core::mem::transmute_copy(&cchmax)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             QueryContextMenu: QueryContextMenu::<Identity, Impl, OFFSET>,
             InvokeCommand: InvokeCommand::<Identity, Impl, OFFSET>,
             GetCommandString: GetCommandString::<Identity, Impl, OFFSET>,
@@ -3651,7 +3655,7 @@ impl IContextMenuCB_Vtbl {
             let this = (*this).get_impl();
             this.CallBack(::core::mem::transmute(&psf), ::core::mem::transmute_copy(&hwndowner), ::core::mem::transmute(&pdtobj), ::core::mem::transmute_copy(&umsg), ::core::mem::transmute_copy(&wparam), ::core::mem::transmute_copy(&lparam)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CallBack: CallBack::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CallBack: CallBack::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IContextMenuCB as ::windows::core::Interface>::IID
@@ -3671,7 +3675,7 @@ impl IContextMenuSite_Vtbl {
             let this = (*this).get_impl();
             this.DoContextMenuPopup(::core::mem::transmute(&punkcontextmenu), ::core::mem::transmute_copy(&fflags), ::core::mem::transmute(&pt)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), DoContextMenuPopup: DoContextMenuPopup::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), DoContextMenuPopup: DoContextMenuPopup::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IContextMenuSite as ::windows::core::Interface>::IID
@@ -3691,7 +3695,7 @@ impl ICopyHookA_Vtbl {
             let this = (*this).get_impl();
             this.CopyCallback(::core::mem::transmute_copy(&hwnd), ::core::mem::transmute_copy(&wfunc), ::core::mem::transmute_copy(&wflags), ::core::mem::transmute(&pszsrcfile), ::core::mem::transmute_copy(&dwsrcattribs), ::core::mem::transmute(&pszdestfile), ::core::mem::transmute_copy(&dwdestattribs))
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CopyCallback: CopyCallback::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CopyCallback: CopyCallback::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ICopyHookA as ::windows::core::Interface>::IID
@@ -3711,7 +3715,7 @@ impl ICopyHookW_Vtbl {
             let this = (*this).get_impl();
             this.CopyCallback(::core::mem::transmute_copy(&hwnd), ::core::mem::transmute_copy(&wfunc), ::core::mem::transmute_copy(&wflags), ::core::mem::transmute(&pszsrcfile), ::core::mem::transmute_copy(&dwsrcattribs), ::core::mem::transmute(&pszdestfile), ::core::mem::transmute_copy(&dwdestattribs))
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CopyCallback: CopyCallback::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CopyCallback: CopyCallback::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ICopyHookW as ::windows::core::Interface>::IID
@@ -3771,7 +3775,7 @@ impl ICreateProcessInputs_Vtbl {
             this.SetEnvironmentVariable(::core::mem::transmute(&pszname), ::core::mem::transmute(&pszvalue)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCreateFlags: GetCreateFlags::<Identity, Impl, OFFSET>,
             SetCreateFlags: SetCreateFlags::<Identity, Impl, OFFSET>,
             AddCreateFlags: AddCreateFlags::<Identity, Impl, OFFSET>,
@@ -3796,7 +3800,7 @@ impl ICreatingProcess_Vtbl {
             let this = (*this).get_impl();
             this.OnCreating(::core::mem::transmute(&pcpi)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnCreating: OnCreating::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnCreating: OnCreating::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ICreatingProcess as ::windows::core::Interface>::IID
@@ -3877,7 +3881,7 @@ impl ICredentialProvider_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetUsageScenario: SetUsageScenario::<Identity, Impl, OFFSET>,
             SetSerialization: SetSerialization::<Identity, Impl, OFFSET>,
             Advise: Advise::<Identity, Impl, OFFSET>,
@@ -4033,7 +4037,7 @@ impl ICredentialProviderCredential_Vtbl {
             this.ReportResult(::core::mem::transmute_copy(&ntsstatus), ::core::mem::transmute_copy(&ntssubstatus), ::core::mem::transmute_copy(&ppszoptionalstatustext), ::core::mem::transmute_copy(&pcpsioptionalstatusicon)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Advise: Advise::<Identity, Impl, OFFSET>,
             UnAdvise: UnAdvise::<Identity, Impl, OFFSET>,
             SetSelected: SetSelected::<Identity, Impl, OFFSET>,
@@ -4158,7 +4162,7 @@ impl ICredentialProviderCredentialEvents_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetFieldState: SetFieldState::<Identity, Impl, OFFSET>,
             SetFieldInteractiveState: SetFieldInteractiveState::<Identity, Impl, OFFSET>,
             SetFieldString: SetFieldString::<Identity, Impl, OFFSET>,
@@ -4229,7 +4233,7 @@ impl ICredentialProviderCredentialWithFieldOptions_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetFieldOptions: GetFieldOptions::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetFieldOptions: GetFieldOptions::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ICredentialProviderCredentialWithFieldOptions as ::windows::core::Interface>::IID
@@ -4246,7 +4250,7 @@ impl ICredentialProviderEvents_Vtbl {
             let this = (*this).get_impl();
             this.CredentialsChanged(::core::mem::transmute_copy(&upadvisecontext)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CredentialsChanged: CredentialsChanged::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CredentialsChanged: CredentialsChanged::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ICredentialProviderEvents as ::windows::core::Interface>::IID
@@ -4279,7 +4283,7 @@ impl ICredentialProviderFilter_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Filter: Filter::<Identity, Impl, OFFSET>,
             UpdateRemoteCredential: UpdateRemoteCredential::<Identity, Impl, OFFSET>,
         }
@@ -4299,7 +4303,7 @@ impl ICredentialProviderSetUserArray_Vtbl {
             let this = (*this).get_impl();
             this.SetUserArray(::core::mem::transmute(&users)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SetUserArray: SetUserArray::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SetUserArray: SetUserArray::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ICredentialProviderSetUserArray as ::windows::core::Interface>::IID
@@ -4362,7 +4366,7 @@ impl ICredentialProviderUser_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSid: GetSid::<Identity, Impl, OFFSET>,
             GetProviderID: GetProviderID::<Identity, Impl, OFFSET>,
             GetStringValue: GetStringValue::<Identity, Impl, OFFSET>,
@@ -4421,7 +4425,7 @@ impl ICredentialProviderUserArray_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetProviderFilter: SetProviderFilter::<Identity, Impl, OFFSET>,
             GetAccountOptions: GetAccountOptions::<Identity, Impl, OFFSET>,
             GetCount: GetCount::<Identity, Impl, OFFSET>,
@@ -4463,7 +4467,7 @@ impl ICurrentWorkingDirectory_Vtbl {
             this.SetDirectory(::core::mem::transmute(&pwzpath)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDirectory: GetDirectory::<Identity, Impl, OFFSET>,
             SetDirectory: SetDirectory::<Identity, Impl, OFFSET>,
         }
@@ -4535,7 +4539,7 @@ impl ICustomDestinationList_Vtbl {
             this.AbortList().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetAppID: SetAppID::<Identity, Impl, OFFSET>,
             BeginList: BeginList::<Identity, Impl, OFFSET>,
             AppendCategory: AppendCategory::<Identity, Impl, OFFSET>,
@@ -4602,7 +4606,7 @@ impl IDataObjectAsyncCapability_Vtbl {
             this.EndOperation(::core::mem::transmute_copy(&hresult), ::core::mem::transmute(&pbcreserved), ::core::mem::transmute_copy(&dweffects)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetAsyncMode: SetAsyncMode::<Identity, Impl, OFFSET>,
             GetAsyncMode: GetAsyncMode::<Identity, Impl, OFFSET>,
             StartOperation: StartOperation::<Identity, Impl, OFFSET>,
@@ -4641,7 +4645,7 @@ impl IDataObjectProvider_Vtbl {
             this.SetDataObject(::core::mem::transmute(&dataobject)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDataObject: GetDataObject::<Identity, Impl, OFFSET>,
             SetDataObject: SetDataObject::<Identity, Impl, OFFSET>,
         }
@@ -4671,7 +4675,7 @@ impl IDataTransferManagerInterop_Vtbl {
             this.ShowShareUIForWindow(::core::mem::transmute_copy(&appwindow)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetForWindow: GetForWindow::<Identity, Impl, OFFSET>,
             ShowShareUIForWindow: ShowShareUIForWindow::<Identity, Impl, OFFSET>,
         }
@@ -4725,7 +4729,7 @@ impl IDefaultExtractIconInit_Vtbl {
             this.SetDefaultIcon(::core::mem::transmute(&pszfile), ::core::mem::transmute_copy(&iicon)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetFlags: SetFlags::<Identity, Impl, OFFSET>,
             SetKey: SetKey::<Identity, Impl, OFFSET>,
             SetNormalIcon: SetNormalIcon::<Identity, Impl, OFFSET>,
@@ -4777,7 +4781,7 @@ impl IDefaultFolderMenuInitialize_Vtbl {
             this.SetHandlerClsid(::core::mem::transmute_copy(&rclsid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             SetMenuRestrictions: SetMenuRestrictions::<Identity, Impl, OFFSET>,
             GetMenuRestrictions: GetMenuRestrictions::<Identity, Impl, OFFSET>,
@@ -4802,7 +4806,7 @@ impl IDelegateFolder_Vtbl {
             let this = (*this).get_impl();
             this.SetItemAlloc(::core::mem::transmute(&pmalloc)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SetItemAlloc: SetItemAlloc::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SetItemAlloc: SetItemAlloc::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDelegateFolder as ::windows::core::Interface>::IID
@@ -4907,7 +4911,7 @@ impl IDeskBandInfo_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetDefaultBandWidth: GetDefaultBandWidth::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetDefaultBandWidth: GetDefaultBandWidth::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDeskBandInfo as ::windows::core::Interface>::IID
@@ -5017,7 +5021,7 @@ impl IDesktopGadget_Vtbl {
             let this = (*this).get_impl();
             this.RunGadget(::core::mem::transmute(&gadgetpath)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), RunGadget: RunGadget::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), RunGadget: RunGadget::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDesktopGadget as ::windows::core::Interface>::IID
@@ -5176,7 +5180,7 @@ impl IDesktopWallpaper_Vtbl {
             this.Enable(::core::mem::transmute_copy(&enable)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetWallpaper: SetWallpaper::<Identity, Impl, OFFSET>,
             GetWallpaper: GetWallpaper::<Identity, Impl, OFFSET>,
             GetMonitorDevicePathAt: GetMonitorDevicePathAt::<Identity, Impl, OFFSET>,
@@ -5219,7 +5223,7 @@ impl IDestinationStreamFactory_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetDestinationStream: GetDestinationStream::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetDestinationStream: GetDestinationStream::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDestinationStreamFactory as ::windows::core::Interface>::IID
@@ -5252,7 +5256,7 @@ impl IDocViewSite_Vtbl {
             let this = (*this).get_impl();
             this.OnSetTitle(::core::mem::transmute_copy(&pvtitle)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnSetTitle: OnSetTitle::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnSetTitle: OnSetTitle::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDocViewSite as ::windows::core::Interface>::IID
@@ -5396,7 +5400,7 @@ impl IDragSourceHelper_Vtbl {
             this.InitializeFromWindow(::core::mem::transmute_copy(&hwnd), ::core::mem::transmute_copy(&ppt), ::core::mem::transmute(&pdataobject)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             InitializeFromBitmap: InitializeFromBitmap::<Identity, Impl, OFFSET>,
             InitializeFromWindow: InitializeFromWindow::<Identity, Impl, OFFSET>,
         }
@@ -5464,7 +5468,7 @@ impl IDropTargetHelper_Vtbl {
             this.Show(::core::mem::transmute_copy(&fshow)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             DragEnter: DragEnter::<Identity, Impl, OFFSET>,
             DragLeave: DragLeave::<Identity, Impl, OFFSET>,
             DragOver: DragOver::<Identity, Impl, OFFSET>,
@@ -5493,7 +5497,7 @@ impl IDynamicHWHandler_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetDynamicInfo: GetDynamicInfo::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetDynamicInfo: GetDynamicInfo::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IDynamicHWHandler as ::windows::core::Interface>::IID
@@ -5553,7 +5557,7 @@ impl IEnumAssocHandlers_Vtbl {
             let this = (*this).get_impl();
             this.Next(::core::mem::transmute_copy(&celt), ::core::mem::transmute_copy(&rgelt), ::core::mem::transmute_copy(&pceltfetched)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Next: Next::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Next: Next::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IEnumAssocHandlers as ::windows::core::Interface>::IID
@@ -5595,7 +5599,7 @@ impl IEnumExplorerCommand_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -5642,7 +5646,7 @@ impl IEnumExtraSearch_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -5692,7 +5696,7 @@ impl IEnumFullIDList_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -5739,7 +5743,7 @@ impl IEnumHLITEM_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -5783,7 +5787,7 @@ impl IEnumIDList_Vtbl {
             this.Clone(::core::mem::transmute_copy(&ppenum))
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -5830,7 +5834,7 @@ impl IEnumObjects_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -5864,7 +5868,7 @@ impl IEnumPublishedApps_Vtbl {
             let this = (*this).get_impl();
             this.Reset().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Next: Next::<Identity, Impl, OFFSET>, Reset: Reset::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Next: Next::<Identity, Impl, OFFSET>, Reset: Reset::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IEnumPublishedApps as ::windows::core::Interface>::IID
@@ -5881,7 +5885,7 @@ impl IEnumReadyCallback_Vtbl {
             let this = (*this).get_impl();
             this.EnumReady().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), EnumReady: EnumReady::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), EnumReady: EnumReady::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IEnumReadyCallback as ::windows::core::Interface>::IID
@@ -5923,7 +5927,7 @@ impl IEnumResources_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -5970,7 +5974,7 @@ impl IEnumShellItems_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -6017,7 +6021,7 @@ impl IEnumSyncMgrConflict_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -6064,7 +6068,7 @@ impl IEnumSyncMgrEvents_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -6111,7 +6115,7 @@ impl IEnumSyncMgrSyncItems_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -6158,7 +6162,7 @@ impl IEnumTravelLogEntry_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -6196,7 +6200,7 @@ impl IEnumerableView_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetEnumReadyCallback: SetEnumReadyCallback::<Identity, Impl, OFFSET>,
             CreateEnumIDListFromContents: CreateEnumIDListFromContents::<Identity, Impl, OFFSET>,
         }
@@ -6256,7 +6260,7 @@ impl IExecuteCommand_Vtbl {
             this.Execute().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetKeyState: SetKeyState::<Identity, Impl, OFFSET>,
             SetParameters: SetParameters::<Identity, Impl, OFFSET>,
             SetPosition: SetPosition::<Identity, Impl, OFFSET>,
@@ -6287,7 +6291,7 @@ impl IExecuteCommandApplicationHostEnvironment_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetValue: GetValue::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetValue: GetValue::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IExecuteCommandApplicationHostEnvironment as ::windows::core::Interface>::IID
@@ -6310,7 +6314,7 @@ impl IExecuteCommandHost_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetUIMode: GetUIMode::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetUIMode: GetUIMode::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IExecuteCommandHost as ::windows::core::Interface>::IID
@@ -6349,7 +6353,7 @@ impl IExpDispSupport_Vtbl {
             this.OnInvoke(::core::mem::transmute_copy(&dispidmember), ::core::mem::transmute_copy(&iid), ::core::mem::transmute_copy(&lcid), ::core::mem::transmute_copy(&wflags), ::core::mem::transmute_copy(&pdispparams), ::core::mem::transmute_copy(&pvarresult), ::core::mem::transmute_copy(&pexcepinfo), ::core::mem::transmute_copy(&puargerr)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             FindConnectionPoint: FindConnectionPoint::<Identity, Impl, OFFSET>,
             OnTranslateAccelerator: OnTranslateAccelerator::<Identity, Impl, OFFSET>,
             OnInvoke: OnInvoke::<Identity, Impl, OFFSET>,
@@ -6392,7 +6396,7 @@ impl IExpDispSupportXP_Vtbl {
             this.OnInvoke(::core::mem::transmute_copy(&dispidmember), ::core::mem::transmute_copy(&iid), ::core::mem::transmute_copy(&lcid), ::core::mem::transmute_copy(&wflags), ::core::mem::transmute_copy(&pdispparams), ::core::mem::transmute_copy(&pvarresult), ::core::mem::transmute_copy(&pexcepinfo), ::core::mem::transmute_copy(&puargerr)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             FindCIE4ConnectionPoint: FindCIE4ConnectionPoint::<Identity, Impl, OFFSET>,
             OnTranslateAccelerator: OnTranslateAccelerator::<Identity, Impl, OFFSET>,
             OnInvoke: OnInvoke::<Identity, Impl, OFFSET>,
@@ -6513,7 +6517,7 @@ impl IExplorerBrowser_Vtbl {
             this.GetCurrentView(::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppv)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             Destroy: Destroy::<Identity, Impl, OFFSET>,
             SetRect: SetRect::<Identity, Impl, OFFSET>,
@@ -6568,7 +6572,7 @@ impl IExplorerBrowserEvents_Vtbl {
             this.OnNavigationFailed(::core::mem::transmute_copy(&pidlfolder)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnNavigationPending: OnNavigationPending::<Identity, Impl, OFFSET>,
             OnViewCreated: OnViewCreated::<Identity, Impl, OFFSET>,
             OnNavigationComplete: OnNavigationComplete::<Identity, Impl, OFFSET>,
@@ -6678,7 +6682,7 @@ impl IExplorerCommand_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTitle: GetTitle::<Identity, Impl, OFFSET>,
             GetIcon: GetIcon::<Identity, Impl, OFFSET>,
             GetToolTip: GetToolTip::<Identity, Impl, OFFSET>,
@@ -6711,7 +6715,7 @@ impl IExplorerCommandProvider_Vtbl {
             this.GetCommand(::core::mem::transmute_copy(&rguidcommandid), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppv)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCommands: GetCommands::<Identity, Impl, OFFSET>,
             GetCommand: GetCommand::<Identity, Impl, OFFSET>,
         }
@@ -6740,7 +6744,7 @@ impl IExplorerCommandState_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetState: GetState::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetState: GetState::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IExplorerCommandState as ::windows::core::Interface>::IID
@@ -6763,7 +6767,7 @@ impl IExplorerPaneVisibility_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetPaneState: GetPaneState::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetPaneState: GetPaneState::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IExplorerPaneVisibility as ::windows::core::Interface>::IID
@@ -6790,7 +6794,7 @@ impl IExtensionServices_Vtbl {
             this.SetAuthenticateData(::core::mem::transmute_copy(&phwnd), ::core::mem::transmute(&pwzusername), ::core::mem::transmute(&pwzpassword)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetAdditionalHeaders: SetAdditionalHeaders::<Identity, Impl, OFFSET>,
             SetAuthenticateData: SetAuthenticateData::<Identity, Impl, OFFSET>,
         }
@@ -6820,7 +6824,7 @@ impl IExtractIconA_Vtbl {
             this.Extract(::core::mem::transmute(&pszfile), ::core::mem::transmute_copy(&niconindex), ::core::mem::transmute_copy(&phiconlarge), ::core::mem::transmute_copy(&phiconsmall), ::core::mem::transmute_copy(&niconsize)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetIconLocation: GetIconLocation::<Identity, Impl, OFFSET>,
             Extract: Extract::<Identity, Impl, OFFSET>,
         }
@@ -6850,7 +6854,7 @@ impl IExtractIconW_Vtbl {
             this.Extract(::core::mem::transmute(&pszfile), ::core::mem::transmute_copy(&niconindex), ::core::mem::transmute_copy(&phiconlarge), ::core::mem::transmute_copy(&phiconsmall), ::core::mem::transmute_copy(&niconsize)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetIconLocation: GetIconLocation::<Identity, Impl, OFFSET>,
             Extract: Extract::<Identity, Impl, OFFSET>,
         }
@@ -6886,7 +6890,7 @@ impl IExtractImage_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetLocation: GetLocation::<Identity, Impl, OFFSET>,
             Extract: Extract::<Identity, Impl, OFFSET>,
         }
@@ -7203,7 +7207,7 @@ impl IFileDialogControlEvents_Vtbl {
             this.OnControlActivating(::core::mem::transmute(&pfdc), ::core::mem::transmute_copy(&dwidctl)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnItemSelected: OnItemSelected::<Identity, Impl, OFFSET>,
             OnButtonClicked: OnButtonClicked::<Identity, Impl, OFFSET>,
             OnCheckButtonToggled: OnCheckButtonToggled::<Identity, Impl, OFFSET>,
@@ -7415,7 +7419,7 @@ impl IFileDialogCustomize_Vtbl {
             this.SetControlItemText(::core::mem::transmute_copy(&dwidctl), ::core::mem::transmute_copy(&dwiditem), ::core::mem::transmute(&pszlabel)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             EnableOpenDropDown: EnableOpenDropDown::<Identity, Impl, OFFSET>,
             AddMenu: AddMenu::<Identity, Impl, OFFSET>,
             AddPushButton: AddPushButton::<Identity, Impl, OFFSET>,
@@ -7509,7 +7513,7 @@ impl IFileDialogEvents_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnFileOk: OnFileOk::<Identity, Impl, OFFSET>,
             OnFolderChanging: OnFolderChanging::<Identity, Impl, OFFSET>,
             OnFolderChange: OnFolderChange::<Identity, Impl, OFFSET>,
@@ -7586,7 +7590,7 @@ impl IFileIsInUse_Vtbl {
             this.CloseFile().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetAppName: GetAppName::<Identity, Impl, OFFSET>,
             GetUsage: GetUsage::<Identity, Impl, OFFSET>,
             GetCapabilities: GetCapabilities::<Identity, Impl, OFFSET>,
@@ -7781,7 +7785,7 @@ impl IFileOperation_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Advise: Advise::<Identity, Impl, OFFSET>,
             Unadvise: Unadvise::<Identity, Impl, OFFSET>,
             SetOperationFlags: SetOperationFlags::<Identity, Impl, OFFSET>,
@@ -7930,7 +7934,7 @@ impl IFileOperationProgressSink_Vtbl {
             this.ResumeTimer().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             StartOperations: StartOperations::<Identity, Impl, OFFSET>,
             FinishOperations: FinishOperations::<Identity, Impl, OFFSET>,
             PreRenameItem: PreRenameItem::<Identity, Impl, OFFSET>,
@@ -8106,7 +8110,7 @@ impl IFileSyncMergeHandler_Vtbl {
             this.ShowResolveConflictUIAsync(::core::mem::transmute(&localfilepath), ::core::mem::transmute_copy(&monitortodisplayon)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Merge: Merge::<Identity, Impl, OFFSET>,
             ShowResolveConflictUIAsync: ShowResolveConflictUIAsync::<Identity, Impl, OFFSET>,
         }
@@ -8142,7 +8146,7 @@ impl IFileSystemBindData_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetFindData: SetFindData::<Identity, Impl, OFFSET>,
             GetFindData: GetFindData::<Identity, Impl, OFFSET>,
         }
@@ -8240,7 +8244,7 @@ impl IFolderBandPriv_Vtbl {
             this.SetNoText(::core::mem::transmute_copy(&fnotext)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetCascade: SetCascade::<Identity, Impl, OFFSET>,
             SetAccelerators: SetAccelerators::<Identity, Impl, OFFSET>,
             SetNoIcons: SetNoIcons::<Identity, Impl, OFFSET>,
@@ -8272,7 +8276,7 @@ impl IFolderFilter_Vtbl {
             this.GetEnumFlags(::core::mem::transmute(&psf), ::core::mem::transmute_copy(&pidlfolder), ::core::mem::transmute_copy(&phwnd), ::core::mem::transmute_copy(&pgrfflags)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ShouldShow: ShouldShow::<Identity, Impl, OFFSET>,
             GetEnumFlags: GetEnumFlags::<Identity, Impl, OFFSET>,
         }
@@ -8292,7 +8296,7 @@ impl IFolderFilterSite_Vtbl {
             let this = (*this).get_impl();
             this.SetFilter(::core::mem::transmute(&punk)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SetFilter: SetFilter::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SetFilter: SetFilter::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IFolderFilterSite as ::windows::core::Interface>::IID
@@ -8433,7 +8437,7 @@ impl IFolderView_Vtbl {
             this.SelectAndPositionItems(::core::mem::transmute_copy(&cidl), ::core::mem::transmute_copy(&apidl), ::core::mem::transmute_copy(&apt), ::core::mem::transmute_copy(&dwflags)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCurrentViewMode: GetCurrentViewMode::<Identity, Impl, OFFSET>,
             SetCurrentViewMode: SetCurrentViewMode::<Identity, Impl, OFFSET>,
             GetFolder: GetFolder::<Identity, Impl, OFFSET>,
@@ -8707,7 +8711,7 @@ impl IFolderViewHost_Vtbl {
             let this = (*this).get_impl();
             this.Initialize(::core::mem::transmute_copy(&hwndparent), ::core::mem::transmute(&pdo), ::core::mem::transmute_copy(&prc)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Initialize: Initialize::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Initialize: Initialize::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IFolderViewHost as ::windows::core::Interface>::IID
@@ -8757,7 +8761,7 @@ impl IFolderViewOptions_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetFolderViewOptions: SetFolderViewOptions::<Identity, Impl, OFFSET>,
             GetFolderViewOptions: GetFolderViewOptions::<Identity, Impl, OFFSET>,
         }
@@ -8835,7 +8839,7 @@ impl IFolderViewSettings_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetColumnPropertyList: GetColumnPropertyList::<Identity, Impl, OFFSET>,
             GetGroupByProperty: GetGroupByProperty::<Identity, Impl, OFFSET>,
             GetViewMode: GetViewMode::<Identity, Impl, OFFSET>,
@@ -8900,7 +8904,7 @@ impl IFrameworkInputPane_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Advise: Advise::<Identity, Impl, OFFSET>,
             AdviseWithHWND: AdviseWithHWND::<Identity, Impl, OFFSET>,
             Unadvise: Unadvise::<Identity, Impl, OFFSET>,
@@ -8932,7 +8936,7 @@ impl IFrameworkInputPaneHandler_Vtbl {
             this.Hiding(::core::mem::transmute_copy(&fensurefocusedelementinview)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Showing: Showing::<Identity, Impl, OFFSET>,
             Hiding: Hiding::<Identity, Impl, OFFSET>,
         }
@@ -8952,7 +8956,7 @@ impl IGetServiceIds_Vtbl {
             let this = (*this).get_impl();
             this.GetServiceIds(::core::mem::transmute_copy(&serviceidcount), ::core::mem::transmute_copy(&serviceids)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetServiceIds: GetServiceIds::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetServiceIds: GetServiceIds::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IGetServiceIds as ::windows::core::Interface>::IID
@@ -8985,7 +8989,7 @@ impl IHWEventHandler_Vtbl {
             this.HandleEventWithContent(::core::mem::transmute(&pszdeviceid), ::core::mem::transmute(&pszaltdeviceid), ::core::mem::transmute(&pszeventtype), ::core::mem::transmute(&pszcontenttypehandler), ::core::mem::transmute(&pdataobject)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             HandleEvent: HandleEvent::<Identity, Impl, OFFSET>,
             HandleEventWithContent: HandleEventWithContent::<Identity, Impl, OFFSET>,
@@ -9033,7 +9037,7 @@ impl IHandlerActivationHost_Vtbl {
             this.BeforeCreateProcess(::core::mem::transmute(&applicationpath), ::core::mem::transmute(&commandline), ::core::mem::transmute(&handlerinfo)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             BeforeCoCreateInstance: BeforeCoCreateInstance::<Identity, Impl, OFFSET>,
             BeforeCreateProcess: BeforeCreateProcess::<Identity, Impl, OFFSET>,
         }
@@ -9084,7 +9088,7 @@ impl IHandlerInfo_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetApplicationDisplayName: GetApplicationDisplayName::<Identity, Impl, OFFSET>,
             GetApplicationPublisher: GetApplicationPublisher::<Identity, Impl, OFFSET>,
             GetApplicationIconReference: GetApplicationIconReference::<Identity, Impl, OFFSET>,
@@ -9234,7 +9238,7 @@ impl IHlink_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetHlinkSite: SetHlinkSite::<Identity, Impl, OFFSET>,
             GetHlinkSite: GetHlinkSite::<Identity, Impl, OFFSET>,
             SetMonikerReference: SetMonikerReference::<Identity, Impl, OFFSET>,
@@ -9390,7 +9394,7 @@ impl IHlinkBrowseContext_Vtbl {
             this.Close(::core::mem::transmute_copy(&reserved)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Register: Register::<Identity, Impl, OFFSET>,
             GetObject: GetObject::<Identity, Impl, OFFSET>,
             Revoke: Revoke::<Identity, Impl, OFFSET>,
@@ -9456,7 +9460,7 @@ impl IHlinkFrame_Vtbl {
             this.UpdateHlink(::core::mem::transmute_copy(&uhlid), ::core::mem::transmute(&pimktarget), ::core::mem::transmute(&pwzlocation), ::core::mem::transmute(&pwzfriendlyname)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetBrowseContext: SetBrowseContext::<Identity, Impl, OFFSET>,
             GetBrowseContext: GetBrowseContext::<Identity, Impl, OFFSET>,
             Navigate: Navigate::<Identity, Impl, OFFSET>,
@@ -9513,7 +9517,7 @@ impl IHlinkSite_Vtbl {
             this.OnNavigationComplete(::core::mem::transmute_copy(&dwsitedata), ::core::mem::transmute_copy(&dwreserved), ::core::mem::transmute_copy(&hrerror), ::core::mem::transmute(&pwzerror)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             QueryService: QueryService::<Identity, Impl, OFFSET>,
             GetMoniker: GetMoniker::<Identity, Impl, OFFSET>,
             ReadyToNavigate: ReadyToNavigate::<Identity, Impl, OFFSET>,
@@ -9581,7 +9585,7 @@ impl IHlinkTarget_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetBrowseContext: SetBrowseContext::<Identity, Impl, OFFSET>,
             GetBrowseContext: GetBrowseContext::<Identity, Impl, OFFSET>,
             Navigate: Navigate::<Identity, Impl, OFFSET>,
@@ -9626,7 +9630,7 @@ impl IHomeGroup_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             IsMember: IsMember::<Identity, Impl, OFFSET>,
             ShowSharingWizard: ShowSharingWizard::<Identity, Impl, OFFSET>,
         }
@@ -9653,7 +9657,7 @@ impl IIOCancelInformation_Vtbl {
             this.GetCancelInformation(::core::mem::transmute_copy(&pdwthreadid), ::core::mem::transmute_copy(&pumsgcancel)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetCancelInformation: SetCancelInformation::<Identity, Impl, OFFSET>,
             GetCancelInformation: GetCancelInformation::<Identity, Impl, OFFSET>,
         }
@@ -9695,7 +9699,7 @@ impl IImageRecompress_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), RecompressImage: RecompressImage::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), RecompressImage: RecompressImage::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IImageRecompress as ::windows::core::Interface>::IID
@@ -9715,7 +9719,7 @@ impl IInitializeCommand_Vtbl {
             let this = (*this).get_impl();
             this.Initialize(::core::mem::transmute(&pszcommandname), ::core::mem::transmute(&ppb)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Initialize: Initialize::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Initialize: Initialize::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IInitializeCommand as ::windows::core::Interface>::IID
@@ -9735,7 +9739,7 @@ impl IInitializeNetworkFolder_Vtbl {
             let this = (*this).get_impl();
             this.Initialize(::core::mem::transmute_copy(&pidl), ::core::mem::transmute_copy(&pidltarget), ::core::mem::transmute_copy(&udisplaytype), ::core::mem::transmute(&pszresname), ::core::mem::transmute(&pszprovider)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Initialize: Initialize::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Initialize: Initialize::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IInitializeNetworkFolder as ::windows::core::Interface>::IID
@@ -9752,7 +9756,7 @@ impl IInitializeObject_Vtbl {
             let this = (*this).get_impl();
             this.Initialize().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Initialize: Initialize::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Initialize: Initialize::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IInitializeObject as ::windows::core::Interface>::IID
@@ -9772,7 +9776,7 @@ impl IInitializeWithBindCtx_Vtbl {
             let this = (*this).get_impl();
             this.Initialize(::core::mem::transmute(&pbc)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Initialize: Initialize::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Initialize: Initialize::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IInitializeWithBindCtx as ::windows::core::Interface>::IID
@@ -9789,7 +9793,7 @@ impl IInitializeWithItem_Vtbl {
             let this = (*this).get_impl();
             this.Initialize(::core::mem::transmute(&psi), ::core::mem::transmute_copy(&grfmode)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Initialize: Initialize::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Initialize: Initialize::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IInitializeWithItem as ::windows::core::Interface>::IID
@@ -9809,7 +9813,7 @@ impl IInitializeWithPropertyStore_Vtbl {
             let this = (*this).get_impl();
             this.Initialize(::core::mem::transmute(&pps)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Initialize: Initialize::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Initialize: Initialize::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IInitializeWithPropertyStore as ::windows::core::Interface>::IID
@@ -9829,7 +9833,7 @@ impl IInitializeWithWindow_Vtbl {
             let this = (*this).get_impl();
             this.Initialize(::core::mem::transmute_copy(&hwnd)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Initialize: Initialize::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Initialize: Initialize::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IInitializeWithWindow as ::windows::core::Interface>::IID
@@ -9862,7 +9866,7 @@ impl IInputObject_Vtbl {
             this.TranslateAcceleratorIO(::core::mem::transmute_copy(&pmsg)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             UIActivateIO: UIActivateIO::<Identity, Impl, OFFSET>,
             HasFocusIO: HasFocusIO::<Identity, Impl, OFFSET>,
             TranslateAcceleratorIO: TranslateAcceleratorIO::<Identity, Impl, OFFSET>,
@@ -9906,7 +9910,7 @@ impl IInputObjectSite_Vtbl {
             let this = (*this).get_impl();
             this.OnFocusChangeIS(::core::mem::transmute(&punkobj), ::core::mem::transmute_copy(&fsetfocus)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnFocusChangeIS: OnFocusChangeIS::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnFocusChangeIS: OnFocusChangeIS::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IInputObjectSite as ::windows::core::Interface>::IID
@@ -9926,7 +9930,7 @@ impl IInputPaneAnimationCoordinator_Vtbl {
             let this = (*this).get_impl();
             this.AddAnimation(::core::mem::transmute(&device), ::core::mem::transmute(&animation)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), AddAnimation: AddAnimation::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), AddAnimation: AddAnimation::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IInputPaneAnimationCoordinator as ::windows::core::Interface>::IID
@@ -9943,7 +9947,7 @@ impl IInputPanelConfiguration_Vtbl {
             let this = (*this).get_impl();
             this.EnableFocusTracking().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), EnableFocusTracking: EnableFocusTracking::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), EnableFocusTracking: EnableFocusTracking::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IInputPanelConfiguration as ::windows::core::Interface>::IID
@@ -9960,7 +9964,10 @@ impl IInputPanelInvocationConfiguration_Vtbl {
             let this = (*this).get_impl();
             this.RequireTouchInEditControl().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), RequireTouchInEditControl: RequireTouchInEditControl::<Identity, Impl, OFFSET> }
+        Self {
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
+            RequireTouchInEditControl: RequireTouchInEditControl::<Identity, Impl, OFFSET>,
+        }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IInputPanelInvocationConfiguration as ::windows::core::Interface>::IID
@@ -9980,7 +9987,7 @@ impl IInsertItem_Vtbl {
             let this = (*this).get_impl();
             this.InsertItem(::core::mem::transmute_copy(&pidl)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), InsertItem: InsertItem::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), InsertItem: InsertItem::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IInsertItem as ::windows::core::Interface>::IID
@@ -10010,7 +10017,7 @@ impl IItemNameLimits_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetValidCharacters: GetValidCharacters::<Identity, Impl, OFFSET>,
             GetMaxLength: GetMaxLength::<Identity, Impl, OFFSET>,
         }
@@ -10124,7 +10131,7 @@ impl IKnownFolder_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetId: GetId::<Identity, Impl, OFFSET>,
             GetCategory: GetCategory::<Identity, Impl, OFFSET>,
             GetShellItem: GetShellItem::<Identity, Impl, OFFSET>,
@@ -10251,7 +10258,7 @@ impl IKnownFolderManager_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             FolderIdFromCsidl: FolderIdFromCsidl::<Identity, Impl, OFFSET>,
             FolderIdToCsidl: FolderIdToCsidl::<Identity, Impl, OFFSET>,
             GetFolderIds: GetFolderIds::<Identity, Impl, OFFSET>,
@@ -10285,7 +10292,7 @@ impl ILaunchSourceAppUserModelId_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetAppUserModelId: GetAppUserModelId::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetAppUserModelId: GetAppUserModelId::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ILaunchSourceAppUserModelId as ::windows::core::Interface>::IID
@@ -10324,7 +10331,7 @@ impl ILaunchSourceViewSizePreference_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSourceViewToPosition: GetSourceViewToPosition::<Identity, Impl, OFFSET>,
             GetSourceViewSizePreference: GetSourceViewSizePreference::<Identity, Impl, OFFSET>,
         }
@@ -10353,7 +10360,7 @@ impl ILaunchTargetMonitor_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetMonitor: GetMonitor::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetMonitor: GetMonitor::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ILaunchTargetMonitor as ::windows::core::Interface>::IID
@@ -10377,7 +10384,7 @@ impl ILaunchTargetViewSizePreference_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTargetViewSizePreference: GetTargetViewSizePreference::<Identity, Impl, OFFSET>,
         }
     }
@@ -10406,7 +10413,7 @@ impl ILaunchUIContext_Vtbl {
             this.SetTabGroupingPreference(::core::mem::transmute_copy(&value)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetAssociatedWindow: SetAssociatedWindow::<Identity, Impl, OFFSET>,
             SetTabGroupingPreference: SetTabGroupingPreference::<Identity, Impl, OFFSET>,
         }
@@ -10426,7 +10433,7 @@ impl ILaunchUIContextProvider_Vtbl {
             let this = (*this).get_impl();
             this.UpdateContext(::core::mem::transmute(&context)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), UpdateContext: UpdateContext::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), UpdateContext: UpdateContext::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ILaunchUIContextProvider as ::windows::core::Interface>::IID
@@ -10453,7 +10460,7 @@ impl IMenuBand_Vtbl {
             this.TranslateMenuMessage(::core::mem::transmute_copy(&pmsg), ::core::mem::transmute_copy(&plret)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             IsMenuMessage: IsMenuMessage::<Identity, Impl, OFFSET>,
             TranslateMenuMessage: TranslateMenuMessage::<Identity, Impl, OFFSET>,
         }
@@ -10513,7 +10520,7 @@ impl IModalWindow_Vtbl {
             let this = (*this).get_impl();
             this.Show(::core::mem::transmute_copy(&hwndowner)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Show: Show::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Show: Show::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IModalWindow as ::windows::core::Interface>::IID
@@ -10558,7 +10565,7 @@ impl INameSpaceTreeAccessible_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnGetDefaultAccessibilityAction: OnGetDefaultAccessibilityAction::<Identity, Impl, OFFSET>,
             OnDoDefaultAccessibilityAction: OnDoDefaultAccessibilityAction::<Identity, Impl, OFFSET>,
             OnGetAccessibilityRole: OnGetAccessibilityRole::<Identity, Impl, OFFSET>,
@@ -10739,7 +10746,7 @@ impl INameSpaceTreeControl_Vtbl {
             this.CollapseAll().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             TreeAdvise: TreeAdvise::<Identity, Impl, OFFSET>,
             TreeUnadvise: TreeUnadvise::<Identity, Impl, OFFSET>,
@@ -10860,7 +10867,7 @@ impl INameSpaceTreeControlCustomDraw_Vtbl {
             this.ItemPostPaint(::core::mem::transmute_copy(&hdc), ::core::mem::transmute_copy(&prc), ::core::mem::transmute_copy(&pnstccditem)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             PrePaint: PrePaint::<Identity, Impl, OFFSET>,
             PostPaint: PostPaint::<Identity, Impl, OFFSET>,
             ItemPrePaint: ItemPrePaint::<Identity, Impl, OFFSET>,
@@ -10916,7 +10923,7 @@ impl INameSpaceTreeControlDropHandler_Vtbl {
             this.OnDragLeave(::core::mem::transmute(&psiover)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnDragEnter: OnDragEnter::<Identity, Impl, OFFSET>,
             OnDragOver: OnDragOver::<Identity, Impl, OFFSET>,
             OnDragPosition: OnDragPosition::<Identity, Impl, OFFSET>,
@@ -11046,7 +11053,7 @@ impl INameSpaceTreeControlEvents_Vtbl {
             this.OnGetDefaultIconIndex(::core::mem::transmute(&psi), ::core::mem::transmute_copy(&pidefaulticon), ::core::mem::transmute_copy(&piopenicon)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnItemClick: OnItemClick::<Identity, Impl, OFFSET>,
             OnPropertyItemCommit: OnPropertyItemCommit::<Identity, Impl, OFFSET>,
             OnItemStateChanging: OnItemStateChanging::<Identity, Impl, OFFSET>,
@@ -11088,7 +11095,7 @@ impl INameSpaceTreeControlFolderCapabilities_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetFolderCapabilities: GetFolderCapabilities::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetFolderCapabilities: GetFolderCapabilities::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<INameSpaceTreeControlFolderCapabilities as ::windows::core::Interface>::IID
@@ -11121,7 +11128,7 @@ impl INamedPropertyBag_Vtbl {
             this.RemovePropertyNPB(::core::mem::transmute(&pszbagname), ::core::mem::transmute(&pszpropname)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ReadPropertyNPB: ReadPropertyNPB::<Identity, Impl, OFFSET>,
             WritePropertyNPB: WritePropertyNPB::<Identity, Impl, OFFSET>,
             RemovePropertyNPB: RemovePropertyNPB::<Identity, Impl, OFFSET>,
@@ -11152,7 +11159,7 @@ impl INamespaceWalk_Vtbl {
             this.GetIDArrayResult(::core::mem::transmute_copy(&pcitems), ::core::mem::transmute_copy(&prgpidl)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Walk: Walk::<Identity, Impl, OFFSET>,
             GetIDArrayResult: GetIDArrayResult::<Identity, Impl, OFFSET>,
         }
@@ -11194,7 +11201,7 @@ impl INamespaceWalkCB_Vtbl {
             this.InitializeProgressDialog(::core::mem::transmute_copy(&ppsztitle), ::core::mem::transmute_copy(&ppszcancel)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             FoundItem: FoundItem::<Identity, Impl, OFFSET>,
             EnterFolder: EnterFolder::<Identity, Impl, OFFSET>,
             LeaveFolder: LeaveFolder::<Identity, Impl, OFFSET>,
@@ -11264,7 +11271,7 @@ impl INetworkFolderInternal_Vtbl {
             this.GetProvider(::core::mem::transmute_copy(&itemidcount), ::core::mem::transmute_copy(&itemids), ::core::mem::transmute_copy(&providermaxlength), ::core::mem::transmute_copy(&provider)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetResourceDisplayType: GetResourceDisplayType::<Identity, Impl, OFFSET>,
             GetIDList: GetIDList::<Identity, Impl, OFFSET>,
             GetProvider: GetProvider::<Identity, Impl, OFFSET>,
@@ -11301,7 +11308,7 @@ impl INewMenuClient_Vtbl {
             this.SelectAndEditItem(::core::mem::transmute_copy(&pidlitem), ::core::mem::transmute_copy(&flags)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             IncludeItems: IncludeItems::<Identity, Impl, OFFSET>,
             SelectAndEditItem: SelectAndEditItem::<Identity, Impl, OFFSET>,
         }
@@ -11355,7 +11362,7 @@ impl INewShortcutHookA_Vtbl {
             this.GetExtension(::core::mem::transmute_copy(&pszextension), ::core::mem::transmute_copy(&cchextension)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetReferent: SetReferent::<Identity, Impl, OFFSET>,
             GetReferent: GetReferent::<Identity, Impl, OFFSET>,
             SetFolder: SetFolder::<Identity, Impl, OFFSET>,
@@ -11413,7 +11420,7 @@ impl INewShortcutHookW_Vtbl {
             this.GetExtension(::core::mem::transmute_copy(&pszextension), ::core::mem::transmute_copy(&cchextension)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetReferent: SetReferent::<Identity, Impl, OFFSET>,
             GetReferent: GetReferent::<Identity, Impl, OFFSET>,
             SetFolder: SetFolder::<Identity, Impl, OFFSET>,
@@ -11466,7 +11473,7 @@ impl INewWindowManager_Vtbl {
             let this = (*this).get_impl();
             this.EvaluateNewWindow(::core::mem::transmute(&pszurl), ::core::mem::transmute(&pszname), ::core::mem::transmute(&pszurlcontext), ::core::mem::transmute(&pszfeatures), ::core::mem::transmute_copy(&freplace), ::core::mem::transmute_copy(&dwflags), ::core::mem::transmute_copy(&dwuseractiontime)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), EvaluateNewWindow: EvaluateNewWindow::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), EvaluateNewWindow: EvaluateNewWindow::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<INewWindowManager as ::windows::core::Interface>::IID
@@ -11486,7 +11493,7 @@ impl INotifyReplica_Vtbl {
             let this = (*this).get_impl();
             this.YouAreAReplica(::core::mem::transmute_copy(&ulcotherreplicas), ::core::mem::transmute_copy(&rgpmkotherreplicas)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), YouAreAReplica: YouAreAReplica::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), YouAreAReplica: YouAreAReplica::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<INotifyReplica as ::windows::core::Interface>::IID
@@ -11510,7 +11517,7 @@ impl IObjMgr_Vtbl {
             this.Remove(::core::mem::transmute(&punk)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Append: Append::<Identity, Impl, OFFSET>,
             Remove: Remove::<Identity, Impl, OFFSET>,
         }
@@ -11530,7 +11537,7 @@ impl IObjectProvider_Vtbl {
             let this = (*this).get_impl();
             this.QueryObject(::core::mem::transmute_copy(&guidobject), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppvout)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), QueryObject: QueryObject::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), QueryObject: QueryObject::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IObjectProvider as ::windows::core::Interface>::IID
@@ -11560,7 +11567,7 @@ impl IObjectWithAppUserModelID_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetAppID: SetAppID::<Identity, Impl, OFFSET>,
             GetAppID: GetAppID::<Identity, Impl, OFFSET>,
         }
@@ -11580,7 +11587,7 @@ impl IObjectWithBackReferences_Vtbl {
             let this = (*this).get_impl();
             this.RemoveBackReferences().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), RemoveBackReferences: RemoveBackReferences::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), RemoveBackReferences: RemoveBackReferences::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IObjectWithBackReferences as ::windows::core::Interface>::IID
@@ -11606,7 +11613,7 @@ impl IObjectWithCancelEvent_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetCancelEvent: GetCancelEvent::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetCancelEvent: GetCancelEvent::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IObjectWithCancelEvent as ::windows::core::Interface>::IID
@@ -11636,7 +11643,7 @@ impl IObjectWithFolderEnumMode_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetMode: SetMode::<Identity, Impl, OFFSET>,
             GetMode: GetMode::<Identity, Impl, OFFSET>,
         }
@@ -11669,7 +11676,7 @@ impl IObjectWithProgID_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetProgID: SetProgID::<Identity, Impl, OFFSET>,
             GetProgID: GetProgID::<Identity, Impl, OFFSET>,
         }
@@ -11696,7 +11703,7 @@ impl IObjectWithSelection_Vtbl {
             this.GetSelection(::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppv)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetSelection: SetSelection::<Identity, Impl, OFFSET>,
             GetSelection: GetSelection::<Identity, Impl, OFFSET>,
         }
@@ -11735,7 +11742,7 @@ impl IOpenControlPanel_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Open: Open::<Identity, Impl, OFFSET>,
             GetPath: GetPath::<Identity, Impl, OFFSET>,
             GetCurrentView: GetCurrentView::<Identity, Impl, OFFSET>,
@@ -11759,7 +11766,7 @@ impl IOpenSearchSource_Vtbl {
             let this = (*this).get_impl();
             this.GetResults(::core::mem::transmute_copy(&hwnd), ::core::mem::transmute(&pszquery), ::core::mem::transmute_copy(&dwstartindex), ::core::mem::transmute_copy(&dwcount), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppv)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetResults: GetResults::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetResults: GetResults::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IOpenSearchSource as ::windows::core::Interface>::IID
@@ -11846,7 +11853,7 @@ impl IOperationsProgressDialog_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             StartProgressDialog: StartProgressDialog::<Identity, Impl, OFFSET>,
             StopProgressDialog: StopProgressDialog::<Identity, Impl, OFFSET>,
             SetOperation: SetOperation::<Identity, Impl, OFFSET>,
@@ -11972,7 +11979,7 @@ impl IPackageDebugSettings_Vtbl {
             this.UnregisterForPackageStateChanges(::core::mem::transmute_copy(&dwcookie)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             EnableDebugging: EnableDebugging::<Identity, Impl, OFFSET>,
             DisableDebugging: DisableDebugging::<Identity, Impl, OFFSET>,
             Suspend: Suspend::<Identity, Impl, OFFSET>,
@@ -12022,7 +12029,7 @@ impl IPackageExecutionStateChangeNotification_Vtbl {
             let this = (*this).get_impl();
             this.OnStateChanged(::core::mem::transmute(&pszpackagefullname), ::core::mem::transmute_copy(&pesnewstate)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnStateChanged: OnStateChanged::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnStateChanged: OnStateChanged::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IPackageExecutionStateChangeNotification as ::windows::core::Interface>::IID
@@ -12049,7 +12056,7 @@ impl IParentAndItem_Vtbl {
             this.GetParentAndItem(::core::mem::transmute_copy(&ppidlparent), ::core::mem::transmute_copy(&ppsf), ::core::mem::transmute_copy(&ppidlchild)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetParentAndItem: SetParentAndItem::<Identity, Impl, OFFSET>,
             GetParentAndItem: GetParentAndItem::<Identity, Impl, OFFSET>,
         }
@@ -12076,7 +12083,7 @@ impl IParseAndCreateItem_Vtbl {
             this.GetItem(::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppv)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetItem: SetItem::<Identity, Impl, OFFSET>,
             GetItem: GetItem::<Identity, Impl, OFFSET>,
         }
@@ -12260,7 +12267,7 @@ impl IPreviewHandler_Vtbl {
             this.TranslateAccelerator(::core::mem::transmute_copy(&pmsg)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetWindow: SetWindow::<Identity, Impl, OFFSET>,
             SetRect: SetRect::<Identity, Impl, OFFSET>,
             DoPreview: DoPreview::<Identity, Impl, OFFSET>,
@@ -12301,7 +12308,7 @@ impl IPreviewHandlerFrame_Vtbl {
             this.TranslateAccelerator(::core::mem::transmute_copy(&pmsg)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetWindowContext: GetWindowContext::<Identity, Impl, OFFSET>,
             TranslateAccelerator: TranslateAccelerator::<Identity, Impl, OFFSET>,
         }
@@ -12337,7 +12344,7 @@ impl IPreviewHandlerVisuals_Vtbl {
             this.SetTextColor(::core::mem::transmute_copy(&color)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetBackgroundColor: SetBackgroundColor::<Identity, Impl, OFFSET>,
             SetFont: SetFont::<Identity, Impl, OFFSET>,
             SetTextColor: SetTextColor::<Identity, Impl, OFFSET>,
@@ -12380,7 +12387,7 @@ impl IPreviousVersionsInfo_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), AreSnapshotsAvailable: AreSnapshotsAvailable::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), AreSnapshotsAvailable: AreSnapshotsAvailable::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IPreviousVersionsInfo as ::windows::core::Interface>::IID
@@ -12413,7 +12420,7 @@ impl IProfferService_Vtbl {
             this.RevokeService(::core::mem::transmute_copy(&cookie)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ProfferService: ProfferService::<Identity, Impl, OFFSET>,
             RevokeService: RevokeService::<Identity, Impl, OFFSET>,
         }
@@ -12491,7 +12498,7 @@ impl IProgressDialog_Vtbl {
             this.Timer(::core::mem::transmute_copy(&dwtimeraction), ::core::mem::transmute_copy(&pvresevered)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             StartProgressDialog: StartProgressDialog::<Identity, Impl, OFFSET>,
             StopProgressDialog: StopProgressDialog::<Identity, Impl, OFFSET>,
             SetTitle: SetTitle::<Identity, Impl, OFFSET>,
@@ -12565,7 +12572,7 @@ impl IPropertyKeyStore_Vtbl {
             this.RemoveKey(::core::mem::transmute_copy(&key)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetKeyCount: GetKeyCount::<Identity, Impl, OFFSET>,
             GetKeyAt: GetKeyAt::<Identity, Impl, OFFSET>,
             AppendKey: AppendKey::<Identity, Impl, OFFSET>,
@@ -12710,7 +12717,7 @@ impl IQueryAssociations_Vtbl {
             this.GetEnum(::core::mem::transmute_copy(&flags), ::core::mem::transmute_copy(&assocenum), ::core::mem::transmute(&pszextra), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppvout)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Init: Init::<Identity, Impl, OFFSET>,
             GetString: GetString::<Identity, Impl, OFFSET>,
             GetKey: GetKey::<Identity, Impl, OFFSET>,
@@ -12733,7 +12740,7 @@ impl IQueryCancelAutoPlay_Vtbl {
             let this = (*this).get_impl();
             this.AllowAutoPlay(::core::mem::transmute(&pszpath), ::core::mem::transmute_copy(&dwcontenttype), ::core::mem::transmute(&pszlabel), ::core::mem::transmute_copy(&dwserialnumber)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), AllowAutoPlay: AllowAutoPlay::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), AllowAutoPlay: AllowAutoPlay::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IQueryCancelAutoPlay as ::windows::core::Interface>::IID
@@ -12763,7 +12770,7 @@ impl IQueryCodePage_Vtbl {
             this.SetCodePage(::core::mem::transmute_copy(&uicodepage)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCodePage: GetCodePage::<Identity, Impl, OFFSET>,
             SetCodePage: SetCodePage::<Identity, Impl, OFFSET>,
         }
@@ -12783,7 +12790,7 @@ impl IQueryContinue_Vtbl {
             let this = (*this).get_impl();
             this.QueryContinue().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), QueryContinue: QueryContinue::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), QueryContinue: QueryContinue::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IQueryContinue as ::windows::core::Interface>::IID
@@ -12836,7 +12843,7 @@ impl IQueryInfo_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetInfoTip: GetInfoTip::<Identity, Impl, OFFSET>,
             GetInfoFlags: GetInfoFlags::<Identity, Impl, OFFSET>,
         }
@@ -12872,7 +12879,7 @@ impl IRegTreeItem_Vtbl {
             this.SetCheckState(::core::mem::transmute_copy(&bcheck)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCheckState: GetCheckState::<Identity, Impl, OFFSET>,
             SetCheckState: SetCheckState::<Identity, Impl, OFFSET>,
         }
@@ -12914,7 +12921,7 @@ impl IRelatedItem_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetItemIDList: GetItemIDList::<Identity, Impl, OFFSET>,
             GetItem: GetItem::<Identity, Impl, OFFSET>,
         }
@@ -12937,7 +12944,7 @@ impl IRemoteComputer_Vtbl {
             let this = (*this).get_impl();
             this.Initialize(::core::mem::transmute(&pszmachine), ::core::mem::transmute_copy(&benumerating)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Initialize: Initialize::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Initialize: Initialize::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IRemoteComputer as ::windows::core::Interface>::IID
@@ -12957,7 +12964,7 @@ impl IResolveShellLink_Vtbl {
             let this = (*this).get_impl();
             this.ResolveShellLink(::core::mem::transmute(&punklink), ::core::mem::transmute_copy(&hwnd), ::core::mem::transmute_copy(&fflags)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), ResolveShellLink: ResolveShellLink::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), ResolveShellLink: ResolveShellLink::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IResolveShellLink as ::windows::core::Interface>::IID
@@ -13008,7 +13015,7 @@ impl IResultsFolder_Vtbl {
             this.RemoveAll().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddItem: AddItem::<Identity, Impl, OFFSET>,
             AddIDList: AddIDList::<Identity, Impl, OFFSET>,
             RemoveItem: RemoveItem::<Identity, Impl, OFFSET>,
@@ -13059,7 +13066,7 @@ impl IRunnableTask_Vtbl {
             this.IsRunning()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Run: Run::<Identity, Impl, OFFSET>,
             Kill: Kill::<Identity, Impl, OFFSET>,
             Suspend: Suspend::<Identity, Impl, OFFSET>,
@@ -13269,7 +13276,7 @@ impl ISearchBoxInfo_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCondition: GetCondition::<Identity, Impl, OFFSET>,
             GetText: GetText::<Identity, Impl, OFFSET>,
         }
@@ -13320,7 +13327,7 @@ impl ISearchContext_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSearchUrl: GetSearchUrl::<Identity, Impl, OFFSET>,
             GetSearchText: GetSearchText::<Identity, Impl, OFFSET>,
             GetSearchStyle: GetSearchStyle::<Identity, Impl, OFFSET>,
@@ -13417,7 +13424,7 @@ impl ISearchFolderItemFactory_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetDisplayName: SetDisplayName::<Identity, Impl, OFFSET>,
             SetFolderTypeID: SetFolderTypeID::<Identity, Impl, OFFSET>,
             SetFolderLogicalViewMode: SetFolderLogicalViewMode::<Identity, Impl, OFFSET>,
@@ -13499,7 +13506,7 @@ impl ISharedBitmap_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSharedBitmap: GetSharedBitmap::<Identity, Impl, OFFSET>,
             GetSize: GetSize::<Identity, Impl, OFFSET>,
             GetFormat: GetFormat::<Identity, Impl, OFFSET>,
@@ -13565,7 +13572,7 @@ impl ISharingConfigurationManager_Vtbl {
             this.ArePrintersShared().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateShare: CreateShare::<Identity, Impl, OFFSET>,
             DeleteShare: DeleteShare::<Identity, Impl, OFFSET>,
             ShareExists: ShareExists::<Identity, Impl, OFFSET>,
@@ -13636,7 +13643,7 @@ impl IShellApp_Vtbl {
             this.IsInstalled().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetAppInfo: GetAppInfo::<Identity, Impl, OFFSET>,
             GetPossibleActions: GetPossibleActions::<Identity, Impl, OFFSET>,
             GetSlowAppInfo: GetSlowAppInfo::<Identity, Impl, OFFSET>,
@@ -13793,7 +13800,7 @@ impl IShellChangeNotify_Vtbl {
             let this = (*this).get_impl();
             this.OnChange(::core::mem::transmute_copy(&levent), ::core::mem::transmute_copy(&pidl1), ::core::mem::transmute_copy(&pidl2)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnChange: OnChange::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnChange: OnChange::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IShellChangeNotify as ::windows::core::Interface>::IID
@@ -13826,7 +13833,7 @@ impl IShellDetails_Vtbl {
             this.ColumnClick(::core::mem::transmute_copy(&icolumn)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDetailsOf: GetDetailsOf::<Identity, Impl, OFFSET>,
             ColumnClick: ColumnClick::<Identity, Impl, OFFSET>,
         }
@@ -14293,7 +14300,7 @@ impl IShellExtInit_Vtbl {
             let this = (*this).get_impl();
             this.Initialize(::core::mem::transmute_copy(&pidlfolder), ::core::mem::transmute(&pdtobj), ::core::mem::transmute_copy(&hkeyprogid)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Initialize: Initialize::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Initialize: Initialize::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IShellExtInit as ::windows::core::Interface>::IID
@@ -14505,7 +14512,7 @@ impl IShellFolder_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ParseDisplayName: ParseDisplayName::<Identity, Impl, OFFSET>,
             EnumObjects: EnumObjects::<Identity, Impl, OFFSET>,
             BindToObject: BindToObject::<Identity, Impl, OFFSET>,
@@ -14650,7 +14657,7 @@ impl IShellFolderBand_Vtbl {
             this.GetBandInfoSFB(::core::mem::transmute_copy(&pbi)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             InitializeSFB: InitializeSFB::<Identity, Impl, OFFSET>,
             SetBandInfoSFB: SetBandInfoSFB::<Identity, Impl, OFFSET>,
             GetBandInfoSFB: GetBandInfoSFB::<Identity, Impl, OFFSET>,
@@ -14903,7 +14910,7 @@ impl IShellFolderView_Vtbl {
             this.SetAutomationObject(::core::mem::transmute(&pdisp)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Rearrange: Rearrange::<Identity, Impl, OFFSET>,
             GetArrangeParam: GetArrangeParam::<Identity, Impl, OFFSET>,
             ArrangeGrid: ArrangeGrid::<Identity, Impl, OFFSET>,
@@ -14952,7 +14959,7 @@ impl IShellFolderViewCB_Vtbl {
             let this = (*this).get_impl();
             this.MessageSFVCB(::core::mem::transmute_copy(&umsg), ::core::mem::transmute_copy(&wparam), ::core::mem::transmute_copy(&lparam)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), MessageSFVCB: MessageSFVCB::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), MessageSFVCB: MessageSFVCB::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IShellFolderViewCB as ::windows::core::Interface>::IID
@@ -15251,7 +15258,7 @@ impl IShellIcon_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetIconOf: GetIconOf::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetIconOf: GetIconOf::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IShellIcon as ::windows::core::Interface>::IID
@@ -15278,7 +15285,7 @@ impl IShellIconOverlay_Vtbl {
             this.GetOverlayIconIndex(::core::mem::transmute_copy(&pidl), ::core::mem::transmute_copy(&piconindex)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetOverlayIndex: GetOverlayIndex::<Identity, Impl, OFFSET>,
             GetOverlayIconIndex: GetOverlayIconIndex::<Identity, Impl, OFFSET>,
         }
@@ -15317,7 +15324,7 @@ impl IShellIconOverlayIdentifier_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             IsMemberOf: IsMemberOf::<Identity, Impl, OFFSET>,
             GetOverlayInfo: GetOverlayInfo::<Identity, Impl, OFFSET>,
             GetPriority: GetPriority::<Identity, Impl, OFFSET>,
@@ -15366,7 +15373,7 @@ impl IShellIconOverlayManager_Vtbl {
             this.OverlayIndexFromImageIndex(::core::mem::transmute_copy(&iimage), ::core::mem::transmute_copy(&piindex), ::core::mem::transmute_copy(&fadd)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetFileOverlayInfo: GetFileOverlayInfo::<Identity, Impl, OFFSET>,
             GetReservedOverlayInfo: GetReservedOverlayInfo::<Identity, Impl, OFFSET>,
             RefreshOverlayImages: RefreshOverlayImages::<Identity, Impl, OFFSET>,
@@ -15579,7 +15586,7 @@ impl IShellImageData_Vtbl {
             this.ReplaceFrame(::core::mem::transmute_copy(&pimg)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Decode: Decode::<Identity, Impl, OFFSET>,
             Draw: Draw::<Identity, Impl, OFFSET>,
             NextFrame: NextFrame::<Identity, Impl, OFFSET>,
@@ -15627,7 +15634,7 @@ impl IShellImageDataAbort_Vtbl {
             let this = (*this).get_impl();
             this.QueryAbort().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), QueryAbort: QueryAbort::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), QueryAbort: QueryAbort::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IShellImageDataAbort as ::windows::core::Interface>::IID
@@ -15690,7 +15697,7 @@ impl IShellImageDataFactory_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateIShellImageData: CreateIShellImageData::<Identity, Impl, OFFSET>,
             CreateImageFromFile: CreateImageFromFile::<Identity, Impl, OFFSET>,
             CreateImageFromStream: CreateImageFromStream::<Identity, Impl, OFFSET>,
@@ -15764,7 +15771,7 @@ impl IShellItem_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             BindToHandler: BindToHandler::<Identity, Impl, OFFSET>,
             GetParent: GetParent::<Identity, Impl, OFFSET>,
             GetDisplayName: GetDisplayName::<Identity, Impl, OFFSET>,
@@ -16006,7 +16013,7 @@ impl IShellItemArray_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             BindToHandler: BindToHandler::<Identity, Impl, OFFSET>,
             GetPropertyStore: GetPropertyStore::<Identity, Impl, OFFSET>,
             GetPropertyDescriptionList: GetPropertyDescriptionList::<Identity, Impl, OFFSET>,
@@ -16044,7 +16051,7 @@ impl IShellItemFilter_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             IncludeItem: IncludeItem::<Identity, Impl, OFFSET>,
             GetEnumFlagsForItem: GetEnumFlagsForItem::<Identity, Impl, OFFSET>,
         }
@@ -16073,7 +16080,7 @@ impl IShellItemImageFactory_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetImage: GetImage::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetImage: GetImage::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IShellItemImageFactory as ::windows::core::Interface>::IID
@@ -16172,7 +16179,7 @@ impl IShellItemResources_Vtbl {
             this.MarkForDelete().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetAttributes: GetAttributes::<Identity, Impl, OFFSET>,
             GetSize: GetSize::<Identity, Impl, OFFSET>,
             GetTimes: GetTimes::<Identity, Impl, OFFSET>,
@@ -16327,7 +16334,7 @@ impl IShellLibrary_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             LoadLibraryFromItem: LoadLibraryFromItem::<Identity, Impl, OFFSET>,
             LoadLibraryFromKnownFolder: LoadLibraryFromKnownFolder::<Identity, Impl, OFFSET>,
             AddFolder: AddFolder::<Identity, Impl, OFFSET>,
@@ -16486,7 +16493,7 @@ impl IShellLinkA_Vtbl {
             this.SetPath(::core::mem::transmute(&pszfile)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetPath: GetPath::<Identity, Impl, OFFSET>,
             GetIDList: GetIDList::<Identity, Impl, OFFSET>,
             SetIDList: SetIDList::<Identity, Impl, OFFSET>,
@@ -16553,7 +16560,7 @@ impl IShellLinkDataList_Vtbl {
             this.SetFlags(::core::mem::transmute_copy(&dwflags)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddDataBlock: AddDataBlock::<Identity, Impl, OFFSET>,
             CopyDataBlock: CopyDataBlock::<Identity, Impl, OFFSET>,
             RemoveDataBlock: RemoveDataBlock::<Identity, Impl, OFFSET>,
@@ -16890,7 +16897,7 @@ impl IShellLinkW_Vtbl {
             this.SetPath(::core::mem::transmute(&pszfile)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetPath: GetPath::<Identity, Impl, OFFSET>,
             GetIDList: GetIDList::<Identity, Impl, OFFSET>,
             SetIDList: SetIDList::<Identity, Impl, OFFSET>,
@@ -16984,7 +16991,7 @@ impl IShellMenu_Vtbl {
             this.SetMenuToolbar(::core::mem::transmute(&punk), ::core::mem::transmute_copy(&dwflags)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             GetMenuInfo: GetMenuInfo::<Identity, Impl, OFFSET>,
             SetShellFolder: SetShellFolder::<Identity, Impl, OFFSET>,
@@ -17014,7 +17021,7 @@ impl IShellMenuCallback_Vtbl {
             let this = (*this).get_impl();
             this.CallbackSM(::core::mem::transmute_copy(&psmd), ::core::mem::transmute_copy(&umsg), ::core::mem::transmute_copy(&wparam), ::core::mem::transmute_copy(&lparam)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CallbackSM: CallbackSM::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CallbackSM: CallbackSM::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IShellMenuCallback as ::windows::core::Interface>::IID
@@ -17264,7 +17271,7 @@ impl IShellPropSheetExt_Vtbl {
             this.ReplacePage(::core::mem::transmute_copy(&upageid), ::core::mem::transmute(&pfnreplacewith), ::core::mem::transmute_copy(&lparam)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddPages: AddPages::<Identity, Impl, OFFSET>,
             ReplacePage: ReplacePage::<Identity, Impl, OFFSET>,
         }
@@ -17284,7 +17291,7 @@ impl IShellRunDll_Vtbl {
             let this = (*this).get_impl();
             this.Run(::core::mem::transmute(&pszargs)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Run: Run::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Run: Run::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IShellRunDll as ::windows::core::Interface>::IID
@@ -17301,7 +17308,7 @@ impl IShellService_Vtbl {
             let this = (*this).get_impl();
             this.SetOwner(::core::mem::transmute(&punkowner)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SetOwner: SetOwner::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SetOwner: SetOwner::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IShellService as ::windows::core::Interface>::IID
@@ -17340,7 +17347,7 @@ impl IShellTaskScheduler_Vtbl {
             this.Status(::core::mem::transmute_copy(&dwreleasestatus), ::core::mem::transmute_copy(&dwthreadtimeout)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddTask: AddTask::<Identity, Impl, OFFSET>,
             RemoveTasks: RemoveTasks::<Identity, Impl, OFFSET>,
             CountTasks: CountTasks::<Identity, Impl, OFFSET>,
@@ -18701,7 +18708,7 @@ impl ISortColumnArray_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCount: GetCount::<Identity, Impl, OFFSET>,
             GetAt: GetAt::<Identity, Impl, OFFSET>,
             GetSortType: GetSortType::<Identity, Impl, OFFSET>,
@@ -18722,7 +18729,7 @@ impl IStartMenuPinnedList_Vtbl {
             let this = (*this).get_impl();
             this.RemoveFromList(::core::mem::transmute(&pitem)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), RemoveFromList: RemoveFromList::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), RemoveFromList: RemoveFromList::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IStartMenuPinnedList as ::windows::core::Interface>::IID
@@ -18764,7 +18771,7 @@ impl IStorageProviderBanners_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetBanner: SetBanner::<Identity, Impl, OFFSET>,
             ClearBanner: ClearBanner::<Identity, Impl, OFFSET>,
             ClearAllBanners: ClearAllBanners::<Identity, Impl, OFFSET>,
@@ -18795,7 +18802,7 @@ impl IStorageProviderCopyHook_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CopyCallback: CopyCallback::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CopyCallback: CopyCallback::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IStorageProviderCopyHook as ::windows::core::Interface>::IID
@@ -18843,7 +18850,7 @@ impl IStorageProviderHandler_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetPropertyHandlerFromPath: GetPropertyHandlerFromPath::<Identity, Impl, OFFSET>,
             GetPropertyHandlerFromUri: GetPropertyHandlerFromUri::<Identity, Impl, OFFSET>,
             GetPropertyHandlerFromFileId: GetPropertyHandlerFromFileId::<Identity, Impl, OFFSET>,
@@ -18880,7 +18887,7 @@ impl IStorageProviderPropertyHandler_Vtbl {
             this.SaveProperties(::core::mem::transmute(&propertiestosave)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RetrieveProperties: RetrieveProperties::<Identity, Impl, OFFSET>,
             SaveProperties: SaveProperties::<Identity, Impl, OFFSET>,
         }
@@ -18950,7 +18957,7 @@ impl IStreamUnbufferedInfo_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetSectorSize: GetSectorSize::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetSectorSize: GetSectorSize::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IStreamUnbufferedInfo as ::windows::core::Interface>::IID
@@ -18983,7 +18990,7 @@ impl ISuspensionDependencyManager_Vtbl {
             this.UngroupChildFromParent(::core::mem::transmute_copy(&childprocesshandle)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RegisterAsChild: RegisterAsChild::<Identity, Impl, OFFSET>,
             GroupChildWithParent: GroupChildWithParent::<Identity, Impl, OFFSET>,
             UngroupChildFromParent: UngroupChildFromParent::<Identity, Impl, OFFSET>,
@@ -19050,7 +19057,7 @@ impl ISyncMgrConflict_Vtbl {
             this.GetResolutionHandler(::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppvresolutionhandler)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetProperty: GetProperty::<Identity, Impl, OFFSET>,
             GetConflictIdInfo: GetConflictIdInfo::<Identity, Impl, OFFSET>,
             GetItemsArray: GetItemsArray::<Identity, Impl, OFFSET>,
@@ -19082,7 +19089,7 @@ impl ISyncMgrConflictFolder_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetConflictIDList: GetConflictIDList::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetConflictIDList: GetConflictIDList::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ISyncMgrConflictFolder as ::windows::core::Interface>::IID
@@ -19118,7 +19125,7 @@ impl ISyncMgrConflictItems_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCount: GetCount::<Identity, Impl, OFFSET>,
             GetItem: GetItem::<Identity, Impl, OFFSET>,
         }
@@ -19138,7 +19145,7 @@ impl ISyncMgrConflictPresenter_Vtbl {
             let this = (*this).get_impl();
             this.PresentConflict(::core::mem::transmute(&pconflict), ::core::mem::transmute(&presolveinfo)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), PresentConflict: PresentConflict::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), PresentConflict: PresentConflict::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ISyncMgrConflictPresenter as ::windows::core::Interface>::IID
@@ -19174,7 +19181,7 @@ impl ISyncMgrConflictResolutionItems_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCount: GetCount::<Identity, Impl, OFFSET>,
             GetItem: GetItem::<Identity, Impl, OFFSET>,
         }
@@ -19258,7 +19265,7 @@ impl ISyncMgrConflictResolveInfo_Vtbl {
             this.SetItemChoices(::core::mem::transmute_copy(&prgiconflictitemindexes), ::core::mem::transmute_copy(&cchoices)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetIterationInfo: GetIterationInfo::<Identity, Impl, OFFSET>,
             GetPresenterNextStep: GetPresenterNextStep::<Identity, Impl, OFFSET>,
             GetPresenterChoice: GetPresenterChoice::<Identity, Impl, OFFSET>,
@@ -19318,7 +19325,7 @@ impl ISyncMgrConflictStore_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             EnumConflicts: EnumConflicts::<Identity, Impl, OFFSET>,
             BindToConflict: BindToConflict::<Identity, Impl, OFFSET>,
             RemoveConflicts: RemoveConflicts::<Identity, Impl, OFFSET>,
@@ -19428,7 +19435,7 @@ impl ISyncMgrControl_Vtbl {
             this.EnableItem(::core::mem::transmute_copy(&fenable), ::core::mem::transmute(&pszhandlerid), ::core::mem::transmute(&pszitemid), ::core::mem::transmute_copy(&hwndowner), ::core::mem::transmute_copy(&ncontrolflags)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             StartHandlerSync: StartHandlerSync::<Identity, Impl, OFFSET>,
             StartItemSync: StartItemSync::<Identity, Impl, OFFSET>,
             StartSyncAll: StartSyncAll::<Identity, Impl, OFFSET>,
@@ -19489,7 +19496,7 @@ impl ISyncMgrEnumItems_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Next: Next::<Identity, Impl, OFFSET>,
             Skip: Skip::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -19641,7 +19648,7 @@ impl ISyncMgrEvent_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetEventID: GetEventID::<Identity, Impl, OFFSET>,
             GetHandlerID: GetHandlerID::<Identity, Impl, OFFSET>,
             GetItemID: GetItemID::<Identity, Impl, OFFSET>,
@@ -19727,7 +19734,7 @@ impl ISyncMgrEventStore_Vtbl {
             this.RemoveEvent(::core::mem::transmute_copy(&pguideventids), ::core::mem::transmute_copy(&cevents)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetEventEnumerator: GetEventEnumerator::<Identity, Impl, OFFSET>,
             GetEventCount: GetEventCount::<Identity, Impl, OFFSET>,
             GetEvent: GetEvent::<Identity, Impl, OFFSET>,
@@ -19819,7 +19826,7 @@ impl ISyncMgrHandler_Vtbl {
             this.Synchronize(::core::mem::transmute_copy(&ppszitemids), ::core::mem::transmute_copy(&citems), ::core::mem::transmute_copy(&hwndowner), ::core::mem::transmute(&psessioncreator), ::core::mem::transmute(&punk)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetName: GetName::<Identity, Impl, OFFSET>,
             GetHandlerInfo: GetHandlerInfo::<Identity, Impl, OFFSET>,
             GetObject: GetObject::<Identity, Impl, OFFSET>,
@@ -19861,7 +19868,7 @@ impl ISyncMgrHandlerCollection_Vtbl {
             this.BindToHandler(::core::mem::transmute(&pszhandlerid), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppv)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetHandlerEnumerator: GetHandlerEnumerator::<Identity, Impl, OFFSET>,
             BindToHandler: BindToHandler::<Identity, Impl, OFFSET>,
         }
@@ -19945,7 +19952,7 @@ impl ISyncMgrHandlerInfo_Vtbl {
             this.IsConnected().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetType: GetType::<Identity, Impl, OFFSET>,
             GetTypeLabel: GetTypeLabel::<Identity, Impl, OFFSET>,
             GetComment: GetComment::<Identity, Impl, OFFSET>,
@@ -19983,7 +19990,7 @@ impl ISyncMgrRegister_Vtbl {
             this.GetHandlerRegistrationInfo(::core::mem::transmute_copy(&clsidhandler), ::core::mem::transmute_copy(&pdwsyncmgrregisterflags)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RegisterSyncMgrHandler: RegisterSyncMgrHandler::<Identity, Impl, OFFSET>,
             UnregisterSyncMgrHandler: UnregisterSyncMgrHandler::<Identity, Impl, OFFSET>,
             GetHandlerRegistrationInfo: GetHandlerRegistrationInfo::<Identity, Impl, OFFSET>,
@@ -20059,7 +20066,7 @@ impl ISyncMgrResolutionHandler_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             QueryAbilities: QueryAbilities::<Identity, Impl, OFFSET>,
             KeepOther: KeepOther::<Identity, Impl, OFFSET>,
             KeepRecent: KeepRecent::<Identity, Impl, OFFSET>,
@@ -20108,7 +20115,7 @@ impl ISyncMgrSessionCreator_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CreateSession: CreateSession::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CreateSession: CreateSession::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ISyncMgrSessionCreator as ::windows::core::Interface>::IID
@@ -20189,7 +20196,7 @@ impl ISyncMgrSyncCallback_Vtbl {
             this.ReportManualSync().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ReportProgress: ReportProgress::<Identity, Impl, OFFSET>,
             SetHandlerProgressText: SetHandlerProgressText::<Identity, Impl, OFFSET>,
             ReportEvent: ReportEvent::<Identity, Impl, OFFSET>,
@@ -20293,7 +20300,7 @@ impl ISyncMgrSyncItem_Vtbl {
             this.Delete().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetItemID: GetItemID::<Identity, Impl, OFFSET>,
             GetName: GetName::<Identity, Impl, OFFSET>,
             GetItemInfo: GetItemInfo::<Identity, Impl, OFFSET>,
@@ -20350,7 +20357,7 @@ impl ISyncMgrSyncItemContainer_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSyncItem: GetSyncItem::<Identity, Impl, OFFSET>,
             GetSyncItemEnumerator: GetSyncItemEnumerator::<Identity, Impl, OFFSET>,
             GetSyncItemCount: GetSyncItemCount::<Identity, Impl, OFFSET>,
@@ -20417,7 +20424,7 @@ impl ISyncMgrSyncItemInfo_Vtbl {
             this.IsConnected().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTypeLabel: GetTypeLabel::<Identity, Impl, OFFSET>,
             GetComment: GetComment::<Identity, Impl, OFFSET>,
             GetLastSyncTime: GetLastSyncTime::<Identity, Impl, OFFSET>,
@@ -20440,7 +20447,7 @@ impl ISyncMgrSyncResult_Vtbl {
             let this = (*this).get_impl();
             this.Result(::core::mem::transmute_copy(&nstatus), ::core::mem::transmute_copy(&cerror), ::core::mem::transmute_copy(&cconflicts)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Result: Result::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Result: Result::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ISyncMgrSyncResult as ::windows::core::Interface>::IID
@@ -20527,7 +20534,7 @@ impl ISyncMgrSynchronize_Vtbl {
             this.ShowError(::core::mem::transmute_copy(&hwndparent), ::core::mem::transmute_copy(&errorid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             GetHandlerInfo: GetHandlerInfo::<Identity, Impl, OFFSET>,
             EnumSyncMgrItems: EnumSyncMgrItems::<Identity, Impl, OFFSET>,
@@ -20607,7 +20614,7 @@ impl ISyncMgrSynchronizeCallback_Vtbl {
             this.EstablishConnection(::core::mem::transmute(&pwszconnection), ::core::mem::transmute_copy(&dwreserved)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ShowPropertiesCompleted: ShowPropertiesCompleted::<Identity, Impl, OFFSET>,
             PrepareForSyncCompleted: PrepareForSyncCompleted::<Identity, Impl, OFFSET>,
             SynchronizeCompleted: SynchronizeCompleted::<Identity, Impl, OFFSET>,
@@ -20641,7 +20648,7 @@ impl ISyncMgrSynchronizeInvoke_Vtbl {
             this.UpdateAll().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             UpdateItems: UpdateItems::<Identity, Impl, OFFSET>,
             UpdateAll: UpdateAll::<Identity, Impl, OFFSET>,
         }
@@ -20664,7 +20671,7 @@ impl ISyncMgrUIOperation_Vtbl {
             let this = (*this).get_impl();
             this.Run(::core::mem::transmute_copy(&hwndowner)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Run: Run::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Run: Run::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ISyncMgrUIOperation as ::windows::core::Interface>::IID
@@ -20709,7 +20716,7 @@ impl ITaskbarList_Vtbl {
             this.SetActiveAlt(::core::mem::transmute_copy(&hwnd)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             HrInit: HrInit::<Identity, Impl, OFFSET>,
             AddTab: AddTab::<Identity, Impl, OFFSET>,
             DeleteTab: DeleteTab::<Identity, Impl, OFFSET>,
@@ -20879,7 +20886,7 @@ impl IThumbnailCache_Vtbl {
             this.GetThumbnailByID(::core::mem::transmute(&thumbnailid), ::core::mem::transmute_copy(&cxyrequestedthumbsize), ::core::mem::transmute_copy(&ppvthumb), ::core::mem::transmute_copy(&poutflags)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetThumbnail: GetThumbnail::<Identity, Impl, OFFSET>,
             GetThumbnailByID: GetThumbnailByID::<Identity, Impl, OFFSET>,
         }
@@ -20899,7 +20906,7 @@ impl IThumbnailCachePrimer_Vtbl {
             let this = (*this).get_impl();
             this.PageInThumbnail(::core::mem::transmute(&psi), ::core::mem::transmute_copy(&wtsflags), ::core::mem::transmute_copy(&cxyrequestedthumbsize)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), PageInThumbnail: PageInThumbnail::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), PageInThumbnail: PageInThumbnail::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IThumbnailCachePrimer as ::windows::core::Interface>::IID
@@ -20925,7 +20932,7 @@ impl IThumbnailCapture_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CaptureThumbnail: CaptureThumbnail::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CaptureThumbnail: CaptureThumbnail::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IThumbnailCapture as ::windows::core::Interface>::IID
@@ -20945,7 +20952,7 @@ impl IThumbnailHandlerFactory_Vtbl {
             let this = (*this).get_impl();
             this.GetThumbnailHandler(::core::mem::transmute_copy(&pidlchild), ::core::mem::transmute(&pbc), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppv)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetThumbnailHandler: GetThumbnailHandler::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetThumbnailHandler: GetThumbnailHandler::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IThumbnailHandlerFactory as ::windows::core::Interface>::IID
@@ -20965,7 +20972,7 @@ impl IThumbnailProvider_Vtbl {
             let this = (*this).get_impl();
             this.GetThumbnail(::core::mem::transmute_copy(&cx), ::core::mem::transmute_copy(&phbmp), ::core::mem::transmute_copy(&pdwalpha)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetThumbnail: GetThumbnail::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetThumbnail: GetThumbnail::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IThumbnailProvider as ::windows::core::Interface>::IID
@@ -20982,7 +20989,7 @@ impl IThumbnailSettings_Vtbl {
             let this = (*this).get_impl();
             this.SetContext(::core::mem::transmute_copy(&dwcontext)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), SetContext: SetContext::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), SetContext: SetContext::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IThumbnailSettings as ::windows::core::Interface>::IID
@@ -21009,7 +21016,7 @@ impl IThumbnailStreamCache_Vtbl {
             this.SetThumbnailStream(::core::mem::transmute(&path), ::core::mem::transmute_copy(&cacheid), ::core::mem::transmute(&thumbnailsize), ::core::mem::transmute(&thumbnailstream)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetThumbnailStream: GetThumbnailStream::<Identity, Impl, OFFSET>,
             SetThumbnailStream: SetThumbnailStream::<Identity, Impl, OFFSET>,
         }
@@ -21062,7 +21069,7 @@ impl ITranscodeImage_Vtbl {
             let this = (*this).get_impl();
             this.TranscodeImage(::core::mem::transmute(&pshellitem), ::core::mem::transmute_copy(&uimaxwidth), ::core::mem::transmute_copy(&uimaxheight), ::core::mem::transmute_copy(&flags), ::core::mem::transmute(&pvimage), ::core::mem::transmute_copy(&puiwidth), ::core::mem::transmute_copy(&puiheight)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), TranscodeImage: TranscodeImage::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), TranscodeImage: TranscodeImage::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ITranscodeImage as ::windows::core::Interface>::IID
@@ -21119,7 +21126,7 @@ impl ITransferAdviseSink_Vtbl {
             this.PropertyFailure(::core::mem::transmute(&psi), ::core::mem::transmute_copy(&pkey), ::core::mem::transmute_copy(&hrerror)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             UpdateProgress: UpdateProgress::<Identity, Impl, OFFSET>,
             UpdateTransferState: UpdateTransferState::<Identity, Impl, OFFSET>,
             ConfirmOverwrite: ConfirmOverwrite::<Identity, Impl, OFFSET>,
@@ -21163,7 +21170,7 @@ impl ITransferDestination_Vtbl {
             this.CreateItem(::core::mem::transmute(&pszname), ::core::mem::transmute_copy(&dwattributes), ::core::mem::transmute_copy(&ullsize), ::core::mem::transmute_copy(&flags), ::core::mem::transmute_copy(&riiditem), ::core::mem::transmute_copy(&ppvitem), ::core::mem::transmute_copy(&riidresources), ::core::mem::transmute_copy(&ppvresources)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Advise: Advise::<Identity, Impl, OFFSET>,
             Unadvise: Unadvise::<Identity, Impl, OFFSET>,
             CreateItem: CreateItem::<Identity, Impl, OFFSET>,
@@ -21315,7 +21322,7 @@ impl ITransferSource_Vtbl {
             this.LeaveFolder(::core::mem::transmute(&psichildfolderdest)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Advise: Advise::<Identity, Impl, OFFSET>,
             Unadvise: Unadvise::<Identity, Impl, OFFSET>,
             SetProperties: SetProperties::<Identity, Impl, OFFSET>,
@@ -21368,7 +21375,7 @@ impl ITravelEntry_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Invoke: Invoke::<Identity, Impl, OFFSET>,
             Update: Update::<Identity, Impl, OFFSET>,
             GetPidl: GetPidl::<Identity, Impl, OFFSET>,
@@ -21471,7 +21478,7 @@ impl ITravelLog_Vtbl {
             this.Revert().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddEntry: AddEntry::<Identity, Impl, OFFSET>,
             UpdateEntry: UpdateEntry::<Identity, Impl, OFFSET>,
             UpdateExternal: UpdateExternal::<Identity, Impl, OFFSET>,
@@ -21528,7 +21535,7 @@ impl ITravelLogClient_Vtbl {
             this.LoadHistoryPosition(::core::mem::transmute(&pszurllocation), ::core::mem::transmute_copy(&dwposition)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             FindWindowByIndex: FindWindowByIndex::<Identity, Impl, OFFSET>,
             GetWindowData: GetWindowData::<Identity, Impl, OFFSET>,
             LoadHistoryPosition: LoadHistoryPosition::<Identity, Impl, OFFSET>,
@@ -21568,7 +21575,7 @@ impl ITravelLogEntry_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetTitle: GetTitle::<Identity, Impl, OFFSET>,
             GetURL: GetURL::<Identity, Impl, OFFSET>,
         }
@@ -21658,7 +21665,7 @@ impl ITravelLogStg_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateEntry: CreateEntry::<Identity, Impl, OFFSET>,
             TravelTo: TravelTo::<Identity, Impl, OFFSET>,
             EnumEntries: EnumEntries::<Identity, Impl, OFFSET>,
@@ -21702,7 +21709,7 @@ impl ITrayDeskBand_Vtbl {
             this.DeskBandRegistrationChanged().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ShowDeskBand: ShowDeskBand::<Identity, Impl, OFFSET>,
             HideDeskBand: HideDeskBand::<Identity, Impl, OFFSET>,
             IsDeskBandShown: IsDeskBandShown::<Identity, Impl, OFFSET>,
@@ -21724,7 +21731,7 @@ impl IURLSearchHook_Vtbl {
             let this = (*this).get_impl();
             this.Translate(::core::mem::transmute_copy(&pwszsearchurl), ::core::mem::transmute_copy(&cchbuffersize)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Translate: Translate::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Translate: Translate::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IURLSearchHook as ::windows::core::Interface>::IID
@@ -21780,7 +21787,7 @@ impl IUniformResourceLocatorA_Vtbl {
             this.InvokeCommand(::core::mem::transmute_copy(&purlici)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetURL: SetURL::<Identity, Impl, OFFSET>,
             GetURL: GetURL::<Identity, Impl, OFFSET>,
             InvokeCommand: InvokeCommand::<Identity, Impl, OFFSET>,
@@ -21823,7 +21830,7 @@ impl IUniformResourceLocatorW_Vtbl {
             this.InvokeCommand(::core::mem::transmute_copy(&purlici)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetURL: SetURL::<Identity, Impl, OFFSET>,
             GetURL: GetURL::<Identity, Impl, OFFSET>,
             InvokeCommand: InvokeCommand::<Identity, Impl, OFFSET>,
@@ -21853,7 +21860,7 @@ impl IUpdateIDList_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Update: Update::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Update: Update::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IUpdateIDList as ::windows::core::Interface>::IID
@@ -21883,7 +21890,7 @@ impl IUserAccountChangeCallback_Vtbl {
             let this = (*this).get_impl();
             this.OnPictureChange(::core::mem::transmute(&pszusername)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnPictureChange: OnPictureChange::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnPictureChange: OnPictureChange::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IUserAccountChangeCallback as ::windows::core::Interface>::IID
@@ -21928,7 +21935,7 @@ impl IUserNotification_Vtbl {
             this.PlaySound(::core::mem::transmute(&pszsoundname)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetBalloonInfo: SetBalloonInfo::<Identity, Impl, OFFSET>,
             SetBalloonRetry: SetBalloonRetry::<Identity, Impl, OFFSET>,
             SetIconInfo: SetIconInfo::<Identity, Impl, OFFSET>,
@@ -21979,7 +21986,7 @@ impl IUserNotification2_Vtbl {
             this.PlaySound(::core::mem::transmute(&pszsoundname)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetBalloonInfo: SetBalloonInfo::<Identity, Impl, OFFSET>,
             SetBalloonRetry: SetBalloonRetry::<Identity, Impl, OFFSET>,
             SetIconInfo: SetIconInfo::<Identity, Impl, OFFSET>,
@@ -22018,7 +22025,7 @@ impl IUserNotificationCallback_Vtbl {
             this.OnContextMenu(::core::mem::transmute_copy(&pt)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnBalloonUserClick: OnBalloonUserClick::<Identity, Impl, OFFSET>,
             OnLeftClick: OnLeftClick::<Identity, Impl, OFFSET>,
             OnContextMenu: OnContextMenu::<Identity, Impl, OFFSET>,
@@ -22080,7 +22087,7 @@ impl IVirtualDesktopManager_Vtbl {
             this.MoveWindowToDesktop(::core::mem::transmute_copy(&toplevelwindow), ::core::mem::transmute_copy(&desktopid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             IsWindowOnCurrentVirtualDesktop: IsWindowOnCurrentVirtualDesktop::<Identity, Impl, OFFSET>,
             GetWindowDesktopId: GetWindowDesktopId::<Identity, Impl, OFFSET>,
             MoveWindowToDesktop: MoveWindowToDesktop::<Identity, Impl, OFFSET>,
@@ -22165,7 +22172,7 @@ impl IVisualProperties_Vtbl {
             this.SetTheme(::core::mem::transmute(&pszsubappname), ::core::mem::transmute(&pszsubidlist)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetWatermark: SetWatermark::<Identity, Impl, OFFSET>,
             SetColor: SetColor::<Identity, Impl, OFFSET>,
             GetColor: GetColor::<Identity, Impl, OFFSET>,
@@ -23060,7 +23067,7 @@ impl IWizardExtension_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddPages: AddPages::<Identity, Impl, OFFSET>,
             GetFirstPage: GetFirstPage::<Identity, Impl, OFFSET>,
             GetLastPage: GetLastPage::<Identity, Impl, OFFSET>,
@@ -23115,7 +23122,7 @@ impl IWizardSite_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetPreviousPage: GetPreviousPage::<Identity, Impl, OFFSET>,
             GetNextPage: GetNextPage::<Identity, Impl, OFFSET>,
             GetCancelledPage: GetCancelledPage::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/UI/Shell/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Shell/mod.rs
@@ -10814,7 +10814,7 @@ unsafe impl ::windows::core::Interface for IACList {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IACList_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Expand: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszexpand: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Shell\"`*"]
@@ -10961,7 +10961,7 @@ unsafe impl ::windows::core::Interface for IAccessibilityDockingService {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAccessibilityDockingService_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Graphics_Gdi")]
     pub GetAvailableSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hmonitor: super::super::Graphics::Gdi::HMONITOR, pcxfixed: *mut u32, pcymax: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Graphics_Gdi"))]
@@ -11021,7 +11021,7 @@ unsafe impl ::windows::core::Interface for IAccessibilityDockingServiceCallback 
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAccessibilityDockingServiceCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Undocked: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, undockreason: UNDOCK_REASON) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Shell\"`*"]
@@ -11073,7 +11073,7 @@ unsafe impl ::windows::core::Interface for IAccessibleObject {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAccessibleObject_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetAccessibleName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszname: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Shell\"`*"]
@@ -11146,7 +11146,7 @@ unsafe impl ::windows::core::Interface for IActionProgress {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IActionProgress_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Begin: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, action: SPACTION, flags: u32) -> ::windows::core::HRESULT,
     pub UpdateProgress: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ulcompleted: u64, ultotal: u64) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -11213,7 +11213,7 @@ unsafe impl ::windows::core::Interface for IActionProgressDialog {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IActionProgressDialog_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, flags: u32, psztitle: ::windows::core::PCWSTR, pszcancel: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub Stop: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -11286,7 +11286,7 @@ unsafe impl ::windows::core::Interface for IAppActivationUIInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppActivationUIInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Graphics_Gdi")]
     pub GetMonitor: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: *mut super::super::Graphics::Gdi::HMONITOR) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Graphics_Gdi"))]
@@ -11361,7 +11361,7 @@ unsafe impl ::windows::core::Interface for IAppPublisher {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppPublisher_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetNumberOfCategories: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwcat: *mut u32) -> ::windows::core::HRESULT,
     pub GetCategories: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pappcategorylist: *mut APPCATEGORYINFOLIST) -> ::windows::core::HRESULT,
     pub GetNumberOfApps: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwapps: *mut u32) -> ::windows::core::HRESULT,
@@ -11435,7 +11435,7 @@ unsafe impl ::windows::core::Interface for IAppVisibility {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppVisibility_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Graphics_Gdi")]
     pub GetAppVisibilityOnMonitor: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hmonitor: super::super::Graphics::Gdi::HMONITOR, pmode: *mut MONITOR_APP_VISIBILITY) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Graphics_Gdi"))]
@@ -11506,7 +11506,7 @@ unsafe impl ::windows::core::Interface for IAppVisibilityEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAppVisibilityEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Graphics_Gdi")]
     pub AppVisibilityOnMonitorChanged: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hmonitor: super::super::Graphics::Gdi::HMONITOR, previousmode: MONITOR_APP_VISIBILITY, currentmode: MONITOR_APP_VISIBILITY) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Graphics_Gdi"))]
@@ -11584,7 +11584,7 @@ unsafe impl ::windows::core::Interface for IApplicationActivationManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IApplicationActivationManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ActivateApplication: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, appusermodelid: ::windows::core::PCWSTR, arguments: ::windows::core::PCWSTR, options: ACTIVATEOPTIONS, processid: *mut u32) -> ::windows::core::HRESULT,
     pub ActivateForFile: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, appusermodelid: ::windows::core::PCWSTR, itemarray: *mut ::core::ffi::c_void, verb: ::windows::core::PCWSTR, processid: *mut u32) -> ::windows::core::HRESULT,
     pub ActivateForProtocol: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, appusermodelid: ::windows::core::PCWSTR, itemarray: *mut ::core::ffi::c_void, processid: *mut u32) -> ::windows::core::HRESULT,
@@ -11674,7 +11674,7 @@ unsafe impl ::windows::core::Interface for IApplicationAssociationRegistration {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IApplicationAssociationRegistration_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub QueryCurrentDefault: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszquery: ::windows::core::PCWSTR, atquerytype: ASSOCIATIONTYPE, alquerylevel: ASSOCIATIONLEVEL, ppszassociation: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub QueryAppIsDefault: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszquery: ::windows::core::PCWSTR, atquerytype: ASSOCIATIONTYPE, alquerylevel: ASSOCIATIONLEVEL, pszappregistryname: ::windows::core::PCWSTR, pfdefault: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -11737,7 +11737,7 @@ unsafe impl ::windows::core::Interface for IApplicationAssociationRegistrationUI
 #[repr(C)]
 #[doc(hidden)]
 pub struct IApplicationAssociationRegistrationUI_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub LaunchAdvancedAssociationUI: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszappregistryname: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Shell\"`*"]
@@ -11811,7 +11811,7 @@ unsafe impl ::windows::core::Interface for IApplicationDesignModeSettings {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IApplicationDesignModeSettings_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub SetNativeDisplaySize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, nativedisplaysizepixels: super::super::Foundation::SIZE) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -12024,7 +12024,7 @@ unsafe impl ::windows::core::Interface for IApplicationDestinations {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IApplicationDestinations_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetAppID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszappid: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub RemoveDestination: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punk: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub RemoveAllDestinations: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -12085,7 +12085,7 @@ unsafe impl ::windows::core::Interface for IApplicationDocumentLists {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IApplicationDocumentLists_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetAppID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszappid: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub GetList: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, listtype: APPDOCLISTTYPE, citemsdesired: u32, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -12169,7 +12169,7 @@ unsafe impl ::windows::core::Interface for IAssocHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAssocHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppsz: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetUIName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppsz: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetIconLocation: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppszpath: *mut ::windows::core::PWSTR, pindex: *mut i32) -> ::windows::core::HRESULT,
@@ -12233,7 +12233,7 @@ unsafe impl ::windows::core::Interface for IAssocHandlerInvoker {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAssocHandlerInvoker_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SupportsSelection: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -12349,7 +12349,7 @@ unsafe impl ::windows::core::Interface for IAttachmentExecute {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAttachmentExecute_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetClientTitle: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psztitle: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub SetClientGuid: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, guid: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub SetLocalPath: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszlocalpath: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
@@ -12434,7 +12434,7 @@ unsafe impl ::windows::core::Interface for IAutoComplete {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAutoComplete_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Init: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hwndedit: super::super::Foundation::HWND, punkacl: *mut ::core::ffi::c_void, pwszregkeypath: ::windows::core::PCWSTR, pwszquickcomplete: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -12581,7 +12581,7 @@ unsafe impl ::windows::core::Interface for IAutoCompleteDropDown {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAutoCompleteDropDown_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDropDownStatus: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwflags: *mut u32, ppwszstring: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub ResetEnumerator: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -12650,7 +12650,7 @@ unsafe impl ::windows::core::Interface for IBandHost {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IBandHost_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub CreateBand: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, rclsidband: *const ::windows::core::GUID, favailable: super::super::Foundation::BOOL, fvisible: super::super::Foundation::BOOL, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -12738,7 +12738,7 @@ unsafe impl ::windows::core::Interface for IBandSite {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IBandSite_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddBand: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punk: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub EnumBands: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, uband: u32, pdwbandid: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Ole")]
@@ -12797,7 +12797,7 @@ unsafe impl ::windows::core::Interface for IBannerNotificationHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IBannerNotificationHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnBannerEvent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, notification: *const BANNER_NOTIFICATION) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Shell\"`*"]
@@ -12864,7 +12864,7 @@ unsafe impl ::windows::core::Interface for IBanneredBar {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IBanneredBar_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetIconSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, iicon: u32) -> ::windows::core::HRESULT,
     pub GetIconSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, piicon: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -12923,7 +12923,7 @@ unsafe impl ::windows::core::Interface for IBrowserFrameOptions {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IBrowserFrameOptions_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetFrameOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwmask: u32, pdwoptions: *mut u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Shell\"`*"]
@@ -13143,7 +13143,7 @@ unsafe impl ::windows::core::Interface for IBrowserService {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IBrowserService_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Ole")]
     pub GetParentSite: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppipsite: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Ole"))]
@@ -15288,7 +15288,7 @@ unsafe impl ::windows::core::Interface for ICDBurn {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICDBurn_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetRecorderDriveLetter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszdrive: ::windows::core::PWSTR, cch: u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub Burn: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hwnd: super::super::Foundation::HWND) -> ::windows::core::HRESULT,
@@ -15346,7 +15346,7 @@ unsafe impl ::windows::core::Interface for ICDBurnExt {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICDBurnExt_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetSupportedActionTypes: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwactions: *mut u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Shell\"`*"]
@@ -15408,7 +15408,7 @@ unsafe impl ::windows::core::Interface for ICategorizer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICategorizer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDescription: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszdesc: ::windows::core::PWSTR, cch: u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_UI_Shell_Common")]
     pub GetCategory: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cidl: u32, apidl: *const *const Common::ITEMIDLIST, rgcategoryids: *mut u32) -> ::windows::core::HRESULT,
@@ -15492,7 +15492,7 @@ unsafe impl ::windows::core::Interface for ICategoryProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICategoryProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
     pub CanCategorizeOnSCID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pscid: *const PropertiesSystem::PROPERTYKEY) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_UI_Shell_PropertiesSystem"))]
@@ -15579,7 +15579,7 @@ unsafe impl ::windows::core::Interface for IColumnManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IColumnManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
     pub SetColumnInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, propkey: *const PropertiesSystem::PROPERTYKEY, pcmci: *const CM_COLUMNINFO) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_UI_Shell_PropertiesSystem"))]
@@ -15656,7 +15656,7 @@ unsafe impl ::windows::core::Interface for IColumnProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IColumnProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psci: *const SHCOLUMNINIT) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Shell_PropertiesSystem"))]
     pub GetColumnInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwindex: u32, psci: *mut SHCOLUMNINFO) -> ::windows::core::HRESULT,
@@ -15734,7 +15734,7 @@ unsafe impl ::windows::core::Interface for ICommDlgBrowser {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICommDlgBrowser_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Ole")]
     pub OnDefaultCommand: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppshv: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Ole"))]
@@ -16054,7 +16054,7 @@ unsafe impl ::windows::core::Interface for IComputerInfoChangeNotify {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IComputerInfoChangeNotify_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ComputerInfoChanged: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Shell\"`*"]
@@ -16259,7 +16259,7 @@ unsafe impl ::windows::core::Interface for IContactManagerInterop {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IContactManagerInterop_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub ShowContactCardForWindow: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, appwindow: super::super::Foundation::HWND, contact: *mut ::core::ffi::c_void, selection: *const super::super::Foundation::RECT, preferredplacement: FLYOUT_PLACEMENT) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -16324,7 +16324,7 @@ unsafe impl ::windows::core::Interface for IContextMenu {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IContextMenu_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
     pub QueryContextMenu: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hmenu: super::WindowsAndMessaging::HMENU, indexmenu: u32, idcmdfirst: u32, idcmdlast: u32, uflags: u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_UI_WindowsAndMessaging"))]
@@ -16593,7 +16593,7 @@ unsafe impl ::windows::core::Interface for IContextMenuCB {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IContextMenuCB_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
     pub CallBack: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psf: *mut ::core::ffi::c_void, hwndowner: super::super::Foundation::HWND, pdtobj: *mut ::core::ffi::c_void, umsg: u32, wparam: super::super::Foundation::WPARAM, lparam: super::super::Foundation::LPARAM) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com")))]
@@ -16650,7 +16650,7 @@ unsafe impl ::windows::core::Interface for IContextMenuSite {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IContextMenuSite_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub DoContextMenuPopup: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punkcontextmenu: *mut ::core::ffi::c_void, fflags: u32, pt: super::super::Foundation::POINT) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -16709,7 +16709,7 @@ unsafe impl ::windows::core::Interface for ICopyHookA {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICopyHookA_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub CopyCallback: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hwnd: super::super::Foundation::HWND, wfunc: u32, wflags: u32, pszsrcfile: ::windows::core::PCSTR, dwsrcattribs: u32, pszdestfile: ::windows::core::PCSTR, dwdestattribs: u32) -> u32,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -16768,7 +16768,7 @@ unsafe impl ::windows::core::Interface for ICopyHookW {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICopyHookW_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub CopyCallback: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hwnd: super::super::Foundation::HWND, wfunc: u32, wflags: u32, pszsrcfile: ::windows::core::PCWSTR, dwsrcattribs: u32, pszdestfile: ::windows::core::PCWSTR, dwdestattribs: u32) -> u32,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -16846,7 +16846,7 @@ unsafe impl ::windows::core::Interface for ICreateProcessInputs {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICreateProcessInputs_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCreateFlags: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwcreationflags: *mut u32) -> ::windows::core::HRESULT,
     pub SetCreateFlags: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwcreationflags: u32) -> ::windows::core::HRESULT,
     pub AddCreateFlags: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwcreationflags: u32) -> ::windows::core::HRESULT,
@@ -16904,7 +16904,7 @@ unsafe impl ::windows::core::Interface for ICreatingProcess {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICreatingProcess_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnCreating: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcpi: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Shell\"`*"]
@@ -16982,7 +16982,7 @@ unsafe impl ::windows::core::Interface for ICredentialProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICredentialProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetUsageScenario: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cpus: CREDENTIAL_PROVIDER_USAGE_SCENARIO, dwflags: u32) -> ::windows::core::HRESULT,
     pub SetSerialization: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcpcs: *const CREDENTIAL_PROVIDER_CREDENTIAL_SERIALIZATION) -> ::windows::core::HRESULT,
     pub Advise: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcpe: *mut ::core::ffi::c_void, upadvisecontext: usize) -> ::windows::core::HRESULT,
@@ -17117,7 +17117,7 @@ unsafe impl ::windows::core::Interface for ICredentialProviderCredential {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICredentialProviderCredential_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Advise: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcpce: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub UnAdvise: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -17407,7 +17407,7 @@ unsafe impl ::windows::core::Interface for ICredentialProviderCredentialEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICredentialProviderCredentialEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetFieldState: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcpc: *mut ::core::ffi::c_void, dwfieldid: u32, cpfs: CREDENTIAL_PROVIDER_FIELD_STATE) -> ::windows::core::HRESULT,
     pub SetFieldInteractiveState: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcpc: *mut ::core::ffi::c_void, dwfieldid: u32, cpfis: CREDENTIAL_PROVIDER_FIELD_INTERACTIVE_STATE) -> ::windows::core::HRESULT,
     pub SetFieldString: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcpc: *mut ::core::ffi::c_void, dwfieldid: u32, psz: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
@@ -17619,7 +17619,7 @@ unsafe impl ::windows::core::Interface for ICredentialProviderCredentialWithFiel
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICredentialProviderCredentialWithFieldOptions_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetFieldOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fieldid: u32, options: *mut CREDENTIAL_PROVIDER_CREDENTIAL_FIELD_OPTIONS) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Shell\"`*"]
@@ -17668,7 +17668,7 @@ unsafe impl ::windows::core::Interface for ICredentialProviderEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICredentialProviderEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CredentialsChanged: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, upadvisecontext: usize) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Shell\"`*"]
@@ -17723,7 +17723,7 @@ unsafe impl ::windows::core::Interface for ICredentialProviderFilter {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICredentialProviderFilter_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Filter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cpus: CREDENTIAL_PROVIDER_USAGE_SCENARIO, dwflags: u32, rgclsidproviders: *const ::windows::core::GUID, rgballow: *mut super::super::Foundation::BOOL, cproviders: u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -17779,7 +17779,7 @@ unsafe impl ::windows::core::Interface for ICredentialProviderSetUserArray {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICredentialProviderSetUserArray_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetUserArray: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, users: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Shell\"`*"]
@@ -17845,7 +17845,7 @@ unsafe impl ::windows::core::Interface for ICredentialProviderUser {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICredentialProviderUser_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetSid: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sid: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetProviderID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, providerid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
@@ -17915,7 +17915,7 @@ unsafe impl ::windows::core::Interface for ICredentialProviderUserArray {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICredentialProviderUserArray_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetProviderFilter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, guidprovidertofilterto: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub GetAccountOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, credentialprovideraccountoptions: *mut CREDENTIAL_PROVIDER_ACCOUNT_OPTIONS) -> ::windows::core::HRESULT,
     pub GetCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, usercount: *mut u32) -> ::windows::core::HRESULT,
@@ -18043,7 +18043,7 @@ unsafe impl ::windows::core::Interface for ICurrentWorkingDirectory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICurrentWorkingDirectory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDirectory: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwzpath: ::windows::core::PWSTR, cchsize: u32) -> ::windows::core::HRESULT,
     pub SetDirectory: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwzpath: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
 }
@@ -18142,7 +18142,7 @@ unsafe impl ::windows::core::Interface for ICustomDestinationList {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICustomDestinationList_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetAppID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszappid: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub BeginList: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcminslots: *mut u32, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_UI_Shell_Common")]
@@ -18238,7 +18238,7 @@ unsafe impl ::windows::core::Interface for IDataObjectAsyncCapability {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDataObjectAsyncCapability_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub SetAsyncMode: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fdoopasync: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -18317,7 +18317,7 @@ unsafe impl ::windows::core::Interface for IDataObjectProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDataObjectProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub GetDataObject: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dataobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -18388,7 +18388,7 @@ unsafe impl ::windows::core::Interface for IDataTransferManagerInterop {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDataTransferManagerInterop_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetForWindow: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, appwindow: super::super::Foundation::HWND, riid: *const ::windows::core::GUID, datatransfermanager: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -18476,7 +18476,7 @@ unsafe impl ::windows::core::Interface for IDefaultExtractIconInit {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDefaultExtractIconInit_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetFlags: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, uflags: u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Registry")]
     pub SetKey: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hkey: super::super::System::Registry::HKEY) -> ::windows::core::HRESULT,
@@ -18551,7 +18551,7 @@ unsafe impl ::windows::core::Interface for IDefaultFolderMenuInitialize {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDefaultFolderMenuInitialize_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry", feature = "Win32_UI_Shell_Common"))]
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hwnd: super::super::Foundation::HWND, pcmcb: *mut ::core::ffi::c_void, pidlfolder: *const Common::ITEMIDLIST, psf: *mut ::core::ffi::c_void, cidl: u32, apidl: *const *const Common::ITEMIDLIST, punkassociation: *mut ::core::ffi::c_void, ckeys: u32, akeys: *const super::super::System::Registry::HKEY) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Registry", feature = "Win32_UI_Shell_Common")))]
@@ -18611,7 +18611,7 @@ unsafe impl ::windows::core::Interface for IDelegateFolder {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDelegateFolder_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub SetItemAlloc: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pmalloc: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -19050,7 +19050,7 @@ unsafe impl ::windows::core::Interface for IDeskBandInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDeskBandInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDefaultBandWidth: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwbandid: u32, dwviewmode: u32, pnwidth: *mut i32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_System_Ole\"`*"]
@@ -19324,7 +19324,7 @@ unsafe impl ::windows::core::Interface for IDesktopGadget {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDesktopGadget_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub RunGadget: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, gadgetpath: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Shell\"`*"]
@@ -19456,7 +19456,7 @@ unsafe impl ::windows::core::Interface for IDesktopWallpaper {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDesktopWallpaper_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetWallpaper: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, monitorid: ::windows::core::PCWSTR, wallpaper: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub GetWallpaper: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, monitorid: ::windows::core::PCWSTR, wallpaper: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetMonitorDevicePathAt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, monitorindex: u32, monitorid: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
@@ -19535,7 +19535,7 @@ unsafe impl ::windows::core::Interface for IDestinationStreamFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDestinationStreamFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub GetDestinationStream: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppstm: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -19659,7 +19659,7 @@ unsafe impl ::windows::core::Interface for IDocViewSite {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDocViewSite_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub OnSetTitle: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pvtitle: *const super::super::System::Com::VARIANT) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole")))]
@@ -20077,7 +20077,7 @@ unsafe impl ::windows::core::Interface for IDragSourceHelper {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDragSourceHelper_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
     pub InitializeFromBitmap: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pshdi: *const SHDRAGIMAGE, pdataobject: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com")))]
@@ -20244,7 +20244,7 @@ unsafe impl ::windows::core::Interface for IDropTargetHelper {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDropTargetHelper_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub DragEnter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hwndtarget: super::super::Foundation::HWND, pdataobject: *mut ::core::ffi::c_void, ppt: *const super::super::Foundation::POINT, dweffect: super::super::System::Ole::DROPEFFECT) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole")))]
@@ -20313,7 +20313,7 @@ unsafe impl ::windows::core::Interface for IDynamicHWHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDynamicHWHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDynamicInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszdeviceid: ::windows::core::PCWSTR, dwcontenttype: u32, ppszaction: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_System_Com\"`*"]
@@ -20470,7 +20470,7 @@ unsafe impl ::windows::core::Interface for IEnumAssocHandlers {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumAssocHandlers_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Shell\"`*"]
@@ -20529,7 +20529,7 @@ unsafe impl ::windows::core::Interface for IEnumExplorerCommand {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumExplorerCommand_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, puicommand: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -20591,7 +20591,7 @@ unsafe impl ::windows::core::Interface for IEnumExtraSearch {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumExtraSearch_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut EXTRASEARCH, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -20655,7 +20655,7 @@ unsafe impl ::windows::core::Interface for IEnumFullIDList {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumFullIDList_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_UI_Shell_Common")]
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut *mut Common::ITEMIDLIST, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_UI_Shell_Common"))]
@@ -20720,7 +20720,7 @@ unsafe impl ::windows::core::Interface for IEnumHLITEM {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumHLITEM_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut HLITEM, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -20783,7 +20783,7 @@ unsafe impl ::windows::core::Interface for IEnumIDList {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumIDList_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_UI_Shell_Common")]
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut *mut Common::ITEMIDLIST, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_UI_Shell_Common"))]
@@ -20848,7 +20848,7 @@ unsafe impl ::windows::core::Interface for IEnumObjects {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumObjects_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, riid: *const ::windows::core::GUID, rgelt: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -20904,7 +20904,7 @@ unsafe impl ::windows::core::Interface for IEnumPublishedApps {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumPublishedApps_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pia: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -20954,7 +20954,7 @@ unsafe impl ::windows::core::Interface for IEnumReadyCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumReadyCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub EnumReady: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Shell\"`*"]
@@ -21013,7 +21013,7 @@ unsafe impl ::windows::core::Interface for IEnumResources {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumResources_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, psir: *mut SHELL_ITEM_RESOURCE, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -21075,7 +21075,7 @@ unsafe impl ::windows::core::Interface for IEnumShellItems {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumShellItems_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -21137,7 +21137,7 @@ unsafe impl ::windows::core::Interface for IEnumSyncMgrConflict {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumSyncMgrConflict_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -21199,7 +21199,7 @@ unsafe impl ::windows::core::Interface for IEnumSyncMgrEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumSyncMgrEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -21261,7 +21261,7 @@ unsafe impl ::windows::core::Interface for IEnumSyncMgrSyncItems {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumSyncMgrSyncItems_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -21323,7 +21323,7 @@ unsafe impl ::windows::core::Interface for IEnumTravelLogEntry {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumTravelLogEntry_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Skip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -21384,7 +21384,7 @@ unsafe impl ::windows::core::Interface for IEnumerableView {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumerableView_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetEnumReadyCallback: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, percb: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_UI_Shell_Common")]
     pub CreateEnumIDListFromContents: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pidlfolder: *const Common::ITEMIDLIST, dwenumflags: u32, ppenumidlist: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -21468,7 +21468,7 @@ unsafe impl ::windows::core::Interface for IExecuteCommand {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IExecuteCommand_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetKeyState: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, grfkeystate: u32) -> ::windows::core::HRESULT,
     pub SetParameters: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszparameters: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -21530,7 +21530,7 @@ unsafe impl ::windows::core::Interface for IExecuteCommandApplicationHostEnviron
 #[repr(C)]
 #[doc(hidden)]
 pub struct IExecuteCommandApplicationHostEnvironment_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetValue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pahe: *mut AHE_TYPE) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Shell\"`*"]
@@ -21580,7 +21580,7 @@ unsafe impl ::windows::core::Interface for IExecuteCommandHost {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IExecuteCommandHost_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetUIMode: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, puimode: *mut EC_HOST_UI_MODE) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Shell\"`*"]
@@ -21642,7 +21642,7 @@ unsafe impl ::windows::core::Interface for IExpDispSupport {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IExpDispSupport_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub FindConnectionPoint: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppccp: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -21715,7 +21715,7 @@ unsafe impl ::windows::core::Interface for IExpDispSupportXP {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IExpDispSupportXP_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub FindCIE4ConnectionPoint: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppccp: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -21847,7 +21847,7 @@ unsafe impl ::windows::core::Interface for IExplorerBrowser {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IExplorerBrowser_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hwndparent: super::super::Foundation::HWND, prc: *const super::super::Foundation::RECT, pfs: *const FOLDERSETTINGS) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -21939,7 +21939,7 @@ unsafe impl ::windows::core::Interface for IExplorerBrowserEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IExplorerBrowserEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_UI_Shell_Common")]
     pub OnNavigationPending: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pidlfolder: *const Common::ITEMIDLIST) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_UI_Shell_Common"))]
@@ -22052,7 +22052,7 @@ unsafe impl ::windows::core::Interface for IExplorerCommand {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IExplorerCommand_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetTitle: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psiitemarray: *mut ::core::ffi::c_void, ppszname: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetIcon: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psiitemarray: *mut ::core::ffi::c_void, ppszicon: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetToolTip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psiitemarray: *mut ::core::ffi::c_void, ppszinfotip: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
@@ -22126,7 +22126,7 @@ unsafe impl ::windows::core::Interface for IExplorerCommandProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IExplorerCommandProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCommands: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punksite: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetCommand: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, rguidcommandid: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -22183,7 +22183,7 @@ unsafe impl ::windows::core::Interface for IExplorerCommandState {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IExplorerCommandState_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetState: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psiitemarray: *mut ::core::ffi::c_void, foktobeslow: super::super::Foundation::BOOL, pcmdstate: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -22236,7 +22236,7 @@ unsafe impl ::windows::core::Interface for IExplorerPaneVisibility {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IExplorerPaneVisibility_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetPaneState: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ep: *const ::windows::core::GUID, peps: *mut u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Shell\"`*"]
@@ -22298,7 +22298,7 @@ unsafe impl ::windows::core::Interface for IExtensionServices {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IExtensionServices_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetAdditionalHeaders: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwzadditionalheaders: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub SetAuthenticateData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, phwnd: super::super::Foundation::HWND, pwzusername: ::windows::core::PCWSTR, pwzpassword: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
@@ -22359,7 +22359,7 @@ unsafe impl ::windows::core::Interface for IExtractIconA {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IExtractIconA_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetIconLocation: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, uflags: u32, psziconfile: ::windows::core::PSTR, cchmax: u32, piindex: *mut i32, pwflags: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
     pub Extract: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszfile: ::windows::core::PCSTR, niconindex: u32, phiconlarge: *mut super::WindowsAndMessaging::HICON, phiconsmall: *mut super::WindowsAndMessaging::HICON, niconsize: u32) -> ::windows::core::HRESULT,
@@ -22420,7 +22420,7 @@ unsafe impl ::windows::core::Interface for IExtractIconW {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IExtractIconW_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetIconLocation: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, uflags: u32, psziconfile: ::windows::core::PWSTR, cchmax: u32, piindex: *mut i32, pwflags: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
     pub Extract: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszfile: ::windows::core::PCWSTR, niconindex: u32, phiconlarge: *mut super::WindowsAndMessaging::HICON, phiconsmall: *mut super::WindowsAndMessaging::HICON, niconsize: u32) -> ::windows::core::HRESULT,
@@ -22481,7 +22481,7 @@ unsafe impl ::windows::core::Interface for IExtractImage {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IExtractImage_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetLocation: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszpathbuffer: ::windows::core::PWSTR, cch: u32, pdwpriority: *mut u32, prgsize: *const super::super::Foundation::SIZE, dwrecclrdepth: u32, pdwflags: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -23049,7 +23049,7 @@ unsafe impl ::windows::core::Interface for IFileDialogControlEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IFileDialogControlEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnItemSelected: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfdc: *mut ::core::ffi::c_void, dwidctl: u32, dwiditem: u32) -> ::windows::core::HRESULT,
     pub OnButtonClicked: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfdc: *mut ::core::ffi::c_void, dwidctl: u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -23227,7 +23227,7 @@ unsafe impl ::windows::core::Interface for IFileDialogCustomize {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IFileDialogCustomize_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub EnableOpenDropDown: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwidctl: u32) -> ::windows::core::HRESULT,
     pub AddMenu: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwidctl: u32, pszlabel: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub AddPushButton: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwidctl: u32, pszlabel: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
@@ -23355,7 +23355,7 @@ unsafe impl ::windows::core::Interface for IFileDialogEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IFileDialogEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnFileOk: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfd: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub OnFolderChanging: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfd: *mut ::core::ffi::c_void, psifolder: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub OnFolderChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfd: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -23428,7 +23428,7 @@ unsafe impl ::windows::core::Interface for IFileIsInUse {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IFileIsInUse_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetAppName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppszname: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetUsage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfut: *mut FILE_USAGE_TYPE) -> ::windows::core::HRESULT,
     pub GetCapabilities: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwcapflags: *mut u32) -> ::windows::core::HRESULT,
@@ -23813,7 +23813,7 @@ unsafe impl ::windows::core::Interface for IFileOperation {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IFileOperation_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Advise: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfops: *mut ::core::ffi::c_void, pdwcookie: *mut u32) -> ::windows::core::HRESULT,
     pub Unadvise: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwcookie: u32) -> ::windows::core::HRESULT,
     pub SetOperationFlags: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwoperationflags: u32) -> ::windows::core::HRESULT,
@@ -24178,7 +24178,7 @@ unsafe impl ::windows::core::Interface for IFileOperationProgressSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IFileOperationProgressSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub StartOperations: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub FinishOperations: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hrresult: ::windows::core::HRESULT) -> ::windows::core::HRESULT,
     pub PreRenameItem: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwflags: u32, psiitem: *mut ::core::ffi::c_void, psznewname: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
@@ -24616,7 +24616,7 @@ unsafe impl ::windows::core::Interface for IFileSyncMergeHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IFileSyncMergeHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Merge: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, localfilepath: ::windows::core::PCWSTR, serverfilepath: ::windows::core::PCWSTR, updatestatus: *mut MERGE_UPDATE_STATUS) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Graphics_Gdi")]
     pub ShowResolveConflictUIAsync: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, localfilepath: ::windows::core::PCWSTR, monitortodisplayon: super::super::Graphics::Gdi::HMONITOR) -> ::windows::core::HRESULT,
@@ -24677,7 +24677,7 @@ unsafe impl ::windows::core::Interface for IFileSystemBindData {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IFileSystemBindData_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_FileSystem"))]
     pub SetFindData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfd: *const super::super::Storage::FileSystem::WIN32_FIND_DATAW) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_Storage_FileSystem")))]
@@ -24851,7 +24851,7 @@ unsafe impl ::windows::core::Interface for IFolderBandPriv {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IFolderBandPriv_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub SetCascade: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fcascade: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -24928,7 +24928,7 @@ unsafe impl ::windows::core::Interface for IFolderFilter {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IFolderFilter_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_UI_Shell_Common")]
     pub ShouldShow: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psf: *mut ::core::ffi::c_void, pidlfolder: *const Common::ITEMIDLIST, pidlitem: *const Common::ITEMIDLIST) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_UI_Shell_Common"))]
@@ -24987,7 +24987,7 @@ unsafe impl ::windows::core::Interface for IFolderFilterSite {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IFolderFilterSite_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetFilter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punk: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Shell\"`*"]
@@ -25100,7 +25100,7 @@ unsafe impl ::windows::core::Interface for IFolderView {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IFolderView_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCurrentViewMode: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pviewmode: *mut u32) -> ::windows::core::HRESULT,
     pub SetCurrentViewMode: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, viewmode: u32) -> ::windows::core::HRESULT,
     pub GetFolder: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -25506,7 +25506,7 @@ unsafe impl ::windows::core::Interface for IFolderViewHost {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IFolderViewHost_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hwndparent: super::super::Foundation::HWND, pdo: *mut ::core::ffi::c_void, prc: *const super::super::Foundation::RECT) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com")))]
@@ -25648,7 +25648,7 @@ unsafe impl ::windows::core::Interface for IFolderViewOptions {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IFolderViewOptions_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetFolderViewOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fvomask: FOLDERVIEWOPTIONS, fvoflags: FOLDERVIEWOPTIONS) -> ::windows::core::HRESULT,
     pub GetFolderViewOptions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfvoflags: *mut FOLDERVIEWOPTIONS) -> ::windows::core::HRESULT,
 }
@@ -25727,7 +25727,7 @@ unsafe impl ::windows::core::Interface for IFolderViewSettings {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IFolderViewSettings_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetColumnPropertyList: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_PropertiesSystem"))]
     pub GetGroupByProperty: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pkey: *mut PropertiesSystem::PROPERTYKEY, pfgroupascending: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -25812,7 +25812,7 @@ unsafe impl ::windows::core::Interface for IFrameworkInputPane {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IFrameworkInputPane_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Advise: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwindow: *mut ::core::ffi::c_void, phandler: *mut ::core::ffi::c_void, pdwcookie: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub AdviseWithHWND: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hwnd: super::super::Foundation::HWND, phandler: *mut ::core::ffi::c_void, pdwcookie: *mut u32) -> ::windows::core::HRESULT,
@@ -25883,7 +25883,7 @@ unsafe impl ::windows::core::Interface for IFrameworkInputPaneHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IFrameworkInputPaneHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Showing: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, prcinputpanescreenlocation: *const super::super::Foundation::RECT, fensurefocusedelementinview: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -25939,7 +25939,7 @@ unsafe impl ::windows::core::Interface for IGetServiceIds {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IGetServiceIds_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetServiceIds: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, serviceidcount: *mut u32, serviceids: *mut *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Shell\"`*"]
@@ -26011,7 +26011,7 @@ unsafe impl ::windows::core::Interface for IHWEventHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IHWEventHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszparams: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub HandleEvent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszdeviceid: ::windows::core::PCWSTR, pszaltdeviceid: ::windows::core::PCWSTR, pszeventtype: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
@@ -26178,7 +26178,7 @@ unsafe impl ::windows::core::Interface for IHandlerActivationHost {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IHandlerActivationHost_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub BeforeCoCreateInstance: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, clsidhandler: *const ::windows::core::GUID, itemsbeingactivated: *mut ::core::ffi::c_void, handlerinfo: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub BeforeCreateProcess: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, applicationpath: ::windows::core::PCWSTR, commandline: ::windows::core::PCWSTR, handlerinfo: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -26237,7 +26237,7 @@ unsafe impl ::windows::core::Interface for IHandlerInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IHandlerInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetApplicationDisplayName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetApplicationPublisher: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetApplicationIconReference: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
@@ -26439,7 +26439,7 @@ unsafe impl ::windows::core::Interface for IHlink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IHlink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetHlinkSite: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pihlsite: *mut ::core::ffi::c_void, dwsitedata: u32) -> ::windows::core::HRESULT,
     pub GetHlinkSite: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppihlsite: *mut *mut ::core::ffi::c_void, pdwsitedata: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
@@ -26596,7 +26596,7 @@ unsafe impl ::windows::core::Interface for IHlinkBrowseContext {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IHlinkBrowseContext_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub Register: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, reserved: u32, piunk: *mut ::core::ffi::c_void, pimk: *mut ::core::ffi::c_void, pdwregister: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -26716,7 +26716,7 @@ unsafe impl ::windows::core::Interface for IHlinkFrame {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IHlinkFrame_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetBrowseContext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pihlbc: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetBrowseContext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppihlbc: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
@@ -26794,7 +26794,7 @@ unsafe impl ::windows::core::Interface for IHlinkSite {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IHlinkSite_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub QueryService: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwsitedata: u32, guidservice: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, ppiunk: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
     pub GetMoniker: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwsitedata: u32, dwassign: u32, dwwhich: u32, ppimk: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -26878,7 +26878,7 @@ unsafe impl ::windows::core::Interface for IHlinkTarget {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IHlinkTarget_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetBrowseContext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pihlbc: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetBrowseContext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppihlbc: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Navigate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, grfhlnf: u32, pwzjumplocation: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
@@ -26946,7 +26946,7 @@ unsafe impl ::windows::core::Interface for IHomeGroup {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IHomeGroup_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub IsMember: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, member: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -27005,7 +27005,7 @@ unsafe impl ::windows::core::Interface for IIOCancelInformation {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IIOCancelInformation_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetCancelInformation: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwthreadid: u32, umsgcancel: u32) -> ::windows::core::HRESULT,
     pub GetCancelInformation: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwthreadid: *mut u32, pumsgcancel: *mut u32) -> ::windows::core::HRESULT,
 }
@@ -27132,7 +27132,7 @@ unsafe impl ::windows::core::Interface for IImageRecompress {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IImageRecompress_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com_StructuredStorage")]
     pub RecompressImage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psi: *mut ::core::ffi::c_void, cx: i32, cy: i32, iquality: i32, pstg: *mut ::core::ffi::c_void, ppstrmout: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com_StructuredStorage"))]
@@ -27190,7 +27190,7 @@ unsafe impl ::windows::core::Interface for IInitializeCommand {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IInitializeCommand_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com_StructuredStorage")]
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszcommandname: ::windows::core::PCWSTR, ppb: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com_StructuredStorage"))]
@@ -27248,7 +27248,7 @@ unsafe impl ::windows::core::Interface for IInitializeNetworkFolder {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IInitializeNetworkFolder_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_UI_Shell_Common")]
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pidl: *const Common::ITEMIDLIST, pidltarget: *const Common::ITEMIDLIST, udisplaytype: u32, pszresname: ::windows::core::PCWSTR, pszprovider: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_UI_Shell_Common"))]
@@ -27300,7 +27300,7 @@ unsafe impl ::windows::core::Interface for IInitializeObject {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IInitializeObject_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Shell\"`*"]
@@ -27354,7 +27354,7 @@ unsafe impl ::windows::core::Interface for IInitializeWithBindCtx {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IInitializeWithBindCtx_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbc: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -27409,7 +27409,7 @@ unsafe impl ::windows::core::Interface for IInitializeWithItem {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IInitializeWithItem_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psi: *mut ::core::ffi::c_void, grfmode: u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Shell\"`*"]
@@ -27463,7 +27463,7 @@ unsafe impl ::windows::core::Interface for IInitializeWithPropertyStore {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IInitializeWithPropertyStore_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pps: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_UI_Shell_PropertiesSystem"))]
@@ -27520,7 +27520,7 @@ unsafe impl ::windows::core::Interface for IInitializeWithWindow {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IInitializeWithWindow_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hwnd: super::super::Foundation::HWND) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -27585,7 +27585,7 @@ unsafe impl ::windows::core::Interface for IInputObject {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IInputObject_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
     pub UIActivateIO: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, factivate: super::super::Foundation::BOOL, pmsg: *const super::WindowsAndMessaging::MSG) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging")))]
@@ -27733,7 +27733,7 @@ unsafe impl ::windows::core::Interface for IInputObjectSite {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IInputObjectSite_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub OnFocusChangeIS: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punkobj: *mut ::core::ffi::c_void, fsetfocus: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -27791,7 +27791,7 @@ unsafe impl ::windows::core::Interface for IInputPaneAnimationCoordinator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IInputPaneAnimationCoordinator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Graphics_DirectComposition")]
     pub AddAnimation: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, device: *mut ::core::ffi::c_void, animation: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Graphics_DirectComposition"))]
@@ -27843,7 +27843,7 @@ unsafe impl ::windows::core::Interface for IInputPanelConfiguration {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IInputPanelConfiguration_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub EnableFocusTracking: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Shell\"`*"]
@@ -27892,7 +27892,7 @@ unsafe impl ::windows::core::Interface for IInputPanelInvocationConfiguration {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IInputPanelInvocationConfiguration_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub RequireTouchInEditControl: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Shell\"`*"]
@@ -27943,7 +27943,7 @@ unsafe impl ::windows::core::Interface for IInsertItem {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IInsertItem_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_UI_Shell_Common")]
     pub InsertItem: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pidl: *const Common::ITEMIDLIST) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_UI_Shell_Common"))]
@@ -28002,7 +28002,7 @@ unsafe impl ::windows::core::Interface for IItemNameLimits {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IItemNameLimits_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetValidCharacters: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppwszvalidchars: *mut ::windows::core::PWSTR, ppwszinvalidchars: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetMaxLength: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszname: ::windows::core::PCWSTR, pimaxnamelen: *mut i32) -> ::windows::core::HRESULT,
 }
@@ -28092,7 +28092,7 @@ unsafe impl ::windows::core::Interface for IKnownFolder {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IKnownFolder_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pkfid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub GetCategory: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcategory: *mut KF_CATEGORY) -> ::windows::core::HRESULT,
     pub GetShellItem: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwflags: u32, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -28200,7 +28200,7 @@ unsafe impl ::windows::core::Interface for IKnownFolderManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IKnownFolderManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub FolderIdFromCsidl: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ncsidl: i32, pfid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub FolderIdToCsidl: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, rfid: *const ::windows::core::GUID, pncsidl: *mut i32) -> ::windows::core::HRESULT,
     pub GetFolderIds: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppkfid: *mut *mut ::windows::core::GUID, pcount: *mut u32) -> ::windows::core::HRESULT,
@@ -28265,7 +28265,7 @@ unsafe impl ::windows::core::Interface for ILaunchSourceAppUserModelId {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ILaunchSourceAppUserModelId_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetAppUserModelId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, launchingapp: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Shell\"`*"]
@@ -28321,7 +28321,7 @@ unsafe impl ::windows::core::Interface for ILaunchSourceViewSizePreference {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ILaunchSourceViewSizePreference_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetSourceViewToPosition: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hwnd: *mut super::super::Foundation::HWND) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -28377,7 +28377,7 @@ unsafe impl ::windows::core::Interface for ILaunchTargetMonitor {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ILaunchTargetMonitor_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Graphics_Gdi")]
     pub GetMonitor: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, monitor: *mut super::super::Graphics::Gdi::HMONITOR) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Graphics_Gdi"))]
@@ -28430,7 +28430,7 @@ unsafe impl ::windows::core::Interface for ILaunchTargetViewSizePreference {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ILaunchTargetViewSizePreference_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetTargetViewSizePreference: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, targetsizeonlaunch: *mut APPLICATION_VIEW_SIZE_PREFERENCE) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Shell\"`*"]
@@ -28487,7 +28487,7 @@ unsafe impl ::windows::core::Interface for ILaunchUIContext {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ILaunchUIContext_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub SetAssociatedWindow: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: super::super::Foundation::HWND) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -28543,7 +28543,7 @@ unsafe impl ::windows::core::Interface for ILaunchUIContextProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ILaunchUIContextProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub UpdateContext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, context: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Shell\"`*"]
@@ -28599,7 +28599,7 @@ unsafe impl ::windows::core::Interface for IMenuBand {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMenuBand_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
     pub IsMenuMessage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pmsg: *const super::WindowsAndMessaging::MSG) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging")))]
@@ -28807,7 +28807,7 @@ unsafe impl ::windows::core::Interface for IModalWindow {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IModalWindow_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Show: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hwndowner: super::super::Foundation::HWND) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -28878,7 +28878,7 @@ unsafe impl ::windows::core::Interface for INameSpaceTreeAccessible {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INameSpaceTreeAccessible_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnGetDefaultAccessibilityAction: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psi: *mut ::core::ffi::c_void, pbstrdefaultaction: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub OnDoDefaultAccessibilityAction: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psi: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -29041,7 +29041,7 @@ unsafe impl ::windows::core::Interface for INameSpaceTreeControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INameSpaceTreeControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hwndparent: super::super::Foundation::HWND, prc: *const super::super::Foundation::RECT, nsctsflags: u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -29337,7 +29337,7 @@ unsafe impl ::windows::core::Interface for INameSpaceTreeControlCustomDraw {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INameSpaceTreeControlCustomDraw_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
     pub PrePaint: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hdc: super::super::Graphics::Gdi::HDC, prc: *const super::super::Foundation::RECT, plres: *mut super::super::Foundation::LRESULT) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi")))]
@@ -29442,7 +29442,7 @@ unsafe impl ::windows::core::Interface for INameSpaceTreeControlDropHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INameSpaceTreeControlDropHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub OnDragEnter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psiover: *mut ::core::ffi::c_void, psiadata: *mut ::core::ffi::c_void, foutsidesource: super::super::Foundation::BOOL, grfkeystate: u32, pdweffect: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -29614,7 +29614,7 @@ unsafe impl ::windows::core::Interface for INameSpaceTreeControlEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INameSpaceTreeControlEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnItemClick: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psi: *mut ::core::ffi::c_void, nstcehittest: u32, nstceclicktype: u32) -> ::windows::core::HRESULT,
     pub OnPropertyItemCommit: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psi: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub OnItemStateChanging: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psi: *mut ::core::ffi::c_void, nstcismask: u32, nstcisstate: u32) -> ::windows::core::HRESULT,
@@ -29690,7 +29690,7 @@ unsafe impl ::windows::core::Interface for INameSpaceTreeControlFolderCapabiliti
 #[repr(C)]
 #[doc(hidden)]
 pub struct INameSpaceTreeControlFolderCapabilities_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetFolderCapabilities: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, nfcmask: NSTCFOLDERCAPABILITIES, pnfcvalue: *mut NSTCFOLDERCAPABILITIES) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Shell\"`*"]
@@ -29761,7 +29761,7 @@ unsafe impl ::windows::core::Interface for INamedPropertyBag {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INamedPropertyBag_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
     pub ReadPropertyNPB: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszbagname: ::windows::core::PCWSTR, pszpropname: ::windows::core::PCWSTR, pvar: *mut super::super::System::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage")))]
@@ -29827,7 +29827,7 @@ unsafe impl ::windows::core::Interface for INamespaceWalk {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INamespaceWalk_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Walk: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punktowalk: *mut ::core::ffi::c_void, dwflags: u32, cdepth: i32, pnswcb: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_UI_Shell_Common")]
     pub GetIDArrayResult: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcitems: *mut u32, prgpidl: *mut *mut *mut Common::ITEMIDLIST) -> ::windows::core::HRESULT,
@@ -29904,7 +29904,7 @@ unsafe impl ::windows::core::Interface for INamespaceWalkCB {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INamespaceWalkCB_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_UI_Shell_Common")]
     pub FoundItem: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psf: *mut ::core::ffi::c_void, pidl: *const Common::ITEMIDLIST) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_UI_Shell_Common"))]
@@ -30068,7 +30068,7 @@ unsafe impl ::windows::core::Interface for INetworkFolderInternal {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INetworkFolderInternal_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetResourceDisplayType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, displaytype: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_UI_Shell_Common")]
     pub GetIDList: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, idlist: *mut *mut Common::ITEMIDLIST) -> ::windows::core::HRESULT,
@@ -30131,7 +30131,7 @@ unsafe impl ::windows::core::Interface for INewMenuClient {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INewMenuClient_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub IncludeItems: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pflags: *mut i32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_UI_Shell_Common")]
     pub SelectAndEditItem: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pidlitem: *const Common::ITEMIDLIST, flags: i32) -> ::windows::core::HRESULT,
@@ -30208,7 +30208,7 @@ unsafe impl ::windows::core::Interface for INewShortcutHookA {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INewShortcutHookA_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub SetReferent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcszreferent: ::windows::core::PCSTR, hwnd: super::super::Foundation::HWND) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -30289,7 +30289,7 @@ unsafe impl ::windows::core::Interface for INewShortcutHookW {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INewShortcutHookW_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub SetReferent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcszreferent: ::windows::core::PCWSTR, hwnd: super::super::Foundation::HWND) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -30485,7 +30485,7 @@ unsafe impl ::windows::core::Interface for INewWindowManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INewWindowManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub EvaluateNewWindow: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszurl: ::windows::core::PCWSTR, pszname: ::windows::core::PCWSTR, pszurlcontext: ::windows::core::PCWSTR, pszfeatures: ::windows::core::PCWSTR, freplace: super::super::Foundation::BOOL, dwflags: u32, dwuseractiontime: u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -30539,7 +30539,7 @@ unsafe impl ::windows::core::Interface for INotifyReplica {
 #[repr(C)]
 #[doc(hidden)]
 pub struct INotifyReplica_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub YouAreAReplica: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ulcotherreplicas: u32, rgpmkotherreplicas: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -30600,7 +30600,7 @@ unsafe impl ::windows::core::Interface for IObjMgr {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IObjMgr_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Append: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punk: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Remove: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punk: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -30654,7 +30654,7 @@ unsafe impl ::windows::core::Interface for IObjectProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IObjectProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub QueryObject: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, guidobject: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, ppvout: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Shell\"`*"]
@@ -30710,7 +30710,7 @@ unsafe impl ::windows::core::Interface for IObjectWithAppUserModelID {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IObjectWithAppUserModelID_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetAppID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszappid: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub GetAppID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppszappid: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
 }
@@ -30760,7 +30760,7 @@ unsafe impl ::windows::core::Interface for IObjectWithBackReferences {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IObjectWithBackReferences_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub RemoveBackReferences: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Shell\"`*"]
@@ -30812,7 +30812,7 @@ unsafe impl ::windows::core::Interface for IObjectWithCancelEvent {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IObjectWithCancelEvent_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetCancelEvent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, phevent: *mut super::super::Foundation::HANDLE) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -30868,7 +30868,7 @@ unsafe impl ::windows::core::Interface for IObjectWithFolderEnumMode {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IObjectWithFolderEnumMode_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetMode: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, femode: FOLDER_ENUM_MODE) -> ::windows::core::HRESULT,
     pub GetMode: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfemode: *mut FOLDER_ENUM_MODE) -> ::windows::core::HRESULT,
 }
@@ -30925,7 +30925,7 @@ unsafe impl ::windows::core::Interface for IObjectWithProgID {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IObjectWithProgID_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetProgID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszprogid: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub GetProgID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppszprogid: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
 }
@@ -30985,7 +30985,7 @@ unsafe impl ::windows::core::Interface for IObjectWithSelection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IObjectWithSelection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetSelection: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psia: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetSelection: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -31050,7 +31050,7 @@ unsafe impl ::windows::core::Interface for IOpenControlPanel {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOpenControlPanel_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Open: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszname: ::windows::core::PCWSTR, pszpage: ::windows::core::PCWSTR, punksite: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetPath: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszname: ::windows::core::PCWSTR, pszpath: ::windows::core::PWSTR, cchpath: u32) -> ::windows::core::HRESULT,
     pub GetCurrentView: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pview: *mut CPVIEW) -> ::windows::core::HRESULT,
@@ -31109,7 +31109,7 @@ unsafe impl ::windows::core::Interface for IOpenSearchSource {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOpenSearchSource_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetResults: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hwnd: super::super::Foundation::HWND, pszquery: ::windows::core::PCWSTR, dwstartindex: u32, dwcount: u32, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -31204,7 +31204,7 @@ unsafe impl ::windows::core::Interface for IOperationsProgressDialog {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IOperationsProgressDialog_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub StartProgressDialog: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hwndowner: super::super::Foundation::HWND, flags: u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -31352,7 +31352,7 @@ unsafe impl ::windows::core::Interface for IPackageDebugSettings {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPackageDebugSettings_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub EnableDebugging: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, packagefullname: ::windows::core::PCWSTR, debuggercommandline: ::windows::core::PCWSTR, environment: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub DisableDebugging: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, packagefullname: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub Suspend: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, packagefullname: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
@@ -31571,7 +31571,7 @@ unsafe impl ::windows::core::Interface for IPackageExecutionStateChangeNotificat
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPackageExecutionStateChangeNotification_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnStateChanged: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszpackagefullname: ::windows::core::PCWSTR, pesnewstate: PACKAGE_EXECUTION_STATE) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Shell\"`*"]
@@ -31630,7 +31630,7 @@ unsafe impl ::windows::core::Interface for IParentAndItem {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IParentAndItem_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_UI_Shell_Common")]
     pub SetParentAndItem: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pidlparent: *const Common::ITEMIDLIST, psf: *mut ::core::ffi::c_void, pidlchild: *const Common::ITEMIDLIST) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_UI_Shell_Common"))]
@@ -31696,7 +31696,7 @@ unsafe impl ::windows::core::Interface for IParseAndCreateItem {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IParseAndCreateItem_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetItem: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psi: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetItem: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -32226,7 +32226,7 @@ unsafe impl ::windows::core::Interface for IPreviewHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPreviewHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub SetWindow: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hwnd: super::super::Foundation::HWND, prc: *const super::super::Foundation::RECT) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -32301,7 +32301,7 @@ unsafe impl ::windows::core::Interface for IPreviewHandlerFrame {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPreviewHandlerFrame_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
     pub GetWindowContext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *mut PREVIEWHANDLERFRAMEINFO) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_UI_WindowsAndMessaging"))]
@@ -32375,7 +32375,7 @@ unsafe impl ::windows::core::Interface for IPreviewHandlerVisuals {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPreviewHandlerVisuals_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub SetBackgroundColor: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, color: super::super::Foundation::COLORREF) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -32512,7 +32512,7 @@ unsafe impl ::windows::core::Interface for IPreviousVersionsInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPreviousVersionsInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub AreSnapshotsAvailable: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszpath: ::windows::core::PCWSTR, foktobeslow: super::super::Foundation::BOOL, pfavailable: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -32573,7 +32573,7 @@ unsafe impl ::windows::core::Interface for IProfferService {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IProfferService_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub ProfferService: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, serviceid: *const ::windows::core::GUID, serviceprovider: *mut ::core::ffi::c_void, cookie: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -32678,7 +32678,7 @@ unsafe impl ::windows::core::Interface for IProgressDialog {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IProgressDialog_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub StartProgressDialog: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hwndparent: super::super::Foundation::HWND, punkenablemodless: *mut ::core::ffi::c_void, dwflags: u32, pvresevered: *const ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -32773,7 +32773,7 @@ unsafe impl ::windows::core::Interface for IPropertyKeyStore {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPropertyKeyStore_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetKeyCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, keycount: *mut i32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
     pub GetKeyAt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: i32, pkey: *mut PropertiesSystem::PROPERTYKEY) -> ::windows::core::HRESULT,
@@ -33198,7 +33198,7 @@ unsafe impl ::windows::core::Interface for IQueryAssociations {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IQueryAssociations_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
     pub Init: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, flags: u32, pszassoc: ::windows::core::PCWSTR, hkprogid: super::super::System::Registry::HKEY, hwnd: super::super::Foundation::HWND) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Registry")))]
@@ -33261,7 +33261,7 @@ unsafe impl ::windows::core::Interface for IQueryCancelAutoPlay {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IQueryCancelAutoPlay_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AllowAutoPlay: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszpath: ::windows::core::PCWSTR, dwcontenttype: u32, pszlabel: ::windows::core::PCWSTR, dwserialnumber: u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Shell\"`*"]
@@ -33314,7 +33314,7 @@ unsafe impl ::windows::core::Interface for IQueryCodePage {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IQueryCodePage_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCodePage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, puicodepage: *mut u32) -> ::windows::core::HRESULT,
     pub SetCodePage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, uicodepage: u32) -> ::windows::core::HRESULT,
 }
@@ -33364,7 +33364,7 @@ unsafe impl ::windows::core::Interface for IQueryContinue {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IQueryContinue_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub QueryContinue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Shell\"`*"]
@@ -33488,7 +33488,7 @@ unsafe impl ::windows::core::Interface for IQueryInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IQueryInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetInfoTip: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwflags: QITIPF_FLAGS, ppwsztip: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetInfoFlags: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwflags: *mut u32) -> ::windows::core::HRESULT,
 }
@@ -33549,7 +33549,7 @@ unsafe impl ::windows::core::Interface for IRegTreeItem {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRegTreeItem_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetCheckState: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbcheck: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -33612,7 +33612,7 @@ unsafe impl ::windows::core::Interface for IRelatedItem {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRelatedItem_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_UI_Shell_Common")]
     pub GetItemIDList: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppidl: *mut *mut Common::ITEMIDLIST) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_UI_Shell_Common"))]
@@ -33671,7 +33671,7 @@ unsafe impl ::windows::core::Interface for IRemoteComputer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRemoteComputer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszmachine: ::windows::core::PCWSTR, benumerating: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -33729,7 +33729,7 @@ unsafe impl ::windows::core::Interface for IResolveShellLink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IResolveShellLink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub ResolveShellLink: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punklink: *mut ::core::ffi::c_void, hwnd: super::super::Foundation::HWND, fflags: u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -33804,7 +33804,7 @@ unsafe impl ::windows::core::Interface for IResultsFolder {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IResultsFolder_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddItem: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psi: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_UI_Shell_Common")]
     pub AddIDList: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pidl: *const Common::ITEMIDLIST, ppidladded: *mut *mut Common::ITEMIDLIST) -> ::windows::core::HRESULT,
@@ -33880,7 +33880,7 @@ unsafe impl ::windows::core::Interface for IRunnableTask {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRunnableTask_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Run: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub Kill: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bwait: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -34125,7 +34125,7 @@ unsafe impl ::windows::core::Interface for ISearchBoxInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISearchBoxInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCondition: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetText: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppsz: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
 }
@@ -34184,7 +34184,7 @@ unsafe impl ::windows::core::Interface for ISearchContext {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISearchContext_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetSearchUrl: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstrsearchurl: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub GetSearchText: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstrsearchtext: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub GetSearchStyle: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwsearchstyle: *mut u32) -> ::windows::core::HRESULT,
@@ -34294,7 +34294,7 @@ unsafe impl ::windows::core::Interface for ISearchFolderItemFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISearchFolderItemFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetDisplayName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszdisplayname: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub SetFolderTypeID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ftid: ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub SetFolderLogicalViewMode: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, flvm: FOLDERLOGICALVIEWMODE) -> ::windows::core::HRESULT,
@@ -34399,7 +34399,7 @@ unsafe impl ::windows::core::Interface for ISharedBitmap {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISharedBitmap_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Graphics_Gdi")]
     pub GetSharedBitmap: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, phbm: *mut super::super::Graphics::Gdi::HBITMAP) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Graphics_Gdi"))]
@@ -34483,7 +34483,7 @@ unsafe impl ::windows::core::Interface for ISharingConfigurationManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISharingConfigurationManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateShare: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dsid: DEF_SHARE_ID, role: SHARE_ROLE) -> ::windows::core::HRESULT,
     pub DeleteShare: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dsid: DEF_SHARE_ID) -> ::windows::core::HRESULT,
     pub ShareExists: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dsid: DEF_SHARE_ID) -> ::windows::core::HRESULT,
@@ -34557,7 +34557,7 @@ unsafe impl ::windows::core::Interface for IShellApp {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IShellApp_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetAppInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pai: *mut APPINFODATA) -> ::windows::core::HRESULT,
     pub GetPossibleActions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwactions: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -34845,7 +34845,7 @@ unsafe impl ::windows::core::Interface for IShellChangeNotify {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IShellChangeNotify_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_UI_Shell_Common")]
     pub OnChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, levent: i32, pidl1: *const Common::ITEMIDLIST, pidl2: *const Common::ITEMIDLIST) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_UI_Shell_Common"))]
@@ -34903,7 +34903,7 @@ unsafe impl ::windows::core::Interface for IShellDetails {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IShellDetails_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_UI_Shell_Common")]
     pub GetDetailsOf: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pidl: *const Common::ITEMIDLIST, icolumn: u32, pdetails: *mut Common::SHELLDETAILS) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_UI_Shell_Common"))]
@@ -36767,7 +36767,7 @@ unsafe impl ::windows::core::Interface for IShellExtInit {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IShellExtInit_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Registry", feature = "Win32_UI_Shell_Common"))]
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pidlfolder: *const Common::ITEMIDLIST, pdtobj: *mut ::core::ffi::c_void, hkeyprogid: super::super::System::Registry::HKEY) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_System_Com", feature = "Win32_System_Registry", feature = "Win32_UI_Shell_Common")))]
@@ -37032,7 +37032,7 @@ unsafe impl ::windows::core::Interface for IShellFolder {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IShellFolder_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_UI_Shell_Common"))]
     pub ParseDisplayName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hwnd: super::super::Foundation::HWND, pbc: *mut ::core::ffi::c_void, pszdisplayname: ::windows::core::PCWSTR, pcheaten: *mut u32, ppidl: *mut *mut Common::ITEMIDLIST, pdwattributes: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_UI_Shell_Common")))]
@@ -37331,7 +37331,7 @@ unsafe impl ::windows::core::Interface for IShellFolderBand {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IShellFolderBand_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_UI_Shell_Common")]
     pub InitializeSFB: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psf: *mut ::core::ffi::c_void, pidl: *const Common::ITEMIDLIST) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_UI_Shell_Common"))]
@@ -37546,7 +37546,7 @@ unsafe impl ::windows::core::Interface for IShellFolderView {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IShellFolderView_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Rearrange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lparamsort: super::super::Foundation::LPARAM) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -37682,7 +37682,7 @@ unsafe impl ::windows::core::Interface for IShellFolderViewCB {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IShellFolderViewCB_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub MessageSFVCB: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, umsg: SFVM_MESSAGE_ID, wparam: super::super::Foundation::WPARAM, lparam: super::super::Foundation::LPARAM) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -38277,7 +38277,7 @@ unsafe impl ::windows::core::Interface for IShellIcon {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IShellIcon_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_UI_Shell_Common")]
     pub GetIconOf: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pidl: *const Common::ITEMIDLIST, flags: u32, piconindex: *mut i32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_UI_Shell_Common"))]
@@ -38336,7 +38336,7 @@ unsafe impl ::windows::core::Interface for IShellIconOverlay {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IShellIconOverlay_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_UI_Shell_Common")]
     pub GetOverlayIndex: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pidl: *const Common::ITEMIDLIST, pindex: *mut i32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_UI_Shell_Common"))]
@@ -38402,7 +38402,7 @@ unsafe impl ::windows::core::Interface for IShellIconOverlayIdentifier {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IShellIconOverlayIdentifier_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub IsMemberOf: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszpath: ::windows::core::PCWSTR, dwattrib: u32) -> ::windows::core::HRESULT,
     pub GetOverlayInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwsziconfile: ::windows::core::PWSTR, cchmax: i32, pindex: *mut i32, pdwflags: *mut u32) -> ::windows::core::HRESULT,
     pub GetPriority: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppriority: *mut i32) -> ::windows::core::HRESULT,
@@ -38476,7 +38476,7 @@ unsafe impl ::windows::core::Interface for IShellIconOverlayManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IShellIconOverlayManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetFileOverlayInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszpath: ::windows::core::PCWSTR, dwattrib: u32, pindex: *mut i32, dwflags: u32) -> ::windows::core::HRESULT,
     pub GetReservedOverlayInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszpath: ::windows::core::PCWSTR, dwattrib: u32, pindex: *mut i32, dwflags: u32, ireservedid: i32) -> ::windows::core::HRESULT,
     pub RefreshOverlayImages: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwflags: u32) -> ::windows::core::HRESULT,
@@ -38641,7 +38641,7 @@ unsafe impl ::windows::core::Interface for IShellImageData {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IShellImageData_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Decode: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwflags: u32, cxdesired: u32, cydesired: u32) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
     pub Draw: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hdc: super::super::Graphics::Gdi::HDC, prcdest: *mut super::super::Foundation::RECT, prcsrc: *mut super::super::Foundation::RECT) -> ::windows::core::HRESULT,
@@ -38731,7 +38731,7 @@ unsafe impl ::windows::core::Interface for IShellImageDataAbort {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IShellImageDataAbort_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub QueryAbort: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Shell\"`*"]
@@ -38804,7 +38804,7 @@ unsafe impl ::windows::core::Interface for IShellImageDataFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IShellImageDataFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateIShellImageData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppshimg: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CreateImageFromFile: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszpath: ::windows::core::PCWSTR, ppshimg: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
@@ -38887,7 +38887,7 @@ unsafe impl ::windows::core::Interface for IShellItem {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IShellItem_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub BindToHandler: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbc: *mut ::core::ffi::c_void, bhid: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -39225,7 +39225,7 @@ unsafe impl ::windows::core::Interface for IShellItemArray {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IShellItemArray_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub BindToHandler: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbc: *mut ::core::ffi::c_void, bhid: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, ppvout: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -39302,7 +39302,7 @@ unsafe impl ::windows::core::Interface for IShellItemFilter {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IShellItemFilter_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub IncludeItem: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psi: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetEnumFlagsForItem: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psi: *mut ::core::ffi::c_void, pgrfflags: *mut u32) -> ::windows::core::HRESULT,
 }
@@ -39355,7 +39355,7 @@ unsafe impl ::windows::core::Interface for IShellItemImageFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IShellItemImageFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
     pub GetImage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, size: super::super::Foundation::SIZE, flags: SIIGBF, phbm: *mut super::super::Graphics::Gdi::HBITMAP) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi")))]
@@ -39450,7 +39450,7 @@ unsafe impl ::windows::core::Interface for IShellItemResources {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IShellItemResources_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetAttributes: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwattributes: *mut u32) -> ::windows::core::HRESULT,
     pub GetSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pullsize: *mut u64) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -39602,7 +39602,7 @@ unsafe impl ::windows::core::Interface for IShellLibrary {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IShellLibrary_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub LoadLibraryFromItem: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psilibrary: *mut ::core::ffi::c_void, grfmode: u32) -> ::windows::core::HRESULT,
     pub LoadLibraryFromKnownFolder: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, kfidlibrary: *const ::windows::core::GUID, grfmode: u32) -> ::windows::core::HRESULT,
     pub AddFolder: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psilocation: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -39750,7 +39750,7 @@ unsafe impl ::windows::core::Interface for IShellLinkA {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IShellLinkA_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_FileSystem"))]
     pub GetPath: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszfile: ::windows::core::PSTR, cch: i32, pfd: *mut super::super::Storage::FileSystem::WIN32_FIND_DATAA, fflags: u32) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_Storage_FileSystem")))]
@@ -39841,7 +39841,7 @@ unsafe impl ::windows::core::Interface for IShellLinkDataList {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IShellLinkDataList_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddDataBlock: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdatablock: *const ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CopyDataBlock: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwsig: u32, ppdatablock: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub RemoveDataBlock: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwsig: u32) -> ::windows::core::HRESULT,
@@ -40290,7 +40290,7 @@ unsafe impl ::windows::core::Interface for IShellLinkW {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IShellLinkW_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_FileSystem"))]
     pub GetPath: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszfile: ::windows::core::PWSTR, cch: i32, pfd: *mut super::super::Storage::FileSystem::WIN32_FIND_DATAW, fflags: u32) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_Storage_FileSystem")))]
@@ -40419,7 +40419,7 @@ unsafe impl ::windows::core::Interface for IShellMenu {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IShellMenu_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psmc: *mut ::core::ffi::c_void, uid: u32, uidancestor: u32, dwflags: u32) -> ::windows::core::HRESULT,
     pub GetMenuInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppsmc: *mut *mut ::core::ffi::c_void, puid: *mut u32, puidancestor: *mut u32, pdwflags: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_System_Registry", feature = "Win32_UI_Shell_Common"))]
@@ -40500,7 +40500,7 @@ unsafe impl ::windows::core::Interface for IShellMenuCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IShellMenuCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common", feature = "Win32_UI_WindowsAndMessaging"))]
     pub CallbackSM: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psmd: *mut SMDATA, umsg: u32, wparam: super::super::Foundation::WPARAM, lparam: super::super::Foundation::LPARAM) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common", feature = "Win32_UI_WindowsAndMessaging")))]
@@ -40832,7 +40832,7 @@ unsafe impl ::windows::core::Interface for IShellPropSheetExt {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IShellPropSheetExt_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Controls"))]
     pub AddPages: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfnaddpage: *mut ::core::ffi::c_void, lparam: super::super::Foundation::LPARAM) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_UI_Controls")))]
@@ -40891,7 +40891,7 @@ unsafe impl ::windows::core::Interface for IShellRunDll {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IShellRunDll_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Run: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszargs: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Shell\"`*"]
@@ -40943,7 +40943,7 @@ unsafe impl ::windows::core::Interface for IShellService {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IShellService_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetOwner: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punkowner: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Shell\"`*"]
@@ -41009,7 +41009,7 @@ unsafe impl ::windows::core::Interface for IShellTaskScheduler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IShellTaskScheduler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddTask: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, prt: *mut ::core::ffi::c_void, rtoid: *const ::windows::core::GUID, lparam: usize, dwpriority: u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub RemoveTasks: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, rtoid: *const ::windows::core::GUID, lparam: usize, bwaitifrunning: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -45597,7 +45597,7 @@ unsafe impl ::windows::core::Interface for ISortColumnArray {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISortColumnArray_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, columncount: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
     pub GetAt: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, index: u32, sortcolumn: *mut SORTCOLUMN) -> ::windows::core::HRESULT,
@@ -45654,7 +45654,7 @@ unsafe impl ::windows::core::Interface for IStartMenuPinnedList {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IStartMenuPinnedList_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub RemoveFromList: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pitem: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Shell\"`*"]
@@ -45729,7 +45729,7 @@ unsafe impl ::windows::core::Interface for IStorageProviderBanners {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IStorageProviderBanners_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetBanner: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, provideridentity: ::windows::core::PCWSTR, subscriptionid: ::windows::core::PCWSTR, contentid: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub ClearBanner: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, provideridentity: ::windows::core::PCWSTR, subscriptionid: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
     pub ClearAllBanners: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, provideridentity: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
@@ -45789,7 +45789,7 @@ unsafe impl ::windows::core::Interface for IStorageProviderCopyHook {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IStorageProviderCopyHook_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub CopyCallback: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hwnd: super::super::Foundation::HWND, operation: u32, flags: u32, srcfile: ::windows::core::PCWSTR, srcattribs: u32, destfile: ::windows::core::PCWSTR, destattribs: u32, result: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -45859,7 +45859,7 @@ unsafe impl ::windows::core::Interface for IStorageProviderHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IStorageProviderHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetPropertyHandlerFromPath: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, path: ::windows::core::PCWSTR, propertyhandler: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetPropertyHandlerFromUri: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, uri: ::windows::core::PCWSTR, propertyhandler: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetPropertyHandlerFromFileId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fileid: ::windows::core::PCWSTR, propertyhandler: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -45921,7 +45921,7 @@ unsafe impl ::windows::core::Interface for IStorageProviderPropertyHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IStorageProviderPropertyHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
     pub RetrieveProperties: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, propertiestoretrieve: *const PropertiesSystem::PROPERTYKEY, propertiestoretrievecount: u32, retrievedproperties: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_UI_Shell_PropertiesSystem"))]
@@ -46164,7 +46164,7 @@ unsafe impl ::windows::core::Interface for IStreamUnbufferedInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IStreamUnbufferedInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetSectorSize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcbsectorsize: *mut u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Shell\"`*"]
@@ -46234,7 +46234,7 @@ unsafe impl ::windows::core::Interface for ISuspensionDependencyManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISuspensionDependencyManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub RegisterAsChild: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, processhandle: super::super::Foundation::HANDLE) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -46320,7 +46320,7 @@ unsafe impl ::windows::core::Interface for ISyncMgrConflict {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISyncMgrConflict_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
     pub GetProperty: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, propkey: *const PropertiesSystem::PROPERTYKEY, ppropvar: *mut super::super::System::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem")))]
@@ -46385,7 +46385,7 @@ unsafe impl ::windows::core::Interface for ISyncMgrConflictFolder {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISyncMgrConflictFolder_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_UI_Shell_Common")]
     pub GetConflictIDList: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pconflict: *mut ::core::ffi::c_void, ppidlconflict: *mut *mut Common::ITEMIDLIST) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_UI_Shell_Common"))]
@@ -46442,7 +46442,7 @@ unsafe impl ::windows::core::Interface for ISyncMgrConflictItems {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISyncMgrConflictItems_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcount: *mut u32) -> ::windows::core::HRESULT,
     pub GetItem: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, iindex: u32, piteminfo: *mut CONFIRM_CONFLICT_ITEM) -> ::windows::core::HRESULT,
 }
@@ -46496,7 +46496,7 @@ unsafe impl ::windows::core::Interface for ISyncMgrConflictPresenter {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISyncMgrConflictPresenter_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub PresentConflict: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pconflict: *mut ::core::ffi::c_void, presolveinfo: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Shell\"`*"]
@@ -46550,7 +46550,7 @@ unsafe impl ::windows::core::Interface for ISyncMgrConflictResolutionItems {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISyncMgrConflictResolutionItems_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcount: *mut u32) -> ::windows::core::HRESULT,
     pub GetItem: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, iindex: u32, piteminfo: *mut CONFIRM_CONFLICT_RESULT_INFO) -> ::windows::core::HRESULT,
 }
@@ -46631,7 +46631,7 @@ unsafe impl ::windows::core::Interface for ISyncMgrConflictResolveInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISyncMgrConflictResolveInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetIterationInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pncurrentconflict: *mut u32, pcconflicts: *mut u32, pcremainingforapplytoall: *mut u32) -> ::windows::core::HRESULT,
     pub GetPresenterNextStep: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pnpresenternextstep: *mut SYNCMGR_PRESENTER_NEXT_STEP) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -46720,7 +46720,7 @@ unsafe impl ::windows::core::Interface for ISyncMgrConflictStore {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISyncMgrConflictStore_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub EnumConflicts: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszhandlerid: ::windows::core::PCWSTR, pszitemid: ::windows::core::PCWSTR, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
     pub BindToConflict: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pconflictidinfo: *const SYNCMGR_CONFLICT_ID_INFO, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -46889,7 +46889,7 @@ unsafe impl ::windows::core::Interface for ISyncMgrControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISyncMgrControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub StartHandlerSync: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszhandlerid: ::windows::core::PCWSTR, hwndowner: super::super::Foundation::HWND, punk: *mut ::core::ffi::c_void, nsynccontrolflags: SYNCMGR_SYNC_CONTROL_FLAGS, presult: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -46982,7 +46982,7 @@ unsafe impl ::windows::core::Interface for ISyncMgrEnumItems {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISyncMgrEnumItems_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, celt: u32, rgelt: *mut SYNCMGRITEM, pceltfetched: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging")))]
@@ -47080,7 +47080,7 @@ unsafe impl ::windows::core::Interface for ISyncMgrEvent {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISyncMgrEvent_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetEventID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pguideventid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub GetHandlerID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppszhandlerid: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetItemID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppszitemid: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
@@ -47229,7 +47229,7 @@ unsafe impl ::windows::core::Interface for ISyncMgrEventStore {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISyncMgrEventStore_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetEventEnumerator: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetEventCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcevents: *mut u32) -> ::windows::core::HRESULT,
     pub GetEvent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, rguideventid: *const ::windows::core::GUID, ppevent: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -47327,7 +47327,7 @@ unsafe impl ::windows::core::Interface for ISyncMgrHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISyncMgrHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppszname: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetHandlerInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pphandlerinfo: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetObject: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, rguidobjectid: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -47403,7 +47403,7 @@ unsafe impl ::windows::core::Interface for ISyncMgrHandlerCollection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISyncMgrHandlerCollection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub GetHandlerEnumerator: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -47480,7 +47480,7 @@ unsafe impl ::windows::core::Interface for ISyncMgrHandlerInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISyncMgrHandlerInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pntype: *mut SYNCMGR_HANDLER_TYPE) -> ::windows::core::HRESULT,
     pub GetTypeLabel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppsztypelabel: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetComment: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppszcomment: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
@@ -47547,7 +47547,7 @@ unsafe impl ::windows::core::Interface for ISyncMgrRegister {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISyncMgrRegister_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub RegisterSyncMgrHandler: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, clsidhandler: *const ::windows::core::GUID, pwszdescription: ::windows::core::PCWSTR, dwsyncmgrregisterflags: u32) -> ::windows::core::HRESULT,
     pub UnregisterSyncMgrHandler: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, clsidhandler: *const ::windows::core::GUID, dwreserved: u32) -> ::windows::core::HRESULT,
     pub GetHandlerRegistrationInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, clsidhandler: *const ::windows::core::GUID, pdwsyncmgrregisterflags: *mut u32) -> ::windows::core::HRESULT,
@@ -47621,7 +47621,7 @@ unsafe impl ::windows::core::Interface for ISyncMgrResolutionHandler {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISyncMgrResolutionHandler_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub QueryAbilities: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwabilities: *mut u32) -> ::windows::core::HRESULT,
     pub KeepOther: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psiother: *mut ::core::ffi::c_void, pfeedback: *mut SYNCMGR_RESOLUTION_FEEDBACK) -> ::windows::core::HRESULT,
     pub KeepRecent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfeedback: *mut SYNCMGR_RESOLUTION_FEEDBACK) -> ::windows::core::HRESULT,
@@ -47753,7 +47753,7 @@ unsafe impl ::windows::core::Interface for ISyncMgrSessionCreator {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISyncMgrSessionCreator_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateSession: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszhandlerid: ::windows::core::PCWSTR, ppszitemids: *const ::windows::core::PWSTR, citems: u32, ppcallback: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Shell\"`*"]
@@ -47862,7 +47862,7 @@ unsafe impl ::windows::core::Interface for ISyncMgrSyncCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISyncMgrSyncCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ReportProgress: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszitemid: ::windows::core::PCWSTR, pszprogresstext: ::windows::core::PCWSTR, nstatus: SYNCMGR_PROGRESS_STATUS, ucurrentstep: u32, umaxstep: u32, pncancelrequest: *mut SYNCMGR_CANCEL_REQUEST) -> ::windows::core::HRESULT,
     pub SetHandlerProgressText: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszprogresstext: ::windows::core::PCWSTR, pncancelrequest: *mut SYNCMGR_CANCEL_REQUEST) -> ::windows::core::HRESULT,
     pub ReportEvent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszitemid: ::windows::core::PCWSTR, nlevel: SYNCMGR_EVENT_LEVEL, nflags: SYNCMGR_EVENT_FLAGS, pszname: ::windows::core::PCWSTR, pszdescription: ::windows::core::PCWSTR, pszlinktext: ::windows::core::PCWSTR, pszlinkreference: ::windows::core::PCWSTR, pszcontext: ::windows::core::PCWSTR, pguideventid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
@@ -47958,7 +47958,7 @@ unsafe impl ::windows::core::Interface for ISyncMgrSyncItem {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISyncMgrSyncItem_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetItemID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppszitemid: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppszname: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetItemInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppiteminfo: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -48029,7 +48029,7 @@ unsafe impl ::windows::core::Interface for ISyncMgrSyncItemContainer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISyncMgrSyncItemContainer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetSyncItem: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszitemid: ::windows::core::PCWSTR, ppitem: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetSyncItemEnumerator: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetSyncItemCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcitems: *mut u32) -> ::windows::core::HRESULT,
@@ -48097,7 +48097,7 @@ unsafe impl ::windows::core::Interface for ISyncMgrSyncItemInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISyncMgrSyncItemInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetTypeLabel: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppsztypelabel: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetComment: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppszcomment: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -48153,7 +48153,7 @@ unsafe impl ::windows::core::Interface for ISyncMgrSyncResult {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISyncMgrSyncResult_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Result: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, nstatus: SYNCMGR_PROGRESS_STATUS, cerror: u32, cconflicts: u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Shell\"`*"]
@@ -48260,7 +48260,7 @@ unsafe impl ::windows::core::Interface for ISyncMgrSynchronize {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISyncMgrSynchronize_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwreserved: u32, dwsyncmgrflags: u32, cbcookie: u32, lpcookie: *const u8) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
     pub GetHandlerInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppsyncmgrhandlerinfo: *mut *mut SYNCMGRHANDLERINFO) -> ::windows::core::HRESULT,
@@ -48368,7 +48368,7 @@ unsafe impl ::windows::core::Interface for ISyncMgrSynchronizeCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISyncMgrSynchronizeCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ShowPropertiesCompleted: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hr: ::windows::core::HRESULT) -> ::windows::core::HRESULT,
     pub PrepareForSyncCompleted: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hr: ::windows::core::HRESULT) -> ::windows::core::HRESULT,
     pub SynchronizeCompleted: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hr: ::windows::core::HRESULT) -> ::windows::core::HRESULT,
@@ -48431,7 +48431,7 @@ unsafe impl ::windows::core::Interface for ISyncMgrSynchronizeInvoke {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISyncMgrSynchronizeInvoke_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub UpdateItems: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwinvokeflags: u32, clsid: *const ::windows::core::GUID, cbcookie: u32, pcookie: *const u8) -> ::windows::core::HRESULT,
     pub UpdateAll: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -48486,7 +48486,7 @@ unsafe impl ::windows::core::Interface for ISyncMgrUIOperation {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISyncMgrUIOperation_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Run: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hwndowner: super::super::Foundation::HWND) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -48570,7 +48570,7 @@ unsafe impl ::windows::core::Interface for ITaskbarList {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITaskbarList_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub HrInit: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub AddTab: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hwnd: super::super::Foundation::HWND) -> ::windows::core::HRESULT,
@@ -49268,7 +49268,7 @@ unsafe impl ::windows::core::Interface for IThumbnailCache {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IThumbnailCache_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetThumbnail: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pshellitem: *mut ::core::ffi::c_void, cxyrequestedthumbsize: u32, flags: WTS_FLAGS, ppvthumb: *mut *mut ::core::ffi::c_void, poutflags: *mut WTS_CACHEFLAGS, pthumbnailid: *mut WTS_THUMBNAILID) -> ::windows::core::HRESULT,
     pub GetThumbnailByID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, thumbnailid: WTS_THUMBNAILID, cxyrequestedthumbsize: u32, ppvthumb: *mut *mut ::core::ffi::c_void, poutflags: *mut WTS_CACHEFLAGS) -> ::windows::core::HRESULT,
 }
@@ -49321,7 +49321,7 @@ unsafe impl ::windows::core::Interface for IThumbnailCachePrimer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IThumbnailCachePrimer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub PageInThumbnail: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psi: *mut ::core::ffi::c_void, wtsflags: WTS_FLAGS, cxyrequestedthumbsize: u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Shell\"`*"]
@@ -49376,7 +49376,7 @@ unsafe impl ::windows::core::Interface for IThumbnailCapture {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IThumbnailCapture_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
     pub CaptureThumbnail: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pmaxsize: *const super::super::Foundation::SIZE, phtmldoc2: *mut ::core::ffi::c_void, phbmthumbnail: *mut super::super::Graphics::Gdi::HBITMAP) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi")))]
@@ -49435,7 +49435,7 @@ unsafe impl ::windows::core::Interface for IThumbnailHandlerFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IThumbnailHandlerFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Shell_Common"))]
     pub GetThumbnailHandler: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pidlchild: *const Common::ITEMIDLIST, pbc: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_System_Com", feature = "Win32_UI_Shell_Common")))]
@@ -49489,7 +49489,7 @@ unsafe impl ::windows::core::Interface for IThumbnailProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IThumbnailProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Graphics_Gdi")]
     pub GetThumbnail: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cx: u32, phbmp: *mut super::super::Graphics::Gdi::HBITMAP, pdwalpha: *mut WTS_ALPHATYPE) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Graphics_Gdi"))]
@@ -49541,7 +49541,7 @@ unsafe impl ::windows::core::Interface for IThumbnailSettings {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IThumbnailSettings_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetContext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwcontext: WTS_CONTEXTFLAGS) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Shell\"`*"]
@@ -49604,7 +49604,7 @@ unsafe impl ::windows::core::Interface for IThumbnailStreamCache {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IThumbnailStreamCache_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
     pub GetThumbnailStream: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, path: ::windows::core::PCWSTR, cacheid: u64, options: ThumbnailStreamCacheOptions, requestedthumbnailsize: u32, thumbnailsize: *mut super::super::Foundation::SIZE, thumbnailstream: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com")))]
@@ -49805,7 +49805,7 @@ unsafe impl ::windows::core::Interface for ITranscodeImage {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITranscodeImage_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub TranscodeImage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pshellitem: *mut ::core::ffi::c_void, uimaxwidth: u32, uimaxheight: u32, flags: u32, pvimage: *mut ::core::ffi::c_void, puiwidth: *mut u32, puiheight: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -49896,7 +49896,7 @@ unsafe impl ::windows::core::Interface for ITransferAdviseSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITransferAdviseSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub UpdateProgress: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ullsizecurrent: u64, ullsizetotal: u64, nfilescurrent: i32, nfilestotal: i32, nfolderscurrent: i32, nfolderstotal: i32) -> ::windows::core::HRESULT,
     pub UpdateTransferState: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ts: u32) -> ::windows::core::HRESULT,
     pub ConfirmOverwrite: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psisource: *mut ::core::ffi::c_void, psidestparent: *mut ::core::ffi::c_void, pszname: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
@@ -49967,7 +49967,7 @@ unsafe impl ::windows::core::Interface for ITransferDestination {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITransferDestination_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Advise: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psink: *mut ::core::ffi::c_void, pdwcookie: *mut u32) -> ::windows::core::HRESULT,
     pub Unadvise: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwcookie: u32) -> ::windows::core::HRESULT,
     pub CreateItem: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszname: ::windows::core::PCWSTR, dwattributes: u32, ullsize: u64, flags: u32, riiditem: *const ::windows::core::GUID, ppvitem: *mut *mut ::core::ffi::c_void, riidresources: *const ::windows::core::GUID, ppvresources: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -50176,7 +50176,7 @@ unsafe impl ::windows::core::Interface for ITransferSource {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITransferSource_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Advise: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psink: *mut ::core::ffi::c_void, pdwcookie: *mut u32) -> ::windows::core::HRESULT,
     pub Unadvise: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwcookie: u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
@@ -50258,7 +50258,7 @@ unsafe impl ::windows::core::Interface for ITravelEntry {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITravelEntry_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Invoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punk: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub Update: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punk: *mut ::core::ffi::c_void, fislocalanchor: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -50387,7 +50387,7 @@ unsafe impl ::windows::core::Interface for ITravelLog {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITravelLog_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub AddEntry: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punk: *mut ::core::ffi::c_void, fislocalanchor: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -50474,7 +50474,7 @@ unsafe impl ::windows::core::Interface for ITravelLogClient {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITravelLogClient_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub FindWindowByIndex: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwid: u32, ppunk: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Shell_Common"))]
     pub GetWindowData: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pstream: *mut ::core::ffi::c_void, pwindata: *mut WINDOWDATA) -> ::windows::core::HRESULT,
@@ -50533,7 +50533,7 @@ unsafe impl ::windows::core::Interface for ITravelLogEntry {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITravelLogEntry_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetTitle: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppsztitle: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     pub GetURL: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppszurl: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
 }
@@ -50623,7 +50623,7 @@ unsafe impl ::windows::core::Interface for ITravelLogStg {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITravelLogStg_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub CreateEntry: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszurl: ::windows::core::PCWSTR, psztitle: ::windows::core::PCWSTR, ptlerelativeto: *mut ::core::ffi::c_void, fprepend: super::super::Foundation::BOOL, pptle: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -50690,7 +50690,7 @@ unsafe impl ::windows::core::Interface for ITrayDeskBand {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITrayDeskBand_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ShowDeskBand: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, clsid: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub HideDeskBand: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, clsid: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub IsDeskBandShown: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, clsid: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
@@ -50742,7 +50742,7 @@ unsafe impl ::windows::core::Interface for IURLSearchHook {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IURLSearchHook_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Translate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pwszsearchurl: ::windows::core::PWSTR, cchbuffersize: u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Shell\"`*"]
@@ -50873,7 +50873,7 @@ unsafe impl ::windows::core::Interface for IUniformResourceLocatorA {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUniformResourceLocatorA_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetURL: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcszurl: ::windows::core::PCSTR, dwinflags: u32) -> ::windows::core::HRESULT,
     pub GetURL: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppszurl: *mut ::windows::core::PSTR) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -50939,7 +50939,7 @@ unsafe impl ::windows::core::Interface for IUniformResourceLocatorW {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUniformResourceLocatorW_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetURL: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcszurl: ::windows::core::PCWSTR, dwinflags: u32) -> ::windows::core::HRESULT,
     pub GetURL: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppszurl: *mut ::windows::core::PWSTR) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -50999,7 +50999,7 @@ unsafe impl ::windows::core::Interface for IUpdateIDList {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUpdateIDList_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Shell_Common"))]
     pub Update: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbc: *mut ::core::ffi::c_void, pidlin: *const Common::ITEMIDLIST, ppidlout: *mut *mut Common::ITEMIDLIST) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_System_Com", feature = "Win32_UI_Shell_Common")))]
@@ -51124,7 +51124,7 @@ unsafe impl ::windows::core::Interface for IUserAccountChangeCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUserAccountChangeCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnPictureChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszusername: ::windows::core::PCWSTR) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Shell\"`*"]
@@ -51201,7 +51201,7 @@ unsafe impl ::windows::core::Interface for IUserNotification {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUserNotification_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetBalloonInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psztitle: ::windows::core::PCWSTR, psztext: ::windows::core::PCWSTR, dwinfoflags: u32) -> ::windows::core::HRESULT,
     pub SetBalloonRetry: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwshowtime: u32, dwinterval: u32, cretrycount: u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
@@ -51286,7 +51286,7 @@ unsafe impl ::windows::core::Interface for IUserNotification2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUserNotification2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetBalloonInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psztitle: ::windows::core::PCWSTR, psztext: ::windows::core::PCWSTR, dwinfoflags: u32) -> ::windows::core::HRESULT,
     pub SetBalloonRetry: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwshowtime: u32, dwinterval: u32, cretrycount: u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
@@ -51354,7 +51354,7 @@ unsafe impl ::windows::core::Interface for IUserNotificationCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUserNotificationCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub OnBalloonUserClick: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pt: *const super::super::Foundation::POINT) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -51507,7 +51507,7 @@ unsafe impl ::windows::core::Interface for IVirtualDesktopManager {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVirtualDesktopManager_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub IsWindowOnCurrentVirtualDesktop: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, toplevelwindow: super::super::Foundation::HWND, oncurrentdesktop: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -51614,7 +51614,7 @@ unsafe impl ::windows::core::Interface for IVisualProperties {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVisualProperties_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Graphics_Gdi")]
     pub SetWatermark: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hbmp: super::super::Graphics::Gdi::HBITMAP, vpwf: VPWATERMARKFLAGS) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Graphics_Gdi"))]
@@ -52960,7 +52960,7 @@ unsafe impl ::windows::core::Interface for IWizardExtension {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWizardExtension_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_UI_Controls")]
     pub AddPages: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, apages: *mut super::Controls::HPROPSHEETPAGE, cpages: u32, pnpagesadded: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_UI_Controls"))]
@@ -53035,7 +53035,7 @@ unsafe impl ::windows::core::Interface for IWizardSite {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWizardSite_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_UI_Controls")]
     pub GetPreviousPage: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, phpage: *mut super::Controls::HPROPSHEETPAGE) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_UI_Controls"))]

--- a/crates/libs/windows/src/Windows/Win32/UI/TabletPC/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/TabletPC/impl.rs
@@ -133,7 +133,7 @@ impl IDynamicRenderer_Vtbl {
             this.Draw(::core::mem::transmute_copy(&hdc)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Enabled: Enabled::<Identity, Impl, OFFSET>,
             SetEnabled: SetEnabled::<Identity, Impl, OFFSET>,
             HWND: HWND::<Identity, Impl, OFFSET>,
@@ -212,7 +212,7 @@ impl IGestureRecognizer_Vtbl {
             this.Reset().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Enabled: Enabled::<Identity, Impl, OFFSET>,
             SetEnabled: SetEnabled::<Identity, Impl, OFFSET>,
             MaxStrokeCount: MaxStrokeCount::<Identity, Impl, OFFSET>,
@@ -246,7 +246,7 @@ impl IHandwrittenTextInsertion_Vtbl {
             this.InsertInkRecognitionResult(::core::mem::transmute(&piinkrecoresult), ::core::mem::transmute_copy(&locale), ::core::mem::transmute_copy(&falternatecontainsautospacinginformation)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             InsertRecognitionResultsArray: InsertRecognitionResultsArray::<Identity, Impl, OFFSET>,
             InsertInkRecognitionResult: InsertInkRecognitionResult::<Identity, Impl, OFFSET>,
         }
@@ -2810,7 +2810,7 @@ impl IInkLineInfo_Vtbl {
             this.Recognize().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetFormat: SetFormat::<Identity, Impl, OFFSET>,
             GetFormat: GetFormat::<Identity, Impl, OFFSET>,
             GetInkExtent: GetInkExtent::<Identity, Impl, OFFSET>,
@@ -6371,7 +6371,7 @@ impl IInputPanelWindowHandle_Vtbl {
             this.SetAttachedEditWindow64(::core::mem::transmute_copy(&attachededitwindow)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AttachedEditWindow32: AttachedEditWindow32::<Identity, Impl, OFFSET>,
             SetAttachedEditWindow32: SetAttachedEditWindow32::<Identity, Impl, OFFSET>,
             AttachedEditWindow64: AttachedEditWindow64::<Identity, Impl, OFFSET>,
@@ -7077,7 +7077,7 @@ impl IRealTimeStylus_Vtbl {
             this.GetPacketDescriptionData(::core::mem::transmute_copy(&tcid), ::core::mem::transmute_copy(&pfinktodevicescalex), ::core::mem::transmute_copy(&pfinktodevicescaley), ::core::mem::transmute_copy(&pcpacketproperties), ::core::mem::transmute_copy(&pppacketproperties)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Enabled: Enabled::<Identity, Impl, OFFSET>,
             SetEnabled: SetEnabled::<Identity, Impl, OFFSET>,
             HWND: HWND::<Identity, Impl, OFFSET>,
@@ -7142,7 +7142,7 @@ impl IRealTimeStylus2_Vtbl {
             this.SetFlicksEnabled(::core::mem::transmute_copy(&fenable)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             FlicksEnabled: FlicksEnabled::<Identity, Impl, OFFSET>,
             SetFlicksEnabled: SetFlicksEnabled::<Identity, Impl, OFFSET>,
         }
@@ -7178,7 +7178,7 @@ impl IRealTimeStylus3_Vtbl {
             this.SetMultiTouchEnabled(::core::mem::transmute_copy(&fenable)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             MultiTouchEnabled: MultiTouchEnabled::<Identity, Impl, OFFSET>,
             SetMultiTouchEnabled: SetMultiTouchEnabled::<Identity, Impl, OFFSET>,
         }
@@ -7205,7 +7205,7 @@ impl IRealTimeStylusSynchronization_Vtbl {
             this.ReleaseLock(::core::mem::transmute_copy(&lock)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AcquireLock: AcquireLock::<Identity, Impl, OFFSET>,
             ReleaseLock: ReleaseLock::<Identity, Impl, OFFSET>,
         }
@@ -7278,7 +7278,7 @@ impl IStrokeBuilder_Vtbl {
             this.putref_Ink(::core::mem::transmute(&piinkobj)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateStroke: CreateStroke::<Identity, Impl, OFFSET>,
             BeginStroke: BeginStroke::<Identity, Impl, OFFSET>,
             AppendPackets: AppendPackets::<Identity, Impl, OFFSET>,
@@ -7421,7 +7421,7 @@ impl IStylusPlugin_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RealTimeStylusEnabled: RealTimeStylusEnabled::<Identity, Impl, OFFSET>,
             RealTimeStylusDisabled: RealTimeStylusDisabled::<Identity, Impl, OFFSET>,
             StylusInRange: StylusInRange::<Identity, Impl, OFFSET>,
@@ -7695,7 +7695,7 @@ impl ITextInputPanel_Vtbl {
             this.Unadvise(::core::mem::transmute(&eventsink)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AttachedEditWindow: AttachedEditWindow::<Identity, Impl, OFFSET>,
             SetAttachedEditWindow: SetAttachedEditWindow::<Identity, Impl, OFFSET>,
             CurrentInteractionMode: CurrentInteractionMode::<Identity, Impl, OFFSET>,
@@ -7808,7 +7808,7 @@ impl ITextInputPanelEventSink_Vtbl {
             this.TextInserted(::core::mem::transmute_copy(&ink)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             InPlaceStateChanging: InPlaceStateChanging::<Identity, Impl, OFFSET>,
             InPlaceStateChanged: InPlaceStateChanged::<Identity, Impl, OFFSET>,
             InPlaceSizeChanging: InPlaceSizeChanging::<Identity, Impl, OFFSET>,
@@ -7847,7 +7847,7 @@ impl ITextInputPanelRunInfo_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), IsTipRunning: IsTipRunning::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), IsTipRunning: IsTipRunning::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ITextInputPanelRunInfo as ::windows::core::Interface>::IID
@@ -7898,7 +7898,7 @@ impl ITipAutoCompleteClient_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AdviseProvider: AdviseProvider::<Identity, Impl, OFFSET>,
             UnadviseProvider: UnadviseProvider::<Identity, Impl, OFFSET>,
             UserSelection: UserSelection::<Identity, Impl, OFFSET>,
@@ -7931,7 +7931,7 @@ impl ITipAutoCompleteProvider_Vtbl {
             this.Show(::core::mem::transmute_copy(&fshow)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             UpdatePendingText: UpdatePendingText::<Identity, Impl, OFFSET>,
             Show: Show::<Identity, Impl, OFFSET>,
         }

--- a/crates/libs/windows/src/Windows/Win32/UI/TabletPC/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/TabletPC/mod.rs
@@ -460,7 +460,7 @@ unsafe impl ::windows::core::Interface for IDynamicRenderer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDynamicRenderer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Enabled: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, benabled: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -586,7 +586,7 @@ unsafe impl ::windows::core::Interface for IGestureRecognizer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IGestureRecognizer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Enabled: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfenabled: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -660,7 +660,7 @@ unsafe impl ::windows::core::Interface for IHandwrittenTextInsertion {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IHandwrittenTextInsertion_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
     pub InsertRecognitionResultsArray: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psaalternates: *const super::super::System::Com::SAFEARRAY, locale: u32, falternatecontainsautospacinginformation: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com")))]
@@ -3583,7 +3583,7 @@ unsafe impl ::windows::core::Interface for IInkLineInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IInkLineInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub SetFormat: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pim: *const INKMETRIC) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -7543,7 +7543,7 @@ unsafe impl ::windows::core::Interface for IInputPanelWindowHandle {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IInputPanelWindowHandle_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AttachedEditWindow32: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, attachededitwindow: *mut i32) -> ::windows::core::HRESULT,
     pub SetAttachedEditWindow32: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, attachededitwindow: i32) -> ::windows::core::HRESULT,
     pub AttachedEditWindow64: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, attachededitwindow: *mut i64) -> ::windows::core::HRESULT,
@@ -8093,7 +8093,7 @@ unsafe impl ::windows::core::Interface for IRealTimeStylus {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRealTimeStylus_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub Enabled: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfenable: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -8222,7 +8222,7 @@ unsafe impl ::windows::core::Interface for IRealTimeStylus2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRealTimeStylus2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub FlicksEnabled: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfenable: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -8289,7 +8289,7 @@ unsafe impl ::windows::core::Interface for IRealTimeStylus3 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRealTimeStylus3_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub MultiTouchEnabled: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfenable: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -8348,7 +8348,7 @@ unsafe impl ::windows::core::Interface for IRealTimeStylusSynchronization {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRealTimeStylusSynchronization_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AcquireLock: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lock: RealTimeStylusLockType) -> ::windows::core::HRESULT,
     pub ReleaseLock: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lock: RealTimeStylusLockType) -> ::windows::core::HRESULT,
 }
@@ -8500,7 +8500,7 @@ unsafe impl ::windows::core::Interface for IStrokeBuilder {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IStrokeBuilder_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub CreateStroke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, cpktbufflength: u32, ppackets: *const i32, cpacketproperties: u32, ppacketproperties: *const PACKET_PROPERTY, finktodevicescalex: f32, finktodevicescaley: f32, ppiinkstroke: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -8858,7 +8858,7 @@ unsafe impl ::windows::core::Interface for IStylusPlugin {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IStylusPlugin_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub RealTimeStylusEnabled: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pirtssrc: *mut ::core::ffi::c_void, ctcidcount: u32, ptcids: *const u32) -> ::windows::core::HRESULT,
     pub RealTimeStylusDisabled: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pirtssrc: *mut ::core::ffi::c_void, ctcidcount: u32, ptcids: *const u32) -> ::windows::core::HRESULT,
     pub StylusInRange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pirtssrc: *mut ::core::ffi::c_void, tcid: u32, sid: u32) -> ::windows::core::HRESULT,
@@ -9239,7 +9239,7 @@ unsafe impl ::windows::core::Interface for ITextInputPanel {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITextInputPanel_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub AttachedEditWindow: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, attachededitwindow: *mut super::super::Foundation::HWND) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -9389,7 +9389,7 @@ unsafe impl ::windows::core::Interface for ITextInputPanelEventSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITextInputPanelEventSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub InPlaceStateChanging: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, oldinplacestate: InPlaceState, newinplacestate: InPlaceState) -> ::windows::core::HRESULT,
     pub InPlaceStateChanged: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, oldinplacestate: InPlaceState, newinplacestate: InPlaceState) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -9470,7 +9470,7 @@ unsafe impl ::windows::core::Interface for ITextInputPanelRunInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITextInputPanelRunInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub IsTipRunning: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfrunning: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -9554,7 +9554,7 @@ unsafe impl ::windows::core::Interface for ITipAutoCompleteClient {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITipAutoCompleteClient_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub AdviseProvider: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hwndfield: super::super::Foundation::HWND, piprovider: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -9627,7 +9627,7 @@ unsafe impl ::windows::core::Interface for ITipAutoCompleteProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITipAutoCompleteProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub UpdatePendingText: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, bstrpendingtext: ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub Show: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fshow: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/UI/TextServices/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/TextServices/impl.rs
@@ -55,7 +55,7 @@ impl IAccClientDocMgr_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDocuments: GetDocuments::<Identity, Impl, OFFSET>,
             LookupByHWND: LookupByHWND::<Identity, Impl, OFFSET>,
             LookupByPoint: LookupByPoint::<Identity, Impl, OFFSET>,
@@ -123,7 +123,7 @@ impl IAccDictionary_Vtbl {
             this.ConvertValueToString(::core::mem::transmute_copy(&term), ::core::mem::transmute_copy(&lcid), ::core::mem::transmute(&varvalue), ::core::mem::transmute_copy(&pbstrresult), ::core::mem::transmute_copy(&plcid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetLocalizedString: GetLocalizedString::<Identity, Impl, OFFSET>,
             GetParentTerm: GetParentTerm::<Identity, Impl, OFFSET>,
             GetMnemonicString: GetMnemonicString::<Identity, Impl, OFFSET>,
@@ -159,7 +159,7 @@ impl IAccServerDocMgr_Vtbl {
             this.OnDocumentFocus(::core::mem::transmute(&punk)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             NewDocument: NewDocument::<Identity, Impl, OFFSET>,
             RevokeDocument: RevokeDocument::<Identity, Impl, OFFSET>,
             OnDocumentFocus: OnDocumentFocus::<Identity, Impl, OFFSET>,
@@ -244,7 +244,7 @@ impl IAccStore_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Register: Register::<Identity, Impl, OFFSET>,
             Unregister: Unregister::<Identity, Impl, OFFSET>,
             GetDocuments: GetDocuments::<Identity, Impl, OFFSET>,
@@ -369,7 +369,7 @@ impl IAnchor_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetGravity: SetGravity::<Identity, Impl, OFFSET>,
             GetGravity: GetGravity::<Identity, Impl, OFFSET>,
             IsEqual: IsEqual::<Identity, Impl, OFFSET>,
@@ -398,7 +398,7 @@ impl IClonableWrapper_Vtbl {
             let this = (*this).get_impl();
             this.CloneNewWrapper(::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppv)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CloneNewWrapper: CloneNewWrapper::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CloneNewWrapper: CloneNewWrapper::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IClonableWrapper as ::windows::core::Interface>::IID
@@ -418,7 +418,7 @@ impl ICoCreateLocally_Vtbl {
             let this = (*this).get_impl();
             this.CoCreateLocally(::core::mem::transmute_copy(&rclsid), ::core::mem::transmute_copy(&dwclscontext), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&punk), ::core::mem::transmute_copy(&riidparam), ::core::mem::transmute(&punkparam), ::core::mem::transmute(&varparam)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), CoCreateLocally: CoCreateLocally::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), CoCreateLocally: CoCreateLocally::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ICoCreateLocally as ::windows::core::Interface>::IID
@@ -438,7 +438,7 @@ impl ICoCreatedLocally_Vtbl {
             let this = (*this).get_impl();
             this.LocalInit(::core::mem::transmute(&punklocalobject), ::core::mem::transmute_copy(&riidparam), ::core::mem::transmute(&punkparam), ::core::mem::transmute(&varparam)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), LocalInit: LocalInit::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), LocalInit: LocalInit::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ICoCreatedLocally as ::windows::core::Interface>::IID
@@ -468,7 +468,7 @@ impl IDocWrap_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetDoc: SetDoc::<Identity, Impl, OFFSET>,
             GetWrappedDoc: GetWrappedDoc::<Identity, Impl, OFFSET>,
         }
@@ -513,7 +513,7 @@ impl IEnumITfCompositionView_Vtbl {
             this.Skip(::core::mem::transmute_copy(&ulcount)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Clone: Clone::<Identity, Impl, OFFSET>,
             Next: Next::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -560,7 +560,7 @@ impl IEnumSpeechCommands_Vtbl {
             this.Skip(::core::mem::transmute_copy(&ulcount)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Clone: Clone::<Identity, Impl, OFFSET>,
             Next: Next::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -607,7 +607,7 @@ impl IEnumTfCandidates_Vtbl {
             this.Skip(::core::mem::transmute_copy(&ulcount)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Clone: Clone::<Identity, Impl, OFFSET>,
             Next: Next::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -654,7 +654,7 @@ impl IEnumTfContextViews_Vtbl {
             this.Skip(::core::mem::transmute_copy(&ulcount)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Clone: Clone::<Identity, Impl, OFFSET>,
             Next: Next::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -701,7 +701,7 @@ impl IEnumTfContexts_Vtbl {
             this.Skip(::core::mem::transmute_copy(&ulcount)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Clone: Clone::<Identity, Impl, OFFSET>,
             Next: Next::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -748,7 +748,7 @@ impl IEnumTfDisplayAttributeInfo_Vtbl {
             this.Skip(::core::mem::transmute_copy(&ulcount)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Clone: Clone::<Identity, Impl, OFFSET>,
             Next: Next::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -795,7 +795,7 @@ impl IEnumTfDocumentMgrs_Vtbl {
             this.Skip(::core::mem::transmute_copy(&ulcount)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Clone: Clone::<Identity, Impl, OFFSET>,
             Next: Next::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -842,7 +842,7 @@ impl IEnumTfFunctionProviders_Vtbl {
             this.Skip(::core::mem::transmute_copy(&ulcount)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Clone: Clone::<Identity, Impl, OFFSET>,
             Next: Next::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -889,7 +889,7 @@ impl IEnumTfInputProcessorProfiles_Vtbl {
             this.Skip(::core::mem::transmute_copy(&ulcount)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Clone: Clone::<Identity, Impl, OFFSET>,
             Next: Next::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -936,7 +936,7 @@ impl IEnumTfLangBarItems_Vtbl {
             this.Skip(::core::mem::transmute_copy(&ulcount)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Clone: Clone::<Identity, Impl, OFFSET>,
             Next: Next::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -986,7 +986,7 @@ impl IEnumTfLanguageProfiles_Vtbl {
             this.Skip(::core::mem::transmute_copy(&ulcount)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Clone: Clone::<Identity, Impl, OFFSET>,
             Next: Next::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -1033,7 +1033,7 @@ impl IEnumTfLatticeElements_Vtbl {
             this.Skip(::core::mem::transmute_copy(&ulcount)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Clone: Clone::<Identity, Impl, OFFSET>,
             Next: Next::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -1080,7 +1080,7 @@ impl IEnumTfProperties_Vtbl {
             this.Skip(::core::mem::transmute_copy(&ulcount)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Clone: Clone::<Identity, Impl, OFFSET>,
             Next: Next::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -1130,7 +1130,7 @@ impl IEnumTfPropertyValue_Vtbl {
             this.Skip(::core::mem::transmute_copy(&ulcount)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Clone: Clone::<Identity, Impl, OFFSET>,
             Next: Next::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -1177,7 +1177,7 @@ impl IEnumTfRanges_Vtbl {
             this.Skip(::core::mem::transmute_copy(&ulcount)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Clone: Clone::<Identity, Impl, OFFSET>,
             Next: Next::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -1224,7 +1224,7 @@ impl IEnumTfUIElements_Vtbl {
             this.Skip(::core::mem::transmute_copy(&ulcount)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Clone: Clone::<Identity, Impl, OFFSET>,
             Next: Next::<Identity, Impl, OFFSET>,
             Reset: Reset::<Identity, Impl, OFFSET>,
@@ -1246,7 +1246,7 @@ impl IInternalDocWrap_Vtbl {
             let this = (*this).get_impl();
             this.NotifyRevoke().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), NotifyRevoke: NotifyRevoke::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), NotifyRevoke: NotifyRevoke::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IInternalDocWrap as ::windows::core::Interface>::IID
@@ -1276,7 +1276,7 @@ impl ISpeechCommandProvider_Vtbl {
             this.ProcessCommand(::core::mem::transmute(&pszcommand), ::core::mem::transmute_copy(&cch), ::core::mem::transmute_copy(&langid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             EnumSpeechCommands: EnumSpeechCommands::<Identity, Impl, OFFSET>,
             ProcessCommand: ProcessCommand::<Identity, Impl, OFFSET>,
         }
@@ -1522,7 +1522,7 @@ impl ITextStoreACP_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AdviseSink: AdviseSink::<Identity, Impl, OFFSET>,
             UnadviseSink: UnadviseSink::<Identity, Impl, OFFSET>,
             RequestLock: RequestLock::<Identity, Impl, OFFSET>,
@@ -1780,7 +1780,7 @@ impl ITextStoreACP2_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AdviseSink: AdviseSink::<Identity, Impl, OFFSET>,
             UnadviseSink: UnadviseSink::<Identity, Impl, OFFSET>,
             RequestLock: RequestLock::<Identity, Impl, OFFSET>,
@@ -1826,7 +1826,7 @@ impl ITextStoreACPEx_Vtbl {
             let this = (*this).get_impl();
             this.ScrollToRect(::core::mem::transmute_copy(&acpstart), ::core::mem::transmute_copy(&acpend), ::core::mem::transmute(&rc), ::core::mem::transmute_copy(&dwposition)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), ScrollToRect: ScrollToRect::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), ScrollToRect: ScrollToRect::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ITextStoreACPEx as ::windows::core::Interface>::IID
@@ -1871,7 +1871,7 @@ impl ITextStoreACPServices_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Serialize: Serialize::<Identity, Impl, OFFSET>,
             Unserialize: Unserialize::<Identity, Impl, OFFSET>,
             ForceLoadProperty: ForceLoadProperty::<Identity, Impl, OFFSET>,
@@ -1936,7 +1936,7 @@ impl ITextStoreACPSink_Vtbl {
             this.OnEndEditTransaction().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnTextChange: OnTextChange::<Identity, Impl, OFFSET>,
             OnSelectionChange: OnSelectionChange::<Identity, Impl, OFFSET>,
             OnLayoutChange: OnLayoutChange::<Identity, Impl, OFFSET>,
@@ -2205,7 +2205,7 @@ impl ITextStoreAnchor_Vtbl {
             this.InsertEmbeddedAtSelection(::core::mem::transmute_copy(&dwflags), ::core::mem::transmute(&pdataobject), ::core::mem::transmute_copy(&ppastart), ::core::mem::transmute_copy(&ppaend)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AdviseSink: AdviseSink::<Identity, Impl, OFFSET>,
             UnadviseSink: UnadviseSink::<Identity, Impl, OFFSET>,
             RequestLock: RequestLock::<Identity, Impl, OFFSET>,
@@ -2253,7 +2253,7 @@ impl ITextStoreAnchorEx_Vtbl {
             let this = (*this).get_impl();
             this.ScrollToRect(::core::mem::transmute(&pstart), ::core::mem::transmute(&pend), ::core::mem::transmute(&rc), ::core::mem::transmute_copy(&dwposition)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), ScrollToRect: ScrollToRect::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), ScrollToRect: ScrollToRect::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ITextStoreAnchorEx as ::windows::core::Interface>::IID
@@ -2313,7 +2313,7 @@ impl ITextStoreAnchorSink_Vtbl {
             this.OnEndEditTransaction().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnTextChange: OnTextChange::<Identity, Impl, OFFSET>,
             OnSelectionChange: OnSelectionChange::<Identity, Impl, OFFSET>,
             OnLayoutChange: OnLayoutChange::<Identity, Impl, OFFSET>,
@@ -2359,7 +2359,7 @@ impl ITfActiveLanguageProfileNotifySink_Vtbl {
             let this = (*this).get_impl();
             this.OnActivated(::core::mem::transmute_copy(&clsid), ::core::mem::transmute_copy(&guidprofile), ::core::mem::transmute_copy(&factivated)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnActivated: OnActivated::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnActivated: OnActivated::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ITfActiveLanguageProfileNotifySink as ::windows::core::Interface>::IID
@@ -2413,7 +2413,7 @@ impl ITfCandidateList_Vtbl {
             this.SetResult(::core::mem::transmute_copy(&nindex), ::core::mem::transmute_copy(&imcr)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             EnumCandidates: EnumCandidates::<Identity, Impl, OFFSET>,
             GetCandidate: GetCandidate::<Identity, Impl, OFFSET>,
             GetCandidateNum: GetCandidateNum::<Identity, Impl, OFFSET>,
@@ -2599,7 +2599,7 @@ impl ITfCandidateString_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetString: GetString::<Identity, Impl, OFFSET>,
             GetIndex: GetIndex::<Identity, Impl, OFFSET>,
         }
@@ -2743,7 +2743,7 @@ impl ITfCategoryMgr_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RegisterCategory: RegisterCategory::<Identity, Impl, OFFSET>,
             UnregisterCategory: UnregisterCategory::<Identity, Impl, OFFSET>,
             EnumCategoriesInItem: EnumCategoriesInItem::<Identity, Impl, OFFSET>,
@@ -2782,7 +2782,7 @@ impl ITfCleanupContextDurationSink_Vtbl {
             this.OnEndCleanupContext().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnStartCleanupContext: OnStartCleanupContext::<Identity, Impl, OFFSET>,
             OnEndCleanupContext: OnEndCleanupContext::<Identity, Impl, OFFSET>,
         }
@@ -2802,7 +2802,7 @@ impl ITfCleanupContextSink_Vtbl {
             let this = (*this).get_impl();
             this.OnCleanupContext(::core::mem::transmute_copy(&ecwrite), ::core::mem::transmute(&pic)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnCleanupContext: OnCleanupContext::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnCleanupContext: OnCleanupContext::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ITfCleanupContextSink as ::windows::core::Interface>::IID
@@ -2825,7 +2825,7 @@ impl ITfClientId_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetClientId: GetClientId::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetClientId: GetClientId::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ITfClientId as ::windows::core::Interface>::IID
@@ -2858,7 +2858,7 @@ impl ITfCompartment_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetValue: SetValue::<Identity, Impl, OFFSET>,
             GetValue: GetValue::<Identity, Impl, OFFSET>,
         }
@@ -2878,7 +2878,7 @@ impl ITfCompartmentEventSink_Vtbl {
             let this = (*this).get_impl();
             this.OnChange(::core::mem::transmute_copy(&rguid)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnChange: OnChange::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnChange: OnChange::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ITfCompartmentEventSink as ::windows::core::Interface>::IID
@@ -2923,7 +2923,7 @@ impl ITfCompartmentMgr_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetCompartment: GetCompartment::<Identity, Impl, OFFSET>,
             ClearCompartment: ClearCompartment::<Identity, Impl, OFFSET>,
             EnumCompartments: EnumCompartments::<Identity, Impl, OFFSET>,
@@ -2969,7 +2969,7 @@ impl ITfComposition_Vtbl {
             this.EndComposition(::core::mem::transmute_copy(&ecwrite)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetRange: GetRange::<Identity, Impl, OFFSET>,
             ShiftStart: ShiftStart::<Identity, Impl, OFFSET>,
             ShiftEnd: ShiftEnd::<Identity, Impl, OFFSET>,
@@ -2991,7 +2991,7 @@ impl ITfCompositionSink_Vtbl {
             let this = (*this).get_impl();
             this.OnCompositionTerminated(::core::mem::transmute_copy(&ecwrite), ::core::mem::transmute(&pcomposition)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnCompositionTerminated: OnCompositionTerminated::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnCompositionTerminated: OnCompositionTerminated::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ITfCompositionSink as ::windows::core::Interface>::IID
@@ -3027,7 +3027,7 @@ impl ITfCompositionView_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetOwnerClsid: GetOwnerClsid::<Identity, Impl, OFFSET>,
             GetRange: GetRange::<Identity, Impl, OFFSET>,
         }
@@ -3054,7 +3054,7 @@ impl ITfConfigureSystemKeystrokeFeed_Vtbl {
             this.EnableSystemKeystrokeFeed().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             DisableSystemKeystrokeFeed: DisableSystemKeystrokeFeed::<Identity, Impl, OFFSET>,
             EnableSystemKeystrokeFeed: EnableSystemKeystrokeFeed::<Identity, Impl, OFFSET>,
         }
@@ -3240,7 +3240,7 @@ impl ITfContext_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             RequestEditSession: RequestEditSession::<Identity, Impl, OFFSET>,
             InWriteSession: InWriteSession::<Identity, Impl, OFFSET>,
             GetSelection: GetSelection::<Identity, Impl, OFFSET>,
@@ -3316,7 +3316,7 @@ impl ITfContextComposition_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             StartComposition: StartComposition::<Identity, Impl, OFFSET>,
             EnumCompositions: EnumCompositions::<Identity, Impl, OFFSET>,
             FindComposition: FindComposition::<Identity, Impl, OFFSET>,
@@ -3384,7 +3384,7 @@ impl ITfContextKeyEventSink_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnKeyDown: OnKeyDown::<Identity, Impl, OFFSET>,
             OnKeyUp: OnKeyUp::<Identity, Impl, OFFSET>,
             OnTestKeyDown: OnTestKeyDown::<Identity, Impl, OFFSET>,
@@ -3470,7 +3470,7 @@ impl ITfContextOwner_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetACPFromPoint: GetACPFromPoint::<Identity, Impl, OFFSET>,
             GetTextExt: GetTextExt::<Identity, Impl, OFFSET>,
             GetScreenExt: GetScreenExt::<Identity, Impl, OFFSET>,
@@ -3533,7 +3533,7 @@ impl ITfContextOwnerCompositionSink_Vtbl {
             this.OnEndComposition(::core::mem::transmute(&pcomposition)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnStartComposition: OnStartComposition::<Identity, Impl, OFFSET>,
             OnUpdateComposition: OnUpdateComposition::<Identity, Impl, OFFSET>,
             OnEndComposition: OnEndComposition::<Identity, Impl, OFFSET>,
@@ -3600,7 +3600,7 @@ impl ITfContextOwnerServices_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnLayoutChange: OnLayoutChange::<Identity, Impl, OFFSET>,
             OnStatusChange: OnStatusChange::<Identity, Impl, OFFSET>,
             OnAttributeChange: OnAttributeChange::<Identity, Impl, OFFSET>,
@@ -3665,7 +3665,7 @@ impl ITfContextView_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetRangeFromPoint: GetRangeFromPoint::<Identity, Impl, OFFSET>,
             GetTextExt: GetTextExt::<Identity, Impl, OFFSET>,
             GetScreenExt: GetScreenExt::<Identity, Impl, OFFSET>,
@@ -3709,7 +3709,7 @@ impl ITfCreatePropertyStore_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             IsStoreSerializable: IsStoreSerializable::<Identity, Impl, OFFSET>,
             CreatePropertyStore: CreatePropertyStore::<Identity, Impl, OFFSET>,
         }
@@ -3775,7 +3775,7 @@ impl ITfDisplayAttributeInfo_Vtbl {
             this.Reset().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetGUID: GetGUID::<Identity, Impl, OFFSET>,
             GetDescription: GetDescription::<Identity, Impl, OFFSET>,
             GetAttributeInfo: GetAttributeInfo::<Identity, Impl, OFFSET>,
@@ -3817,7 +3817,7 @@ impl ITfDisplayAttributeMgr_Vtbl {
             this.GetDisplayAttributeInfo(::core::mem::transmute_copy(&guid), ::core::mem::transmute_copy(&ppinfo), ::core::mem::transmute_copy(&pclsidowner)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnUpdateInfo: OnUpdateInfo::<Identity, Impl, OFFSET>,
             EnumDisplayAttributeInfo: EnumDisplayAttributeInfo::<Identity, Impl, OFFSET>,
             GetDisplayAttributeInfo: GetDisplayAttributeInfo::<Identity, Impl, OFFSET>,
@@ -3838,7 +3838,7 @@ impl ITfDisplayAttributeNotifySink_Vtbl {
             let this = (*this).get_impl();
             this.OnUpdateInfo().into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnUpdateInfo: OnUpdateInfo::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnUpdateInfo: OnUpdateInfo::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ITfDisplayAttributeNotifySink as ::windows::core::Interface>::IID
@@ -3874,7 +3874,7 @@ impl ITfDisplayAttributeProvider_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             EnumDisplayAttributeInfo: EnumDisplayAttributeInfo::<Identity, Impl, OFFSET>,
             GetDisplayAttributeInfo: GetDisplayAttributeInfo::<Identity, Impl, OFFSET>,
         }
@@ -3943,7 +3943,7 @@ impl ITfDocumentMgr_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateContext: CreateContext::<Identity, Impl, OFFSET>,
             Push: Push::<Identity, Impl, OFFSET>,
             Pop: Pop::<Identity, Impl, OFFSET>,
@@ -3989,7 +3989,7 @@ impl ITfEditRecord_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSelectionStatus: GetSelectionStatus::<Identity, Impl, OFFSET>,
             GetTextAndPropertyUpdates: GetTextAndPropertyUpdates::<Identity, Impl, OFFSET>,
         }
@@ -4009,7 +4009,7 @@ impl ITfEditSession_Vtbl {
             let this = (*this).get_impl();
             this.DoEditSession(::core::mem::transmute_copy(&ec)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), DoEditSession: DoEditSession::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), DoEditSession: DoEditSession::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ITfEditSession as ::windows::core::Interface>::IID
@@ -4033,7 +4033,7 @@ impl ITfEditTransactionSink_Vtbl {
             this.OnEndEditTransaction(::core::mem::transmute(&pic)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnStartEditTransaction: OnStartEditTransaction::<Identity, Impl, OFFSET>,
             OnEndEditTransaction: OnEndEditTransaction::<Identity, Impl, OFFSET>,
         }
@@ -4080,7 +4080,7 @@ impl ITfFnBalloon_Vtbl {
             let this = (*this).get_impl();
             this.UpdateBalloon(::core::mem::transmute_copy(&style), ::core::mem::transmute(&pch), ::core::mem::transmute_copy(&cch)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), UpdateBalloon: UpdateBalloon::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), UpdateBalloon: UpdateBalloon::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ITfFnBalloon as ::windows::core::Interface>::IID
@@ -4541,7 +4541,7 @@ impl ITfFunction_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetDisplayName: GetDisplayName::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetDisplayName: GetDisplayName::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ITfFunction as ::windows::core::Interface>::IID
@@ -4589,7 +4589,7 @@ impl ITfFunctionProvider_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetType: GetType::<Identity, Impl, OFFSET>,
             GetDescription: GetDescription::<Identity, Impl, OFFSET>,
             GetFunction: GetFunction::<Identity, Impl, OFFSET>,
@@ -4610,7 +4610,7 @@ impl ITfInputProcessorProfileActivationSink_Vtbl {
             let this = (*this).get_impl();
             this.OnActivated(::core::mem::transmute_copy(&dwprofiletype), ::core::mem::transmute_copy(&langid), ::core::mem::transmute_copy(&clsid), ::core::mem::transmute_copy(&catid), ::core::mem::transmute_copy(&guidprofile), ::core::mem::transmute_copy(&hkl), ::core::mem::transmute_copy(&dwflags)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnActivated: OnActivated::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnActivated: OnActivated::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ITfInputProcessorProfileActivationSink as ::windows::core::Interface>::IID
@@ -4705,7 +4705,7 @@ impl ITfInputProcessorProfileMgr_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             ActivateProfile: ActivateProfile::<Identity, Impl, OFFSET>,
             DeactivateProfile: DeactivateProfile::<Identity, Impl, OFFSET>,
             GetProfile: GetProfile::<Identity, Impl, OFFSET>,
@@ -4738,7 +4738,7 @@ impl ITfInputProcessorProfileSubstituteLayout_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSubstituteKeyboardLayout: GetSubstituteKeyboardLayout::<Identity, Impl, OFFSET>,
         }
     }
@@ -4893,7 +4893,7 @@ impl ITfInputProcessorProfiles_Vtbl {
             this.SubstituteKeyboardLayout(::core::mem::transmute_copy(&rclsid), ::core::mem::transmute_copy(&langid), ::core::mem::transmute_copy(&guidprofile), ::core::mem::transmute_copy(&hkl)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Register: Register::<Identity, Impl, OFFSET>,
             Unregister: Unregister::<Identity, Impl, OFFSET>,
             AddLanguageProfile: AddLanguageProfile::<Identity, Impl, OFFSET>,
@@ -4995,7 +4995,7 @@ impl ITfInputScope_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetInputScopes: GetInputScopes::<Identity, Impl, OFFSET>,
             GetPhrase: GetPhrase::<Identity, Impl, OFFSET>,
             GetRegularExpression: GetRegularExpression::<Identity, Impl, OFFSET>,
@@ -5066,7 +5066,7 @@ impl ITfInsertAtSelection_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             InsertTextAtSelection: InsertTextAtSelection::<Identity, Impl, OFFSET>,
             InsertEmbeddedAtSelection: InsertEmbeddedAtSelection::<Identity, Impl, OFFSET>,
         }
@@ -5132,7 +5132,7 @@ impl ITfIntegratableCandidateListUIElement_Vtbl {
             this.FinalizeExactCompositionString().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetIntegrationStyle: SetIntegrationStyle::<Identity, Impl, OFFSET>,
             GetSelectionStyle: GetSelectionStyle::<Identity, Impl, OFFSET>,
             OnKeyDown: OnKeyDown::<Identity, Impl, OFFSET>,
@@ -5219,7 +5219,7 @@ impl ITfKeyEventSink_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnSetFocus: OnSetFocus::<Identity, Impl, OFFSET>,
             OnTestKeyDown: OnTestKeyDown::<Identity, Impl, OFFSET>,
             OnTestKeyUp: OnTestKeyUp::<Identity, Impl, OFFSET>,
@@ -5253,7 +5253,7 @@ impl ITfKeyTraceEventSink_Vtbl {
             this.OnKeyTraceUp(::core::mem::transmute_copy(&wparam), ::core::mem::transmute_copy(&lparam)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnKeyTraceDown: OnKeyTraceDown::<Identity, Impl, OFFSET>,
             OnKeyTraceUp: OnKeyTraceUp::<Identity, Impl, OFFSET>,
         }
@@ -5409,7 +5409,7 @@ impl ITfKeystrokeMgr_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AdviseKeyEventSink: AdviseKeyEventSink::<Identity, Impl, OFFSET>,
             UnadviseKeyEventSink: UnadviseKeyEventSink::<Identity, Impl, OFFSET>,
             GetForeground: GetForeground::<Identity, Impl, OFFSET>,
@@ -5463,7 +5463,7 @@ impl ITfLMLattice_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             QueryType: QueryType::<Identity, Impl, OFFSET>,
             EnumLatticeElements: EnumLatticeElements::<Identity, Impl, OFFSET>,
         }
@@ -5523,7 +5523,7 @@ impl ITfLangBarEventSink_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnSetFocus: OnSetFocus::<Identity, Impl, OFFSET>,
             OnThreadTerminate: OnThreadTerminate::<Identity, Impl, OFFSET>,
             OnThreadItemChange: OnThreadItemChange::<Identity, Impl, OFFSET>,
@@ -5587,7 +5587,7 @@ impl ITfLangBarItem_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetInfo: GetInfo::<Identity, Impl, OFFSET>,
             GetStatus: GetStatus::<Identity, Impl, OFFSET>,
             Show: Show::<Identity, Impl, OFFSET>,
@@ -5940,7 +5940,7 @@ impl ITfLangBarItemMgr_Vtbl {
             this.UnadviseItemsSink(::core::mem::transmute_copy(&ulcount), ::core::mem::transmute_copy(&pdwcookie)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             EnumItems: EnumItems::<Identity, Impl, OFFSET>,
             GetItem: GetItem::<Identity, Impl, OFFSET>,
             AddItem: AddItem::<Identity, Impl, OFFSET>,
@@ -5970,7 +5970,7 @@ impl ITfLangBarItemSink_Vtbl {
             let this = (*this).get_impl();
             this.OnUpdate(::core::mem::transmute_copy(&dwflags)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnUpdate: OnUpdate::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnUpdate: OnUpdate::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ITfLangBarItemSink as ::windows::core::Interface>::IID
@@ -6051,7 +6051,7 @@ impl ITfLangBarMgr_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AdviseEventSink: AdviseEventSink::<Identity, Impl, OFFSET>,
             UnadviseEventSink: UnadviseEventSink::<Identity, Impl, OFFSET>,
             GetThreadMarshalInterface: GetThreadMarshalInterface::<Identity, Impl, OFFSET>,
@@ -6094,7 +6094,7 @@ impl ITfLanguageProfileNotifySink_Vtbl {
             this.OnLanguageChanged().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnLanguageChange: OnLanguageChange::<Identity, Impl, OFFSET>,
             OnLanguageChanged: OnLanguageChanged::<Identity, Impl, OFFSET>,
         }
@@ -6121,7 +6121,7 @@ impl ITfMSAAControl_Vtbl {
             this.SystemDisableMSAA().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SystemEnableMSAA: SystemEnableMSAA::<Identity, Impl, OFFSET>,
             SystemDisableMSAA: SystemDisableMSAA::<Identity, Impl, OFFSET>,
         }
@@ -6144,7 +6144,7 @@ impl ITfMenu_Vtbl {
             let this = (*this).get_impl();
             this.AddMenuItem(::core::mem::transmute_copy(&uid), ::core::mem::transmute_copy(&dwflags), ::core::mem::transmute_copy(&hbmp), ::core::mem::transmute_copy(&hbmpmask), ::core::mem::transmute(&pch), ::core::mem::transmute_copy(&cch), ::core::mem::transmute_copy(&ppmenu)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), AddMenuItem: AddMenuItem::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), AddMenuItem: AddMenuItem::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ITfMenu as ::windows::core::Interface>::IID
@@ -6183,7 +6183,7 @@ impl ITfMessagePump_Vtbl {
             this.GetMessageW(::core::mem::transmute_copy(&pmsg), ::core::mem::transmute_copy(&hwnd), ::core::mem::transmute_copy(&wmsgfiltermin), ::core::mem::transmute_copy(&wmsgfiltermax), ::core::mem::transmute_copy(&pfresult)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             PeekMessageA: PeekMessageA::<Identity, Impl, OFFSET>,
             GetMessageA: GetMessageA::<Identity, Impl, OFFSET>,
             PeekMessageW: PeekMessageW::<Identity, Impl, OFFSET>,
@@ -6214,7 +6214,7 @@ impl ITfMouseSink_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnMouseEvent: OnMouseEvent::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnMouseEvent: OnMouseEvent::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ITfMouseSink as ::windows::core::Interface>::IID
@@ -6244,7 +6244,7 @@ impl ITfMouseTracker_Vtbl {
             this.UnadviseMouseSink(::core::mem::transmute_copy(&dwcookie)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AdviseMouseSink: AdviseMouseSink::<Identity, Impl, OFFSET>,
             UnadviseMouseSink: UnadviseMouseSink::<Identity, Impl, OFFSET>,
         }
@@ -6277,7 +6277,7 @@ impl ITfMouseTrackerACP_Vtbl {
             this.UnadviseMouseSink(::core::mem::transmute_copy(&dwcookie)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AdviseMouseSink: AdviseMouseSink::<Identity, Impl, OFFSET>,
             UnadviseMouseSink: UnadviseMouseSink::<Identity, Impl, OFFSET>,
         }
@@ -6306,7 +6306,7 @@ impl ITfPersistentPropertyLoaderACP_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), LoadProperty: LoadProperty::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), LoadProperty: LoadProperty::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ITfPersistentPropertyLoaderACP as ::windows::core::Interface>::IID
@@ -6323,7 +6323,7 @@ impl ITfPreservedKeyNotifySink_Vtbl {
             let this = (*this).get_impl();
             this.OnUpdated(::core::mem::transmute_copy(&pprekey)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnUpdated: OnUpdated::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnUpdated: OnUpdated::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ITfPreservedKeyNotifySink as ::windows::core::Interface>::IID
@@ -6490,7 +6490,7 @@ impl ITfPropertyStore_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetType: GetType::<Identity, Impl, OFFSET>,
             GetDataType: GetDataType::<Identity, Impl, OFFSET>,
             GetData: GetData::<Identity, Impl, OFFSET>,
@@ -6526,7 +6526,7 @@ impl ITfQueryEmbedded_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), QueryInsertEmbedded: QueryInsertEmbedded::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), QueryInsertEmbedded: QueryInsertEmbedded::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ITfQueryEmbedded as ::windows::core::Interface>::IID
@@ -6745,7 +6745,7 @@ impl ITfRange_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetText: GetText::<Identity, Impl, OFFSET>,
             SetText: SetText::<Identity, Impl, OFFSET>,
             GetFormattedText: GetFormattedText::<Identity, Impl, OFFSET>,
@@ -6815,7 +6815,7 @@ impl ITfRangeBackup_Vtbl {
             let this = (*this).get_impl();
             this.Restore(::core::mem::transmute_copy(&ec), ::core::mem::transmute(&prange)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), Restore: Restore::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), Restore: Restore::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ITfRangeBackup as ::windows::core::Interface>::IID
@@ -6872,7 +6872,7 @@ impl ITfReadOnlyProperty_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetType: GetType::<Identity, Impl, OFFSET>,
             EnumRanges: EnumRanges::<Identity, Impl, OFFSET>,
             GetValue: GetValue::<Identity, Impl, OFFSET>,
@@ -6994,7 +6994,7 @@ impl ITfReverseConversion_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), DoReverseConversion: DoReverseConversion::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), DoReverseConversion: DoReverseConversion::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ITfReverseConversion as ::windows::core::Interface>::IID
@@ -7030,7 +7030,7 @@ impl ITfReverseConversionList_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetLength: GetLength::<Identity, Impl, OFFSET>,
             GetString: GetString::<Identity, Impl, OFFSET>,
         }
@@ -7056,7 +7056,7 @@ impl ITfReverseConversionMgr_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetReverseConversion: GetReverseConversion::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetReverseConversion: GetReverseConversion::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ITfReverseConversionMgr as ::windows::core::Interface>::IID
@@ -7086,7 +7086,7 @@ impl ITfSource_Vtbl {
             this.UnadviseSink(::core::mem::transmute_copy(&dwcookie)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AdviseSink: AdviseSink::<Identity, Impl, OFFSET>,
             UnadviseSink: UnadviseSink::<Identity, Impl, OFFSET>,
         }
@@ -7113,7 +7113,7 @@ impl ITfSourceSingle_Vtbl {
             this.UnadviseSingleSink(::core::mem::transmute_copy(&tid), ::core::mem::transmute_copy(&riid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AdviseSingleSink: AdviseSingleSink::<Identity, Impl, OFFSET>,
             UnadviseSingleSink: UnadviseSingleSink::<Identity, Impl, OFFSET>,
         }
@@ -7149,7 +7149,7 @@ impl ITfSpeechUIServer_Vtbl {
             this.UpdateBalloon(::core::mem::transmute_copy(&style), ::core::mem::transmute(&pch), ::core::mem::transmute_copy(&cch)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Initialize: Initialize::<Identity, Impl, OFFSET>,
             ShowUI: ShowUI::<Identity, Impl, OFFSET>,
             UpdateBalloon: UpdateBalloon::<Identity, Impl, OFFSET>,
@@ -7170,7 +7170,7 @@ impl ITfStatusSink_Vtbl {
             let this = (*this).get_impl();
             this.OnStatusChange(::core::mem::transmute(&pic), ::core::mem::transmute_copy(&dwflags)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnStatusChange: OnStatusChange::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnStatusChange: OnStatusChange::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ITfStatusSink as ::windows::core::Interface>::IID
@@ -7200,7 +7200,7 @@ impl ITfSystemDeviceTypeLangBarItem_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetIconMode: SetIconMode::<Identity, Impl, OFFSET>,
             GetIconMode: GetIconMode::<Identity, Impl, OFFSET>,
         }
@@ -7230,7 +7230,7 @@ impl ITfSystemLangBarItem_Vtbl {
             this.SetTooltipString(::core::mem::transmute(&pchtooltip), ::core::mem::transmute_copy(&cch)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetIcon: SetIcon::<Identity, Impl, OFFSET>,
             SetTooltipString: SetTooltipString::<Identity, Impl, OFFSET>,
         }
@@ -7257,7 +7257,7 @@ impl ITfSystemLangBarItemSink_Vtbl {
             this.OnMenuSelect(::core::mem::transmute_copy(&wid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             InitMenu: InitMenu::<Identity, Impl, OFFSET>,
             OnMenuSelect: OnMenuSelect::<Identity, Impl, OFFSET>,
         }
@@ -7290,7 +7290,7 @@ impl ITfSystemLangBarItemText_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetItemText: SetItemText::<Identity, Impl, OFFSET>,
             GetItemText: GetItemText::<Identity, Impl, OFFSET>,
         }
@@ -7310,7 +7310,7 @@ impl ITfTextEditSink_Vtbl {
             let this = (*this).get_impl();
             this.OnEndEdit(::core::mem::transmute(&pic), ::core::mem::transmute_copy(&ecreadonly), ::core::mem::transmute(&peditrecord)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnEndEdit: OnEndEdit::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnEndEdit: OnEndEdit::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ITfTextEditSink as ::windows::core::Interface>::IID
@@ -7334,7 +7334,7 @@ impl ITfTextInputProcessor_Vtbl {
             this.Deactivate().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Activate: Activate::<Identity, Impl, OFFSET>,
             Deactivate: Deactivate::<Identity, Impl, OFFSET>,
         }
@@ -7371,7 +7371,7 @@ impl ITfTextLayoutSink_Vtbl {
             let this = (*this).get_impl();
             this.OnLayoutChange(::core::mem::transmute(&pic), ::core::mem::transmute_copy(&lcode), ::core::mem::transmute(&pview)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnLayoutChange: OnLayoutChange::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnLayoutChange: OnLayoutChange::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<ITfTextLayoutSink as ::windows::core::Interface>::IID
@@ -7395,7 +7395,7 @@ impl ITfThreadFocusSink_Vtbl {
             this.OnKillThreadFocus().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnSetThreadFocus: OnSetThreadFocus::<Identity, Impl, OFFSET>,
             OnKillThreadFocus: OnKillThreadFocus::<Identity, Impl, OFFSET>,
         }
@@ -7533,7 +7533,7 @@ impl ITfThreadMgr_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Activate: Activate::<Identity, Impl, OFFSET>,
             Deactivate: Deactivate::<Identity, Impl, OFFSET>,
             CreateDocumentMgr: CreateDocumentMgr::<Identity, Impl, OFFSET>,
@@ -7698,7 +7698,7 @@ impl ITfThreadMgr2_Vtbl {
             this.ResumeKeystrokeHandling().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Activate: Activate::<Identity, Impl, OFFSET>,
             Deactivate: Deactivate::<Identity, Impl, OFFSET>,
             CreateDocumentMgr: CreateDocumentMgr::<Identity, Impl, OFFSET>,
@@ -7755,7 +7755,7 @@ impl ITfThreadMgrEventSink_Vtbl {
             this.OnPopContext(::core::mem::transmute(&pic)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnInitDocumentMgr: OnInitDocumentMgr::<Identity, Impl, OFFSET>,
             OnUninitDocumentMgr: OnUninitDocumentMgr::<Identity, Impl, OFFSET>,
             OnSetFocus: OnSetFocus::<Identity, Impl, OFFSET>,
@@ -7850,7 +7850,7 @@ impl ITfTransitoryExtensionSink_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnTransitoryExtensionUpdated: OnTransitoryExtensionUpdated::<Identity, Impl, OFFSET>,
         }
     }
@@ -7935,7 +7935,7 @@ impl ITfUIElement_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDescription: GetDescription::<Identity, Impl, OFFSET>,
             GetGUID: GetGUID::<Identity, Impl, OFFSET>,
             Show: Show::<Identity, Impl, OFFSET>,
@@ -7997,7 +7997,7 @@ impl ITfUIElementMgr_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             BeginUIElement: BeginUIElement::<Identity, Impl, OFFSET>,
             UpdateUIElement: UpdateUIElement::<Identity, Impl, OFFSET>,
             EndUIElement: EndUIElement::<Identity, Impl, OFFSET>,
@@ -8036,7 +8036,7 @@ impl ITfUIElementSink_Vtbl {
             this.EndUIElement(::core::mem::transmute_copy(&dwuielementid)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             BeginUIElement: BeginUIElement::<Identity, Impl, OFFSET>,
             UpdateUIElement: UpdateUIElement::<Identity, Impl, OFFSET>,
             EndUIElement: EndUIElement::<Identity, Impl, OFFSET>,
@@ -8091,7 +8091,7 @@ impl IUIManagerEventSink_Vtbl {
             this.OnWindowClosed().into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             OnWindowOpening: OnWindowOpening::<Identity, Impl, OFFSET>,
             OnWindowOpened: OnWindowOpened::<Identity, Impl, OFFSET>,
             OnWindowUpdating: OnWindowUpdating::<Identity, Impl, OFFSET>,
@@ -8164,7 +8164,7 @@ impl IVersionInfo_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetSubcomponentCount: GetSubcomponentCount::<Identity, Impl, OFFSET>,
             GetImplementationID: GetImplementationID::<Identity, Impl, OFFSET>,
             GetBuildVersion: GetBuildVersion::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/UI/TextServices/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/TextServices/mod.rs
@@ -97,7 +97,7 @@ unsafe impl ::windows::core::Interface for IAccClientDocMgr {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAccClientDocMgr_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub GetDocuments: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, enumunknown: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -178,7 +178,7 @@ unsafe impl ::windows::core::Interface for IAccDictionary {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAccDictionary_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetLocalizedString: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, term: *const ::windows::core::GUID, lcid: u32, presult: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>, plcid: *mut u32) -> ::windows::core::HRESULT,
     pub GetParentTerm: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, term: *const ::windows::core::GUID, pparentterm: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub GetMnemonicString: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, term: *const ::windows::core::GUID, presult: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
@@ -249,7 +249,7 @@ unsafe impl ::windows::core::Interface for IAccServerDocMgr {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAccServerDocMgr_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub NewDocument: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, punk: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub RevokeDocument: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punk: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub OnDocumentFocus: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punk: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -340,7 +340,7 @@ unsafe impl ::windows::core::Interface for IAccStore {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAccStore_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Register: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, punk: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Unregister: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punk: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
@@ -456,7 +456,7 @@ unsafe impl ::windows::core::Interface for IAnchor {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAnchor_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetGravity: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, gravity: TsGravity) -> ::windows::core::HRESULT,
     pub GetGravity: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pgravity: *mut TsGravity) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -525,7 +525,7 @@ unsafe impl ::windows::core::Interface for IClonableWrapper {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IClonableWrapper_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CloneNewWrapper: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_TextServices\"`*"]
@@ -580,7 +580,7 @@ unsafe impl ::windows::core::Interface for ICoCreateLocally {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICoCreateLocally_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub CoCreateLocally: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, rclsid: *const ::windows::core::GUID, dwclscontext: u32, riid: *const ::windows::core::GUID, punk: *mut *mut ::core::ffi::c_void, riidparam: *const ::windows::core::GUID, punkparam: *mut ::core::ffi::c_void, varparam: ::core::mem::ManuallyDrop<super::super::System::Com::VARIANT>) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole")))]
@@ -639,7 +639,7 @@ unsafe impl ::windows::core::Interface for ICoCreatedLocally {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ICoCreatedLocally_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub LocalInit: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punklocalobject: *mut ::core::ffi::c_void, riidparam: *const ::windows::core::GUID, punkparam: *mut ::core::ffi::c_void, varparam: ::core::mem::ManuallyDrop<super::super::System::Com::VARIANT>) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole")))]
@@ -698,7 +698,7 @@ unsafe impl ::windows::core::Interface for IDocWrap {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IDocWrap_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetDoc: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, punk: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetWrappedDoc: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppunk: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -758,7 +758,7 @@ unsafe impl ::windows::core::Interface for IEnumITfCompositionView {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumITfCompositionView_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Clone: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ulcount: u32, rgcompositionview: *mut *mut ::core::ffi::c_void, pcfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -820,7 +820,7 @@ unsafe impl ::windows::core::Interface for IEnumSpeechCommands {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumSpeechCommands_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Clone: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ulcount: u32, pspcmds: *mut *mut u16, pcfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -882,7 +882,7 @@ unsafe impl ::windows::core::Interface for IEnumTfCandidates {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumTfCandidates_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Clone: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ulcount: u32, ppcand: *mut *mut ::core::ffi::c_void, pcfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -944,7 +944,7 @@ unsafe impl ::windows::core::Interface for IEnumTfContextViews {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumTfContextViews_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Clone: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ulcount: u32, rgviews: *mut *mut ::core::ffi::c_void, pcfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1006,7 +1006,7 @@ unsafe impl ::windows::core::Interface for IEnumTfContexts {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumTfContexts_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Clone: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ulcount: u32, rgcontext: *mut *mut ::core::ffi::c_void, pcfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1068,7 +1068,7 @@ unsafe impl ::windows::core::Interface for IEnumTfDisplayAttributeInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumTfDisplayAttributeInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Clone: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ulcount: u32, rginfo: *mut *mut ::core::ffi::c_void, pcfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1130,7 +1130,7 @@ unsafe impl ::windows::core::Interface for IEnumTfDocumentMgrs {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumTfDocumentMgrs_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Clone: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ulcount: u32, rgdocumentmgr: *mut *mut ::core::ffi::c_void, pcfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1192,7 +1192,7 @@ unsafe impl ::windows::core::Interface for IEnumTfFunctionProviders {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumTfFunctionProviders_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Clone: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ulcount: u32, ppcmdobj: *mut *mut ::core::ffi::c_void, pcfetch: *mut u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1254,7 +1254,7 @@ unsafe impl ::windows::core::Interface for IEnumTfInputProcessorProfiles {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumTfInputProcessorProfiles_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Clone: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ulcount: u32, pprofile: *mut TF_INPUTPROCESSORPROFILE, pcfetch: *mut u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1316,7 +1316,7 @@ unsafe impl ::windows::core::Interface for IEnumTfLangBarItems {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumTfLangBarItems_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Clone: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ulcount: u32, ppitem: *mut *mut ::core::ffi::c_void, pcfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1380,7 +1380,7 @@ unsafe impl ::windows::core::Interface for IEnumTfLanguageProfiles {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumTfLanguageProfiles_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Clone: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ulcount: u32, pprofile: *mut TF_LANGUAGEPROFILE, pcfetch: *mut u32) -> ::windows::core::HRESULT,
@@ -1445,7 +1445,7 @@ unsafe impl ::windows::core::Interface for IEnumTfLatticeElements {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumTfLatticeElements_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Clone: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ulcount: u32, rgselements: *mut TF_LMLATTELEMENT, pcfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1507,7 +1507,7 @@ unsafe impl ::windows::core::Interface for IEnumTfProperties {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumTfProperties_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Clone: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ulcount: u32, ppprop: *mut *mut ::core::ffi::c_void, pcfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1571,7 +1571,7 @@ unsafe impl ::windows::core::Interface for IEnumTfPropertyValue {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumTfPropertyValue_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Clone: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ulcount: u32, rgvalues: *mut TF_PROPERTYVAL, pcfetched: *mut u32) -> ::windows::core::HRESULT,
@@ -1636,7 +1636,7 @@ unsafe impl ::windows::core::Interface for IEnumTfRanges {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumTfRanges_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Clone: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ulcount: u32, pprange: *mut *mut ::core::ffi::c_void, pcfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1698,7 +1698,7 @@ unsafe impl ::windows::core::Interface for IEnumTfUIElements {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IEnumTfUIElements_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Clone: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Next: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ulcount: u32, ppelement: *mut *mut ::core::ffi::c_void, pcfetched: *mut u32) -> ::windows::core::HRESULT,
     pub Reset: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -1750,7 +1750,7 @@ unsafe impl ::windows::core::Interface for IInternalDocWrap {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IInternalDocWrap_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub NotifyRevoke: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_TextServices\"`*"]
@@ -1803,7 +1803,7 @@ unsafe impl ::windows::core::Interface for ISpeechCommandProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ISpeechCommandProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub EnumSpeechCommands: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, langid: u16, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub ProcessCommand: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pszcommand: ::windows::core::PCWSTR, cch: u32, langid: u16) -> ::windows::core::HRESULT,
 }
@@ -1976,7 +1976,7 @@ unsafe impl ::windows::core::Interface for ITextStoreACP {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITextStoreACP_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AdviseSink: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, punk: *mut ::core::ffi::c_void, dwmask: u32) -> ::windows::core::HRESULT,
     pub UnadviseSink: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punk: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub RequestLock: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwlockflags: u32, phrsession: *mut ::windows::core::HRESULT) -> ::windows::core::HRESULT,
@@ -2203,7 +2203,7 @@ unsafe impl ::windows::core::Interface for ITextStoreACP2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITextStoreACP2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AdviseSink: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, punk: *mut ::core::ffi::c_void, dwmask: u32) -> ::windows::core::HRESULT,
     pub UnadviseSink: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punk: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub RequestLock: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwlockflags: u32, phrsession: *mut ::windows::core::HRESULT) -> ::windows::core::HRESULT,
@@ -2311,7 +2311,7 @@ unsafe impl ::windows::core::Interface for ITextStoreACPEx {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITextStoreACPEx_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub ScrollToRect: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, acpstart: i32, acpend: i32, rc: super::super::Foundation::RECT, dwposition: u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -2390,7 +2390,7 @@ unsafe impl ::windows::core::Interface for ITextStoreACPServices {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITextStoreACPServices_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub Serialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pprop: *mut ::core::ffi::c_void, prange: *mut ::core::ffi::c_void, phdr: *mut TF_PERSISTENT_PROPERTY_HEADER_ACP, pstream: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -2469,7 +2469,7 @@ unsafe impl ::windows::core::Interface for ITextStoreACPSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITextStoreACPSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnTextChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwflags: TEXT_STORE_TEXT_CHANGE_FLAGS, pchange: *const TS_TEXTCHANGE) -> ::windows::core::HRESULT,
     pub OnSelectionChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub OnLayoutChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lcode: TsLayoutCode, vcview: u32) -> ::windows::core::HRESULT,
@@ -2776,7 +2776,7 @@ unsafe impl ::windows::core::Interface for ITextStoreAnchor {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITextStoreAnchor_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AdviseSink: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, punk: *mut ::core::ffi::c_void, dwmask: u32) -> ::windows::core::HRESULT,
     pub UnadviseSink: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punk: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub RequestLock: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwlockflags: u32, phrsession: *mut ::windows::core::HRESULT) -> ::windows::core::HRESULT,
@@ -2896,7 +2896,7 @@ unsafe impl ::windows::core::Interface for ITextStoreAnchorEx {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITextStoreAnchorEx_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub ScrollToRect: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pstart: *mut ::core::ffi::c_void, pend: *mut ::core::ffi::c_void, rc: super::super::Foundation::RECT, dwposition: u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -2977,7 +2977,7 @@ unsafe impl ::windows::core::Interface for ITextStoreAnchorSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITextStoreAnchorSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnTextChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwflags: TEXT_STORE_CHANGE_FLAGS, pastart: *mut ::core::ffi::c_void, paend: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub OnSelectionChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub OnLayoutChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lcode: TsLayoutCode, vcview: u32) -> ::windows::core::HRESULT,
@@ -3134,7 +3134,7 @@ unsafe impl ::windows::core::Interface for ITfActiveLanguageProfileNotifySink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfActiveLanguageProfileNotifySink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub OnActivated: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, clsid: *const ::windows::core::GUID, guidprofile: *const ::windows::core::GUID, factivated: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -3198,7 +3198,7 @@ unsafe impl ::windows::core::Interface for ITfCandidateList {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfCandidateList_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub EnumCandidates: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetCandidate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, nindex: u32, ppcand: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetCandidateNum: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pncnt: *mut u32) -> ::windows::core::HRESULT,
@@ -3514,7 +3514,7 @@ unsafe impl ::windows::core::Interface for ITfCandidateString {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfCandidateString_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetString: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstr: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub GetIndex: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pnindex: *mut u32) -> ::windows::core::HRESULT,
 }
@@ -3616,7 +3616,7 @@ unsafe impl ::windows::core::Interface for ITfCategoryMgr {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfCategoryMgr_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub RegisterCategory: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, rclsid: *const ::windows::core::GUID, rcatid: *const ::windows::core::GUID, rguid: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub UnregisterCategory: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, rclsid: *const ::windows::core::GUID, rcatid: *const ::windows::core::GUID, rguid: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
@@ -3690,7 +3690,7 @@ unsafe impl ::windows::core::Interface for ITfCleanupContextDurationSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfCleanupContextDurationSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnStartCleanupContext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub OnEndCleanupContext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -3743,7 +3743,7 @@ unsafe impl ::windows::core::Interface for ITfCleanupContextSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfCleanupContextSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnCleanupContext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ecwrite: u32, pic: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_TextServices\"`*"]
@@ -3793,7 +3793,7 @@ unsafe impl ::windows::core::Interface for ITfClientId {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfClientId_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetClientId: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, rclsid: *const ::windows::core::GUID, ptid: *mut u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_TextServices\"`*"]
@@ -3850,7 +3850,7 @@ unsafe impl ::windows::core::Interface for ITfCompartment {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfCompartment_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
     pub SetValue: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, tid: u32, pvarvalue: *const super::super::System::Com::VARIANT) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole")))]
@@ -3906,7 +3906,7 @@ unsafe impl ::windows::core::Interface for ITfCompartmentEventSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfCompartmentEventSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, rguid: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_TextServices\"`*"]
@@ -3965,7 +3965,7 @@ unsafe impl ::windows::core::Interface for ITfCompartmentMgr {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfCompartmentMgr_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetCompartment: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, rguid: *const ::windows::core::GUID, ppcomp: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub ClearCompartment: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, tid: u32, rguid: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
@@ -4035,7 +4035,7 @@ unsafe impl ::windows::core::Interface for ITfComposition {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfComposition_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetRange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pprange: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub ShiftStart: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ecwrite: u32, pnewstart: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub ShiftEnd: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ecwrite: u32, pnewend: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -4090,7 +4090,7 @@ unsafe impl ::windows::core::Interface for ITfCompositionSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfCompositionSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnCompositionTerminated: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ecwrite: u32, pcomposition: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_TextServices\"`*"]
@@ -4144,7 +4144,7 @@ unsafe impl ::windows::core::Interface for ITfCompositionView {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfCompositionView_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetOwnerClsid: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pclsid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub GetRange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pprange: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -4197,7 +4197,7 @@ unsafe impl ::windows::core::Interface for ITfConfigureSystemKeystrokeFeed {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfConfigureSystemKeystrokeFeed_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub DisableSystemKeystrokeFeed: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub EnableSystemKeystrokeFeed: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -4314,7 +4314,7 @@ unsafe impl ::windows::core::Interface for ITfContext {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfContext_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub RequestEditSession: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, tid: u32, pes: *mut ::core::ffi::c_void, dwflags: TF_CONTEXT_EDIT_CONTEXT_FLAGS, phrsession: *mut ::windows::core::HRESULT) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub InWriteSession: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, tid: u32, pfwritesession: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -4410,7 +4410,7 @@ unsafe impl ::windows::core::Interface for ITfContextComposition {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfContextComposition_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub StartComposition: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ecwrite: u32, pcompositionrange: *mut ::core::ffi::c_void, psink: *mut ::core::ffi::c_void, ppcomposition: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub EnumCompositions: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub FindComposition: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ecread: u32, ptestrange: *mut ::core::ffi::c_void, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -4499,7 +4499,7 @@ unsafe impl ::windows::core::Interface for ITfContextKeyEventSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfContextKeyEventSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub OnKeyDown: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wparam: super::super::Foundation::WPARAM, lparam: super::super::Foundation::LPARAM, pfeaten: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -4593,7 +4593,7 @@ unsafe impl ::windows::core::Interface for ITfContextOwner {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfContextOwner_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetACPFromPoint: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptscreen: *const super::super::Foundation::POINT, dwflags: u32, pacp: *mut i32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -4775,7 +4775,7 @@ unsafe impl ::windows::core::Interface for ITfContextOwnerCompositionSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfContextOwnerCompositionSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub OnStartComposition: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcomposition: *mut ::core::ffi::c_void, pfok: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -4865,7 +4865,7 @@ unsafe impl ::windows::core::Interface for ITfContextOwnerServices {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfContextOwnerServices_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnLayoutChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub OnStatusChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwflags: u32) -> ::windows::core::HRESULT,
     pub OnAttributeChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, rguidattribute: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
@@ -4949,7 +4949,7 @@ unsafe impl ::windows::core::Interface for ITfContextView {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfContextView_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetRangeFromPoint: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ec: u32, ppt: *const super::super::Foundation::POINT, dwflags: u32, pprange: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -5030,7 +5030,7 @@ unsafe impl ::windows::core::Interface for ITfCreatePropertyStore {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfCreatePropertyStore_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub IsStoreSerializable: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, guidprop: *const ::windows::core::GUID, prange: *mut ::core::ffi::c_void, ppropstore: *mut ::core::ffi::c_void, pfserializable: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -5105,7 +5105,7 @@ unsafe impl ::windows::core::Interface for ITfDisplayAttributeInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfDisplayAttributeInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetGUID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pguid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub GetDescription: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstrdesc: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -5171,7 +5171,7 @@ unsafe impl ::windows::core::Interface for ITfDisplayAttributeMgr {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfDisplayAttributeMgr_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnUpdateInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub EnumDisplayAttributeInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetDisplayAttributeInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, guid: *const ::windows::core::GUID, ppinfo: *mut *mut ::core::ffi::c_void, pclsidowner: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
@@ -5222,7 +5222,7 @@ unsafe impl ::windows::core::Interface for ITfDisplayAttributeNotifySink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfDisplayAttributeNotifySink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnUpdateInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_TextServices\"`*"]
@@ -5276,7 +5276,7 @@ unsafe impl ::windows::core::Interface for ITfDisplayAttributeProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfDisplayAttributeProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub EnumDisplayAttributeInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetDisplayAttributeInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, guid: *const ::windows::core::GUID, ppinfo: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -5350,7 +5350,7 @@ unsafe impl ::windows::core::Interface for ITfDocumentMgr {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfDocumentMgr_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateContext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, tidowner: u32, dwflags: u32, punk: *mut ::core::ffi::c_void, ppic: *mut *mut ::core::ffi::c_void, pectextstore: *mut u32) -> ::windows::core::HRESULT,
     pub Push: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pic: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Pop: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwflags: u32) -> ::windows::core::HRESULT,
@@ -5411,7 +5411,7 @@ unsafe impl ::windows::core::Interface for ITfEditRecord {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfEditRecord_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub GetSelectionStatus: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfchanged: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -5464,7 +5464,7 @@ unsafe impl ::windows::core::Interface for ITfEditSession {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfEditSession_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub DoEditSession: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ec: u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_TextServices\"`*"]
@@ -5522,7 +5522,7 @@ unsafe impl ::windows::core::Interface for ITfEditTransactionSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfEditTransactionSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnStartEditTransaction: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pic: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub OnEndEditTransaction: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pic: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -5651,7 +5651,7 @@ unsafe impl ::windows::core::Interface for ITfFnBalloon {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfFnBalloon_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub UpdateBalloon: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, style: TfLBBalloonStyle, pch: ::windows::core::PCWSTR, cch: u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_TextServices\"`*"]
@@ -6960,7 +6960,7 @@ unsafe impl ::windows::core::Interface for ITfFunction {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfFunction_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDisplayName: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstrname: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_TextServices\"`*"]
@@ -7018,7 +7018,7 @@ unsafe impl ::windows::core::Interface for ITfFunctionProvider {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfFunctionProvider_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pguid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub GetDescription: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstrdesc: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub GetFunction: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, rguid: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, ppunk: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -7072,7 +7072,7 @@ unsafe impl ::windows::core::Interface for ITfInputProcessorProfileActivationSin
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfInputProcessorProfileActivationSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnActivated: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwprofiletype: u32, langid: u16, clsid: *const ::windows::core::GUID, catid: *const ::windows::core::GUID, guidprofile: *const ::windows::core::GUID, hkl: HKL, dwflags: u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_TextServices\"`*"]
@@ -7160,7 +7160,7 @@ unsafe impl ::windows::core::Interface for ITfInputProcessorProfileMgr {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfInputProcessorProfileMgr_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub ActivateProfile: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwprofiletype: u32, langid: u16, clsid: *const ::windows::core::GUID, guidprofile: *const ::windows::core::GUID, hkl: HKL, dwflags: u32) -> ::windows::core::HRESULT,
     pub DeactivateProfile: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwprofiletype: u32, langid: u16, clsid: *const ::windows::core::GUID, guidprofile: *const ::windows::core::GUID, hkl: HKL, dwflags: u32) -> ::windows::core::HRESULT,
     pub GetProfile: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwprofiletype: u32, langid: u16, clsid: *const ::windows::core::GUID, guidprofile: *const ::windows::core::GUID, hkl: HKL, pprofile: *mut TF_INPUTPROCESSORPROFILE) -> ::windows::core::HRESULT,
@@ -7220,7 +7220,7 @@ unsafe impl ::windows::core::Interface for ITfInputProcessorProfileSubstituteLay
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfInputProcessorProfileSubstituteLayout_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetSubstituteKeyboardLayout: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, rclsid: *const ::windows::core::GUID, langid: u16, guidprofile: *const ::windows::core::GUID, phkl: *mut HKL) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_TextServices\"`*"]
@@ -7342,7 +7342,7 @@ unsafe impl ::windows::core::Interface for ITfInputProcessorProfiles {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfInputProcessorProfiles_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Register: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, rclsid: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub Unregister: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, rclsid: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub AddLanguageProfile: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, rclsid: *const ::windows::core::GUID, langid: u16, guidprofile: *const ::windows::core::GUID, pchdesc: ::windows::core::PCWSTR, cchdesc: u32, pchiconfile: ::windows::core::PCWSTR, cchfile: u32, uiconindex: u32) -> ::windows::core::HRESULT,
@@ -7575,7 +7575,7 @@ unsafe impl ::windows::core::Interface for ITfInputScope {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfInputScope_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetInputScopes: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pprginputscopes: *mut *mut InputScope, pccount: *mut u32) -> ::windows::core::HRESULT,
     pub GetPhrase: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppbstrphrases: *mut *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>, pccount: *mut u32) -> ::windows::core::HRESULT,
     pub GetRegularExpression: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstrregexp: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
@@ -7726,7 +7726,7 @@ unsafe impl ::windows::core::Interface for ITfInsertAtSelection {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfInsertAtSelection_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub InsertTextAtSelection: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ec: u32, dwflags: INSERT_TEXT_AT_SELECTION_FLAGS, pchtext: ::windows::core::PCWSTR, cch: i32, pprange: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
     pub InsertEmbeddedAtSelection: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ec: u32, dwflags: u32, pdataobject: *mut ::core::ffi::c_void, pprange: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -7802,7 +7802,7 @@ unsafe impl ::windows::core::Interface for ITfIntegratableCandidateListUIElement
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfIntegratableCandidateListUIElement_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetIntegrationStyle: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, guidintegrationstyle: ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub GetSelectionStyle: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptfselectionstyle: *mut TfIntegratableCandidateListSelectionStyle) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -7919,7 +7919,7 @@ unsafe impl ::windows::core::Interface for ITfKeyEventSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfKeyEventSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub OnSetFocus: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fforeground: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -8006,7 +8006,7 @@ unsafe impl ::windows::core::Interface for ITfKeyTraceEventSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfKeyTraceEventSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub OnKeyTraceDown: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wparam: super::super::Foundation::WPARAM, lparam: super::super::Foundation::LPARAM) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -8150,7 +8150,7 @@ unsafe impl ::windows::core::Interface for ITfKeystrokeMgr {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfKeystrokeMgr_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub AdviseKeyEventSink: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, tid: u32, psink: *mut ::core::ffi::c_void, fforeground: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -8240,7 +8240,7 @@ unsafe impl ::windows::core::Interface for ITfLMLattice {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfLMLattice_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub QueryType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, rguidtype: *const ::windows::core::GUID, pfsupported: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -8317,7 +8317,7 @@ unsafe impl ::windows::core::Interface for ITfLangBarEventSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfLangBarEventSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnSetFocus: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwthreadid: u32) -> ::windows::core::HRESULT,
     pub OnThreadTerminate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwthreadid: u32) -> ::windows::core::HRESULT,
     pub OnThreadItemChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwthreadid: u32) -> ::windows::core::HRESULT,
@@ -8394,7 +8394,7 @@ unsafe impl ::windows::core::Interface for ITfLangBarItem {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfLangBarItem_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinfo: *mut TF_LANGBARITEMINFO) -> ::windows::core::HRESULT,
     pub GetStatus: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwstatus: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -8950,7 +8950,7 @@ unsafe impl ::windows::core::Interface for ITfLangBarItemMgr {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfLangBarItemMgr_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub EnumItems: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppenum: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetItem: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, rguid: *const ::windows::core::GUID, ppitem: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub AddItem: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, punk: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -9013,7 +9013,7 @@ unsafe impl ::windows::core::Interface for ITfLangBarItemSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfLangBarItemSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnUpdate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwflags: u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_TextServices\"`*"]
@@ -9102,7 +9102,7 @@ unsafe impl ::windows::core::Interface for ITfLangBarMgr {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfLangBarMgr_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub AdviseEventSink: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, psink: *mut ::core::ffi::c_void, hwnd: super::super::Foundation::HWND, dwflags: u32, pdwcookie: *const u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -9171,7 +9171,7 @@ unsafe impl ::windows::core::Interface for ITfLanguageProfileNotifySink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfLanguageProfileNotifySink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub OnLanguageChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, langid: u16, pfaccept: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -9227,7 +9227,7 @@ unsafe impl ::windows::core::Interface for ITfMSAAControl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfMSAAControl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SystemEnableMSAA: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub SystemDisableMSAA: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -9283,7 +9283,7 @@ unsafe impl ::windows::core::Interface for ITfMenu {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfMenu_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Graphics_Gdi")]
     pub AddMenuItem: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, uid: u32, dwflags: u32, hbmp: super::super::Graphics::Gdi::HBITMAP, hbmpmask: super::super::Graphics::Gdi::HBITMAP, pch: ::windows::core::PCWSTR, cch: u32, ppmenu: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Graphics_Gdi"))]
@@ -9364,7 +9364,7 @@ unsafe impl ::windows::core::Interface for ITfMessagePump {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfMessagePump_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
     pub PeekMessageA: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pmsg: *mut super::WindowsAndMessaging::MSG, hwnd: super::super::Foundation::HWND, wmsgfiltermin: u32, wmsgfiltermax: u32, wremovemsg: u32, pfresult: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging")))]
@@ -9431,7 +9431,7 @@ unsafe impl ::windows::core::Interface for ITfMouseSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfMouseSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub OnMouseEvent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, uedge: u32, uquadrant: u32, dwbtnstatus: u32, pfeaten: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -9491,7 +9491,7 @@ unsafe impl ::windows::core::Interface for ITfMouseTracker {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfMouseTracker_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AdviseMouseSink: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, range: *mut ::core::ffi::c_void, psink: *mut ::core::ffi::c_void, pdwcookie: *mut u32) -> ::windows::core::HRESULT,
     pub UnadviseMouseSink: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwcookie: u32) -> ::windows::core::HRESULT,
 }
@@ -9549,7 +9549,7 @@ unsafe impl ::windows::core::Interface for ITfMouseTrackerACP {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfMouseTrackerACP_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AdviseMouseSink: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, range: *mut ::core::ffi::c_void, psink: *mut ::core::ffi::c_void, pdwcookie: *mut u32) -> ::windows::core::HRESULT,
     pub UnadviseMouseSink: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwcookie: u32) -> ::windows::core::HRESULT,
 }
@@ -9602,7 +9602,7 @@ unsafe impl ::windows::core::Interface for ITfPersistentPropertyLoaderACP {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfPersistentPropertyLoaderACP_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_System_Com")]
     pub LoadProperty: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, phdr: *const TF_PERSISTENT_PROPERTY_HEADER_ACP, ppstream: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_System_Com"))]
@@ -9654,7 +9654,7 @@ unsafe impl ::windows::core::Interface for ITfPreservedKeyNotifySink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfPreservedKeyNotifySink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnUpdated: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pprekey: *const TF_PRESERVEDKEY) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_TextServices\"`*"]
@@ -9874,7 +9874,7 @@ unsafe impl ::windows::core::Interface for ITfPropertyStore {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfPropertyStore_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pguid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub GetDataType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwreserved: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -9946,7 +9946,7 @@ unsafe impl ::windows::core::Interface for ITfQueryEmbedded {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfQueryEmbedded_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
     pub QueryInsertEmbedded: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pguidservice: *const ::windows::core::GUID, pformatetc: *const super::super::System::Com::FORMATETC, pfinsertable: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com")))]
@@ -10110,7 +10110,7 @@ unsafe impl ::windows::core::Interface for ITfRange {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfRange_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetText: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ec: u32, dwflags: u32, pchtext: ::windows::core::PWSTR, cchmax: u32, pcch: *mut u32) -> ::windows::core::HRESULT,
     pub SetText: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ec: u32, dwflags: u32, pchtext: ::windows::core::PCWSTR, cch: i32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
@@ -10390,7 +10390,7 @@ unsafe impl ::windows::core::Interface for ITfRangeBackup {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfRangeBackup_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Restore: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ec: u32, prange: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_TextServices\"`*"]
@@ -10459,7 +10459,7 @@ unsafe impl ::windows::core::Interface for ITfReadOnlyProperty {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfReadOnlyProperty_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetType: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pguid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub EnumRanges: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ec: u32, ppenum: *mut *mut ::core::ffi::c_void, ptargetrange: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -10635,7 +10635,7 @@ unsafe impl ::windows::core::Interface for ITfReverseConversion {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfReverseConversion_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub DoReverseConversion: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, lpstr: ::windows::core::PCWSTR, pplist: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_TextServices\"`*"]
@@ -10689,7 +10689,7 @@ unsafe impl ::windows::core::Interface for ITfReverseConversionList {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfReverseConversionList_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetLength: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, puindex: *mut u32) -> ::windows::core::HRESULT,
     pub GetString: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, uindex: u32, pbstr: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
 }
@@ -10740,7 +10740,7 @@ unsafe impl ::windows::core::Interface for ITfReverseConversionMgr {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfReverseConversionMgr_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetReverseConversion: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, langid: u16, guidprofile: *const ::windows::core::GUID, dwflag: u32, ppreverseconversion: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_TextServices\"`*"]
@@ -10796,7 +10796,7 @@ unsafe impl ::windows::core::Interface for ITfSource {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfSource_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AdviseSink: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, punk: *mut ::core::ffi::c_void, pdwcookie: *mut u32) -> ::windows::core::HRESULT,
     pub UnadviseSink: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwcookie: u32) -> ::windows::core::HRESULT,
 }
@@ -10852,7 +10852,7 @@ unsafe impl ::windows::core::Interface for ITfSourceSingle {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfSourceSingle_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AdviseSingleSink: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, tid: u32, riid: *const ::windows::core::GUID, punk: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub UnadviseSingleSink: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, tid: u32, riid: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
 }
@@ -10913,7 +10913,7 @@ unsafe impl ::windows::core::Interface for ITfSpeechUIServer {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfSpeechUIServer_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Initialize: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
     pub ShowUI: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fshow: super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
@@ -10970,7 +10970,7 @@ unsafe impl ::windows::core::Interface for ITfStatusSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfStatusSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnStatusChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pic: *mut ::core::ffi::c_void, dwflags: u32) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_TextServices\"`*"]
@@ -11023,7 +11023,7 @@ unsafe impl ::windows::core::Interface for ITfSystemDeviceTypeLangBarItem {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfSystemDeviceTypeLangBarItem_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetIconMode: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwflags: LANG_BAR_ITEM_ICON_MODE_FLAGS) -> ::windows::core::HRESULT,
     pub GetIconMode: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwflags: *mut u32) -> ::windows::core::HRESULT,
 }
@@ -11081,7 +11081,7 @@ unsafe impl ::windows::core::Interface for ITfSystemLangBarItem {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfSystemLangBarItem_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
     pub SetIcon: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, hicon: super::WindowsAndMessaging::HICON) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_UI_WindowsAndMessaging"))]
@@ -11140,7 +11140,7 @@ unsafe impl ::windows::core::Interface for ITfSystemLangBarItemSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfSystemLangBarItemSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub InitMenu: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pmenu: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub OnMenuSelect: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, wid: u32) -> ::windows::core::HRESULT,
 }
@@ -11194,7 +11194,7 @@ unsafe impl ::windows::core::Interface for ITfSystemLangBarItemText {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfSystemLangBarItemText_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetItemText: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pch: ::windows::core::PCWSTR, cch: u32) -> ::windows::core::HRESULT,
     pub GetItemText: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstrtext: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
 }
@@ -11248,7 +11248,7 @@ unsafe impl ::windows::core::Interface for ITfTextEditSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfTextEditSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnEndEdit: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pic: *mut ::core::ffi::c_void, ecreadonly: u32, peditrecord: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_TextServices\"`*"]
@@ -11303,7 +11303,7 @@ unsafe impl ::windows::core::Interface for ITfTextInputProcessor {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfTextInputProcessor_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Activate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptim: *mut ::core::ffi::c_void, tid: u32) -> ::windows::core::HRESULT,
     pub Deactivate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -11433,7 +11433,7 @@ unsafe impl ::windows::core::Interface for ITfTextLayoutSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfTextLayoutSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnLayoutChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pic: *mut ::core::ffi::c_void, lcode: TfLayoutCode, pview: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_TextServices\"`*"]
@@ -11485,7 +11485,7 @@ unsafe impl ::windows::core::Interface for ITfThreadFocusSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfThreadFocusSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnSetThreadFocus: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub OnKillThreadFocus: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -11585,7 +11585,7 @@ unsafe impl ::windows::core::Interface for ITfThreadMgr {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfThreadMgr_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Activate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptid: *mut u32) -> ::windows::core::HRESULT,
     pub Deactivate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CreateDocumentMgr: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppdim: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -11703,7 +11703,7 @@ unsafe impl ::windows::core::Interface for ITfThreadMgr2 {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfThreadMgr2_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Activate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ptid: *mut u32) -> ::windows::core::HRESULT,
     pub Deactivate: unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CreateDocumentMgr: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppdim: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -11796,7 +11796,7 @@ unsafe impl ::windows::core::Interface for ITfThreadMgrEventSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfThreadMgrEventSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnInitDocumentMgr: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdim: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub OnUninitDocumentMgr: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdim: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub OnSetFocus: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdimfocus: *mut ::core::ffi::c_void, pdimprevfocus: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -12066,7 +12066,7 @@ unsafe impl ::windows::core::Interface for ITfTransitoryExtensionSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfTransitoryExtensionSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub OnTransitoryExtensionUpdated: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pic: *mut ::core::ffi::c_void, ecreadonly: u32, presultrange: *mut ::core::ffi::c_void, pcompositionrange: *mut ::core::ffi::c_void, pfdeleteresultrange: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -12224,7 +12224,7 @@ unsafe impl ::windows::core::Interface for ITfUIElement {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfUIElement_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDescription: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstrdescription: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub GetGUID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pguid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Foundation")]
@@ -12301,7 +12301,7 @@ unsafe impl ::windows::core::Interface for ITfUIElementMgr {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfUIElementMgr_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub BeginUIElement: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pelement: *mut ::core::ffi::c_void, pbshow: *mut super::super::Foundation::BOOL, pdwuielementid: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -12365,7 +12365,7 @@ unsafe impl ::windows::core::Interface for ITfUIElementSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ITfUIElementSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub BeginUIElement: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, dwuielementid: u32, pbshow: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -12442,7 +12442,7 @@ unsafe impl ::windows::core::Interface for IUIManagerEventSink {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IUIManagerEventSink_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Foundation")]
     pub OnWindowOpening: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, prcbounds: *const super::super::Foundation::RECT) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Foundation"))]
@@ -12524,7 +12524,7 @@ unsafe impl ::windows::core::Interface for IVersionInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVersionInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetSubcomponentCount: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ulsub: u32, ulcount: *mut u32) -> ::windows::core::HRESULT,
     pub GetImplementationID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ulsub: u32, implid: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub GetBuildVersion: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ulsub: u32, pdwmajor: *mut u32, pdwminor: *mut u32) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/UI/Wpf/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Wpf/impl.rs
@@ -37,7 +37,7 @@ impl IMILBitmapEffect_Vtbl {
             this.SetInputSource(::core::mem::transmute_copy(&uiindex), ::core::mem::transmute(&pbitmapsource)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetOutput: GetOutput::<Identity, Impl, OFFSET>,
             GetParentEffect: GetParentEffect::<Identity, Impl, OFFSET>,
             SetInputSource: SetInputSource::<Identity, Impl, OFFSET>,
@@ -77,7 +77,7 @@ impl IMILBitmapEffectConnections_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetInputConnector: GetInputConnector::<Identity, Impl, OFFSET>,
             GetOutputConnector: GetOutputConnector::<Identity, Impl, OFFSET>,
         }
@@ -140,7 +140,7 @@ impl IMILBitmapEffectConnectionsInfo_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetNumberInputs: GetNumberInputs::<Identity, Impl, OFFSET>,
             GetNumberOutputs: GetNumberOutputs::<Identity, Impl, OFFSET>,
             GetInputConnectorInfo: GetInputConnectorInfo::<Identity, Impl, OFFSET>,
@@ -244,7 +244,7 @@ impl IMILBitmapEffectConnectorInfo_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetIndex: GetIndex::<Identity, Impl, OFFSET>,
             GetOptimalFormat: GetOptimalFormat::<Identity, Impl, OFFSET>,
             GetNumberFormats: GetNumberFormats::<Identity, Impl, OFFSET>,
@@ -273,7 +273,7 @@ impl IMILBitmapEffectEvents_Vtbl {
             this.DirtyRegion(::core::mem::transmute(&peffect), ::core::mem::transmute_copy(&prect)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             PropertyChange: PropertyChange::<Identity, Impl, OFFSET>,
             DirtyRegion: DirtyRegion::<Identity, Impl, OFFSET>,
         }
@@ -324,7 +324,7 @@ impl IMILBitmapEffectFactory_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CreateEffect: CreateEffect::<Identity, Impl, OFFSET>,
             CreateContext: CreateContext::<Identity, Impl, OFFSET>,
             CreateEffectOuter: CreateEffectOuter::<Identity, Impl, OFFSET>,
@@ -370,7 +370,7 @@ impl IMILBitmapEffectGroup_Vtbl {
             this.Add(::core::mem::transmute(&peffect)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetInteriorInputConnector: GetInteriorInputConnector::<Identity, Impl, OFFSET>,
             GetInteriorOutputConnector: GetInteriorOutputConnector::<Identity, Impl, OFFSET>,
             Add: Add::<Identity, Impl, OFFSET>,
@@ -416,7 +416,7 @@ impl IMILBitmapEffectGroupImpl_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             Preprocess: Preprocess::<Identity, Impl, OFFSET>,
             GetNumberChildren: GetNumberChildren::<Identity, Impl, OFFSET>,
             GetChildren: GetChildren::<Identity, Impl, OFFSET>,
@@ -495,7 +495,7 @@ impl IMILBitmapEffectImpl_Vtbl {
             this.Initialize(::core::mem::transmute(&pinner)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             IsInPlaceModificationAllowed: IsInPlaceModificationAllowed::<Identity, Impl, OFFSET>,
             SetParentEffect: SetParentEffect::<Identity, Impl, OFFSET>,
             GetInputSource: GetInputSource::<Identity, Impl, OFFSET>,
@@ -559,7 +559,7 @@ impl IMILBitmapEffectInteriorInputConnector_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetInputConnector: GetInputConnector::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetInputConnector: GetInputConnector::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMILBitmapEffectInteriorInputConnector as ::windows::core::Interface>::IID
@@ -582,7 +582,7 @@ impl IMILBitmapEffectInteriorOutputConnector_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), GetOutputConnector: GetOutputConnector::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), GetOutputConnector: GetOutputConnector::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IMILBitmapEffectInteriorOutputConnector as ::windows::core::Interface>::IID
@@ -645,7 +645,7 @@ impl IMILBitmapEffectOutputConnectorImpl_Vtbl {
             this.RemoveBackLink(::core::mem::transmute(&pconnection)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AddBackLink: AddBackLink::<Identity, Impl, OFFSET>,
             RemoveBackLink: RemoveBackLink::<Identity, Impl, OFFSET>,
         }
@@ -711,7 +711,7 @@ impl IMILBitmapEffectPrimitive_Vtbl {
             this.GetAffineMatrix(::core::mem::transmute_copy(&uiindex), ::core::mem::transmute_copy(&pmatrix)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetOutput: GetOutput::<Identity, Impl, OFFSET>,
             TransformPoint: TransformPoint::<Identity, Impl, OFFSET>,
             TransformRect: TransformRect::<Identity, Impl, OFFSET>,
@@ -748,7 +748,7 @@ impl IMILBitmapEffectPrimitiveImpl_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             IsDirty: IsDirty::<Identity, Impl, OFFSET>,
             IsVolatile: IsVolatile::<Identity, Impl, OFFSET>,
         }
@@ -823,7 +823,7 @@ impl IMILBitmapEffectRenderContext_Vtbl {
             this.SetRegionOfInterest(::core::mem::transmute_copy(&prect)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             SetOutputPixelFormat: SetOutputPixelFormat::<Identity, Impl, OFFSET>,
             GetOutputPixelFormat: GetOutputPixelFormat::<Identity, Impl, OFFSET>,
             SetUseSoftwareRenderer: SetUseSoftwareRenderer::<Identity, Impl, OFFSET>,
@@ -880,7 +880,7 @@ impl IMILBitmapEffectRenderContextImpl_Vtbl {
             this.UpdateOutputBounds(::core::mem::transmute_copy(&prect)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetUseSoftwareRenderer: GetUseSoftwareRenderer::<Identity, Impl, OFFSET>,
             GetTransform: GetTransform::<Identity, Impl, OFFSET>,
             UpdateTransform: UpdateTransform::<Identity, Impl, OFFSET>,
@@ -946,7 +946,7 @@ impl IMILBitmapEffects_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             _NewEnum: _NewEnum::<Identity, Impl, OFFSET>,
             Parent: Parent::<Identity, Impl, OFFSET>,
             Item: Item::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/UI/Wpf/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Wpf/mod.rs
@@ -62,7 +62,7 @@ unsafe impl ::windows::core::Interface for IMILBitmapEffect {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMILBitmapEffect_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Graphics_Imaging")]
     pub GetOutput: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, uiindex: u32, pcontext: *mut ::core::ffi::c_void, ppbitmapsource: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Graphics_Imaging"))]
@@ -124,7 +124,7 @@ unsafe impl ::windows::core::Interface for IMILBitmapEffectConnections {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMILBitmapEffectConnections_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetInputConnector: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, uiindex: u32, ppconnector: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetOutputConnector: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, uiindex: u32, ppconnector: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -187,7 +187,7 @@ unsafe impl ::windows::core::Interface for IMILBitmapEffectConnectionsInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMILBitmapEffectConnectionsInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetNumberInputs: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, puinuminputs: *mut u32) -> ::windows::core::HRESULT,
     pub GetNumberOutputs: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, puinumoutputs: *mut u32) -> ::windows::core::HRESULT,
     pub GetInputConnectorInfo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, uiindex: u32, ppconnectorinfo: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -338,7 +338,7 @@ unsafe impl ::windows::core::Interface for IMILBitmapEffectConnectorInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMILBitmapEffectConnectorInfo_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetIndex: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, puiindex: *mut u32) -> ::windows::core::HRESULT,
     pub GetOptimalFormat: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pformat: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub GetNumberFormats: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pulnumberformats: *mut u32) -> ::windows::core::HRESULT,
@@ -399,7 +399,7 @@ unsafe impl ::windows::core::Interface for IMILBitmapEffectEvents {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMILBitmapEffectEvents_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub PropertyChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, peffect: *mut ::core::ffi::c_void, bstrpropertyname: ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT,
     pub DirtyRegion: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, peffect: *mut ::core::ffi::c_void, prect: *const MilRectD) -> ::windows::core::HRESULT,
 }
@@ -458,7 +458,7 @@ unsafe impl ::windows::core::Interface for IMILBitmapEffectFactory {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMILBitmapEffectFactory_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CreateEffect: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pguideffect: *const ::windows::core::GUID, ppeffect: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CreateContext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppcontext: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub CreateEffectOuter: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppeffect: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -520,7 +520,7 @@ unsafe impl ::windows::core::Interface for IMILBitmapEffectGroup {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMILBitmapEffectGroup_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetInteriorInputConnector: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, uiindex: u32, ppconnector: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetInteriorOutputConnector: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, uiindex: u32, ppconnector: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Add: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, peffect: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -582,7 +582,7 @@ unsafe impl ::windows::core::Interface for IMILBitmapEffectGroupImpl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMILBitmapEffectGroupImpl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub Preprocess: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcontext: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetNumberChildren: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, puinumberchildren: *mut u32) -> ::windows::core::HRESULT,
     pub GetChildren: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pchildren: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
@@ -675,7 +675,7 @@ unsafe impl ::windows::core::Interface for IMILBitmapEffectImpl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMILBitmapEffectImpl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub IsInPlaceModificationAllowed: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, poutputconnector: *mut ::core::ffi::c_void, pfmodifyinplace: *mut i16) -> ::windows::core::HRESULT,
     pub SetParentEffect: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pparenteffect: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Graphics_Imaging")]
@@ -851,7 +851,7 @@ unsafe impl ::windows::core::Interface for IMILBitmapEffectInteriorInputConnecto
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMILBitmapEffectInteriorInputConnector_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetInputConnector: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pinputconnector: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Wpf\"`*"]
@@ -901,7 +901,7 @@ unsafe impl ::windows::core::Interface for IMILBitmapEffectInteriorOutputConnect
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMILBitmapEffectInteriorOutputConnector_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetOutputConnector: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, poutputconnector: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Wpf\"`*"]
@@ -1068,7 +1068,7 @@ unsafe impl ::windows::core::Interface for IMILBitmapEffectOutputConnectorImpl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMILBitmapEffectOutputConnectorImpl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AddBackLink: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pconnection: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub RemoveBackLink: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pconnection: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
 }
@@ -1148,7 +1148,7 @@ unsafe impl ::windows::core::Interface for IMILBitmapEffectPrimitive {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMILBitmapEffectPrimitive_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     #[cfg(feature = "Win32_Graphics_Imaging")]
     pub GetOutput: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, uiindex: u32, pcontext: *mut ::core::ffi::c_void, pfmodifyinplace: *mut i16, ppbitmapsource: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(not(feature = "Win32_Graphics_Imaging"))]
@@ -1212,7 +1212,7 @@ unsafe impl ::windows::core::Interface for IMILBitmapEffectPrimitiveImpl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMILBitmapEffectPrimitiveImpl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub IsDirty: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, uioutputindex: u32, pfdirty: *mut i16) -> ::windows::core::HRESULT,
     pub IsVolatile: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, uioutputindex: u32, pfvolatile: *mut i16) -> ::windows::core::HRESULT,
 }
@@ -1285,7 +1285,7 @@ unsafe impl ::windows::core::Interface for IMILBitmapEffectRenderContext {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMILBitmapEffectRenderContext_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub SetOutputPixelFormat: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, format: *const ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub GetOutputPixelFormat: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pformat: *mut ::windows::core::GUID) -> ::windows::core::HRESULT,
     pub SetUseSoftwareRenderer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, fsoftware: i16) -> ::windows::core::HRESULT,
@@ -1354,7 +1354,7 @@ unsafe impl ::windows::core::Interface for IMILBitmapEffectRenderContextImpl {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMILBitmapEffectRenderContextImpl_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetUseSoftwareRenderer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pfsoftware: *mut i16) -> ::windows::core::HRESULT,
     pub GetTransform: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pmatrix: *mut MILMatrixF) -> ::windows::core::HRESULT,
     pub UpdateTransform: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pmatrix: *const MILMatrixF) -> ::windows::core::HRESULT,
@@ -1420,7 +1420,7 @@ unsafe impl ::windows::core::Interface for IMILBitmapEffects {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IMILBitmapEffects_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub _NewEnum: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppiureturn: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Parent: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppeffect: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub Item: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, uindex: u32, ppeffect: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/Windows/Win32/UI/Xaml/Diagnostics/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Xaml/Diagnostics/impl.rs
@@ -49,7 +49,7 @@ impl IBitmapData_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             CopyBytesTo: CopyBytesTo::<Identity, Impl, OFFSET>,
             GetStride: GetStride::<Identity, Impl, OFFSET>,
             GetBitmapDescription: GetBitmapDescription::<Identity, Impl, OFFSET>,
@@ -153,7 +153,7 @@ impl IVisualTreeService_Vtbl {
             this.ClearChildren(::core::mem::transmute_copy(&parent)).into()
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             AdviseVisualTreeChange: AdviseVisualTreeChange::<Identity, Impl, OFFSET>,
             UnadviseVisualTreeChange: UnadviseVisualTreeChange::<Identity, Impl, OFFSET>,
             GetEnums: GetEnums::<Identity, Impl, OFFSET>,
@@ -295,7 +295,7 @@ impl IVisualTreeServiceCallback_Vtbl {
             let this = (*this).get_impl();
             this.OnVisualTreeChange(::core::mem::transmute(&relation), ::core::mem::transmute(&element), ::core::mem::transmute_copy(&mutationtype)).into()
         }
-        Self { base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(), OnVisualTreeChange: OnVisualTreeChange::<Identity, Impl, OFFSET> }
+        Self { base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(), OnVisualTreeChange: OnVisualTreeChange::<Identity, Impl, OFFSET> }
     }
     pub fn matches(iid: &windows::core::GUID) -> bool {
         iid == &<IVisualTreeServiceCallback as ::windows::core::Interface>::IID
@@ -417,7 +417,7 @@ impl IXamlDiagnostics_Vtbl {
             }
         }
         Self {
-            base__: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),
+            base__: ::windows::core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
             GetDispatcher: GetDispatcher::<Identity, Impl, OFFSET>,
             GetUiLayer: GetUiLayer::<Identity, Impl, OFFSET>,
             GetApplication: GetApplication::<Identity, Impl, OFFSET>,

--- a/crates/libs/windows/src/Windows/Win32/UI/Xaml/Diagnostics/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Xaml/Diagnostics/mod.rs
@@ -89,7 +89,7 @@ unsafe impl ::windows::core::Interface for IBitmapData {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IBitmapData_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub CopyBytesTo: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sourceoffsetinbytes: u32, maxbytestocopy: u32, pvbytes: *mut u8, numberofbytescopied: *mut u32) -> ::windows::core::HRESULT,
     pub GetStride: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pstride: *mut u32) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -192,7 +192,7 @@ unsafe impl ::windows::core::Interface for IVisualTreeService {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVisualTreeService_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub AdviseVisualTreeChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcallback: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub UnadviseVisualTreeChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pcallback: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     #[cfg(feature = "Win32_System_Com")]
@@ -561,7 +561,7 @@ unsafe impl ::windows::core::Interface for IVisualTreeServiceCallback {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IVisualTreeServiceCallback_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub OnVisualTreeChange: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, relation: ParentChildRelation, element: ::core::mem::ManuallyDrop<VisualElement>, mutationtype: VisualMutationType) -> ::windows::core::HRESULT,
 }
 #[doc = "*Required features: `\"Win32_UI_Xaml_Diagnostics\"`*"]
@@ -719,7 +719,7 @@ unsafe impl ::windows::core::Interface for IXamlDiagnostics {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXamlDiagnostics_Vtbl {
-    pub base__: ::windows::core::IUnknownVtbl,
+    pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetDispatcher: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppdispatcher: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetUiLayer: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pplayer: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,
     pub GetApplication: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, ppapplication: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT,

--- a/crates/libs/windows/src/core/bindings.rs
+++ b/crates/libs/windows/src/core/bindings.rs
@@ -261,7 +261,7 @@ unsafe impl Interface for IAgileObject {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAgileObject_Vtbl {
-    pub base__: IUnknownVtbl,
+    pub base__: IUnknown_Vtbl,
 }
 
 #[repr(transparent)]
@@ -307,7 +307,7 @@ unsafe impl Interface for IErrorInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IErrorInfo_Vtbl {
-    pub base__: IUnknownVtbl,
+    pub base__: IUnknown_Vtbl,
     pub GetGUID: unsafe extern "system" fn(this: *mut c_void, pguid: *mut GUID) -> HRESULT,
     pub GetSource: unsafe extern "system" fn(this: *mut c_void, pbstrsource: *mut BSTR) -> HRESULT,
     pub GetDescription: unsafe extern "system" fn(this: *mut c_void, pbstrdescription: *mut BSTR) -> HRESULT,
@@ -345,7 +345,7 @@ unsafe impl Interface for IAgileReference {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IAgileReference_Vtbl {
-    pub base__: IUnknownVtbl,
+    pub base__: IUnknown_Vtbl,
     pub Resolve: unsafe extern "system" fn(this: *mut c_void, riid: *const GUID, ppvobjectreference: *mut *mut c_void) -> HRESULT,
 }
 
@@ -375,7 +375,7 @@ unsafe impl Interface for ILanguageExceptionErrorInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct ILanguageExceptionErrorInfo_Vtbl {
-    pub base__: IUnknownVtbl,
+    pub base__: IUnknown_Vtbl,
     pub GetLanguageException: unsafe extern "system" fn(this: *mut c_void, languageexception: *mut *mut c_void) -> HRESULT,
 }
 
@@ -456,7 +456,7 @@ unsafe impl Interface for IRestrictedErrorInfo {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRestrictedErrorInfo_Vtbl {
-    pub base__: IUnknownVtbl,
+    pub base__: IUnknown_Vtbl,
     pub GetErrorDetails: unsafe extern "system" fn(this: *mut c_void, description: *mut BSTR, error: *mut HRESULT, restricteddescription: *mut BSTR, capabilitysid: *mut BSTR) -> HRESULT,
     pub GetReference: unsafe extern "system" fn(this: *mut c_void, reference: *mut BSTR) -> HRESULT,
 }
@@ -490,7 +490,7 @@ unsafe impl Interface for IWeakReference {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWeakReference_Vtbl {
-    pub base__: IUnknownVtbl,
+    pub base__: IUnknown_Vtbl,
     pub Resolve: unsafe extern "system" fn(this: *mut c_void, riid: *const GUID, objectreference: *mut *mut c_void) -> HRESULT,
 }
 
@@ -520,6 +520,6 @@ unsafe impl Interface for IWeakReferenceSource {
 #[repr(C)]
 #[doc(hidden)]
 pub struct IWeakReferenceSource_Vtbl {
-    pub base__: IUnknownVtbl,
+    pub base__: IUnknown_Vtbl,
     pub GetWeakReference: unsafe extern "system" fn(this: *mut c_void, weakreference: *mut *mut c_void) -> HRESULT,
 }

--- a/crates/libs/windows/src/core/inspectable.rs
+++ b/crates/libs/windows/src/core/inspectable.rs
@@ -23,7 +23,7 @@ impl IInspectable {
 #[doc(hidden)]
 #[repr(C)]
 pub struct IInspectableVtbl {
-    pub base: IUnknownVtbl,
+    pub base: IUnknown_Vtbl,
     pub GetIids: unsafe extern "system" fn(this: *mut core::ffi::c_void, count: *mut u32, values: *mut *mut GUID) -> HRESULT,
     pub GetRuntimeClassName: unsafe extern "system" fn(this: *mut core::ffi::c_void, value: *mut *mut core::ffi::c_void) -> HRESULT,
     pub GetTrustLevel: unsafe extern "system" fn(this: *mut core::ffi::c_void, value: *mut i32) -> HRESULT,
@@ -150,6 +150,6 @@ impl IInspectableVtbl {
             *value = 0;
             HRESULT(0)
         }
-        Self { base: IUnknownVtbl::new::<Identity, OFFSET>(), GetIids, GetRuntimeClassName: GetRuntimeClassName::<Name>, GetTrustLevel }
+        Self { base: IUnknown_Vtbl::new::<Identity, OFFSET>(), GetIids, GetRuntimeClassName: GetRuntimeClassName::<Name>, GetTrustLevel }
     }
 }

--- a/crates/libs/windows/src/core/unknown.rs
+++ b/crates/libs/windows/src/core/unknown.rs
@@ -9,14 +9,14 @@ pub struct IUnknown(core::ptr::NonNull<core::ffi::c_void>);
 
 #[doc(hidden)]
 #[repr(C)]
-pub struct IUnknownVtbl {
+pub struct IUnknown_Vtbl {
     pub QueryInterface: unsafe extern "system" fn(this: *mut core::ffi::c_void, iid: &GUID, interface: *mut *const core::ffi::c_void) -> HRESULT,
     pub AddRef: unsafe extern "system" fn(this: *mut core::ffi::c_void) -> u32,
     pub Release: unsafe extern "system" fn(this: *mut core::ffi::c_void) -> u32,
 }
 
 unsafe impl Interface for IUnknown {
-    type Vtable = IUnknownVtbl;
+    type Vtable = IUnknown_Vtbl;
 
     const IID: GUID = GUID::from_u128(0x00000000_0000_0000_c000_000000000046);
 }
@@ -82,7 +82,7 @@ pub trait IUnknownImpl {
 }
 
 #[cfg(any(feature = "interface", feature = "implement"))]
-impl IUnknownVtbl {
+impl IUnknown_Vtbl {
     pub const fn new<T: IUnknownImpl, const OFFSET: isize>() -> Self {
         unsafe extern "system" fn QueryInterface<T: IUnknownImpl, const OFFSET: isize>(this: *mut core::ffi::c_void, iid: &GUID, interface: *mut *const core::ffi::c_void) -> HRESULT {
             let this = (this as *mut *mut core::ffi::c_void).offset(OFFSET) as *mut T;

--- a/crates/libs/windows/src/core/weak_ref_count.rs
+++ b/crates/libs/windows/src/core/weak_ref_count.rs
@@ -98,12 +98,12 @@ impl TearOff {
     }
 
     const STRONG_VTABLE: IWeakReferenceSource_Vtbl = IWeakReferenceSource_Vtbl {
-        base__: IUnknownVtbl { QueryInterface: Self::StrongQueryInterface, AddRef: Self::StrongAddRef, Release: Self::StrongRelease },
+        base__: IUnknown_Vtbl { QueryInterface: Self::StrongQueryInterface, AddRef: Self::StrongAddRef, Release: Self::StrongRelease },
         GetWeakReference: Self::StrongDowngrade,
     };
 
     const WEAK_VTABLE: IWeakReference_Vtbl = IWeakReference_Vtbl {
-        base__: IUnknownVtbl { QueryInterface: Self::WeakQueryInterface, AddRef: Self::WeakAddRef, Release: Self::WeakRelease },
+        base__: IUnknown_Vtbl { QueryInterface: Self::WeakQueryInterface, AddRef: Self::WeakAddRef, Release: Self::WeakRelease },
         Resolve: Self::WeakUpgrade,
     };
 
@@ -120,7 +120,7 @@ impl TearOff {
     }
 
     unsafe fn query_interface(&self, iid: &GUID, interface: *mut *const core::ffi::c_void) -> HRESULT {
-        ((*(*(self.object as *mut *mut _) as *mut IUnknownVtbl)).QueryInterface)(self.object, iid, interface)
+        ((*(*(self.object as *mut *mut _) as *mut IUnknown_Vtbl)).QueryInterface)(self.object, iid, interface)
     }
 
     unsafe extern "system" fn StrongQueryInterface(ptr: *mut core::ffi::c_void, iid: &GUID, interface: *mut *const core::ffi::c_void) -> HRESULT {
@@ -177,7 +177,7 @@ impl TearOff {
 
         // Forward strong `Release` to the object so that it can destroy itself. It will then
         // decrement its weak reference and allow the tear-off to be released as needed.
-        ((*(*(this.object as *mut *mut _) as *mut IUnknownVtbl)).Release)((*this).object)
+        ((*(*(this.object as *mut *mut _) as *mut IUnknown_Vtbl)).Release)((*this).object)
     }
 
     unsafe extern "system" fn WeakRelease(ptr: *mut core::ffi::c_void) -> u32 {

--- a/crates/tests/interface/tests/com_from_existing.rs
+++ b/crates/tests/interface/tests/com_from_existing.rs
@@ -1,0 +1,38 @@
+#![allow(non_snake_case)]
+
+use windows::{core::*, Win32::Foundation::*, Win32::System::Com::*};
+
+// The `interface` macro defines a new local interface (based on IPersistMemory) that derives from an existing interface defined by the `windows` crate.
+#[interface("BD1AE5E0-A6AE-11CE-BD37-504200C10000")]
+unsafe trait ITestPersistMemory: IPersist {
+    unsafe fn IsDirty(&self) -> HRESULT;
+}
+
+// The `implement` macro can implement both kinds of interfaces as the necessary type information is the same either way.
+#[implement(ITestPersistMemory, IPersist)]
+struct Test;
+
+impl IPersist_Impl for Test {
+    fn GetClassID(&self) -> Result<GUID> {
+        Ok("CEE1D356-0860-4262-90D4-C77423F0E352".into())
+    }
+}
+
+impl ITestPersistMemory_Impl for Test {
+    unsafe fn IsDirty(&self) -> HRESULT {
+        S_FALSE
+    }
+}
+
+#[test]
+fn test() -> Result<()> {
+    unsafe {
+    let p: IPersist = Test.into();
+    assert_eq!(p.GetClassID()?, "CEE1D356-0860-4262-90D4-C77423F0E352".into());
+
+    let m: ITestPersistMemory = p.cast()?;
+    assert_eq!(m.IsDirty(), S_FALSE);
+
+    Ok(())
+    }
+}

--- a/crates/tests/interface/tests/com_from_existing.rs
+++ b/crates/tests/interface/tests/com_from_existing.rs
@@ -27,12 +27,12 @@ impl ITestPersistMemory_Impl for Test {
 #[test]
 fn test() -> Result<()> {
     unsafe {
-    let p: IPersist = Test.into();
-    assert_eq!(p.GetClassID()?, "CEE1D356-0860-4262-90D4-C77423F0E352".into());
+        let p: IPersist = Test.into();
+        assert_eq!(p.GetClassID()?, "CEE1D356-0860-4262-90D4-C77423F0E352".into());
 
-    let m: ITestPersistMemory = p.cast()?;
-    assert_eq!(m.IsDirty(), S_FALSE);
+        let m: ITestPersistMemory = p.cast()?;
+        assert_eq!(m.IsDirty(), S_FALSE);
 
-    Ok(())
+        Ok(())
     }
 }


### PR DESCRIPTION
The `interface` macro used a slightly different naming scheme for vtable types, preventing it from declaring interfaces derived from existing interfaces previously defined in the `windows` crate. This just aligns the naming of vtable types to allow this scenario, along with a test to validate this works. 
