### PR TITLE
Exclude default `winmd` files from `windows-metadata` crate

### DIFF
--- a/crates/libs/metadata/Cargo.toml
+++ b/crates/libs/metadata/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "Code gen support for the windows crate"
 repository = "https://github.com/microsoft/windows-rs"
+exclude = ["/default"]
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"


### PR DESCRIPTION
These winmd files no longer need to be packaged up with the crate. This reduces the overall size of the published crate from nearly 7MB to around 29KB. 😊 
