### PR TITLE
Fix `HSTRING` to conform to Rust's aliasing rules

### DIFF
--- a/crates/libs/windows/src/core/strings/hstring.rs
+++ b/crates/libs/windows/src/core/strings/hstring.rs
@@ -408,11 +408,11 @@ impl Header {
         header
     }
 
-    fn duplicate(&mut self) -> *mut Header {
+    fn duplicate(&self) -> *mut Header {
         if self.flags & REFERENCE_FLAG == 0 {
             // If this is not a "fast pass" string then simply increment the reference count.
             self.count.add_ref();
-            self
+            self as *const Header as *mut Header
         } else {
             // Otherwise, allocate a new string and copy the value into the new string.
             let copy = Header::alloc(self.len);


### PR DESCRIPTION
Pointers derived from `&mut` references must still uphold the uniqueness guarantee. Fortunately the fix is simple here:  we just use a shared reference when duplicating `HSTRING`s. Casting between pointer types is fine, it's effectively just a lint.

Fixes: #2056
