### PR TITLE
Add support for non-COM interfaces

### DIFF
--- a/crates/libs/bindgen/src/classes.rs
+++ b/crates/libs/bindgen/src/classes.rs
@@ -104,7 +104,7 @@ fn gen_class(gen: &Gen, def: TypeDef) -> TokenStream {
 
         tokens.combine(&gen.interface_core_traits(def, &[], &name, &TokenStream::new(), &TokenStream::new(), &features));
         tokens.combine(&gen.interface_winrt_trait(def, &[], &name, &TokenStream::new(), &TokenStream::new(), &features));
-        tokens.combine(&gen.interface_trait(def, &[], &name, &TokenStream::new(), &features));
+        tokens.combine(&gen.interface_trait(def, &[], &name, &TokenStream::new(), &features, true));
         tokens.combine(&gen.runtime_name_trait(def, &[], &name, &TokenStream::new(), &features));
         tokens.combine(&gen.async_get(def, &[], &name, &TokenStream::new(), &TokenStream::new(), &features));
         tokens.combine(&iterators::gen(gen, def, &[], &name, &TokenStream::new(), &TokenStream::new(), &cfg));

--- a/crates/libs/bindgen/src/delegates.rs
+++ b/crates/libs/bindgen/src/delegates.rs
@@ -142,7 +142,7 @@ fn gen_win_delegate(gen: &Gen, def: TypeDef) -> TokenStream {
     };
 
     tokens.combine(&gen.interface_core_traits(def, generics, &ident, &constraints, &phantoms, &features));
-    tokens.combine(&gen.interface_trait(def, generics, &ident, &constraints, &features));
+    tokens.combine(&gen.interface_trait(def, generics, &ident, &constraints, &features, true));
     tokens.combine(&gen.interface_winrt_trait(def, generics, &ident, &constraints, &phantoms, &features));
     tokens.combine(&gen.interface_vtbl(def, generics, &ident, &constraints, &features));
     tokens

--- a/crates/libs/interface/src/lib.rs
+++ b/crates/libs/interface/src/lib.rs
@@ -56,7 +56,7 @@ macro_rules! expected_token {
 struct Interface {
     visibility: syn::Visibility,
     name: syn::Ident,
-    parent: syn::Path,
+    parent: Option<syn::Path>,
     methods: Vec<InterfaceMethod>,
     docs: Vec<syn::Attribute>,
 }
@@ -67,7 +67,7 @@ impl Interface {
         let vis = &self.visibility;
         let name = &self.name;
         let docs = &self.docs;
-        let parent = self.parent();
+        let parent = self.parent_type();
         let vtable_name = quote::format_ident!("{}_Vtbl", name);
         let guid = guid.to_tokens()?;
         let implementation = self.gen_implementation();
@@ -80,7 +80,6 @@ impl Interface {
             #(#docs)*
             #vis struct #name(#parent);
             #implementation
-
             unsafe impl ::windows::core::Vtable for #name {
                 type Vtable = #vtable_name;
             }
@@ -150,7 +149,7 @@ impl Interface {
 
         quote! {
             #[allow(non_camel_case_types)]
-            #vis trait #name: #parent Sized {
+            #vis trait #name: Sized + #parent {
                 #(#methods)*
             }
         }
@@ -160,8 +159,9 @@ impl Interface {
     fn gen_vtable(&self, vtable_name: &syn::Ident) -> proc_macro2::TokenStream {
         let vis = &self.visibility;
         let name = &self.name;
-        let parent_vtable = self.parent_vtable();
-        let parent_vtable_generics = if self.parent_is_iunknown() { quote!(Identity, OFFSET) } else { quote!(Identity, Impl, OFFSET) };
+        let trait_name = quote::format_ident!("{}_Impl", name);
+        let implvtbl_name = quote::format_ident!("{}_ImplVtbl", name);
+
         let vtable_entries = self
             .methods
             .iter()
@@ -174,7 +174,10 @@ impl Interface {
                 }
             })
             .collect::<Vec<_>>();
-        let trait_name = quote::format_ident!("{}_Impl", name);
+
+        let parent_vtable_generics = if self.parent_is_iunknown() { quote!(Identity, OFFSET) } else { quote!(Identity, Impl, OFFSET) };
+        let parent_vtable = self.parent_vtable();
+
         let functions = self
             .methods
             .iter()
@@ -190,41 +193,85 @@ impl Interface {
                     })
                     .collect::<Vec<_>>();
                 let ret = &m.ret;
-                quote! {
-                    unsafe extern "system" fn #name<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: #trait_name, const OFFSET: isize>(this: *mut ::core::ffi::c_void, #(#args),*) #ret {
-                        let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-                        let this = (*this).get_impl();
-                        this.#name(#(#params),*).into()
+                if parent_vtable.is_some() {
+                    quote! {
+                        unsafe extern "system" fn #name<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: #trait_name, const OFFSET: isize>(this: *mut ::core::ffi::c_void, #(#args),*) #ret {
+                            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
+                            let this = (*this).get_impl();
+                            this.#name(#(#params),*).into()
+                        }
+                    }
+                } else {
+                    quote! {
+                        unsafe extern "system" fn #name<Impl: #trait_name>(this: *mut ::core::ffi::c_void, #(#args),*) #ret {
+                            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+                            let this = (*this).this as *const Impl;
+                            (*this).#name(#(#params),*).into()
+                        }
                     }
                 }
             })
             .collect::<Vec<_>>();
+
         let entries = self
             .methods
             .iter()
             .map(|m| {
                 let name = &m.name;
-                quote! {
-                        #name: #name::<Identity, Impl, OFFSET>
+                if parent_vtable.is_some() {
+                    quote! {
+                            #name: #name::<Identity, Impl, OFFSET>
+                    }
+                } else {
+                    quote! {
+                            #name: #name::<Impl>
+                    }
                 }
             })
             .collect::<Vec<_>>();
-        quote! {
-            #[repr(C)]
-            #[doc(hidden)]
-            #vis struct #vtable_name {
-                pub base__: #parent_vtable,
-                #(#vtable_entries)*
-            }
 
-            impl #vtable_name {
-                pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: #trait_name, const OFFSET: isize>() -> Self {
-                    #(#functions)*
-                    Self { base__: #parent_vtable::new::<#parent_vtable_generics>(), #(#entries),* }
+        if let Some(parent_vtable) = parent_vtable {
+            quote! {
+                #[repr(C)]
+                #[doc(hidden)]
+                #vis struct #vtable_name {
+                    pub base__: #parent_vtable,
+                    #(#vtable_entries)*
                 }
+                impl #vtable_name {
+                    pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: #trait_name, const OFFSET: isize>() -> Self {
+                        #(#functions)*
+                        Self { base__: #parent_vtable::new::<#parent_vtable_generics>(), #(#entries),* }
+                    }
 
-                pub fn matches(iid: &windows::core::GUID) -> bool {
-                    iid == &<#name as ::windows::core::Interface>::IID
+                    pub fn matches(iid: &windows::core::GUID) -> bool {
+                        iid == &<#name as ::windows::core::Interface>::IID
+                    }
+                }
+            }
+        } else {
+            quote! {
+                #[repr(C)]
+                #[doc(hidden)]
+                #vis struct #vtable_name {
+                    #(#vtable_entries)*
+                }
+                impl #vtable_name {
+                    pub const fn new<Impl: #trait_name>() -> Self {
+                        #(#functions)*
+                        Self { #(#entries),* }
+                    }
+                }
+                struct #implvtbl_name<T: #trait_name> (::std::marker::PhantomData<T>);
+                impl<T: #trait_name> #implvtbl_name<T> {
+                    const VTABLE: #vtable_name = #vtable_name::new::<T>();
+                }
+                impl #name {
+                    fn new<'a, T: #trait_name>(this: &'a T) -> ::windows::core::ScopedInterface<'a, #name> {
+                        let this = ::windows::core::ScopedHeap { vtable: &#implvtbl_name::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
+                        let this = ::std::mem::ManuallyDrop::new(::std::boxed::Box::new(this));
+                        unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
+                    }
                 }
             }
         }
@@ -264,33 +311,50 @@ impl Interface {
         }
     }
 
-    fn parent(&self) -> proc_macro2::TokenStream {
-        let p = &self.parent;
-        quote!(#p)
+    fn parent_type(&self) -> proc_macro2::TokenStream {
+        if let Some(parent) = &self.parent {
+            quote!(#parent)
+        } else {
+            quote!(::std::ptr::NonNull<::std::ffi::c_void>)
+        }
     }
 
-    fn parent_vtable(&self) -> proc_macro2::TokenStream {
-        let i = self.parent_ident();
-        let i = quote::format_ident!("{}_Vtbl", i);
-        quote!(#i)
+    fn parent_vtable(&self) -> Option<proc_macro2::TokenStream> {
+        if let Some(i) = self.parent_ident() {
+            let i = quote::format_ident!("{}_Vtbl", i);
+            Some(quote!(#i))
+        } else {
+            None
+        }
     }
 
     fn parent_is_iunknown(&self) -> bool {
-        self.parent_ident() == "IUnknown"
+        if let Some(ident) = self.parent_ident() {
+            ident == "IUnknown"
+        } else {
+            false
+        }
     }
 
-    fn parent_ident(&self) -> &syn::Ident {
-        &self.parent.segments.last().as_ref().expect("segements should never be empty").ident
+    fn parent_ident(&self) -> Option<&syn::Ident> {
+        if let Some(parent) = &self.parent {
+            Some(&parent.segments.last().as_ref().expect("segements should never be empty").ident)
+        } else {
+            None
+        }
     }
 
     /// Gets the parent trait constrait which is nothing if the parent is IUnknown
     fn parent_trait_constraint(&self) -> proc_macro2::TokenStream {
-        let i = self.parent_ident();
-        if i == "IUnknown" {
-            return quote!();
+        if let Some(i) = self.parent_ident() {
+            if i == "IUnknown" {
+                return quote!();
+            }
+            let i = quote::format_ident!("{}_Impl", i);
+            quote!(#i)
+        } else {
+            quote!()
         }
-        let i = quote::format_ident!("{}_Impl", i);
-        quote!(#i +)
     }
 }
 
@@ -311,8 +375,8 @@ impl Parse for Interface {
         let _ = input.parse::<syn::Token![unsafe]>()?;
         let _ = input.parse::<syn::Token![trait]>()?;
         let name = input.parse::<syn::Ident>()?;
-        let _ = input.parse::<syn::Token![:]>().map_err(|_| syn::Error::new(name.span(), format!("Interfaces must inherit from another interface like so: `interface {}: IParentInterface`", name)))?;
-        let parent = input.parse::<syn::Path>()?;
+        let _ = input.parse::<syn::Token![:]>();
+        let parent = input.parse::<syn::Path>().ok();
         let content;
         syn::braced!(content in input);
         let mut methods = Vec::new();
@@ -332,11 +396,14 @@ impl Parse for Interface {
 ///     fn GetValue(&self, value: *mut f64) -> HRESULT;
 /// }
 /// ```
-struct Guid(syn::LitStr);
+struct Guid(Option<syn::LitStr>);
 
 impl Guid {
-    /// The various chunks of a COM interface GUID separated by "-"
-    fn chunks(&self) -> syn::Result<[String; 5]> {
+    fn to_tokens(&self) -> syn::Result<proc_macro2::TokenStream> {
+        fn hex_lit(num: &str) -> syn::LitInt {
+            syn::LitInt::new(&format!("0x{}", num), proc_macro2::Span::call_site())
+        }
+
         fn ensure_length(part: Option<&str>, index: usize, length: usize, span: proc_macro2::Span) -> syn::Result<String> {
             let part = match part {
                 Some(p) => p,
@@ -350,54 +417,51 @@ impl Guid {
             Ok(part.to_owned())
         }
 
-        let guid_value = self.0.value();
-        let mut delimited = guid_value.split('-').fuse();
-        let chunks = [ensure_length(delimited.next(), 0, 8, self.0.span())?, ensure_length(delimited.next(), 1, 4, self.0.span())?, ensure_length(delimited.next(), 2, 4, self.0.span())?, ensure_length(delimited.next(), 3, 4, self.0.span())?, ensure_length(delimited.next(), 4, 12, self.0.span())?];
+        if let Some(value) = &self.0 {
+            let guid_value = value.value();
+            let mut delimited = guid_value.split('-').fuse();
+            let chunks = [ensure_length(delimited.next(), 0, 8, value.span())?, ensure_length(delimited.next(), 1, 4, value.span())?, ensure_length(delimited.next(), 2, 4, value.span())?, ensure_length(delimited.next(), 3, 4, value.span())?, ensure_length(delimited.next(), 4, 12, value.span())?];
 
-        Ok(chunks)
-    }
+            let data1 = hex_lit(&chunks[0]);
+            let data2 = hex_lit(&chunks[1]);
+            let data3 = hex_lit(&chunks[2]);
+            let (data4_1, data4_2) = chunks[3].split_at(2);
+            let data4_1 = hex_lit(data4_1);
+            let data4_2 = hex_lit(data4_2);
+            let (data4_3, rest) = chunks[4].split_at(2);
+            let data4_3 = hex_lit(data4_3);
 
-    fn to_tokens(&self) -> syn::Result<proc_macro2::TokenStream> {
-        fn hex_lit(num: &str) -> syn::LitInt {
-            syn::LitInt::new(&format!("0x{}", num), proc_macro2::Span::call_site())
+            let (data4_4, rest) = rest.split_at(2);
+            let data4_4 = hex_lit(data4_4);
+
+            let (data4_5, rest) = rest.split_at(2);
+            let data4_5 = hex_lit(data4_5);
+
+            let (data4_6, rest) = rest.split_at(2);
+            let data4_6 = hex_lit(data4_6);
+
+            let (data4_7, data4_8) = rest.split_at(2);
+            let data4_7 = hex_lit(data4_7);
+            let data4_8 = hex_lit(data4_8);
+            Ok(quote! {
+                ::windows::core::GUID {
+                    data1: #data1,
+                    data2: #data2,
+                    data3: #data3,
+                    data4: [#data4_1, #data4_2, #data4_3, #data4_4, #data4_5, #data4_6, #data4_7, #data4_8]
+                }
+            })
+        } else {
+            Ok(quote! {
+                ::windows::core::GUID::zeroed()
+            })
         }
-
-        let chunks = self.chunks()?;
-        let data1 = hex_lit(&chunks[0]);
-        let data2 = hex_lit(&chunks[1]);
-        let data3 = hex_lit(&chunks[2]);
-        let (data4_1, data4_2) = chunks[3].split_at(2);
-        let data4_1 = hex_lit(data4_1);
-        let data4_2 = hex_lit(data4_2);
-        let (data4_3, rest) = chunks[4].split_at(2);
-        let data4_3 = hex_lit(data4_3);
-
-        let (data4_4, rest) = rest.split_at(2);
-        let data4_4 = hex_lit(data4_4);
-
-        let (data4_5, rest) = rest.split_at(2);
-        let data4_5 = hex_lit(data4_5);
-
-        let (data4_6, rest) = rest.split_at(2);
-        let data4_6 = hex_lit(data4_6);
-
-        let (data4_7, data4_8) = rest.split_at(2);
-        let data4_7 = hex_lit(data4_7);
-        let data4_8 = hex_lit(data4_8);
-        Ok(quote! {
-            ::windows::core::GUID {
-                data1: #data1,
-                data2: #data2,
-                data3: #data3,
-                data4: [#data4_1, #data4_2, #data4_3, #data4_4, #data4_5, #data4_6, #data4_7, #data4_8]
-            }
-        })
     }
 }
 
 impl Parse for Guid {
     fn parse(cursor: ParseStream) -> syn::Result<Self> {
-        let string: syn::LitStr = cursor.parse()?;
+        let string: Option<syn::LitStr> = cursor.parse().ok();
 
         Ok(Self(string))
     }

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D/impl.rs
@@ -62,22 +62,30 @@ pub trait ID3DInclude_Impl: Sized {
     fn Open(&self, includetype: D3D_INCLUDE_TYPE, pfilename: &::windows::core::PCSTR, pparentdata: *const ::core::ffi::c_void, ppdata: *mut *mut ::core::ffi::c_void, pbytes: *mut u32) -> ::windows::core::Result<()>;
     fn Close(&self, pdata: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
-impl ::windows::core::RuntimeName for ID3DInclude {}
 impl ID3DInclude_Vtbl {
-    pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3DInclude_Impl, const OFFSET: isize>() -> ID3DInclude_Vtbl {
-        unsafe extern "system" fn Open<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3DInclude_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, includetype: D3D_INCLUDE_TYPE, pfilename: ::windows::core::PCSTR, pparentdata: *const ::core::ffi::c_void, ppdata: *mut *mut ::core::ffi::c_void, pbytes: *mut u32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+    pub const fn new<Impl: ID3DInclude_Impl>() -> ID3DInclude_Vtbl {
+        unsafe extern "system" fn Open<Impl: ID3DInclude_Impl>(this: *mut ::core::ffi::c_void, includetype: D3D_INCLUDE_TYPE, pfilename: ::windows::core::PCSTR, pparentdata: *const ::core::ffi::c_void, ppdata: *mut *mut ::core::ffi::c_void, pbytes: *mut u32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.Open(::core::mem::transmute_copy(&includetype), ::core::mem::transmute(&pfilename), ::core::mem::transmute_copy(&pparentdata), ::core::mem::transmute_copy(&ppdata), ::core::mem::transmute_copy(&pbytes)).into()
         }
-        unsafe extern "system" fn Close<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3DInclude_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdata: *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn Close<Impl: ID3DInclude_Impl>(this: *mut ::core::ffi::c_void, pdata: *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.Close(::core::mem::transmute_copy(&pdata)).into()
         }
-        Self { Open: Open::<Identity, Impl, OFFSET>, Close: Close::<Identity, Impl, OFFSET> }
+        Self { Open: Open::<Impl>, Close: Close::<Impl> }
     }
-    pub fn matches(iid: &windows::core::GUID) -> bool {
-        iid == &<ID3DInclude as ::windows::core::Interface>::IID
+}
+#[doc(hidden)]
+struct ID3DInclude_ImplVtbl<T: ID3DInclude_Impl>(::std::marker::PhantomData<T>);
+impl<T: ID3DInclude_Impl> ID3DInclude_ImplVtbl<T> {
+    const VTABLE: ID3DInclude_Vtbl = ID3DInclude_Vtbl::new::<T>();
+}
+impl ID3DInclude {
+    pub fn new<'a, T: ID3DInclude_Impl>(this: &'a T) -> ::windows::core::ScopedInterface<'a, Self> {
+        let this = ::windows::core::ScopedHeap { vtable: &ID3DInclude_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
+        let this = ::std::mem::ManuallyDrop::new(::std::boxed::Box::new(this));
+        unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D/mod.rs
@@ -119,7 +119,16 @@ pub struct ID3DDestructionNotifier_Vtbl {
 }
 #[doc = "*Required features: `\"Win32_Graphics_Direct3D\"`*"]
 #[repr(transparent)]
-pub struct ID3DInclude(::windows::core::IUnknown);
+pub struct ID3DInclude(::std::ptr::NonNull<::std::ffi::c_void>);
+unsafe impl ::windows::core::Abi for Option<ID3DInclude> {
+    type Abi = *mut ::std::ffi::c_void;
+}
+unsafe impl ::windows::core::Abi for ID3DInclude {
+    type Abi = *mut ::std::ffi::c_void;
+    fn abi_is_possibly_valid(abi: &Self::Abi) -> bool {
+        !abi.is_null()
+    }
+}
 impl ID3DInclude {
     pub unsafe fn Open<'a, P0>(&self, includetype: D3D_INCLUDE_TYPE, pfilename: P0, pparentdata: *const ::core::ffi::c_void, ppdata: *mut *mut ::core::ffi::c_void, pbytes: *mut u32) -> ::windows::core::Result<()>
     where
@@ -151,9 +160,6 @@ unsafe impl ::core::marker::Send for ID3DInclude {}
 unsafe impl ::core::marker::Sync for ID3DInclude {}
 unsafe impl ::windows::core::Vtable for ID3DInclude {
     type Vtable = ID3DInclude_Vtbl;
-}
-unsafe impl ::windows::core::Interface for ID3DInclude {
-    const IID: ::windows::core::GUID = ::windows::core::GUID::zeroed();
 }
 #[repr(C)]
 #[doc(hidden)]

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D10/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D10/impl.rs
@@ -1263,13 +1263,11 @@ pub trait ID3D10EffectBlendVariable_Impl: Sized + ID3D10EffectVariable_Impl {
     fn GetBackingStore(&self, index: u32, pblenddesc: *mut D3D10_BLEND_DESC) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::windows::core::RuntimeName for ID3D10EffectBlendVariable {}
-#[cfg(feature = "Win32_Foundation")]
 impl ID3D10EffectBlendVariable_Vtbl {
-    pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectBlendVariable_Impl, const OFFSET: isize>() -> ID3D10EffectBlendVariable_Vtbl {
-        unsafe extern "system" fn GetBlendState<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectBlendVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: u32, ppblendstate: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+    pub const fn new<Impl: ID3D10EffectBlendVariable_Impl>() -> ID3D10EffectBlendVariable_Vtbl {
+        unsafe extern "system" fn GetBlendState<Impl: ID3D10EffectBlendVariable_Impl>(this: *mut ::core::ffi::c_void, index: u32, ppblendstate: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             match this.GetBlendState(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(ppblendstate, ::core::mem::transmute(ok__));
@@ -1278,19 +1276,27 @@ impl ID3D10EffectBlendVariable_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        unsafe extern "system" fn GetBackingStore<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectBlendVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: u32, pblenddesc: *mut D3D10_BLEND_DESC) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetBackingStore<Impl: ID3D10EffectBlendVariable_Impl>(this: *mut ::core::ffi::c_void, index: u32, pblenddesc: *mut D3D10_BLEND_DESC) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetBackingStore(::core::mem::transmute_copy(&index), ::core::mem::transmute_copy(&pblenddesc)).into()
         }
-        Self {
-            base__: ID3D10EffectVariable_Vtbl::new::<Identity, Impl, OFFSET>(),
-            GetBlendState: GetBlendState::<Identity, Impl, OFFSET>,
-            GetBackingStore: GetBackingStore::<Identity, Impl, OFFSET>,
-        }
+        Self { base__: ID3D10EffectVariable_Vtbl::new::<Impl>(), GetBlendState: GetBlendState::<Impl>, GetBackingStore: GetBackingStore::<Impl> }
     }
-    pub fn matches(iid: &windows::core::GUID) -> bool {
-        iid == &<ID3D10EffectBlendVariable as ::windows::core::Interface>::IID || iid == &<ID3D10EffectVariable as ::windows::core::Interface>::IID
+}
+#[doc(hidden)]
+#[cfg(feature = "Win32_Foundation")]
+struct ID3D10EffectBlendVariable_ImplVtbl<T: ID3D10EffectBlendVariable_Impl>(::std::marker::PhantomData<T>);
+#[cfg(feature = "Win32_Foundation")]
+impl<T: ID3D10EffectBlendVariable_Impl> ID3D10EffectBlendVariable_ImplVtbl<T> {
+    const VTABLE: ID3D10EffectBlendVariable_Vtbl = ID3D10EffectBlendVariable_Vtbl::new::<T>();
+}
+#[cfg(feature = "Win32_Foundation")]
+impl ID3D10EffectBlendVariable {
+    pub fn new<'a, T: ID3D10EffectBlendVariable_Impl>(this: &'a T) -> ::windows::core::ScopedInterface<'a, Self> {
+        let this = ::windows::core::ScopedHeap { vtable: &ID3D10EffectBlendVariable_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
+        let this = ::std::mem::ManuallyDrop::new(::std::boxed::Box::new(this));
+        unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1301,18 +1307,16 @@ pub trait ID3D10EffectConstantBuffer_Impl: Sized + ID3D10EffectVariable_Impl {
     fn GetTextureBuffer(&self) -> ::windows::core::Result<ID3D10ShaderResourceView>;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::windows::core::RuntimeName for ID3D10EffectConstantBuffer {}
-#[cfg(feature = "Win32_Foundation")]
 impl ID3D10EffectConstantBuffer_Vtbl {
-    pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectConstantBuffer_Impl, const OFFSET: isize>() -> ID3D10EffectConstantBuffer_Vtbl {
-        unsafe extern "system" fn SetConstantBuffer<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectConstantBuffer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pconstantbuffer: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+    pub const fn new<Impl: ID3D10EffectConstantBuffer_Impl>() -> ID3D10EffectConstantBuffer_Vtbl {
+        unsafe extern "system" fn SetConstantBuffer<Impl: ID3D10EffectConstantBuffer_Impl>(this: *mut ::core::ffi::c_void, pconstantbuffer: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.SetConstantBuffer(::core::mem::transmute(&pconstantbuffer)).into()
         }
-        unsafe extern "system" fn GetConstantBuffer<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectConstantBuffer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppconstantbuffer: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetConstantBuffer<Impl: ID3D10EffectConstantBuffer_Impl>(this: *mut ::core::ffi::c_void, ppconstantbuffer: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             match this.GetConstantBuffer() {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(ppconstantbuffer, ::core::mem::transmute(ok__));
@@ -1321,14 +1325,14 @@ impl ID3D10EffectConstantBuffer_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        unsafe extern "system" fn SetTextureBuffer<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectConstantBuffer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ptexturebuffer: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn SetTextureBuffer<Impl: ID3D10EffectConstantBuffer_Impl>(this: *mut ::core::ffi::c_void, ptexturebuffer: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.SetTextureBuffer(::core::mem::transmute(&ptexturebuffer)).into()
         }
-        unsafe extern "system" fn GetTextureBuffer<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectConstantBuffer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pptexturebuffer: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetTextureBuffer<Impl: ID3D10EffectConstantBuffer_Impl>(this: *mut ::core::ffi::c_void, pptexturebuffer: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             match this.GetTextureBuffer() {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(pptexturebuffer, ::core::mem::transmute(ok__));
@@ -1338,15 +1342,27 @@ impl ID3D10EffectConstantBuffer_Vtbl {
             }
         }
         Self {
-            base__: ID3D10EffectVariable_Vtbl::new::<Identity, Impl, OFFSET>(),
-            SetConstantBuffer: SetConstantBuffer::<Identity, Impl, OFFSET>,
-            GetConstantBuffer: GetConstantBuffer::<Identity, Impl, OFFSET>,
-            SetTextureBuffer: SetTextureBuffer::<Identity, Impl, OFFSET>,
-            GetTextureBuffer: GetTextureBuffer::<Identity, Impl, OFFSET>,
+            base__: ID3D10EffectVariable_Vtbl::new::<Impl>(),
+            SetConstantBuffer: SetConstantBuffer::<Impl>,
+            GetConstantBuffer: GetConstantBuffer::<Impl>,
+            SetTextureBuffer: SetTextureBuffer::<Impl>,
+            GetTextureBuffer: GetTextureBuffer::<Impl>,
         }
     }
-    pub fn matches(iid: &windows::core::GUID) -> bool {
-        iid == &<ID3D10EffectConstantBuffer as ::windows::core::Interface>::IID || iid == &<ID3D10EffectVariable as ::windows::core::Interface>::IID
+}
+#[doc(hidden)]
+#[cfg(feature = "Win32_Foundation")]
+struct ID3D10EffectConstantBuffer_ImplVtbl<T: ID3D10EffectConstantBuffer_Impl>(::std::marker::PhantomData<T>);
+#[cfg(feature = "Win32_Foundation")]
+impl<T: ID3D10EffectConstantBuffer_Impl> ID3D10EffectConstantBuffer_ImplVtbl<T> {
+    const VTABLE: ID3D10EffectConstantBuffer_Vtbl = ID3D10EffectConstantBuffer_Vtbl::new::<T>();
+}
+#[cfg(feature = "Win32_Foundation")]
+impl ID3D10EffectConstantBuffer {
+    pub fn new<'a, T: ID3D10EffectConstantBuffer_Impl>(this: &'a T) -> ::windows::core::ScopedInterface<'a, Self> {
+        let this = ::windows::core::ScopedHeap { vtable: &ID3D10EffectConstantBuffer_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
+        let this = ::std::mem::ManuallyDrop::new(::std::boxed::Box::new(this));
+        unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1355,13 +1371,11 @@ pub trait ID3D10EffectDepthStencilVariable_Impl: Sized + ID3D10EffectVariable_Im
     fn GetBackingStore(&self, index: u32) -> ::windows::core::Result<D3D10_DEPTH_STENCIL_DESC>;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::windows::core::RuntimeName for ID3D10EffectDepthStencilVariable {}
-#[cfg(feature = "Win32_Foundation")]
 impl ID3D10EffectDepthStencilVariable_Vtbl {
-    pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectDepthStencilVariable_Impl, const OFFSET: isize>() -> ID3D10EffectDepthStencilVariable_Vtbl {
-        unsafe extern "system" fn GetDepthStencilState<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectDepthStencilVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: u32, ppdepthstencilstate: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+    pub const fn new<Impl: ID3D10EffectDepthStencilVariable_Impl>() -> ID3D10EffectDepthStencilVariable_Vtbl {
+        unsafe extern "system" fn GetDepthStencilState<Impl: ID3D10EffectDepthStencilVariable_Impl>(this: *mut ::core::ffi::c_void, index: u32, ppdepthstencilstate: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             match this.GetDepthStencilState(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(ppdepthstencilstate, ::core::mem::transmute(ok__));
@@ -1370,9 +1384,9 @@ impl ID3D10EffectDepthStencilVariable_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        unsafe extern "system" fn GetBackingStore<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectDepthStencilVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: u32, pdepthstencildesc: *mut D3D10_DEPTH_STENCIL_DESC) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetBackingStore<Impl: ID3D10EffectDepthStencilVariable_Impl>(this: *mut ::core::ffi::c_void, index: u32, pdepthstencildesc: *mut D3D10_DEPTH_STENCIL_DESC) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             match this.GetBackingStore(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(pdepthstencildesc, ::core::mem::transmute(ok__));
@@ -1381,14 +1395,22 @@ impl ID3D10EffectDepthStencilVariable_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self {
-            base__: ID3D10EffectVariable_Vtbl::new::<Identity, Impl, OFFSET>(),
-            GetDepthStencilState: GetDepthStencilState::<Identity, Impl, OFFSET>,
-            GetBackingStore: GetBackingStore::<Identity, Impl, OFFSET>,
-        }
+        Self { base__: ID3D10EffectVariable_Vtbl::new::<Impl>(), GetDepthStencilState: GetDepthStencilState::<Impl>, GetBackingStore: GetBackingStore::<Impl> }
     }
-    pub fn matches(iid: &windows::core::GUID) -> bool {
-        iid == &<ID3D10EffectDepthStencilVariable as ::windows::core::Interface>::IID || iid == &<ID3D10EffectVariable as ::windows::core::Interface>::IID
+}
+#[doc(hidden)]
+#[cfg(feature = "Win32_Foundation")]
+struct ID3D10EffectDepthStencilVariable_ImplVtbl<T: ID3D10EffectDepthStencilVariable_Impl>(::std::marker::PhantomData<T>);
+#[cfg(feature = "Win32_Foundation")]
+impl<T: ID3D10EffectDepthStencilVariable_Impl> ID3D10EffectDepthStencilVariable_ImplVtbl<T> {
+    const VTABLE: ID3D10EffectDepthStencilVariable_Vtbl = ID3D10EffectDepthStencilVariable_Vtbl::new::<T>();
+}
+#[cfg(feature = "Win32_Foundation")]
+impl ID3D10EffectDepthStencilVariable {
+    pub fn new<'a, T: ID3D10EffectDepthStencilVariable_Impl>(this: &'a T) -> ::windows::core::ScopedInterface<'a, Self> {
+        let this = ::windows::core::ScopedHeap { vtable: &ID3D10EffectDepthStencilVariable_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
+        let this = ::std::mem::ManuallyDrop::new(::std::boxed::Box::new(this));
+        unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1399,18 +1421,16 @@ pub trait ID3D10EffectDepthStencilViewVariable_Impl: Sized + ID3D10EffectVariabl
     fn GetDepthStencilArray(&self, ppresources: *mut ::core::option::Option<ID3D10DepthStencilView>, offset: u32, count: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::windows::core::RuntimeName for ID3D10EffectDepthStencilViewVariable {}
-#[cfg(feature = "Win32_Foundation")]
 impl ID3D10EffectDepthStencilViewVariable_Vtbl {
-    pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectDepthStencilViewVariable_Impl, const OFFSET: isize>() -> ID3D10EffectDepthStencilViewVariable_Vtbl {
-        unsafe extern "system" fn SetDepthStencil<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectDepthStencilViewVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, presource: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+    pub const fn new<Impl: ID3D10EffectDepthStencilViewVariable_Impl>() -> ID3D10EffectDepthStencilViewVariable_Vtbl {
+        unsafe extern "system" fn SetDepthStencil<Impl: ID3D10EffectDepthStencilViewVariable_Impl>(this: *mut ::core::ffi::c_void, presource: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.SetDepthStencil(::core::mem::transmute(&presource)).into()
         }
-        unsafe extern "system" fn GetDepthStencil<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectDepthStencilViewVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppresource: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetDepthStencil<Impl: ID3D10EffectDepthStencilViewVariable_Impl>(this: *mut ::core::ffi::c_void, ppresource: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             match this.GetDepthStencil() {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(ppresource, ::core::mem::transmute(ok__));
@@ -1419,26 +1439,38 @@ impl ID3D10EffectDepthStencilViewVariable_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        unsafe extern "system" fn SetDepthStencilArray<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectDepthStencilViewVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppresources: *const *mut ::core::ffi::c_void, offset: u32, count: u32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn SetDepthStencilArray<Impl: ID3D10EffectDepthStencilViewVariable_Impl>(this: *mut ::core::ffi::c_void, ppresources: *const *mut ::core::ffi::c_void, offset: u32, count: u32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.SetDepthStencilArray(::core::mem::transmute_copy(&ppresources), ::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&count)).into()
         }
-        unsafe extern "system" fn GetDepthStencilArray<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectDepthStencilViewVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppresources: *mut *mut ::core::ffi::c_void, offset: u32, count: u32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetDepthStencilArray<Impl: ID3D10EffectDepthStencilViewVariable_Impl>(this: *mut ::core::ffi::c_void, ppresources: *mut *mut ::core::ffi::c_void, offset: u32, count: u32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetDepthStencilArray(::core::mem::transmute_copy(&ppresources), ::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&count)).into()
         }
         Self {
-            base__: ID3D10EffectVariable_Vtbl::new::<Identity, Impl, OFFSET>(),
-            SetDepthStencil: SetDepthStencil::<Identity, Impl, OFFSET>,
-            GetDepthStencil: GetDepthStencil::<Identity, Impl, OFFSET>,
-            SetDepthStencilArray: SetDepthStencilArray::<Identity, Impl, OFFSET>,
-            GetDepthStencilArray: GetDepthStencilArray::<Identity, Impl, OFFSET>,
+            base__: ID3D10EffectVariable_Vtbl::new::<Impl>(),
+            SetDepthStencil: SetDepthStencil::<Impl>,
+            GetDepthStencil: GetDepthStencil::<Impl>,
+            SetDepthStencilArray: SetDepthStencilArray::<Impl>,
+            GetDepthStencilArray: GetDepthStencilArray::<Impl>,
         }
     }
-    pub fn matches(iid: &windows::core::GUID) -> bool {
-        iid == &<ID3D10EffectDepthStencilViewVariable as ::windows::core::Interface>::IID || iid == &<ID3D10EffectVariable as ::windows::core::Interface>::IID
+}
+#[doc(hidden)]
+#[cfg(feature = "Win32_Foundation")]
+struct ID3D10EffectDepthStencilViewVariable_ImplVtbl<T: ID3D10EffectDepthStencilViewVariable_Impl>(::std::marker::PhantomData<T>);
+#[cfg(feature = "Win32_Foundation")]
+impl<T: ID3D10EffectDepthStencilViewVariable_Impl> ID3D10EffectDepthStencilViewVariable_ImplVtbl<T> {
+    const VTABLE: ID3D10EffectDepthStencilViewVariable_Vtbl = ID3D10EffectDepthStencilViewVariable_Vtbl::new::<T>();
+}
+#[cfg(feature = "Win32_Foundation")]
+impl ID3D10EffectDepthStencilViewVariable {
+    pub fn new<'a, T: ID3D10EffectDepthStencilViewVariable_Impl>(this: &'a T) -> ::windows::core::ScopedInterface<'a, Self> {
+        let this = ::windows::core::ScopedHeap { vtable: &ID3D10EffectDepthStencilViewVariable_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
+        let this = ::std::mem::ManuallyDrop::new(::std::boxed::Box::new(this));
+        unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1453,64 +1485,74 @@ pub trait ID3D10EffectMatrixVariable_Impl: Sized + ID3D10EffectVariable_Impl {
     fn GetMatrixTransposeArray(&self, pdata: *mut f32, offset: u32, count: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::windows::core::RuntimeName for ID3D10EffectMatrixVariable {}
-#[cfg(feature = "Win32_Foundation")]
 impl ID3D10EffectMatrixVariable_Vtbl {
-    pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectMatrixVariable_Impl, const OFFSET: isize>() -> ID3D10EffectMatrixVariable_Vtbl {
-        unsafe extern "system" fn SetMatrix<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectMatrixVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdata: *mut f32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+    pub const fn new<Impl: ID3D10EffectMatrixVariable_Impl>() -> ID3D10EffectMatrixVariable_Vtbl {
+        unsafe extern "system" fn SetMatrix<Impl: ID3D10EffectMatrixVariable_Impl>(this: *mut ::core::ffi::c_void, pdata: *mut f32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.SetMatrix(::core::mem::transmute_copy(&pdata)).into()
         }
-        unsafe extern "system" fn GetMatrix<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectMatrixVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdata: *mut f32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetMatrix<Impl: ID3D10EffectMatrixVariable_Impl>(this: *mut ::core::ffi::c_void, pdata: *mut f32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetMatrix(::core::mem::transmute_copy(&pdata)).into()
         }
-        unsafe extern "system" fn SetMatrixArray<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectMatrixVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdata: *mut f32, offset: u32, count: u32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn SetMatrixArray<Impl: ID3D10EffectMatrixVariable_Impl>(this: *mut ::core::ffi::c_void, pdata: *mut f32, offset: u32, count: u32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.SetMatrixArray(::core::mem::transmute_copy(&pdata), ::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&count)).into()
         }
-        unsafe extern "system" fn GetMatrixArray<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectMatrixVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdata: *mut f32, offset: u32, count: u32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetMatrixArray<Impl: ID3D10EffectMatrixVariable_Impl>(this: *mut ::core::ffi::c_void, pdata: *mut f32, offset: u32, count: u32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetMatrixArray(::core::mem::transmute_copy(&pdata), ::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&count)).into()
         }
-        unsafe extern "system" fn SetMatrixTranspose<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectMatrixVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdata: *mut f32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn SetMatrixTranspose<Impl: ID3D10EffectMatrixVariable_Impl>(this: *mut ::core::ffi::c_void, pdata: *mut f32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.SetMatrixTranspose(::core::mem::transmute_copy(&pdata)).into()
         }
-        unsafe extern "system" fn GetMatrixTranspose<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectMatrixVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdata: *mut f32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetMatrixTranspose<Impl: ID3D10EffectMatrixVariable_Impl>(this: *mut ::core::ffi::c_void, pdata: *mut f32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetMatrixTranspose(::core::mem::transmute_copy(&pdata)).into()
         }
-        unsafe extern "system" fn SetMatrixTransposeArray<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectMatrixVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdata: *mut f32, offset: u32, count: u32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn SetMatrixTransposeArray<Impl: ID3D10EffectMatrixVariable_Impl>(this: *mut ::core::ffi::c_void, pdata: *mut f32, offset: u32, count: u32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.SetMatrixTransposeArray(::core::mem::transmute_copy(&pdata), ::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&count)).into()
         }
-        unsafe extern "system" fn GetMatrixTransposeArray<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectMatrixVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdata: *mut f32, offset: u32, count: u32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetMatrixTransposeArray<Impl: ID3D10EffectMatrixVariable_Impl>(this: *mut ::core::ffi::c_void, pdata: *mut f32, offset: u32, count: u32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetMatrixTransposeArray(::core::mem::transmute_copy(&pdata), ::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&count)).into()
         }
         Self {
-            base__: ID3D10EffectVariable_Vtbl::new::<Identity, Impl, OFFSET>(),
-            SetMatrix: SetMatrix::<Identity, Impl, OFFSET>,
-            GetMatrix: GetMatrix::<Identity, Impl, OFFSET>,
-            SetMatrixArray: SetMatrixArray::<Identity, Impl, OFFSET>,
-            GetMatrixArray: GetMatrixArray::<Identity, Impl, OFFSET>,
-            SetMatrixTranspose: SetMatrixTranspose::<Identity, Impl, OFFSET>,
-            GetMatrixTranspose: GetMatrixTranspose::<Identity, Impl, OFFSET>,
-            SetMatrixTransposeArray: SetMatrixTransposeArray::<Identity, Impl, OFFSET>,
-            GetMatrixTransposeArray: GetMatrixTransposeArray::<Identity, Impl, OFFSET>,
+            base__: ID3D10EffectVariable_Vtbl::new::<Impl>(),
+            SetMatrix: SetMatrix::<Impl>,
+            GetMatrix: GetMatrix::<Impl>,
+            SetMatrixArray: SetMatrixArray::<Impl>,
+            GetMatrixArray: GetMatrixArray::<Impl>,
+            SetMatrixTranspose: SetMatrixTranspose::<Impl>,
+            GetMatrixTranspose: GetMatrixTranspose::<Impl>,
+            SetMatrixTransposeArray: SetMatrixTransposeArray::<Impl>,
+            GetMatrixTransposeArray: GetMatrixTransposeArray::<Impl>,
         }
     }
-    pub fn matches(iid: &windows::core::GUID) -> bool {
-        iid == &<ID3D10EffectMatrixVariable as ::windows::core::Interface>::IID || iid == &<ID3D10EffectVariable as ::windows::core::Interface>::IID
+}
+#[doc(hidden)]
+#[cfg(feature = "Win32_Foundation")]
+struct ID3D10EffectMatrixVariable_ImplVtbl<T: ID3D10EffectMatrixVariable_Impl>(::std::marker::PhantomData<T>);
+#[cfg(feature = "Win32_Foundation")]
+impl<T: ID3D10EffectMatrixVariable_Impl> ID3D10EffectMatrixVariable_ImplVtbl<T> {
+    const VTABLE: ID3D10EffectMatrixVariable_Vtbl = ID3D10EffectMatrixVariable_Vtbl::new::<T>();
+}
+#[cfg(feature = "Win32_Foundation")]
+impl ID3D10EffectMatrixVariable {
+    pub fn new<'a, T: ID3D10EffectMatrixVariable_Impl>(this: &'a T) -> ::windows::core::ScopedInterface<'a, Self> {
+        let this = ::windows::core::ScopedHeap { vtable: &ID3D10EffectMatrixVariable_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
+        let this = ::std::mem::ManuallyDrop::new(::std::boxed::Box::new(this));
+        unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1526,53 +1568,51 @@ pub trait ID3D10EffectPass_Impl: Sized {
     fn ComputeStateBlockMask(&self) -> ::windows::core::Result<D3D10_STATE_BLOCK_MASK>;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::windows::core::RuntimeName for ID3D10EffectPass {}
-#[cfg(feature = "Win32_Foundation")]
 impl ID3D10EffectPass_Vtbl {
-    pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectPass_Impl, const OFFSET: isize>() -> ID3D10EffectPass_Vtbl {
-        unsafe extern "system" fn IsValid<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectPass_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> super::super::Foundation::BOOL {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+    pub const fn new<Impl: ID3D10EffectPass_Impl>() -> ID3D10EffectPass_Vtbl {
+        unsafe extern "system" fn IsValid<Impl: ID3D10EffectPass_Impl>(this: *mut ::core::ffi::c_void) -> super::super::Foundation::BOOL {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.IsValid()
         }
-        unsafe extern "system" fn GetDesc<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectPass_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D10_PASS_DESC) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetDesc<Impl: ID3D10EffectPass_Impl>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D10_PASS_DESC) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetDesc(::core::mem::transmute_copy(&pdesc)).into()
         }
-        unsafe extern "system" fn GetVertexShaderDesc<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectPass_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D10_PASS_SHADER_DESC) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetVertexShaderDesc<Impl: ID3D10EffectPass_Impl>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D10_PASS_SHADER_DESC) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetVertexShaderDesc(::core::mem::transmute_copy(&pdesc)).into()
         }
-        unsafe extern "system" fn GetGeometryShaderDesc<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectPass_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D10_PASS_SHADER_DESC) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetGeometryShaderDesc<Impl: ID3D10EffectPass_Impl>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D10_PASS_SHADER_DESC) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetGeometryShaderDesc(::core::mem::transmute_copy(&pdesc)).into()
         }
-        unsafe extern "system" fn GetPixelShaderDesc<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectPass_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D10_PASS_SHADER_DESC) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetPixelShaderDesc<Impl: ID3D10EffectPass_Impl>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D10_PASS_SHADER_DESC) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetPixelShaderDesc(::core::mem::transmute_copy(&pdesc)).into()
         }
-        unsafe extern "system" fn GetAnnotationByIndex<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectPass_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: u32) -> ::core::option::Option<ID3D10EffectVariable> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetAnnotationByIndex<Impl: ID3D10EffectPass_Impl>(this: *mut ::core::ffi::c_void, index: u32) -> ::core::option::Option<ID3D10EffectVariable> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetAnnotationByIndex(::core::mem::transmute_copy(&index))
         }
-        unsafe extern "system" fn GetAnnotationByName<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectPass_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, name: ::windows::core::PCSTR) -> ::core::option::Option<ID3D10EffectVariable> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetAnnotationByName<Impl: ID3D10EffectPass_Impl>(this: *mut ::core::ffi::c_void, name: ::windows::core::PCSTR) -> ::core::option::Option<ID3D10EffectVariable> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetAnnotationByName(::core::mem::transmute(&name))
         }
-        unsafe extern "system" fn Apply<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectPass_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, flags: u32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn Apply<Impl: ID3D10EffectPass_Impl>(this: *mut ::core::ffi::c_void, flags: u32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.Apply(::core::mem::transmute_copy(&flags)).into()
         }
-        unsafe extern "system" fn ComputeStateBlockMask<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectPass_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pstateblockmask: *mut D3D10_STATE_BLOCK_MASK) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn ComputeStateBlockMask<Impl: ID3D10EffectPass_Impl>(this: *mut ::core::ffi::c_void, pstateblockmask: *mut D3D10_STATE_BLOCK_MASK) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             match this.ComputeStateBlockMask() {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(pstateblockmask, ::core::mem::transmute(ok__));
@@ -1582,19 +1622,31 @@ impl ID3D10EffectPass_Vtbl {
             }
         }
         Self {
-            IsValid: IsValid::<Identity, Impl, OFFSET>,
-            GetDesc: GetDesc::<Identity, Impl, OFFSET>,
-            GetVertexShaderDesc: GetVertexShaderDesc::<Identity, Impl, OFFSET>,
-            GetGeometryShaderDesc: GetGeometryShaderDesc::<Identity, Impl, OFFSET>,
-            GetPixelShaderDesc: GetPixelShaderDesc::<Identity, Impl, OFFSET>,
-            GetAnnotationByIndex: GetAnnotationByIndex::<Identity, Impl, OFFSET>,
-            GetAnnotationByName: GetAnnotationByName::<Identity, Impl, OFFSET>,
-            Apply: Apply::<Identity, Impl, OFFSET>,
-            ComputeStateBlockMask: ComputeStateBlockMask::<Identity, Impl, OFFSET>,
+            IsValid: IsValid::<Impl>,
+            GetDesc: GetDesc::<Impl>,
+            GetVertexShaderDesc: GetVertexShaderDesc::<Impl>,
+            GetGeometryShaderDesc: GetGeometryShaderDesc::<Impl>,
+            GetPixelShaderDesc: GetPixelShaderDesc::<Impl>,
+            GetAnnotationByIndex: GetAnnotationByIndex::<Impl>,
+            GetAnnotationByName: GetAnnotationByName::<Impl>,
+            Apply: Apply::<Impl>,
+            ComputeStateBlockMask: ComputeStateBlockMask::<Impl>,
         }
     }
-    pub fn matches(iid: &windows::core::GUID) -> bool {
-        iid == &<ID3D10EffectPass as ::windows::core::Interface>::IID
+}
+#[doc(hidden)]
+#[cfg(feature = "Win32_Foundation")]
+struct ID3D10EffectPass_ImplVtbl<T: ID3D10EffectPass_Impl>(::std::marker::PhantomData<T>);
+#[cfg(feature = "Win32_Foundation")]
+impl<T: ID3D10EffectPass_Impl> ID3D10EffectPass_ImplVtbl<T> {
+    const VTABLE: ID3D10EffectPass_Vtbl = ID3D10EffectPass_Vtbl::new::<T>();
+}
+#[cfg(feature = "Win32_Foundation")]
+impl ID3D10EffectPass {
+    pub fn new<'a, T: ID3D10EffectPass_Impl>(this: &'a T) -> ::windows::core::ScopedInterface<'a, Self> {
+        let this = ::windows::core::ScopedHeap { vtable: &ID3D10EffectPass_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
+        let this = ::std::mem::ManuallyDrop::new(::std::boxed::Box::new(this));
+        unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
 pub trait ID3D10EffectPool_Impl: Sized {
@@ -1620,13 +1672,11 @@ pub trait ID3D10EffectRasterizerVariable_Impl: Sized + ID3D10EffectVariable_Impl
     fn GetBackingStore(&self, index: u32) -> ::windows::core::Result<D3D10_RASTERIZER_DESC>;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::windows::core::RuntimeName for ID3D10EffectRasterizerVariable {}
-#[cfg(feature = "Win32_Foundation")]
 impl ID3D10EffectRasterizerVariable_Vtbl {
-    pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectRasterizerVariable_Impl, const OFFSET: isize>() -> ID3D10EffectRasterizerVariable_Vtbl {
-        unsafe extern "system" fn GetRasterizerState<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectRasterizerVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: u32, pprasterizerstate: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+    pub const fn new<Impl: ID3D10EffectRasterizerVariable_Impl>() -> ID3D10EffectRasterizerVariable_Vtbl {
+        unsafe extern "system" fn GetRasterizerState<Impl: ID3D10EffectRasterizerVariable_Impl>(this: *mut ::core::ffi::c_void, index: u32, pprasterizerstate: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             match this.GetRasterizerState(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(pprasterizerstate, ::core::mem::transmute(ok__));
@@ -1635,9 +1685,9 @@ impl ID3D10EffectRasterizerVariable_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        unsafe extern "system" fn GetBackingStore<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectRasterizerVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: u32, prasterizerdesc: *mut D3D10_RASTERIZER_DESC) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetBackingStore<Impl: ID3D10EffectRasterizerVariable_Impl>(this: *mut ::core::ffi::c_void, index: u32, prasterizerdesc: *mut D3D10_RASTERIZER_DESC) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             match this.GetBackingStore(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(prasterizerdesc, ::core::mem::transmute(ok__));
@@ -1646,14 +1696,22 @@ impl ID3D10EffectRasterizerVariable_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self {
-            base__: ID3D10EffectVariable_Vtbl::new::<Identity, Impl, OFFSET>(),
-            GetRasterizerState: GetRasterizerState::<Identity, Impl, OFFSET>,
-            GetBackingStore: GetBackingStore::<Identity, Impl, OFFSET>,
-        }
+        Self { base__: ID3D10EffectVariable_Vtbl::new::<Impl>(), GetRasterizerState: GetRasterizerState::<Impl>, GetBackingStore: GetBackingStore::<Impl> }
     }
-    pub fn matches(iid: &windows::core::GUID) -> bool {
-        iid == &<ID3D10EffectRasterizerVariable as ::windows::core::Interface>::IID || iid == &<ID3D10EffectVariable as ::windows::core::Interface>::IID
+}
+#[doc(hidden)]
+#[cfg(feature = "Win32_Foundation")]
+struct ID3D10EffectRasterizerVariable_ImplVtbl<T: ID3D10EffectRasterizerVariable_Impl>(::std::marker::PhantomData<T>);
+#[cfg(feature = "Win32_Foundation")]
+impl<T: ID3D10EffectRasterizerVariable_Impl> ID3D10EffectRasterizerVariable_ImplVtbl<T> {
+    const VTABLE: ID3D10EffectRasterizerVariable_Vtbl = ID3D10EffectRasterizerVariable_Vtbl::new::<T>();
+}
+#[cfg(feature = "Win32_Foundation")]
+impl ID3D10EffectRasterizerVariable {
+    pub fn new<'a, T: ID3D10EffectRasterizerVariable_Impl>(this: &'a T) -> ::windows::core::ScopedInterface<'a, Self> {
+        let this = ::windows::core::ScopedHeap { vtable: &ID3D10EffectRasterizerVariable_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
+        let this = ::std::mem::ManuallyDrop::new(::std::boxed::Box::new(this));
+        unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1664,18 +1722,16 @@ pub trait ID3D10EffectRenderTargetViewVariable_Impl: Sized + ID3D10EffectVariabl
     fn GetRenderTargetArray(&self, ppresources: *mut ::core::option::Option<ID3D10RenderTargetView>, offset: u32, count: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::windows::core::RuntimeName for ID3D10EffectRenderTargetViewVariable {}
-#[cfg(feature = "Win32_Foundation")]
 impl ID3D10EffectRenderTargetViewVariable_Vtbl {
-    pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectRenderTargetViewVariable_Impl, const OFFSET: isize>() -> ID3D10EffectRenderTargetViewVariable_Vtbl {
-        unsafe extern "system" fn SetRenderTarget<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectRenderTargetViewVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, presource: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+    pub const fn new<Impl: ID3D10EffectRenderTargetViewVariable_Impl>() -> ID3D10EffectRenderTargetViewVariable_Vtbl {
+        unsafe extern "system" fn SetRenderTarget<Impl: ID3D10EffectRenderTargetViewVariable_Impl>(this: *mut ::core::ffi::c_void, presource: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.SetRenderTarget(::core::mem::transmute(&presource)).into()
         }
-        unsafe extern "system" fn GetRenderTarget<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectRenderTargetViewVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppresource: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetRenderTarget<Impl: ID3D10EffectRenderTargetViewVariable_Impl>(this: *mut ::core::ffi::c_void, ppresource: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             match this.GetRenderTarget() {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(ppresource, ::core::mem::transmute(ok__));
@@ -1684,26 +1740,38 @@ impl ID3D10EffectRenderTargetViewVariable_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        unsafe extern "system" fn SetRenderTargetArray<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectRenderTargetViewVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppresources: *const *mut ::core::ffi::c_void, offset: u32, count: u32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn SetRenderTargetArray<Impl: ID3D10EffectRenderTargetViewVariable_Impl>(this: *mut ::core::ffi::c_void, ppresources: *const *mut ::core::ffi::c_void, offset: u32, count: u32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.SetRenderTargetArray(::core::mem::transmute_copy(&ppresources), ::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&count)).into()
         }
-        unsafe extern "system" fn GetRenderTargetArray<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectRenderTargetViewVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppresources: *mut *mut ::core::ffi::c_void, offset: u32, count: u32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetRenderTargetArray<Impl: ID3D10EffectRenderTargetViewVariable_Impl>(this: *mut ::core::ffi::c_void, ppresources: *mut *mut ::core::ffi::c_void, offset: u32, count: u32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetRenderTargetArray(::core::mem::transmute_copy(&ppresources), ::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&count)).into()
         }
         Self {
-            base__: ID3D10EffectVariable_Vtbl::new::<Identity, Impl, OFFSET>(),
-            SetRenderTarget: SetRenderTarget::<Identity, Impl, OFFSET>,
-            GetRenderTarget: GetRenderTarget::<Identity, Impl, OFFSET>,
-            SetRenderTargetArray: SetRenderTargetArray::<Identity, Impl, OFFSET>,
-            GetRenderTargetArray: GetRenderTargetArray::<Identity, Impl, OFFSET>,
+            base__: ID3D10EffectVariable_Vtbl::new::<Impl>(),
+            SetRenderTarget: SetRenderTarget::<Impl>,
+            GetRenderTarget: GetRenderTarget::<Impl>,
+            SetRenderTargetArray: SetRenderTargetArray::<Impl>,
+            GetRenderTargetArray: GetRenderTargetArray::<Impl>,
         }
     }
-    pub fn matches(iid: &windows::core::GUID) -> bool {
-        iid == &<ID3D10EffectRenderTargetViewVariable as ::windows::core::Interface>::IID || iid == &<ID3D10EffectVariable as ::windows::core::Interface>::IID
+}
+#[doc(hidden)]
+#[cfg(feature = "Win32_Foundation")]
+struct ID3D10EffectRenderTargetViewVariable_ImplVtbl<T: ID3D10EffectRenderTargetViewVariable_Impl>(::std::marker::PhantomData<T>);
+#[cfg(feature = "Win32_Foundation")]
+impl<T: ID3D10EffectRenderTargetViewVariable_Impl> ID3D10EffectRenderTargetViewVariable_ImplVtbl<T> {
+    const VTABLE: ID3D10EffectRenderTargetViewVariable_Vtbl = ID3D10EffectRenderTargetViewVariable_Vtbl::new::<T>();
+}
+#[cfg(feature = "Win32_Foundation")]
+impl ID3D10EffectRenderTargetViewVariable {
+    pub fn new<'a, T: ID3D10EffectRenderTargetViewVariable_Impl>(this: &'a T) -> ::windows::core::ScopedInterface<'a, Self> {
+        let this = ::windows::core::ScopedHeap { vtable: &ID3D10EffectRenderTargetViewVariable_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
+        let this = ::std::mem::ManuallyDrop::new(::std::boxed::Box::new(this));
+        unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1712,13 +1780,11 @@ pub trait ID3D10EffectSamplerVariable_Impl: Sized + ID3D10EffectVariable_Impl {
     fn GetBackingStore(&self, index: u32) -> ::windows::core::Result<D3D10_SAMPLER_DESC>;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::windows::core::RuntimeName for ID3D10EffectSamplerVariable {}
-#[cfg(feature = "Win32_Foundation")]
 impl ID3D10EffectSamplerVariable_Vtbl {
-    pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectSamplerVariable_Impl, const OFFSET: isize>() -> ID3D10EffectSamplerVariable_Vtbl {
-        unsafe extern "system" fn GetSampler<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectSamplerVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: u32, ppsampler: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+    pub const fn new<Impl: ID3D10EffectSamplerVariable_Impl>() -> ID3D10EffectSamplerVariable_Vtbl {
+        unsafe extern "system" fn GetSampler<Impl: ID3D10EffectSamplerVariable_Impl>(this: *mut ::core::ffi::c_void, index: u32, ppsampler: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             match this.GetSampler(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(ppsampler, ::core::mem::transmute(ok__));
@@ -1727,9 +1793,9 @@ impl ID3D10EffectSamplerVariable_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        unsafe extern "system" fn GetBackingStore<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectSamplerVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: u32, psamplerdesc: *mut D3D10_SAMPLER_DESC) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetBackingStore<Impl: ID3D10EffectSamplerVariable_Impl>(this: *mut ::core::ffi::c_void, index: u32, psamplerdesc: *mut D3D10_SAMPLER_DESC) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             match this.GetBackingStore(::core::mem::transmute_copy(&index)) {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(psamplerdesc, ::core::mem::transmute(ok__));
@@ -1738,14 +1804,22 @@ impl ID3D10EffectSamplerVariable_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self {
-            base__: ID3D10EffectVariable_Vtbl::new::<Identity, Impl, OFFSET>(),
-            GetSampler: GetSampler::<Identity, Impl, OFFSET>,
-            GetBackingStore: GetBackingStore::<Identity, Impl, OFFSET>,
-        }
+        Self { base__: ID3D10EffectVariable_Vtbl::new::<Impl>(), GetSampler: GetSampler::<Impl>, GetBackingStore: GetBackingStore::<Impl> }
     }
-    pub fn matches(iid: &windows::core::GUID) -> bool {
-        iid == &<ID3D10EffectSamplerVariable as ::windows::core::Interface>::IID || iid == &<ID3D10EffectVariable as ::windows::core::Interface>::IID
+}
+#[doc(hidden)]
+#[cfg(feature = "Win32_Foundation")]
+struct ID3D10EffectSamplerVariable_ImplVtbl<T: ID3D10EffectSamplerVariable_Impl>(::std::marker::PhantomData<T>);
+#[cfg(feature = "Win32_Foundation")]
+impl<T: ID3D10EffectSamplerVariable_Impl> ID3D10EffectSamplerVariable_ImplVtbl<T> {
+    const VTABLE: ID3D10EffectSamplerVariable_Vtbl = ID3D10EffectSamplerVariable_Vtbl::new::<T>();
+}
+#[cfg(feature = "Win32_Foundation")]
+impl ID3D10EffectSamplerVariable {
+    pub fn new<'a, T: ID3D10EffectSamplerVariable_Impl>(this: &'a T) -> ::windows::core::ScopedInterface<'a, Self> {
+        let this = ::windows::core::ScopedHeap { vtable: &ID3D10EffectSamplerVariable_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
+        let this = ::std::mem::ManuallyDrop::new(::std::boxed::Box::new(this));
+        unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1764,18 +1838,16 @@ pub trait ID3D10EffectScalarVariable_Impl: Sized + ID3D10EffectVariable_Impl {
     fn GetBoolArray(&self, pdata: *mut super::super::Foundation::BOOL, offset: u32, count: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::windows::core::RuntimeName for ID3D10EffectScalarVariable {}
-#[cfg(feature = "Win32_Foundation")]
 impl ID3D10EffectScalarVariable_Vtbl {
-    pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectScalarVariable_Impl, const OFFSET: isize>() -> ID3D10EffectScalarVariable_Vtbl {
-        unsafe extern "system" fn SetFloat<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectScalarVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, value: f32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+    pub const fn new<Impl: ID3D10EffectScalarVariable_Impl>() -> ID3D10EffectScalarVariable_Vtbl {
+        unsafe extern "system" fn SetFloat<Impl: ID3D10EffectScalarVariable_Impl>(this: *mut ::core::ffi::c_void, value: f32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.SetFloat(::core::mem::transmute_copy(&value)).into()
         }
-        unsafe extern "system" fn GetFloat<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectScalarVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pvalue: *mut f32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetFloat<Impl: ID3D10EffectScalarVariable_Impl>(this: *mut ::core::ffi::c_void, pvalue: *mut f32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             match this.GetFloat() {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
@@ -1784,24 +1856,24 @@ impl ID3D10EffectScalarVariable_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        unsafe extern "system" fn SetFloatArray<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectScalarVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdata: *const f32, offset: u32, count: u32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn SetFloatArray<Impl: ID3D10EffectScalarVariable_Impl>(this: *mut ::core::ffi::c_void, pdata: *const f32, offset: u32, count: u32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.SetFloatArray(::core::mem::transmute_copy(&pdata), ::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&count)).into()
         }
-        unsafe extern "system" fn GetFloatArray<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectScalarVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdata: *mut f32, offset: u32, count: u32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetFloatArray<Impl: ID3D10EffectScalarVariable_Impl>(this: *mut ::core::ffi::c_void, pdata: *mut f32, offset: u32, count: u32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetFloatArray(::core::mem::transmute_copy(&pdata), ::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&count)).into()
         }
-        unsafe extern "system" fn SetInt<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectScalarVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, value: i32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn SetInt<Impl: ID3D10EffectScalarVariable_Impl>(this: *mut ::core::ffi::c_void, value: i32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.SetInt(::core::mem::transmute_copy(&value)).into()
         }
-        unsafe extern "system" fn GetInt<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectScalarVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pvalue: *mut i32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetInt<Impl: ID3D10EffectScalarVariable_Impl>(this: *mut ::core::ffi::c_void, pvalue: *mut i32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             match this.GetInt() {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
@@ -1810,24 +1882,24 @@ impl ID3D10EffectScalarVariable_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        unsafe extern "system" fn SetIntArray<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectScalarVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdata: *const i32, offset: u32, count: u32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn SetIntArray<Impl: ID3D10EffectScalarVariable_Impl>(this: *mut ::core::ffi::c_void, pdata: *const i32, offset: u32, count: u32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.SetIntArray(::core::mem::transmute_copy(&pdata), ::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&count)).into()
         }
-        unsafe extern "system" fn GetIntArray<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectScalarVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdata: *mut i32, offset: u32, count: u32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetIntArray<Impl: ID3D10EffectScalarVariable_Impl>(this: *mut ::core::ffi::c_void, pdata: *mut i32, offset: u32, count: u32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetIntArray(::core::mem::transmute_copy(&pdata), ::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&count)).into()
         }
-        unsafe extern "system" fn SetBool<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectScalarVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, value: super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn SetBool<Impl: ID3D10EffectScalarVariable_Impl>(this: *mut ::core::ffi::c_void, value: super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.SetBool(::core::mem::transmute_copy(&value)).into()
         }
-        unsafe extern "system" fn GetBool<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectScalarVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pvalue: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetBool<Impl: ID3D10EffectScalarVariable_Impl>(this: *mut ::core::ffi::c_void, pvalue: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             match this.GetBool() {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(pvalue, ::core::mem::transmute(ok__));
@@ -1836,34 +1908,46 @@ impl ID3D10EffectScalarVariable_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        unsafe extern "system" fn SetBoolArray<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectScalarVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdata: *const super::super::Foundation::BOOL, offset: u32, count: u32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn SetBoolArray<Impl: ID3D10EffectScalarVariable_Impl>(this: *mut ::core::ffi::c_void, pdata: *const super::super::Foundation::BOOL, offset: u32, count: u32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.SetBoolArray(::core::mem::transmute_copy(&pdata), ::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&count)).into()
         }
-        unsafe extern "system" fn GetBoolArray<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectScalarVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdata: *mut super::super::Foundation::BOOL, offset: u32, count: u32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetBoolArray<Impl: ID3D10EffectScalarVariable_Impl>(this: *mut ::core::ffi::c_void, pdata: *mut super::super::Foundation::BOOL, offset: u32, count: u32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetBoolArray(::core::mem::transmute_copy(&pdata), ::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&count)).into()
         }
         Self {
-            base__: ID3D10EffectVariable_Vtbl::new::<Identity, Impl, OFFSET>(),
-            SetFloat: SetFloat::<Identity, Impl, OFFSET>,
-            GetFloat: GetFloat::<Identity, Impl, OFFSET>,
-            SetFloatArray: SetFloatArray::<Identity, Impl, OFFSET>,
-            GetFloatArray: GetFloatArray::<Identity, Impl, OFFSET>,
-            SetInt: SetInt::<Identity, Impl, OFFSET>,
-            GetInt: GetInt::<Identity, Impl, OFFSET>,
-            SetIntArray: SetIntArray::<Identity, Impl, OFFSET>,
-            GetIntArray: GetIntArray::<Identity, Impl, OFFSET>,
-            SetBool: SetBool::<Identity, Impl, OFFSET>,
-            GetBool: GetBool::<Identity, Impl, OFFSET>,
-            SetBoolArray: SetBoolArray::<Identity, Impl, OFFSET>,
-            GetBoolArray: GetBoolArray::<Identity, Impl, OFFSET>,
+            base__: ID3D10EffectVariable_Vtbl::new::<Impl>(),
+            SetFloat: SetFloat::<Impl>,
+            GetFloat: GetFloat::<Impl>,
+            SetFloatArray: SetFloatArray::<Impl>,
+            GetFloatArray: GetFloatArray::<Impl>,
+            SetInt: SetInt::<Impl>,
+            GetInt: GetInt::<Impl>,
+            SetIntArray: SetIntArray::<Impl>,
+            GetIntArray: GetIntArray::<Impl>,
+            SetBool: SetBool::<Impl>,
+            GetBool: GetBool::<Impl>,
+            SetBoolArray: SetBoolArray::<Impl>,
+            GetBoolArray: GetBoolArray::<Impl>,
         }
     }
-    pub fn matches(iid: &windows::core::GUID) -> bool {
-        iid == &<ID3D10EffectScalarVariable as ::windows::core::Interface>::IID || iid == &<ID3D10EffectVariable as ::windows::core::Interface>::IID
+}
+#[doc(hidden)]
+#[cfg(feature = "Win32_Foundation")]
+struct ID3D10EffectScalarVariable_ImplVtbl<T: ID3D10EffectScalarVariable_Impl>(::std::marker::PhantomData<T>);
+#[cfg(feature = "Win32_Foundation")]
+impl<T: ID3D10EffectScalarVariable_Impl> ID3D10EffectScalarVariable_ImplVtbl<T> {
+    const VTABLE: ID3D10EffectScalarVariable_Vtbl = ID3D10EffectScalarVariable_Vtbl::new::<T>();
+}
+#[cfg(feature = "Win32_Foundation")]
+impl ID3D10EffectScalarVariable {
+    pub fn new<'a, T: ID3D10EffectScalarVariable_Impl>(this: &'a T) -> ::windows::core::ScopedInterface<'a, Self> {
+        let this = ::windows::core::ScopedHeap { vtable: &ID3D10EffectScalarVariable_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
+        let this = ::std::mem::ManuallyDrop::new(::std::boxed::Box::new(this));
+        unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -1874,18 +1958,16 @@ pub trait ID3D10EffectShaderResourceVariable_Impl: Sized + ID3D10EffectVariable_
     fn GetResourceArray(&self, ppresources: *mut ::core::option::Option<ID3D10ShaderResourceView>, offset: u32, count: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::windows::core::RuntimeName for ID3D10EffectShaderResourceVariable {}
-#[cfg(feature = "Win32_Foundation")]
 impl ID3D10EffectShaderResourceVariable_Vtbl {
-    pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectShaderResourceVariable_Impl, const OFFSET: isize>() -> ID3D10EffectShaderResourceVariable_Vtbl {
-        unsafe extern "system" fn SetResource<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectShaderResourceVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, presource: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+    pub const fn new<Impl: ID3D10EffectShaderResourceVariable_Impl>() -> ID3D10EffectShaderResourceVariable_Vtbl {
+        unsafe extern "system" fn SetResource<Impl: ID3D10EffectShaderResourceVariable_Impl>(this: *mut ::core::ffi::c_void, presource: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.SetResource(::core::mem::transmute(&presource)).into()
         }
-        unsafe extern "system" fn GetResource<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectShaderResourceVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppresource: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetResource<Impl: ID3D10EffectShaderResourceVariable_Impl>(this: *mut ::core::ffi::c_void, ppresource: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             match this.GetResource() {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(ppresource, ::core::mem::transmute(ok__));
@@ -1894,26 +1976,38 @@ impl ID3D10EffectShaderResourceVariable_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        unsafe extern "system" fn SetResourceArray<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectShaderResourceVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppresources: *const *mut ::core::ffi::c_void, offset: u32, count: u32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn SetResourceArray<Impl: ID3D10EffectShaderResourceVariable_Impl>(this: *mut ::core::ffi::c_void, ppresources: *const *mut ::core::ffi::c_void, offset: u32, count: u32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.SetResourceArray(::core::mem::transmute_copy(&ppresources), ::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&count)).into()
         }
-        unsafe extern "system" fn GetResourceArray<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectShaderResourceVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppresources: *mut *mut ::core::ffi::c_void, offset: u32, count: u32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetResourceArray<Impl: ID3D10EffectShaderResourceVariable_Impl>(this: *mut ::core::ffi::c_void, ppresources: *mut *mut ::core::ffi::c_void, offset: u32, count: u32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetResourceArray(::core::mem::transmute_copy(&ppresources), ::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&count)).into()
         }
         Self {
-            base__: ID3D10EffectVariable_Vtbl::new::<Identity, Impl, OFFSET>(),
-            SetResource: SetResource::<Identity, Impl, OFFSET>,
-            GetResource: GetResource::<Identity, Impl, OFFSET>,
-            SetResourceArray: SetResourceArray::<Identity, Impl, OFFSET>,
-            GetResourceArray: GetResourceArray::<Identity, Impl, OFFSET>,
+            base__: ID3D10EffectVariable_Vtbl::new::<Impl>(),
+            SetResource: SetResource::<Impl>,
+            GetResource: GetResource::<Impl>,
+            SetResourceArray: SetResourceArray::<Impl>,
+            GetResourceArray: GetResourceArray::<Impl>,
         }
     }
-    pub fn matches(iid: &windows::core::GUID) -> bool {
-        iid == &<ID3D10EffectShaderResourceVariable as ::windows::core::Interface>::IID || iid == &<ID3D10EffectVariable as ::windows::core::Interface>::IID
+}
+#[doc(hidden)]
+#[cfg(feature = "Win32_Foundation")]
+struct ID3D10EffectShaderResourceVariable_ImplVtbl<T: ID3D10EffectShaderResourceVariable_Impl>(::std::marker::PhantomData<T>);
+#[cfg(feature = "Win32_Foundation")]
+impl<T: ID3D10EffectShaderResourceVariable_Impl> ID3D10EffectShaderResourceVariable_ImplVtbl<T> {
+    const VTABLE: ID3D10EffectShaderResourceVariable_Vtbl = ID3D10EffectShaderResourceVariable_Vtbl::new::<T>();
+}
+#[cfg(feature = "Win32_Foundation")]
+impl ID3D10EffectShaderResourceVariable {
+    pub fn new<'a, T: ID3D10EffectShaderResourceVariable_Impl>(this: &'a T) -> ::windows::core::ScopedInterface<'a, Self> {
+        let this = ::windows::core::ScopedHeap { vtable: &ID3D10EffectShaderResourceVariable_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
+        let this = ::std::mem::ManuallyDrop::new(::std::boxed::Box::new(this));
+        unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D"))]
@@ -1926,13 +2020,11 @@ pub trait ID3D10EffectShaderVariable_Impl: Sized + ID3D10EffectVariable_Impl {
     fn GetOutputSignatureElementDesc(&self, shaderindex: u32, element: u32) -> ::windows::core::Result<D3D10_SIGNATURE_PARAMETER_DESC>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D"))]
-impl ::windows::core::RuntimeName for ID3D10EffectShaderVariable {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D"))]
 impl ID3D10EffectShaderVariable_Vtbl {
-    pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectShaderVariable_Impl, const OFFSET: isize>() -> ID3D10EffectShaderVariable_Vtbl {
-        unsafe extern "system" fn GetShaderDesc<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectShaderVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, shaderindex: u32, pdesc: *mut D3D10_EFFECT_SHADER_DESC) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+    pub const fn new<Impl: ID3D10EffectShaderVariable_Impl>() -> ID3D10EffectShaderVariable_Vtbl {
+        unsafe extern "system" fn GetShaderDesc<Impl: ID3D10EffectShaderVariable_Impl>(this: *mut ::core::ffi::c_void, shaderindex: u32, pdesc: *mut D3D10_EFFECT_SHADER_DESC) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             match this.GetShaderDesc(::core::mem::transmute_copy(&shaderindex)) {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
@@ -1941,9 +2033,9 @@ impl ID3D10EffectShaderVariable_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        unsafe extern "system" fn GetVertexShader<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectShaderVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, shaderindex: u32, ppvs: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetVertexShader<Impl: ID3D10EffectShaderVariable_Impl>(this: *mut ::core::ffi::c_void, shaderindex: u32, ppvs: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             match this.GetVertexShader(::core::mem::transmute_copy(&shaderindex)) {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(ppvs, ::core::mem::transmute(ok__));
@@ -1952,9 +2044,9 @@ impl ID3D10EffectShaderVariable_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        unsafe extern "system" fn GetGeometryShader<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectShaderVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, shaderindex: u32, ppgs: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetGeometryShader<Impl: ID3D10EffectShaderVariable_Impl>(this: *mut ::core::ffi::c_void, shaderindex: u32, ppgs: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             match this.GetGeometryShader(::core::mem::transmute_copy(&shaderindex)) {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(ppgs, ::core::mem::transmute(ok__));
@@ -1963,9 +2055,9 @@ impl ID3D10EffectShaderVariable_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        unsafe extern "system" fn GetPixelShader<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectShaderVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, shaderindex: u32, ppps: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetPixelShader<Impl: ID3D10EffectShaderVariable_Impl>(this: *mut ::core::ffi::c_void, shaderindex: u32, ppps: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             match this.GetPixelShader(::core::mem::transmute_copy(&shaderindex)) {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(ppps, ::core::mem::transmute(ok__));
@@ -1974,9 +2066,9 @@ impl ID3D10EffectShaderVariable_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        unsafe extern "system" fn GetInputSignatureElementDesc<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectShaderVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, shaderindex: u32, element: u32, pdesc: *mut D3D10_SIGNATURE_PARAMETER_DESC) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetInputSignatureElementDesc<Impl: ID3D10EffectShaderVariable_Impl>(this: *mut ::core::ffi::c_void, shaderindex: u32, element: u32, pdesc: *mut D3D10_SIGNATURE_PARAMETER_DESC) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             match this.GetInputSignatureElementDesc(::core::mem::transmute_copy(&shaderindex), ::core::mem::transmute_copy(&element)) {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
@@ -1985,9 +2077,9 @@ impl ID3D10EffectShaderVariable_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        unsafe extern "system" fn GetOutputSignatureElementDesc<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectShaderVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, shaderindex: u32, element: u32, pdesc: *mut D3D10_SIGNATURE_PARAMETER_DESC) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetOutputSignatureElementDesc<Impl: ID3D10EffectShaderVariable_Impl>(this: *mut ::core::ffi::c_void, shaderindex: u32, element: u32, pdesc: *mut D3D10_SIGNATURE_PARAMETER_DESC) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             match this.GetOutputSignatureElementDesc(::core::mem::transmute_copy(&shaderindex), ::core::mem::transmute_copy(&element)) {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
@@ -1997,17 +2089,29 @@ impl ID3D10EffectShaderVariable_Vtbl {
             }
         }
         Self {
-            base__: ID3D10EffectVariable_Vtbl::new::<Identity, Impl, OFFSET>(),
-            GetShaderDesc: GetShaderDesc::<Identity, Impl, OFFSET>,
-            GetVertexShader: GetVertexShader::<Identity, Impl, OFFSET>,
-            GetGeometryShader: GetGeometryShader::<Identity, Impl, OFFSET>,
-            GetPixelShader: GetPixelShader::<Identity, Impl, OFFSET>,
-            GetInputSignatureElementDesc: GetInputSignatureElementDesc::<Identity, Impl, OFFSET>,
-            GetOutputSignatureElementDesc: GetOutputSignatureElementDesc::<Identity, Impl, OFFSET>,
+            base__: ID3D10EffectVariable_Vtbl::new::<Impl>(),
+            GetShaderDesc: GetShaderDesc::<Impl>,
+            GetVertexShader: GetVertexShader::<Impl>,
+            GetGeometryShader: GetGeometryShader::<Impl>,
+            GetPixelShader: GetPixelShader::<Impl>,
+            GetInputSignatureElementDesc: GetInputSignatureElementDesc::<Impl>,
+            GetOutputSignatureElementDesc: GetOutputSignatureElementDesc::<Impl>,
         }
     }
-    pub fn matches(iid: &windows::core::GUID) -> bool {
-        iid == &<ID3D10EffectShaderVariable as ::windows::core::Interface>::IID || iid == &<ID3D10EffectVariable as ::windows::core::Interface>::IID
+}
+#[doc(hidden)]
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D"))]
+struct ID3D10EffectShaderVariable_ImplVtbl<T: ID3D10EffectShaderVariable_Impl>(::std::marker::PhantomData<T>);
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D"))]
+impl<T: ID3D10EffectShaderVariable_Impl> ID3D10EffectShaderVariable_ImplVtbl<T> {
+    const VTABLE: ID3D10EffectShaderVariable_Vtbl = ID3D10EffectShaderVariable_Vtbl::new::<T>();
+}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D"))]
+impl ID3D10EffectShaderVariable {
+    pub fn new<'a, T: ID3D10EffectShaderVariable_Impl>(this: &'a T) -> ::windows::core::ScopedInterface<'a, Self> {
+        let this = ::windows::core::ScopedHeap { vtable: &ID3D10EffectShaderVariable_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
+        let this = ::std::mem::ManuallyDrop::new(::std::boxed::Box::new(this));
+        unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2016,13 +2120,11 @@ pub trait ID3D10EffectStringVariable_Impl: Sized + ID3D10EffectVariable_Impl {
     fn GetStringArray(&self, ppstrings: *mut ::windows::core::PSTR, offset: u32, count: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::windows::core::RuntimeName for ID3D10EffectStringVariable {}
-#[cfg(feature = "Win32_Foundation")]
 impl ID3D10EffectStringVariable_Vtbl {
-    pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectStringVariable_Impl, const OFFSET: isize>() -> ID3D10EffectStringVariable_Vtbl {
-        unsafe extern "system" fn GetString<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectStringVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppstring: *mut ::windows::core::PSTR) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+    pub const fn new<Impl: ID3D10EffectStringVariable_Impl>() -> ID3D10EffectStringVariable_Vtbl {
+        unsafe extern "system" fn GetString<Impl: ID3D10EffectStringVariable_Impl>(this: *mut ::core::ffi::c_void, ppstring: *mut ::windows::core::PSTR) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             match this.GetString() {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(ppstring, ::core::mem::transmute(ok__));
@@ -2031,19 +2133,27 @@ impl ID3D10EffectStringVariable_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        unsafe extern "system" fn GetStringArray<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectStringVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppstrings: *mut ::windows::core::PSTR, offset: u32, count: u32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetStringArray<Impl: ID3D10EffectStringVariable_Impl>(this: *mut ::core::ffi::c_void, ppstrings: *mut ::windows::core::PSTR, offset: u32, count: u32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetStringArray(::core::mem::transmute_copy(&ppstrings), ::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&count)).into()
         }
-        Self {
-            base__: ID3D10EffectVariable_Vtbl::new::<Identity, Impl, OFFSET>(),
-            GetString: GetString::<Identity, Impl, OFFSET>,
-            GetStringArray: GetStringArray::<Identity, Impl, OFFSET>,
-        }
+        Self { base__: ID3D10EffectVariable_Vtbl::new::<Impl>(), GetString: GetString::<Impl>, GetStringArray: GetStringArray::<Impl> }
     }
-    pub fn matches(iid: &windows::core::GUID) -> bool {
-        iid == &<ID3D10EffectStringVariable as ::windows::core::Interface>::IID || iid == &<ID3D10EffectVariable as ::windows::core::Interface>::IID
+}
+#[doc(hidden)]
+#[cfg(feature = "Win32_Foundation")]
+struct ID3D10EffectStringVariable_ImplVtbl<T: ID3D10EffectStringVariable_Impl>(::std::marker::PhantomData<T>);
+#[cfg(feature = "Win32_Foundation")]
+impl<T: ID3D10EffectStringVariable_Impl> ID3D10EffectStringVariable_ImplVtbl<T> {
+    const VTABLE: ID3D10EffectStringVariable_Vtbl = ID3D10EffectStringVariable_Vtbl::new::<T>();
+}
+#[cfg(feature = "Win32_Foundation")]
+impl ID3D10EffectStringVariable {
+    pub fn new<'a, T: ID3D10EffectStringVariable_Impl>(this: &'a T) -> ::windows::core::ScopedInterface<'a, Self> {
+        let this = ::windows::core::ScopedHeap { vtable: &ID3D10EffectStringVariable_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
+        let this = ::std::mem::ManuallyDrop::new(::std::boxed::Box::new(this));
+        unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2057,43 +2167,41 @@ pub trait ID3D10EffectTechnique_Impl: Sized {
     fn ComputeStateBlockMask(&self) -> ::windows::core::Result<D3D10_STATE_BLOCK_MASK>;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::windows::core::RuntimeName for ID3D10EffectTechnique {}
-#[cfg(feature = "Win32_Foundation")]
 impl ID3D10EffectTechnique_Vtbl {
-    pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectTechnique_Impl, const OFFSET: isize>() -> ID3D10EffectTechnique_Vtbl {
-        unsafe extern "system" fn IsValid<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectTechnique_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> super::super::Foundation::BOOL {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+    pub const fn new<Impl: ID3D10EffectTechnique_Impl>() -> ID3D10EffectTechnique_Vtbl {
+        unsafe extern "system" fn IsValid<Impl: ID3D10EffectTechnique_Impl>(this: *mut ::core::ffi::c_void) -> super::super::Foundation::BOOL {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.IsValid()
         }
-        unsafe extern "system" fn GetDesc<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectTechnique_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D10_TECHNIQUE_DESC) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetDesc<Impl: ID3D10EffectTechnique_Impl>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D10_TECHNIQUE_DESC) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetDesc(::core::mem::transmute_copy(&pdesc)).into()
         }
-        unsafe extern "system" fn GetAnnotationByIndex<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectTechnique_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: u32) -> ::core::option::Option<ID3D10EffectVariable> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetAnnotationByIndex<Impl: ID3D10EffectTechnique_Impl>(this: *mut ::core::ffi::c_void, index: u32) -> ::core::option::Option<ID3D10EffectVariable> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetAnnotationByIndex(::core::mem::transmute_copy(&index))
         }
-        unsafe extern "system" fn GetAnnotationByName<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectTechnique_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, name: ::windows::core::PCSTR) -> ::core::option::Option<ID3D10EffectVariable> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetAnnotationByName<Impl: ID3D10EffectTechnique_Impl>(this: *mut ::core::ffi::c_void, name: ::windows::core::PCSTR) -> ::core::option::Option<ID3D10EffectVariable> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetAnnotationByName(::core::mem::transmute(&name))
         }
-        unsafe extern "system" fn GetPassByIndex<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectTechnique_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: u32) -> ::core::option::Option<ID3D10EffectPass> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetPassByIndex<Impl: ID3D10EffectTechnique_Impl>(this: *mut ::core::ffi::c_void, index: u32) -> ::core::option::Option<ID3D10EffectPass> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetPassByIndex(::core::mem::transmute_copy(&index))
         }
-        unsafe extern "system" fn GetPassByName<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectTechnique_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, name: ::windows::core::PCSTR) -> ::core::option::Option<ID3D10EffectPass> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetPassByName<Impl: ID3D10EffectTechnique_Impl>(this: *mut ::core::ffi::c_void, name: ::windows::core::PCSTR) -> ::core::option::Option<ID3D10EffectPass> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetPassByName(::core::mem::transmute(&name))
         }
-        unsafe extern "system" fn ComputeStateBlockMask<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectTechnique_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pstateblockmask: *mut D3D10_STATE_BLOCK_MASK) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn ComputeStateBlockMask<Impl: ID3D10EffectTechnique_Impl>(this: *mut ::core::ffi::c_void, pstateblockmask: *mut D3D10_STATE_BLOCK_MASK) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             match this.ComputeStateBlockMask() {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(pstateblockmask, ::core::mem::transmute(ok__));
@@ -2103,17 +2211,29 @@ impl ID3D10EffectTechnique_Vtbl {
             }
         }
         Self {
-            IsValid: IsValid::<Identity, Impl, OFFSET>,
-            GetDesc: GetDesc::<Identity, Impl, OFFSET>,
-            GetAnnotationByIndex: GetAnnotationByIndex::<Identity, Impl, OFFSET>,
-            GetAnnotationByName: GetAnnotationByName::<Identity, Impl, OFFSET>,
-            GetPassByIndex: GetPassByIndex::<Identity, Impl, OFFSET>,
-            GetPassByName: GetPassByName::<Identity, Impl, OFFSET>,
-            ComputeStateBlockMask: ComputeStateBlockMask::<Identity, Impl, OFFSET>,
+            IsValid: IsValid::<Impl>,
+            GetDesc: GetDesc::<Impl>,
+            GetAnnotationByIndex: GetAnnotationByIndex::<Impl>,
+            GetAnnotationByName: GetAnnotationByName::<Impl>,
+            GetPassByIndex: GetPassByIndex::<Impl>,
+            GetPassByName: GetPassByName::<Impl>,
+            ComputeStateBlockMask: ComputeStateBlockMask::<Impl>,
         }
     }
-    pub fn matches(iid: &windows::core::GUID) -> bool {
-        iid == &<ID3D10EffectTechnique as ::windows::core::Interface>::IID
+}
+#[doc(hidden)]
+#[cfg(feature = "Win32_Foundation")]
+struct ID3D10EffectTechnique_ImplVtbl<T: ID3D10EffectTechnique_Impl>(::std::marker::PhantomData<T>);
+#[cfg(feature = "Win32_Foundation")]
+impl<T: ID3D10EffectTechnique_Impl> ID3D10EffectTechnique_ImplVtbl<T> {
+    const VTABLE: ID3D10EffectTechnique_Vtbl = ID3D10EffectTechnique_Vtbl::new::<T>();
+}
+#[cfg(feature = "Win32_Foundation")]
+impl ID3D10EffectTechnique {
+    pub fn new<'a, T: ID3D10EffectTechnique_Impl>(this: &'a T) -> ::windows::core::ScopedInterface<'a, Self> {
+        let this = ::windows::core::ScopedHeap { vtable: &ID3D10EffectTechnique_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
+        let this = ::std::mem::ManuallyDrop::new(::std::boxed::Box::new(this));
+        unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D"))]
@@ -2127,57 +2247,67 @@ pub trait ID3D10EffectType_Impl: Sized {
     fn GetMemberSemantic(&self, index: u32) -> ::windows::core::PSTR;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D"))]
-impl ::windows::core::RuntimeName for ID3D10EffectType {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D"))]
 impl ID3D10EffectType_Vtbl {
-    pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectType_Impl, const OFFSET: isize>() -> ID3D10EffectType_Vtbl {
-        unsafe extern "system" fn IsValid<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectType_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> super::super::Foundation::BOOL {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+    pub const fn new<Impl: ID3D10EffectType_Impl>() -> ID3D10EffectType_Vtbl {
+        unsafe extern "system" fn IsValid<Impl: ID3D10EffectType_Impl>(this: *mut ::core::ffi::c_void) -> super::super::Foundation::BOOL {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.IsValid()
         }
-        unsafe extern "system" fn GetDesc<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectType_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D10_EFFECT_TYPE_DESC) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetDesc<Impl: ID3D10EffectType_Impl>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D10_EFFECT_TYPE_DESC) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetDesc(::core::mem::transmute_copy(&pdesc)).into()
         }
-        unsafe extern "system" fn GetMemberTypeByIndex<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectType_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: u32) -> ::core::option::Option<ID3D10EffectType> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetMemberTypeByIndex<Impl: ID3D10EffectType_Impl>(this: *mut ::core::ffi::c_void, index: u32) -> ::core::option::Option<ID3D10EffectType> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetMemberTypeByIndex(::core::mem::transmute_copy(&index))
         }
-        unsafe extern "system" fn GetMemberTypeByName<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectType_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, name: ::windows::core::PCSTR) -> ::core::option::Option<ID3D10EffectType> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetMemberTypeByName<Impl: ID3D10EffectType_Impl>(this: *mut ::core::ffi::c_void, name: ::windows::core::PCSTR) -> ::core::option::Option<ID3D10EffectType> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetMemberTypeByName(::core::mem::transmute(&name))
         }
-        unsafe extern "system" fn GetMemberTypeBySemantic<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectType_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, semantic: ::windows::core::PCSTR) -> ::core::option::Option<ID3D10EffectType> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetMemberTypeBySemantic<Impl: ID3D10EffectType_Impl>(this: *mut ::core::ffi::c_void, semantic: ::windows::core::PCSTR) -> ::core::option::Option<ID3D10EffectType> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetMemberTypeBySemantic(::core::mem::transmute(&semantic))
         }
-        unsafe extern "system" fn GetMemberName<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectType_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: u32) -> ::windows::core::PSTR {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetMemberName<Impl: ID3D10EffectType_Impl>(this: *mut ::core::ffi::c_void, index: u32) -> ::windows::core::PSTR {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetMemberName(::core::mem::transmute_copy(&index))
         }
-        unsafe extern "system" fn GetMemberSemantic<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectType_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: u32) -> ::windows::core::PSTR {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetMemberSemantic<Impl: ID3D10EffectType_Impl>(this: *mut ::core::ffi::c_void, index: u32) -> ::windows::core::PSTR {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetMemberSemantic(::core::mem::transmute_copy(&index))
         }
         Self {
-            IsValid: IsValid::<Identity, Impl, OFFSET>,
-            GetDesc: GetDesc::<Identity, Impl, OFFSET>,
-            GetMemberTypeByIndex: GetMemberTypeByIndex::<Identity, Impl, OFFSET>,
-            GetMemberTypeByName: GetMemberTypeByName::<Identity, Impl, OFFSET>,
-            GetMemberTypeBySemantic: GetMemberTypeBySemantic::<Identity, Impl, OFFSET>,
-            GetMemberName: GetMemberName::<Identity, Impl, OFFSET>,
-            GetMemberSemantic: GetMemberSemantic::<Identity, Impl, OFFSET>,
+            IsValid: IsValid::<Impl>,
+            GetDesc: GetDesc::<Impl>,
+            GetMemberTypeByIndex: GetMemberTypeByIndex::<Impl>,
+            GetMemberTypeByName: GetMemberTypeByName::<Impl>,
+            GetMemberTypeBySemantic: GetMemberTypeBySemantic::<Impl>,
+            GetMemberName: GetMemberName::<Impl>,
+            GetMemberSemantic: GetMemberSemantic::<Impl>,
         }
     }
-    pub fn matches(iid: &windows::core::GUID) -> bool {
-        iid == &<ID3D10EffectType as ::windows::core::Interface>::IID
+}
+#[doc(hidden)]
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D"))]
+struct ID3D10EffectType_ImplVtbl<T: ID3D10EffectType_Impl>(::std::marker::PhantomData<T>);
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D"))]
+impl<T: ID3D10EffectType_Impl> ID3D10EffectType_ImplVtbl<T> {
+    const VTABLE: ID3D10EffectType_Vtbl = ID3D10EffectType_Vtbl::new::<T>();
+}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D"))]
+impl ID3D10EffectType {
+    pub fn new<'a, T: ID3D10EffectType_Impl>(this: &'a T) -> ::windows::core::ScopedInterface<'a, Self> {
+        let this = ::windows::core::ScopedHeap { vtable: &ID3D10EffectType_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
+        let this = ::std::mem::ManuallyDrop::new(::std::boxed::Box::new(this));
+        unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2209,23 +2339,21 @@ pub trait ID3D10EffectVariable_Impl: Sized {
     fn GetRawValue(&self, pdata: *mut ::core::ffi::c_void, offset: u32, bytecount: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::windows::core::RuntimeName for ID3D10EffectVariable {}
-#[cfg(feature = "Win32_Foundation")]
 impl ID3D10EffectVariable_Vtbl {
-    pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectVariable_Impl, const OFFSET: isize>() -> ID3D10EffectVariable_Vtbl {
-        unsafe extern "system" fn IsValid<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> super::super::Foundation::BOOL {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+    pub const fn new<Impl: ID3D10EffectVariable_Impl>() -> ID3D10EffectVariable_Vtbl {
+        unsafe extern "system" fn IsValid<Impl: ID3D10EffectVariable_Impl>(this: *mut ::core::ffi::c_void) -> super::super::Foundation::BOOL {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.IsValid()
         }
-        unsafe extern "system" fn GetType<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::core::option::Option<ID3D10EffectType> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetType<Impl: ID3D10EffectVariable_Impl>(this: *mut ::core::ffi::c_void) -> ::core::option::Option<ID3D10EffectType> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetType()
         }
-        unsafe extern "system" fn GetDesc<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D10_EFFECT_VARIABLE_DESC) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetDesc<Impl: ID3D10EffectVariable_Impl>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D10_EFFECT_VARIABLE_DESC) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             match this.GetDesc() {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
@@ -2234,146 +2362,158 @@ impl ID3D10EffectVariable_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        unsafe extern "system" fn GetAnnotationByIndex<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: u32) -> ::core::option::Option<ID3D10EffectVariable> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetAnnotationByIndex<Impl: ID3D10EffectVariable_Impl>(this: *mut ::core::ffi::c_void, index: u32) -> ::core::option::Option<ID3D10EffectVariable> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetAnnotationByIndex(::core::mem::transmute_copy(&index))
         }
-        unsafe extern "system" fn GetAnnotationByName<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, name: ::windows::core::PCSTR) -> ::core::option::Option<ID3D10EffectVariable> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetAnnotationByName<Impl: ID3D10EffectVariable_Impl>(this: *mut ::core::ffi::c_void, name: ::windows::core::PCSTR) -> ::core::option::Option<ID3D10EffectVariable> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetAnnotationByName(::core::mem::transmute(&name))
         }
-        unsafe extern "system" fn GetMemberByIndex<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: u32) -> ::core::option::Option<ID3D10EffectVariable> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetMemberByIndex<Impl: ID3D10EffectVariable_Impl>(this: *mut ::core::ffi::c_void, index: u32) -> ::core::option::Option<ID3D10EffectVariable> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetMemberByIndex(::core::mem::transmute_copy(&index))
         }
-        unsafe extern "system" fn GetMemberByName<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, name: ::windows::core::PCSTR) -> ::core::option::Option<ID3D10EffectVariable> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetMemberByName<Impl: ID3D10EffectVariable_Impl>(this: *mut ::core::ffi::c_void, name: ::windows::core::PCSTR) -> ::core::option::Option<ID3D10EffectVariable> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetMemberByName(::core::mem::transmute(&name))
         }
-        unsafe extern "system" fn GetMemberBySemantic<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, semantic: ::windows::core::PCSTR) -> ::core::option::Option<ID3D10EffectVariable> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetMemberBySemantic<Impl: ID3D10EffectVariable_Impl>(this: *mut ::core::ffi::c_void, semantic: ::windows::core::PCSTR) -> ::core::option::Option<ID3D10EffectVariable> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetMemberBySemantic(::core::mem::transmute(&semantic))
         }
-        unsafe extern "system" fn GetElement<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: u32) -> ::core::option::Option<ID3D10EffectVariable> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetElement<Impl: ID3D10EffectVariable_Impl>(this: *mut ::core::ffi::c_void, index: u32) -> ::core::option::Option<ID3D10EffectVariable> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetElement(::core::mem::transmute_copy(&index))
         }
-        unsafe extern "system" fn GetParentConstantBuffer<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::core::option::Option<ID3D10EffectConstantBuffer> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetParentConstantBuffer<Impl: ID3D10EffectVariable_Impl>(this: *mut ::core::ffi::c_void) -> ::core::option::Option<ID3D10EffectConstantBuffer> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetParentConstantBuffer()
         }
-        unsafe extern "system" fn AsScalar<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::core::option::Option<ID3D10EffectScalarVariable> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn AsScalar<Impl: ID3D10EffectVariable_Impl>(this: *mut ::core::ffi::c_void) -> ::core::option::Option<ID3D10EffectScalarVariable> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.AsScalar()
         }
-        unsafe extern "system" fn AsVector<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::core::option::Option<ID3D10EffectVectorVariable> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn AsVector<Impl: ID3D10EffectVariable_Impl>(this: *mut ::core::ffi::c_void) -> ::core::option::Option<ID3D10EffectVectorVariable> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.AsVector()
         }
-        unsafe extern "system" fn AsMatrix<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::core::option::Option<ID3D10EffectMatrixVariable> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn AsMatrix<Impl: ID3D10EffectVariable_Impl>(this: *mut ::core::ffi::c_void) -> ::core::option::Option<ID3D10EffectMatrixVariable> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.AsMatrix()
         }
-        unsafe extern "system" fn AsString<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::core::option::Option<ID3D10EffectStringVariable> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn AsString<Impl: ID3D10EffectVariable_Impl>(this: *mut ::core::ffi::c_void) -> ::core::option::Option<ID3D10EffectStringVariable> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.AsString()
         }
-        unsafe extern "system" fn AsShaderResource<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::core::option::Option<ID3D10EffectShaderResourceVariable> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn AsShaderResource<Impl: ID3D10EffectVariable_Impl>(this: *mut ::core::ffi::c_void) -> ::core::option::Option<ID3D10EffectShaderResourceVariable> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.AsShaderResource()
         }
-        unsafe extern "system" fn AsRenderTargetView<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::core::option::Option<ID3D10EffectRenderTargetViewVariable> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn AsRenderTargetView<Impl: ID3D10EffectVariable_Impl>(this: *mut ::core::ffi::c_void) -> ::core::option::Option<ID3D10EffectRenderTargetViewVariable> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.AsRenderTargetView()
         }
-        unsafe extern "system" fn AsDepthStencilView<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::core::option::Option<ID3D10EffectDepthStencilViewVariable> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn AsDepthStencilView<Impl: ID3D10EffectVariable_Impl>(this: *mut ::core::ffi::c_void) -> ::core::option::Option<ID3D10EffectDepthStencilViewVariable> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.AsDepthStencilView()
         }
-        unsafe extern "system" fn AsConstantBuffer<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::core::option::Option<ID3D10EffectConstantBuffer> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn AsConstantBuffer<Impl: ID3D10EffectVariable_Impl>(this: *mut ::core::ffi::c_void) -> ::core::option::Option<ID3D10EffectConstantBuffer> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.AsConstantBuffer()
         }
-        unsafe extern "system" fn AsShader<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::core::option::Option<ID3D10EffectShaderVariable> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn AsShader<Impl: ID3D10EffectVariable_Impl>(this: *mut ::core::ffi::c_void) -> ::core::option::Option<ID3D10EffectShaderVariable> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.AsShader()
         }
-        unsafe extern "system" fn AsBlend<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::core::option::Option<ID3D10EffectBlendVariable> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn AsBlend<Impl: ID3D10EffectVariable_Impl>(this: *mut ::core::ffi::c_void) -> ::core::option::Option<ID3D10EffectBlendVariable> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.AsBlend()
         }
-        unsafe extern "system" fn AsDepthStencil<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::core::option::Option<ID3D10EffectDepthStencilVariable> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn AsDepthStencil<Impl: ID3D10EffectVariable_Impl>(this: *mut ::core::ffi::c_void) -> ::core::option::Option<ID3D10EffectDepthStencilVariable> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.AsDepthStencil()
         }
-        unsafe extern "system" fn AsRasterizer<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::core::option::Option<ID3D10EffectRasterizerVariable> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn AsRasterizer<Impl: ID3D10EffectVariable_Impl>(this: *mut ::core::ffi::c_void) -> ::core::option::Option<ID3D10EffectRasterizerVariable> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.AsRasterizer()
         }
-        unsafe extern "system" fn AsSampler<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::core::option::Option<ID3D10EffectSamplerVariable> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn AsSampler<Impl: ID3D10EffectVariable_Impl>(this: *mut ::core::ffi::c_void) -> ::core::option::Option<ID3D10EffectSamplerVariable> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.AsSampler()
         }
-        unsafe extern "system" fn SetRawValue<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdata: *const ::core::ffi::c_void, offset: u32, bytecount: u32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn SetRawValue<Impl: ID3D10EffectVariable_Impl>(this: *mut ::core::ffi::c_void, pdata: *const ::core::ffi::c_void, offset: u32, bytecount: u32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.SetRawValue(::core::mem::transmute_copy(&pdata), ::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&bytecount)).into()
         }
-        unsafe extern "system" fn GetRawValue<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdata: *mut ::core::ffi::c_void, offset: u32, bytecount: u32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetRawValue<Impl: ID3D10EffectVariable_Impl>(this: *mut ::core::ffi::c_void, pdata: *mut ::core::ffi::c_void, offset: u32, bytecount: u32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetRawValue(::core::mem::transmute_copy(&pdata), ::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&bytecount)).into()
         }
         Self {
-            IsValid: IsValid::<Identity, Impl, OFFSET>,
-            GetType: GetType::<Identity, Impl, OFFSET>,
-            GetDesc: GetDesc::<Identity, Impl, OFFSET>,
-            GetAnnotationByIndex: GetAnnotationByIndex::<Identity, Impl, OFFSET>,
-            GetAnnotationByName: GetAnnotationByName::<Identity, Impl, OFFSET>,
-            GetMemberByIndex: GetMemberByIndex::<Identity, Impl, OFFSET>,
-            GetMemberByName: GetMemberByName::<Identity, Impl, OFFSET>,
-            GetMemberBySemantic: GetMemberBySemantic::<Identity, Impl, OFFSET>,
-            GetElement: GetElement::<Identity, Impl, OFFSET>,
-            GetParentConstantBuffer: GetParentConstantBuffer::<Identity, Impl, OFFSET>,
-            AsScalar: AsScalar::<Identity, Impl, OFFSET>,
-            AsVector: AsVector::<Identity, Impl, OFFSET>,
-            AsMatrix: AsMatrix::<Identity, Impl, OFFSET>,
-            AsString: AsString::<Identity, Impl, OFFSET>,
-            AsShaderResource: AsShaderResource::<Identity, Impl, OFFSET>,
-            AsRenderTargetView: AsRenderTargetView::<Identity, Impl, OFFSET>,
-            AsDepthStencilView: AsDepthStencilView::<Identity, Impl, OFFSET>,
-            AsConstantBuffer: AsConstantBuffer::<Identity, Impl, OFFSET>,
-            AsShader: AsShader::<Identity, Impl, OFFSET>,
-            AsBlend: AsBlend::<Identity, Impl, OFFSET>,
-            AsDepthStencil: AsDepthStencil::<Identity, Impl, OFFSET>,
-            AsRasterizer: AsRasterizer::<Identity, Impl, OFFSET>,
-            AsSampler: AsSampler::<Identity, Impl, OFFSET>,
-            SetRawValue: SetRawValue::<Identity, Impl, OFFSET>,
-            GetRawValue: GetRawValue::<Identity, Impl, OFFSET>,
+            IsValid: IsValid::<Impl>,
+            GetType: GetType::<Impl>,
+            GetDesc: GetDesc::<Impl>,
+            GetAnnotationByIndex: GetAnnotationByIndex::<Impl>,
+            GetAnnotationByName: GetAnnotationByName::<Impl>,
+            GetMemberByIndex: GetMemberByIndex::<Impl>,
+            GetMemberByName: GetMemberByName::<Impl>,
+            GetMemberBySemantic: GetMemberBySemantic::<Impl>,
+            GetElement: GetElement::<Impl>,
+            GetParentConstantBuffer: GetParentConstantBuffer::<Impl>,
+            AsScalar: AsScalar::<Impl>,
+            AsVector: AsVector::<Impl>,
+            AsMatrix: AsMatrix::<Impl>,
+            AsString: AsString::<Impl>,
+            AsShaderResource: AsShaderResource::<Impl>,
+            AsRenderTargetView: AsRenderTargetView::<Impl>,
+            AsDepthStencilView: AsDepthStencilView::<Impl>,
+            AsConstantBuffer: AsConstantBuffer::<Impl>,
+            AsShader: AsShader::<Impl>,
+            AsBlend: AsBlend::<Impl>,
+            AsDepthStencil: AsDepthStencil::<Impl>,
+            AsRasterizer: AsRasterizer::<Impl>,
+            AsSampler: AsSampler::<Impl>,
+            SetRawValue: SetRawValue::<Impl>,
+            GetRawValue: GetRawValue::<Impl>,
         }
     }
-    pub fn matches(iid: &windows::core::GUID) -> bool {
-        iid == &<ID3D10EffectVariable as ::windows::core::Interface>::IID
+}
+#[doc(hidden)]
+#[cfg(feature = "Win32_Foundation")]
+struct ID3D10EffectVariable_ImplVtbl<T: ID3D10EffectVariable_Impl>(::std::marker::PhantomData<T>);
+#[cfg(feature = "Win32_Foundation")]
+impl<T: ID3D10EffectVariable_Impl> ID3D10EffectVariable_ImplVtbl<T> {
+    const VTABLE: ID3D10EffectVariable_Vtbl = ID3D10EffectVariable_Vtbl::new::<T>();
+}
+#[cfg(feature = "Win32_Foundation")]
+impl ID3D10EffectVariable {
+    pub fn new<'a, T: ID3D10EffectVariable_Impl>(this: &'a T) -> ::windows::core::ScopedInterface<'a, Self> {
+        let this = ::windows::core::ScopedHeap { vtable: &ID3D10EffectVariable_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
+        let this = ::std::mem::ManuallyDrop::new(::std::boxed::Box::new(this));
+        unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -2392,88 +2532,98 @@ pub trait ID3D10EffectVectorVariable_Impl: Sized + ID3D10EffectVariable_Impl {
     fn GetFloatVectorArray(&self, pdata: *mut f32, offset: u32, count: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::windows::core::RuntimeName for ID3D10EffectVectorVariable {}
-#[cfg(feature = "Win32_Foundation")]
 impl ID3D10EffectVectorVariable_Vtbl {
-    pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectVectorVariable_Impl, const OFFSET: isize>() -> ID3D10EffectVectorVariable_Vtbl {
-        unsafe extern "system" fn SetBoolVector<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectVectorVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdata: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+    pub const fn new<Impl: ID3D10EffectVectorVariable_Impl>() -> ID3D10EffectVectorVariable_Vtbl {
+        unsafe extern "system" fn SetBoolVector<Impl: ID3D10EffectVectorVariable_Impl>(this: *mut ::core::ffi::c_void, pdata: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.SetBoolVector(::core::mem::transmute_copy(&pdata)).into()
         }
-        unsafe extern "system" fn SetIntVector<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectVectorVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdata: *mut i32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn SetIntVector<Impl: ID3D10EffectVectorVariable_Impl>(this: *mut ::core::ffi::c_void, pdata: *mut i32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.SetIntVector(::core::mem::transmute_copy(&pdata)).into()
         }
-        unsafe extern "system" fn SetFloatVector<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectVectorVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdata: *mut f32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn SetFloatVector<Impl: ID3D10EffectVectorVariable_Impl>(this: *mut ::core::ffi::c_void, pdata: *mut f32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.SetFloatVector(::core::mem::transmute_copy(&pdata)).into()
         }
-        unsafe extern "system" fn GetBoolVector<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectVectorVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdata: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetBoolVector<Impl: ID3D10EffectVectorVariable_Impl>(this: *mut ::core::ffi::c_void, pdata: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetBoolVector(::core::mem::transmute_copy(&pdata)).into()
         }
-        unsafe extern "system" fn GetIntVector<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectVectorVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdata: *mut i32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetIntVector<Impl: ID3D10EffectVectorVariable_Impl>(this: *mut ::core::ffi::c_void, pdata: *mut i32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetIntVector(::core::mem::transmute_copy(&pdata)).into()
         }
-        unsafe extern "system" fn GetFloatVector<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectVectorVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdata: *mut f32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetFloatVector<Impl: ID3D10EffectVectorVariable_Impl>(this: *mut ::core::ffi::c_void, pdata: *mut f32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetFloatVector(::core::mem::transmute_copy(&pdata)).into()
         }
-        unsafe extern "system" fn SetBoolVectorArray<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectVectorVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdata: *mut super::super::Foundation::BOOL, offset: u32, count: u32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn SetBoolVectorArray<Impl: ID3D10EffectVectorVariable_Impl>(this: *mut ::core::ffi::c_void, pdata: *mut super::super::Foundation::BOOL, offset: u32, count: u32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.SetBoolVectorArray(::core::mem::transmute_copy(&pdata), ::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&count)).into()
         }
-        unsafe extern "system" fn SetIntVectorArray<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectVectorVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdata: *mut i32, offset: u32, count: u32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn SetIntVectorArray<Impl: ID3D10EffectVectorVariable_Impl>(this: *mut ::core::ffi::c_void, pdata: *mut i32, offset: u32, count: u32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.SetIntVectorArray(::core::mem::transmute_copy(&pdata), ::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&count)).into()
         }
-        unsafe extern "system" fn SetFloatVectorArray<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectVectorVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdata: *mut f32, offset: u32, count: u32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn SetFloatVectorArray<Impl: ID3D10EffectVectorVariable_Impl>(this: *mut ::core::ffi::c_void, pdata: *mut f32, offset: u32, count: u32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.SetFloatVectorArray(::core::mem::transmute_copy(&pdata), ::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&count)).into()
         }
-        unsafe extern "system" fn GetBoolVectorArray<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectVectorVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdata: *mut super::super::Foundation::BOOL, offset: u32, count: u32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetBoolVectorArray<Impl: ID3D10EffectVectorVariable_Impl>(this: *mut ::core::ffi::c_void, pdata: *mut super::super::Foundation::BOOL, offset: u32, count: u32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetBoolVectorArray(::core::mem::transmute_copy(&pdata), ::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&count)).into()
         }
-        unsafe extern "system" fn GetIntVectorArray<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectVectorVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdata: *mut i32, offset: u32, count: u32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetIntVectorArray<Impl: ID3D10EffectVectorVariable_Impl>(this: *mut ::core::ffi::c_void, pdata: *mut i32, offset: u32, count: u32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetIntVectorArray(::core::mem::transmute_copy(&pdata), ::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&count)).into()
         }
-        unsafe extern "system" fn GetFloatVectorArray<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10EffectVectorVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdata: *mut f32, offset: u32, count: u32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetFloatVectorArray<Impl: ID3D10EffectVectorVariable_Impl>(this: *mut ::core::ffi::c_void, pdata: *mut f32, offset: u32, count: u32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetFloatVectorArray(::core::mem::transmute_copy(&pdata), ::core::mem::transmute_copy(&offset), ::core::mem::transmute_copy(&count)).into()
         }
         Self {
-            base__: ID3D10EffectVariable_Vtbl::new::<Identity, Impl, OFFSET>(),
-            SetBoolVector: SetBoolVector::<Identity, Impl, OFFSET>,
-            SetIntVector: SetIntVector::<Identity, Impl, OFFSET>,
-            SetFloatVector: SetFloatVector::<Identity, Impl, OFFSET>,
-            GetBoolVector: GetBoolVector::<Identity, Impl, OFFSET>,
-            GetIntVector: GetIntVector::<Identity, Impl, OFFSET>,
-            GetFloatVector: GetFloatVector::<Identity, Impl, OFFSET>,
-            SetBoolVectorArray: SetBoolVectorArray::<Identity, Impl, OFFSET>,
-            SetIntVectorArray: SetIntVectorArray::<Identity, Impl, OFFSET>,
-            SetFloatVectorArray: SetFloatVectorArray::<Identity, Impl, OFFSET>,
-            GetBoolVectorArray: GetBoolVectorArray::<Identity, Impl, OFFSET>,
-            GetIntVectorArray: GetIntVectorArray::<Identity, Impl, OFFSET>,
-            GetFloatVectorArray: GetFloatVectorArray::<Identity, Impl, OFFSET>,
+            base__: ID3D10EffectVariable_Vtbl::new::<Impl>(),
+            SetBoolVector: SetBoolVector::<Impl>,
+            SetIntVector: SetIntVector::<Impl>,
+            SetFloatVector: SetFloatVector::<Impl>,
+            GetBoolVector: GetBoolVector::<Impl>,
+            GetIntVector: GetIntVector::<Impl>,
+            GetFloatVector: GetFloatVector::<Impl>,
+            SetBoolVectorArray: SetBoolVectorArray::<Impl>,
+            SetIntVectorArray: SetIntVectorArray::<Impl>,
+            SetFloatVectorArray: SetFloatVectorArray::<Impl>,
+            GetBoolVectorArray: GetBoolVectorArray::<Impl>,
+            GetIntVectorArray: GetIntVectorArray::<Impl>,
+            GetFloatVectorArray: GetFloatVectorArray::<Impl>,
         }
     }
-    pub fn matches(iid: &windows::core::GUID) -> bool {
-        iid == &<ID3D10EffectVectorVariable as ::windows::core::Interface>::IID || iid == &<ID3D10EffectVariable as ::windows::core::Interface>::IID
+}
+#[doc(hidden)]
+#[cfg(feature = "Win32_Foundation")]
+struct ID3D10EffectVectorVariable_ImplVtbl<T: ID3D10EffectVectorVariable_Impl>(::std::marker::PhantomData<T>);
+#[cfg(feature = "Win32_Foundation")]
+impl<T: ID3D10EffectVectorVariable_Impl> ID3D10EffectVectorVariable_ImplVtbl<T> {
+    const VTABLE: ID3D10EffectVectorVariable_Vtbl = ID3D10EffectVectorVariable_Vtbl::new::<T>();
+}
+#[cfg(feature = "Win32_Foundation")]
+impl ID3D10EffectVectorVariable {
+    pub fn new<'a, T: ID3D10EffectVectorVariable_Impl>(this: &'a T) -> ::windows::core::ScopedInterface<'a, Self> {
+        let this = ::windows::core::ScopedHeap { vtable: &ID3D10EffectVectorVariable_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
+        let this = ::std::mem::ManuallyDrop::new(::std::boxed::Box::new(this));
+        unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
 pub trait ID3D10GeometryShader_Impl: Sized + ID3D10DeviceChild_Impl {}
@@ -3211,13 +3361,11 @@ pub trait ID3D10ShaderReflectionConstantBuffer_Impl: Sized {
     fn GetVariableByName(&self, name: &::windows::core::PCSTR) -> ::core::option::Option<ID3D10ShaderReflectionVariable>;
 }
 #[cfg(feature = "Win32_Graphics_Direct3D")]
-impl ::windows::core::RuntimeName for ID3D10ShaderReflectionConstantBuffer {}
-#[cfg(feature = "Win32_Graphics_Direct3D")]
 impl ID3D10ShaderReflectionConstantBuffer_Vtbl {
-    pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10ShaderReflectionConstantBuffer_Impl, const OFFSET: isize>() -> ID3D10ShaderReflectionConstantBuffer_Vtbl {
-        unsafe extern "system" fn GetDesc<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10ShaderReflectionConstantBuffer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D10_SHADER_BUFFER_DESC) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+    pub const fn new<Impl: ID3D10ShaderReflectionConstantBuffer_Impl>() -> ID3D10ShaderReflectionConstantBuffer_Vtbl {
+        unsafe extern "system" fn GetDesc<Impl: ID3D10ShaderReflectionConstantBuffer_Impl>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D10_SHADER_BUFFER_DESC) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             match this.GetDesc() {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
@@ -3226,24 +3374,32 @@ impl ID3D10ShaderReflectionConstantBuffer_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        unsafe extern "system" fn GetVariableByIndex<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10ShaderReflectionConstantBuffer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: u32) -> ::core::option::Option<ID3D10ShaderReflectionVariable> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetVariableByIndex<Impl: ID3D10ShaderReflectionConstantBuffer_Impl>(this: *mut ::core::ffi::c_void, index: u32) -> ::core::option::Option<ID3D10ShaderReflectionVariable> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetVariableByIndex(::core::mem::transmute_copy(&index))
         }
-        unsafe extern "system" fn GetVariableByName<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10ShaderReflectionConstantBuffer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, name: ::windows::core::PCSTR) -> ::core::option::Option<ID3D10ShaderReflectionVariable> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetVariableByName<Impl: ID3D10ShaderReflectionConstantBuffer_Impl>(this: *mut ::core::ffi::c_void, name: ::windows::core::PCSTR) -> ::core::option::Option<ID3D10ShaderReflectionVariable> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetVariableByName(::core::mem::transmute(&name))
         }
-        Self {
-            GetDesc: GetDesc::<Identity, Impl, OFFSET>,
-            GetVariableByIndex: GetVariableByIndex::<Identity, Impl, OFFSET>,
-            GetVariableByName: GetVariableByName::<Identity, Impl, OFFSET>,
-        }
+        Self { GetDesc: GetDesc::<Impl>, GetVariableByIndex: GetVariableByIndex::<Impl>, GetVariableByName: GetVariableByName::<Impl> }
     }
-    pub fn matches(iid: &windows::core::GUID) -> bool {
-        iid == &<ID3D10ShaderReflectionConstantBuffer as ::windows::core::Interface>::IID
+}
+#[doc(hidden)]
+#[cfg(feature = "Win32_Graphics_Direct3D")]
+struct ID3D10ShaderReflectionConstantBuffer_ImplVtbl<T: ID3D10ShaderReflectionConstantBuffer_Impl>(::std::marker::PhantomData<T>);
+#[cfg(feature = "Win32_Graphics_Direct3D")]
+impl<T: ID3D10ShaderReflectionConstantBuffer_Impl> ID3D10ShaderReflectionConstantBuffer_ImplVtbl<T> {
+    const VTABLE: ID3D10ShaderReflectionConstantBuffer_Vtbl = ID3D10ShaderReflectionConstantBuffer_Vtbl::new::<T>();
+}
+#[cfg(feature = "Win32_Graphics_Direct3D")]
+impl ID3D10ShaderReflectionConstantBuffer {
+    pub fn new<'a, T: ID3D10ShaderReflectionConstantBuffer_Impl>(this: &'a T) -> ::windows::core::ScopedInterface<'a, Self> {
+        let this = ::windows::core::ScopedHeap { vtable: &ID3D10ShaderReflectionConstantBuffer_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
+        let this = ::std::mem::ManuallyDrop::new(::std::boxed::Box::new(this));
+        unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D")]
@@ -3254,51 +3410,60 @@ pub trait ID3D10ShaderReflectionType_Impl: Sized {
     fn GetMemberTypeName(&self, index: u32) -> ::windows::core::PSTR;
 }
 #[cfg(feature = "Win32_Graphics_Direct3D")]
-impl ::windows::core::RuntimeName for ID3D10ShaderReflectionType {}
-#[cfg(feature = "Win32_Graphics_Direct3D")]
 impl ID3D10ShaderReflectionType_Vtbl {
-    pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10ShaderReflectionType_Impl, const OFFSET: isize>() -> ID3D10ShaderReflectionType_Vtbl {
-        unsafe extern "system" fn GetDesc<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10ShaderReflectionType_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D10_SHADER_TYPE_DESC) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+    pub const fn new<Impl: ID3D10ShaderReflectionType_Impl>() -> ID3D10ShaderReflectionType_Vtbl {
+        unsafe extern "system" fn GetDesc<Impl: ID3D10ShaderReflectionType_Impl>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D10_SHADER_TYPE_DESC) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetDesc(::core::mem::transmute_copy(&pdesc)).into()
         }
-        unsafe extern "system" fn GetMemberTypeByIndex<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10ShaderReflectionType_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: u32) -> ::core::option::Option<ID3D10ShaderReflectionType> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetMemberTypeByIndex<Impl: ID3D10ShaderReflectionType_Impl>(this: *mut ::core::ffi::c_void, index: u32) -> ::core::option::Option<ID3D10ShaderReflectionType> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetMemberTypeByIndex(::core::mem::transmute_copy(&index))
         }
-        unsafe extern "system" fn GetMemberTypeByName<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10ShaderReflectionType_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, name: ::windows::core::PCSTR) -> ::core::option::Option<ID3D10ShaderReflectionType> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetMemberTypeByName<Impl: ID3D10ShaderReflectionType_Impl>(this: *mut ::core::ffi::c_void, name: ::windows::core::PCSTR) -> ::core::option::Option<ID3D10ShaderReflectionType> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetMemberTypeByName(::core::mem::transmute(&name))
         }
-        unsafe extern "system" fn GetMemberTypeName<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10ShaderReflectionType_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: u32) -> ::windows::core::PSTR {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetMemberTypeName<Impl: ID3D10ShaderReflectionType_Impl>(this: *mut ::core::ffi::c_void, index: u32) -> ::windows::core::PSTR {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetMemberTypeName(::core::mem::transmute_copy(&index))
         }
         Self {
-            GetDesc: GetDesc::<Identity, Impl, OFFSET>,
-            GetMemberTypeByIndex: GetMemberTypeByIndex::<Identity, Impl, OFFSET>,
-            GetMemberTypeByName: GetMemberTypeByName::<Identity, Impl, OFFSET>,
-            GetMemberTypeName: GetMemberTypeName::<Identity, Impl, OFFSET>,
+            GetDesc: GetDesc::<Impl>,
+            GetMemberTypeByIndex: GetMemberTypeByIndex::<Impl>,
+            GetMemberTypeByName: GetMemberTypeByName::<Impl>,
+            GetMemberTypeName: GetMemberTypeName::<Impl>,
         }
     }
-    pub fn matches(iid: &windows::core::GUID) -> bool {
-        iid == &<ID3D10ShaderReflectionType as ::windows::core::Interface>::IID
+}
+#[doc(hidden)]
+#[cfg(feature = "Win32_Graphics_Direct3D")]
+struct ID3D10ShaderReflectionType_ImplVtbl<T: ID3D10ShaderReflectionType_Impl>(::std::marker::PhantomData<T>);
+#[cfg(feature = "Win32_Graphics_Direct3D")]
+impl<T: ID3D10ShaderReflectionType_Impl> ID3D10ShaderReflectionType_ImplVtbl<T> {
+    const VTABLE: ID3D10ShaderReflectionType_Vtbl = ID3D10ShaderReflectionType_Vtbl::new::<T>();
+}
+#[cfg(feature = "Win32_Graphics_Direct3D")]
+impl ID3D10ShaderReflectionType {
+    pub fn new<'a, T: ID3D10ShaderReflectionType_Impl>(this: &'a T) -> ::windows::core::ScopedInterface<'a, Self> {
+        let this = ::windows::core::ScopedHeap { vtable: &ID3D10ShaderReflectionType_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
+        let this = ::std::mem::ManuallyDrop::new(::std::boxed::Box::new(this));
+        unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
 pub trait ID3D10ShaderReflectionVariable_Impl: Sized {
     fn GetDesc(&self) -> ::windows::core::Result<D3D10_SHADER_VARIABLE_DESC>;
     fn GetType(&self) -> ::core::option::Option<ID3D10ShaderReflectionType>;
 }
-impl ::windows::core::RuntimeName for ID3D10ShaderReflectionVariable {}
 impl ID3D10ShaderReflectionVariable_Vtbl {
-    pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10ShaderReflectionVariable_Impl, const OFFSET: isize>() -> ID3D10ShaderReflectionVariable_Vtbl {
-        unsafe extern "system" fn GetDesc<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10ShaderReflectionVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D10_SHADER_VARIABLE_DESC) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+    pub const fn new<Impl: ID3D10ShaderReflectionVariable_Impl>() -> ID3D10ShaderReflectionVariable_Vtbl {
+        unsafe extern "system" fn GetDesc<Impl: ID3D10ShaderReflectionVariable_Impl>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D10_SHADER_VARIABLE_DESC) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             match this.GetDesc() {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
@@ -3307,15 +3472,24 @@ impl ID3D10ShaderReflectionVariable_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        unsafe extern "system" fn GetType<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D10ShaderReflectionVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::core::option::Option<ID3D10ShaderReflectionType> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetType<Impl: ID3D10ShaderReflectionVariable_Impl>(this: *mut ::core::ffi::c_void) -> ::core::option::Option<ID3D10ShaderReflectionType> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetType()
         }
-        Self { GetDesc: GetDesc::<Identity, Impl, OFFSET>, GetType: GetType::<Identity, Impl, OFFSET> }
+        Self { GetDesc: GetDesc::<Impl>, GetType: GetType::<Impl> }
     }
-    pub fn matches(iid: &windows::core::GUID) -> bool {
-        iid == &<ID3D10ShaderReflectionVariable as ::windows::core::Interface>::IID
+}
+#[doc(hidden)]
+struct ID3D10ShaderReflectionVariable_ImplVtbl<T: ID3D10ShaderReflectionVariable_Impl>(::std::marker::PhantomData<T>);
+impl<T: ID3D10ShaderReflectionVariable_Impl> ID3D10ShaderReflectionVariable_ImplVtbl<T> {
+    const VTABLE: ID3D10ShaderReflectionVariable_Vtbl = ID3D10ShaderReflectionVariable_Vtbl::new::<T>();
+}
+impl ID3D10ShaderReflectionVariable {
+    pub fn new<'a, T: ID3D10ShaderReflectionVariable_Impl>(this: &'a T) -> ::windows::core::ScopedInterface<'a, Self> {
+        let this = ::windows::core::ScopedHeap { vtable: &ID3D10ShaderReflectionVariable_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
+        let this = ::std::mem::ManuallyDrop::new(::std::boxed::Box::new(this));
+        unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D10/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D10/mod.rs
@@ -2496,7 +2496,16 @@ pub struct ID3D10Effect_Vtbl {
 }
 #[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`*"]
 #[repr(transparent)]
-pub struct ID3D10EffectBlendVariable(::windows::core::IUnknown);
+pub struct ID3D10EffectBlendVariable(::std::ptr::NonNull<::std::ffi::c_void>);
+unsafe impl ::windows::core::Abi for Option<ID3D10EffectBlendVariable> {
+    type Abi = *mut ::std::ffi::c_void;
+}
+unsafe impl ::windows::core::Abi for ID3D10EffectBlendVariable {
+    type Abi = *mut ::std::ffi::c_void;
+    fn abi_is_possibly_valid(abi: &Self::Abi) -> bool {
+        !abi.is_null()
+    }
+}
 impl ID3D10EffectBlendVariable {
     #[doc = "*Required features: `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
@@ -2631,9 +2640,6 @@ unsafe impl ::core::marker::Sync for ID3D10EffectBlendVariable {}
 unsafe impl ::windows::core::Vtable for ID3D10EffectBlendVariable {
     type Vtable = ID3D10EffectBlendVariable_Vtbl;
 }
-unsafe impl ::windows::core::Interface for ID3D10EffectBlendVariable {
-    const IID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1fcd2294_df6d_4eae_86b3_0e9160cfb07b);
-}
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D10EffectBlendVariable_Vtbl {
@@ -2646,7 +2652,16 @@ pub struct ID3D10EffectBlendVariable_Vtbl {
 }
 #[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`*"]
 #[repr(transparent)]
-pub struct ID3D10EffectConstantBuffer(::windows::core::IUnknown);
+pub struct ID3D10EffectConstantBuffer(::std::ptr::NonNull<::std::ffi::c_void>);
+unsafe impl ::windows::core::Abi for Option<ID3D10EffectConstantBuffer> {
+    type Abi = *mut ::std::ffi::c_void;
+}
+unsafe impl ::windows::core::Abi for ID3D10EffectConstantBuffer {
+    type Abi = *mut ::std::ffi::c_void;
+    fn abi_is_possibly_valid(abi: &Self::Abi) -> bool {
+        !abi.is_null()
+    }
+}
 impl ID3D10EffectConstantBuffer {
     #[doc = "*Required features: `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
@@ -2792,9 +2807,6 @@ unsafe impl ::core::marker::Sync for ID3D10EffectConstantBuffer {}
 unsafe impl ::windows::core::Vtable for ID3D10EffectConstantBuffer {
     type Vtable = ID3D10EffectConstantBuffer_Vtbl;
 }
-unsafe impl ::windows::core::Interface for ID3D10EffectConstantBuffer {
-    const IID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x56648f4d_cc8b_4444_a5ad_b5a3d76e91b3);
-}
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D10EffectConstantBuffer_Vtbl {
@@ -2806,7 +2818,16 @@ pub struct ID3D10EffectConstantBuffer_Vtbl {
 }
 #[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`*"]
 #[repr(transparent)]
-pub struct ID3D10EffectDepthStencilVariable(::windows::core::IUnknown);
+pub struct ID3D10EffectDepthStencilVariable(::std::ptr::NonNull<::std::ffi::c_void>);
+unsafe impl ::windows::core::Abi for Option<ID3D10EffectDepthStencilVariable> {
+    type Abi = *mut ::std::ffi::c_void;
+}
+unsafe impl ::windows::core::Abi for ID3D10EffectDepthStencilVariable {
+    type Abi = *mut ::std::ffi::c_void;
+    fn abi_is_possibly_valid(abi: &Self::Abi) -> bool {
+        !abi.is_null()
+    }
+}
 impl ID3D10EffectDepthStencilVariable {
     #[doc = "*Required features: `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
@@ -2942,9 +2963,6 @@ unsafe impl ::core::marker::Sync for ID3D10EffectDepthStencilVariable {}
 unsafe impl ::windows::core::Vtable for ID3D10EffectDepthStencilVariable {
     type Vtable = ID3D10EffectDepthStencilVariable_Vtbl;
 }
-unsafe impl ::windows::core::Interface for ID3D10EffectDepthStencilVariable {
-    const IID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xaf482368_330a_46a5_9a5c_01c71af24c8d);
-}
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D10EffectDepthStencilVariable_Vtbl {
@@ -2957,7 +2975,16 @@ pub struct ID3D10EffectDepthStencilVariable_Vtbl {
 }
 #[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`*"]
 #[repr(transparent)]
-pub struct ID3D10EffectDepthStencilViewVariable(::windows::core::IUnknown);
+pub struct ID3D10EffectDepthStencilViewVariable(::std::ptr::NonNull<::std::ffi::c_void>);
+unsafe impl ::windows::core::Abi for Option<ID3D10EffectDepthStencilViewVariable> {
+    type Abi = *mut ::std::ffi::c_void;
+}
+unsafe impl ::windows::core::Abi for ID3D10EffectDepthStencilViewVariable {
+    type Abi = *mut ::std::ffi::c_void;
+    fn abi_is_possibly_valid(abi: &Self::Abi) -> bool {
+        !abi.is_null()
+    }
+}
 impl ID3D10EffectDepthStencilViewVariable {
     #[doc = "*Required features: `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
@@ -3099,9 +3126,6 @@ unsafe impl ::core::marker::Sync for ID3D10EffectDepthStencilViewVariable {}
 unsafe impl ::windows::core::Vtable for ID3D10EffectDepthStencilViewVariable {
     type Vtable = ID3D10EffectDepthStencilViewVariable_Vtbl;
 }
-unsafe impl ::windows::core::Interface for ID3D10EffectDepthStencilViewVariable {
-    const IID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3e02c918_cc79_4985_b622_2d92ad701623);
-}
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D10EffectDepthStencilViewVariable_Vtbl {
@@ -3113,7 +3137,16 @@ pub struct ID3D10EffectDepthStencilViewVariable_Vtbl {
 }
 #[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`*"]
 #[repr(transparent)]
-pub struct ID3D10EffectMatrixVariable(::windows::core::IUnknown);
+pub struct ID3D10EffectMatrixVariable(::std::ptr::NonNull<::std::ffi::c_void>);
+unsafe impl ::windows::core::Abi for Option<ID3D10EffectMatrixVariable> {
+    type Abi = *mut ::std::ffi::c_void;
+}
+unsafe impl ::windows::core::Abi for ID3D10EffectMatrixVariable {
+    type Abi = *mut ::std::ffi::c_void;
+    fn abi_is_possibly_valid(abi: &Self::Abi) -> bool {
+        !abi.is_null()
+    }
+}
 impl ID3D10EffectMatrixVariable {
     #[doc = "*Required features: `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
@@ -3263,9 +3296,6 @@ unsafe impl ::core::marker::Sync for ID3D10EffectMatrixVariable {}
 unsafe impl ::windows::core::Vtable for ID3D10EffectMatrixVariable {
     type Vtable = ID3D10EffectMatrixVariable_Vtbl;
 }
-unsafe impl ::windows::core::Interface for ID3D10EffectMatrixVariable {
-    const IID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x50666c24_b82f_4eed_a172_5b6e7e8522e0);
-}
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D10EffectMatrixVariable_Vtbl {
@@ -3281,7 +3311,16 @@ pub struct ID3D10EffectMatrixVariable_Vtbl {
 }
 #[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`*"]
 #[repr(transparent)]
-pub struct ID3D10EffectPass(::windows::core::IUnknown);
+pub struct ID3D10EffectPass(::std::ptr::NonNull<::std::ffi::c_void>);
+unsafe impl ::windows::core::Abi for Option<ID3D10EffectPass> {
+    type Abi = *mut ::std::ffi::c_void;
+}
+unsafe impl ::windows::core::Abi for ID3D10EffectPass {
+    type Abi = *mut ::std::ffi::c_void;
+    fn abi_is_possibly_valid(abi: &Self::Abi) -> bool {
+        !abi.is_null()
+    }
+}
 impl ID3D10EffectPass {
     #[doc = "*Required features: `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
@@ -3337,9 +3376,6 @@ unsafe impl ::core::marker::Send for ID3D10EffectPass {}
 unsafe impl ::core::marker::Sync for ID3D10EffectPass {}
 unsafe impl ::windows::core::Vtable for ID3D10EffectPass {
     type Vtable = ID3D10EffectPass_Vtbl;
-}
-unsafe impl ::windows::core::Interface for ID3D10EffectPass {
-    const IID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5cfbeb89_1a06_46e0_b282_e3f9bfa36a54);
 }
 #[repr(C)]
 #[doc(hidden)]
@@ -3412,7 +3448,16 @@ pub struct ID3D10EffectPool_Vtbl {
 }
 #[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`*"]
 #[repr(transparent)]
-pub struct ID3D10EffectRasterizerVariable(::windows::core::IUnknown);
+pub struct ID3D10EffectRasterizerVariable(::std::ptr::NonNull<::std::ffi::c_void>);
+unsafe impl ::windows::core::Abi for Option<ID3D10EffectRasterizerVariable> {
+    type Abi = *mut ::std::ffi::c_void;
+}
+unsafe impl ::windows::core::Abi for ID3D10EffectRasterizerVariable {
+    type Abi = *mut ::std::ffi::c_void;
+    fn abi_is_possibly_valid(abi: &Self::Abi) -> bool {
+        !abi.is_null()
+    }
+}
 impl ID3D10EffectRasterizerVariable {
     #[doc = "*Required features: `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
@@ -3548,9 +3593,6 @@ unsafe impl ::core::marker::Sync for ID3D10EffectRasterizerVariable {}
 unsafe impl ::windows::core::Vtable for ID3D10EffectRasterizerVariable {
     type Vtable = ID3D10EffectRasterizerVariable_Vtbl;
 }
-unsafe impl ::windows::core::Interface for ID3D10EffectRasterizerVariable {
-    const IID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x21af9f0e_4d94_4ea9_9785_2cb76b8c0b34);
-}
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D10EffectRasterizerVariable_Vtbl {
@@ -3563,7 +3605,16 @@ pub struct ID3D10EffectRasterizerVariable_Vtbl {
 }
 #[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`*"]
 #[repr(transparent)]
-pub struct ID3D10EffectRenderTargetViewVariable(::windows::core::IUnknown);
+pub struct ID3D10EffectRenderTargetViewVariable(::std::ptr::NonNull<::std::ffi::c_void>);
+unsafe impl ::windows::core::Abi for Option<ID3D10EffectRenderTargetViewVariable> {
+    type Abi = *mut ::std::ffi::c_void;
+}
+unsafe impl ::windows::core::Abi for ID3D10EffectRenderTargetViewVariable {
+    type Abi = *mut ::std::ffi::c_void;
+    fn abi_is_possibly_valid(abi: &Self::Abi) -> bool {
+        !abi.is_null()
+    }
+}
 impl ID3D10EffectRenderTargetViewVariable {
     #[doc = "*Required features: `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
@@ -3705,9 +3756,6 @@ unsafe impl ::core::marker::Sync for ID3D10EffectRenderTargetViewVariable {}
 unsafe impl ::windows::core::Vtable for ID3D10EffectRenderTargetViewVariable {
     type Vtable = ID3D10EffectRenderTargetViewVariable_Vtbl;
 }
-unsafe impl ::windows::core::Interface for ID3D10EffectRenderTargetViewVariable {
-    const IID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x28ca0cc3_c2c9_40bb_b57f_67b737122b17);
-}
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D10EffectRenderTargetViewVariable_Vtbl {
@@ -3719,7 +3767,16 @@ pub struct ID3D10EffectRenderTargetViewVariable_Vtbl {
 }
 #[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`*"]
 #[repr(transparent)]
-pub struct ID3D10EffectSamplerVariable(::windows::core::IUnknown);
+pub struct ID3D10EffectSamplerVariable(::std::ptr::NonNull<::std::ffi::c_void>);
+unsafe impl ::windows::core::Abi for Option<ID3D10EffectSamplerVariable> {
+    type Abi = *mut ::std::ffi::c_void;
+}
+unsafe impl ::windows::core::Abi for ID3D10EffectSamplerVariable {
+    type Abi = *mut ::std::ffi::c_void;
+    fn abi_is_possibly_valid(abi: &Self::Abi) -> bool {
+        !abi.is_null()
+    }
+}
 impl ID3D10EffectSamplerVariable {
     #[doc = "*Required features: `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
@@ -3853,9 +3910,6 @@ unsafe impl ::core::marker::Sync for ID3D10EffectSamplerVariable {}
 unsafe impl ::windows::core::Vtable for ID3D10EffectSamplerVariable {
     type Vtable = ID3D10EffectSamplerVariable_Vtbl;
 }
-unsafe impl ::windows::core::Interface for ID3D10EffectSamplerVariable {
-    const IID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6530d5c7_07e9_4271_a418_e7ce4bd1e480);
-}
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D10EffectSamplerVariable_Vtbl {
@@ -3865,7 +3919,16 @@ pub struct ID3D10EffectSamplerVariable_Vtbl {
 }
 #[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`*"]
 #[repr(transparent)]
-pub struct ID3D10EffectScalarVariable(::windows::core::IUnknown);
+pub struct ID3D10EffectScalarVariable(::std::ptr::NonNull<::std::ffi::c_void>);
+unsafe impl ::windows::core::Abi for Option<ID3D10EffectScalarVariable> {
+    type Abi = *mut ::std::ffi::c_void;
+}
+unsafe impl ::windows::core::Abi for ID3D10EffectScalarVariable {
+    type Abi = *mut ::std::ffi::c_void;
+    fn abi_is_possibly_valid(abi: &Self::Abi) -> bool {
+        !abi.is_null()
+    }
+}
 impl ID3D10EffectScalarVariable {
     #[doc = "*Required features: `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
@@ -4041,9 +4104,6 @@ unsafe impl ::core::marker::Sync for ID3D10EffectScalarVariable {}
 unsafe impl ::windows::core::Vtable for ID3D10EffectScalarVariable {
     type Vtable = ID3D10EffectScalarVariable_Vtbl;
 }
-unsafe impl ::windows::core::Interface for ID3D10EffectScalarVariable {
-    const IID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x00e48f7b_d2c8_49e8_a86c_022dee53431f);
-}
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D10EffectScalarVariable_Vtbl {
@@ -4075,7 +4135,16 @@ pub struct ID3D10EffectScalarVariable_Vtbl {
 }
 #[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`*"]
 #[repr(transparent)]
-pub struct ID3D10EffectShaderResourceVariable(::windows::core::IUnknown);
+pub struct ID3D10EffectShaderResourceVariable(::std::ptr::NonNull<::std::ffi::c_void>);
+unsafe impl ::windows::core::Abi for Option<ID3D10EffectShaderResourceVariable> {
+    type Abi = *mut ::std::ffi::c_void;
+}
+unsafe impl ::windows::core::Abi for ID3D10EffectShaderResourceVariable {
+    type Abi = *mut ::std::ffi::c_void;
+    fn abi_is_possibly_valid(abi: &Self::Abi) -> bool {
+        !abi.is_null()
+    }
+}
 impl ID3D10EffectShaderResourceVariable {
     #[doc = "*Required features: `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
@@ -4217,9 +4286,6 @@ unsafe impl ::core::marker::Sync for ID3D10EffectShaderResourceVariable {}
 unsafe impl ::windows::core::Vtable for ID3D10EffectShaderResourceVariable {
     type Vtable = ID3D10EffectShaderResourceVariable_Vtbl;
 }
-unsafe impl ::windows::core::Interface for ID3D10EffectShaderResourceVariable {
-    const IID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc0a7157b_d872_4b1d_8073_efc2acd4b1fc);
-}
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D10EffectShaderResourceVariable_Vtbl {
@@ -4231,7 +4297,16 @@ pub struct ID3D10EffectShaderResourceVariable_Vtbl {
 }
 #[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`*"]
 #[repr(transparent)]
-pub struct ID3D10EffectShaderVariable(::windows::core::IUnknown);
+pub struct ID3D10EffectShaderVariable(::std::ptr::NonNull<::std::ffi::c_void>);
+unsafe impl ::windows::core::Abi for Option<ID3D10EffectShaderVariable> {
+    type Abi = *mut ::std::ffi::c_void;
+}
+unsafe impl ::windows::core::Abi for ID3D10EffectShaderVariable {
+    type Abi = *mut ::std::ffi::c_void;
+    fn abi_is_possibly_valid(abi: &Self::Abi) -> bool {
+        !abi.is_null()
+    }
+}
 impl ID3D10EffectShaderVariable {
     #[doc = "*Required features: `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
@@ -4387,9 +4462,6 @@ unsafe impl ::core::marker::Sync for ID3D10EffectShaderVariable {}
 unsafe impl ::windows::core::Vtable for ID3D10EffectShaderVariable {
     type Vtable = ID3D10EffectShaderVariable_Vtbl;
 }
-unsafe impl ::windows::core::Interface for ID3D10EffectShaderVariable {
-    const IID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x80849279_c799_4797_8c33_0407a07d9e06);
-}
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D10EffectShaderVariable_Vtbl {
@@ -4412,7 +4484,16 @@ pub struct ID3D10EffectShaderVariable_Vtbl {
 }
 #[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`*"]
 #[repr(transparent)]
-pub struct ID3D10EffectStringVariable(::windows::core::IUnknown);
+pub struct ID3D10EffectStringVariable(::std::ptr::NonNull<::std::ffi::c_void>);
+unsafe impl ::windows::core::Abi for Option<ID3D10EffectStringVariable> {
+    type Abi = *mut ::std::ffi::c_void;
+}
+unsafe impl ::windows::core::Abi for ID3D10EffectStringVariable {
+    type Abi = *mut ::std::ffi::c_void;
+    fn abi_is_possibly_valid(abi: &Self::Abi) -> bool {
+        !abi.is_null()
+    }
+}
 impl ID3D10EffectStringVariable {
     #[doc = "*Required features: `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
@@ -4545,9 +4626,6 @@ unsafe impl ::core::marker::Sync for ID3D10EffectStringVariable {}
 unsafe impl ::windows::core::Vtable for ID3D10EffectStringVariable {
     type Vtable = ID3D10EffectStringVariable_Vtbl;
 }
-unsafe impl ::windows::core::Interface for ID3D10EffectStringVariable {
-    const IID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x71417501_8df9_4e0a_a78a_255f9756baff);
-}
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D10EffectStringVariable_Vtbl {
@@ -4557,7 +4635,16 @@ pub struct ID3D10EffectStringVariable_Vtbl {
 }
 #[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`*"]
 #[repr(transparent)]
-pub struct ID3D10EffectTechnique(::windows::core::IUnknown);
+pub struct ID3D10EffectTechnique(::std::ptr::NonNull<::std::ffi::c_void>);
+unsafe impl ::windows::core::Abi for Option<ID3D10EffectTechnique> {
+    type Abi = *mut ::std::ffi::c_void;
+}
+unsafe impl ::windows::core::Abi for ID3D10EffectTechnique {
+    type Abi = *mut ::std::ffi::c_void;
+    fn abi_is_possibly_valid(abi: &Self::Abi) -> bool {
+        !abi.is_null()
+    }
+}
 impl ID3D10EffectTechnique {
     #[doc = "*Required features: `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
@@ -4611,9 +4698,6 @@ unsafe impl ::core::marker::Sync for ID3D10EffectTechnique {}
 unsafe impl ::windows::core::Vtable for ID3D10EffectTechnique {
     type Vtable = ID3D10EffectTechnique_Vtbl;
 }
-unsafe impl ::windows::core::Interface for ID3D10EffectTechnique {
-    const IID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xdb122ce8_d1c9_4292_b237_24ed3de8b175);
-}
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D10EffectTechnique_Vtbl {
@@ -4630,7 +4714,16 @@ pub struct ID3D10EffectTechnique_Vtbl {
 }
 #[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`*"]
 #[repr(transparent)]
-pub struct ID3D10EffectType(::windows::core::IUnknown);
+pub struct ID3D10EffectType(::std::ptr::NonNull<::std::ffi::c_void>);
+unsafe impl ::windows::core::Abi for Option<ID3D10EffectType> {
+    type Abi = *mut ::std::ffi::c_void;
+}
+unsafe impl ::windows::core::Abi for ID3D10EffectType {
+    type Abi = *mut ::std::ffi::c_void;
+    fn abi_is_possibly_valid(abi: &Self::Abi) -> bool {
+        !abi.is_null()
+    }
+}
 impl ID3D10EffectType {
     #[doc = "*Required features: `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
@@ -4685,9 +4778,6 @@ unsafe impl ::core::marker::Sync for ID3D10EffectType {}
 unsafe impl ::windows::core::Vtable for ID3D10EffectType {
     type Vtable = ID3D10EffectType_Vtbl;
 }
-unsafe impl ::windows::core::Interface for ID3D10EffectType {
-    const IID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4e9e1ddc_cd9d_4772_a837_00180b9b88fd);
-}
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D10EffectType_Vtbl {
@@ -4707,7 +4797,16 @@ pub struct ID3D10EffectType_Vtbl {
 }
 #[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`*"]
 #[repr(transparent)]
-pub struct ID3D10EffectVariable(::windows::core::IUnknown);
+pub struct ID3D10EffectVariable(::std::ptr::NonNull<::std::ffi::c_void>);
+unsafe impl ::windows::core::Abi for Option<ID3D10EffectVariable> {
+    type Abi = *mut ::std::ffi::c_void;
+}
+unsafe impl ::windows::core::Abi for ID3D10EffectVariable {
+    type Abi = *mut ::std::ffi::c_void;
+    fn abi_is_possibly_valid(abi: &Self::Abi) -> bool {
+        !abi.is_null()
+    }
+}
 impl ID3D10EffectVariable {
     #[doc = "*Required features: `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
@@ -4818,9 +4917,6 @@ unsafe impl ::core::marker::Sync for ID3D10EffectVariable {}
 unsafe impl ::windows::core::Vtable for ID3D10EffectVariable {
     type Vtable = ID3D10EffectVariable_Vtbl;
 }
-unsafe impl ::windows::core::Interface for ID3D10EffectVariable {
-    const IID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xae897105_00e6_45bf_bb8e_281dd6db8e1b);
-}
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D10EffectVariable_Vtbl {
@@ -4855,7 +4951,16 @@ pub struct ID3D10EffectVariable_Vtbl {
 }
 #[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`*"]
 #[repr(transparent)]
-pub struct ID3D10EffectVectorVariable(::windows::core::IUnknown);
+pub struct ID3D10EffectVectorVariable(::std::ptr::NonNull<::std::ffi::c_void>);
+unsafe impl ::windows::core::Abi for Option<ID3D10EffectVectorVariable> {
+    type Abi = *mut ::std::ffi::c_void;
+}
+unsafe impl ::windows::core::Abi for ID3D10EffectVectorVariable {
+    type Abi = *mut ::std::ffi::c_void;
+    fn abi_is_possibly_valid(abi: &Self::Abi) -> bool {
+        !abi.is_null()
+    }
+}
 impl ID3D10EffectVectorVariable {
     #[doc = "*Required features: `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
@@ -5024,9 +5129,6 @@ unsafe impl ::core::marker::Send for ID3D10EffectVectorVariable {}
 unsafe impl ::core::marker::Sync for ID3D10EffectVectorVariable {}
 unsafe impl ::windows::core::Vtable for ID3D10EffectVectorVariable {
     type Vtable = ID3D10EffectVectorVariable_Vtbl;
-}
-unsafe impl ::windows::core::Interface for ID3D10EffectVectorVariable {
-    const IID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x62b98c44_1f82_4c67_bcd0_72cf8f217e81);
 }
 #[repr(C)]
 #[doc(hidden)]
@@ -6493,7 +6595,16 @@ pub struct ID3D10ShaderReflection1_Vtbl {
 }
 #[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`*"]
 #[repr(transparent)]
-pub struct ID3D10ShaderReflectionConstantBuffer(::windows::core::IUnknown);
+pub struct ID3D10ShaderReflectionConstantBuffer(::std::ptr::NonNull<::std::ffi::c_void>);
+unsafe impl ::windows::core::Abi for Option<ID3D10ShaderReflectionConstantBuffer> {
+    type Abi = *mut ::std::ffi::c_void;
+}
+unsafe impl ::windows::core::Abi for ID3D10ShaderReflectionConstantBuffer {
+    type Abi = *mut ::std::ffi::c_void;
+    fn abi_is_possibly_valid(abi: &Self::Abi) -> bool {
+        !abi.is_null()
+    }
+}
 impl ID3D10ShaderReflectionConstantBuffer {
     #[doc = "*Required features: `\"Win32_Graphics_Direct3D\"`*"]
     #[cfg(feature = "Win32_Graphics_Direct3D")]
@@ -6532,9 +6643,6 @@ unsafe impl ::core::marker::Sync for ID3D10ShaderReflectionConstantBuffer {}
 unsafe impl ::windows::core::Vtable for ID3D10ShaderReflectionConstantBuffer {
     type Vtable = ID3D10ShaderReflectionConstantBuffer_Vtbl;
 }
-unsafe impl ::windows::core::Interface for ID3D10ShaderReflectionConstantBuffer {
-    const IID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x66c66a94_dddd_4b62_a66a_f0da33c2b4d0);
-}
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D10ShaderReflectionConstantBuffer_Vtbl {
@@ -6547,7 +6655,16 @@ pub struct ID3D10ShaderReflectionConstantBuffer_Vtbl {
 }
 #[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`*"]
 #[repr(transparent)]
-pub struct ID3D10ShaderReflectionType(::windows::core::IUnknown);
+pub struct ID3D10ShaderReflectionType(::std::ptr::NonNull<::std::ffi::c_void>);
+unsafe impl ::windows::core::Abi for Option<ID3D10ShaderReflectionType> {
+    type Abi = *mut ::std::ffi::c_void;
+}
+unsafe impl ::windows::core::Abi for ID3D10ShaderReflectionType {
+    type Abi = *mut ::std::ffi::c_void;
+    fn abi_is_possibly_valid(abi: &Self::Abi) -> bool {
+        !abi.is_null()
+    }
+}
 impl ID3D10ShaderReflectionType {
     #[doc = "*Required features: `\"Win32_Graphics_Direct3D\"`*"]
     #[cfg(feature = "Win32_Graphics_Direct3D")]
@@ -6588,9 +6705,6 @@ unsafe impl ::core::marker::Sync for ID3D10ShaderReflectionType {}
 unsafe impl ::windows::core::Vtable for ID3D10ShaderReflectionType {
     type Vtable = ID3D10ShaderReflectionType_Vtbl;
 }
-unsafe impl ::windows::core::Interface for ID3D10ShaderReflectionType {
-    const IID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc530ad7d_9b16_4395_a979_ba2ecff83add);
-}
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D10ShaderReflectionType_Vtbl {
@@ -6604,7 +6718,16 @@ pub struct ID3D10ShaderReflectionType_Vtbl {
 }
 #[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`*"]
 #[repr(transparent)]
-pub struct ID3D10ShaderReflectionVariable(::windows::core::IUnknown);
+pub struct ID3D10ShaderReflectionVariable(::std::ptr::NonNull<::std::ffi::c_void>);
+unsafe impl ::windows::core::Abi for Option<ID3D10ShaderReflectionVariable> {
+    type Abi = *mut ::std::ffi::c_void;
+}
+unsafe impl ::windows::core::Abi for ID3D10ShaderReflectionVariable {
+    type Abi = *mut ::std::ffi::c_void;
+    fn abi_is_possibly_valid(abi: &Self::Abi) -> bool {
+        !abi.is_null()
+    }
+}
 impl ID3D10ShaderReflectionVariable {
     pub unsafe fn GetDesc(&self) -> ::windows::core::Result<D3D10_SHADER_VARIABLE_DESC> {
         let mut result__ = ::core::mem::MaybeUninit::zeroed();
@@ -6634,9 +6757,6 @@ unsafe impl ::core::marker::Send for ID3D10ShaderReflectionVariable {}
 unsafe impl ::core::marker::Sync for ID3D10ShaderReflectionVariable {}
 unsafe impl ::windows::core::Vtable for ID3D10ShaderReflectionVariable {
     type Vtable = ID3D10ShaderReflectionVariable_Vtbl;
-}
-unsafe impl ::windows::core::Interface for ID3D10ShaderReflectionVariable {
-    const IID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1bf63c95_2650_405d_99c1_3636bd1da0a1);
 }
 #[repr(C)]
 #[doc(hidden)]

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D11/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D11/impl.rs
@@ -2516,13 +2516,11 @@ pub trait ID3D11FunctionParameterReflection_Impl: Sized {
     fn GetDesc(&self) -> ::windows::core::Result<D3D11_PARAMETER_DESC>;
 }
 #[cfg(feature = "Win32_Graphics_Direct3D")]
-impl ::windows::core::RuntimeName for ID3D11FunctionParameterReflection {}
-#[cfg(feature = "Win32_Graphics_Direct3D")]
 impl ID3D11FunctionParameterReflection_Vtbl {
-    pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D11FunctionParameterReflection_Impl, const OFFSET: isize>() -> ID3D11FunctionParameterReflection_Vtbl {
-        unsafe extern "system" fn GetDesc<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D11FunctionParameterReflection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D11_PARAMETER_DESC) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+    pub const fn new<Impl: ID3D11FunctionParameterReflection_Impl>() -> ID3D11FunctionParameterReflection_Vtbl {
+        unsafe extern "system" fn GetDesc<Impl: ID3D11FunctionParameterReflection_Impl>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D11_PARAMETER_DESC) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             match this.GetDesc() {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
@@ -2531,10 +2529,22 @@ impl ID3D11FunctionParameterReflection_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { GetDesc: GetDesc::<Identity, Impl, OFFSET> }
+        Self { GetDesc: GetDesc::<Impl> }
     }
-    pub fn matches(iid: &windows::core::GUID) -> bool {
-        iid == &<ID3D11FunctionParameterReflection as ::windows::core::Interface>::IID
+}
+#[doc(hidden)]
+#[cfg(feature = "Win32_Graphics_Direct3D")]
+struct ID3D11FunctionParameterReflection_ImplVtbl<T: ID3D11FunctionParameterReflection_Impl>(::std::marker::PhantomData<T>);
+#[cfg(feature = "Win32_Graphics_Direct3D")]
+impl<T: ID3D11FunctionParameterReflection_Impl> ID3D11FunctionParameterReflection_ImplVtbl<T> {
+    const VTABLE: ID3D11FunctionParameterReflection_Vtbl = ID3D11FunctionParameterReflection_Vtbl::new::<T>();
+}
+#[cfg(feature = "Win32_Graphics_Direct3D")]
+impl ID3D11FunctionParameterReflection {
+    pub fn new<'a, T: ID3D11FunctionParameterReflection_Impl>(this: &'a T) -> ::windows::core::ScopedInterface<'a, Self> {
+        let this = ::windows::core::ScopedHeap { vtable: &ID3D11FunctionParameterReflection_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
+        let this = ::std::mem::ManuallyDrop::new(::std::boxed::Box::new(this));
+        unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D"))]
@@ -2548,13 +2558,11 @@ pub trait ID3D11FunctionReflection_Impl: Sized {
     fn GetFunctionParameter(&self, parameterindex: i32) -> ::core::option::Option<ID3D11FunctionParameterReflection>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D"))]
-impl ::windows::core::RuntimeName for ID3D11FunctionReflection {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D"))]
 impl ID3D11FunctionReflection_Vtbl {
-    pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D11FunctionReflection_Impl, const OFFSET: isize>() -> ID3D11FunctionReflection_Vtbl {
-        unsafe extern "system" fn GetDesc<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D11FunctionReflection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D11_FUNCTION_DESC) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+    pub const fn new<Impl: ID3D11FunctionReflection_Impl>() -> ID3D11FunctionReflection_Vtbl {
+        unsafe extern "system" fn GetDesc<Impl: ID3D11FunctionReflection_Impl>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D11_FUNCTION_DESC) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             match this.GetDesc() {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
@@ -2563,19 +2571,19 @@ impl ID3D11FunctionReflection_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        unsafe extern "system" fn GetConstantBufferByIndex<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D11FunctionReflection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bufferindex: u32) -> ::core::option::Option<ID3D11ShaderReflectionConstantBuffer> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetConstantBufferByIndex<Impl: ID3D11FunctionReflection_Impl>(this: *mut ::core::ffi::c_void, bufferindex: u32) -> ::core::option::Option<ID3D11ShaderReflectionConstantBuffer> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetConstantBufferByIndex(::core::mem::transmute_copy(&bufferindex))
         }
-        unsafe extern "system" fn GetConstantBufferByName<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D11FunctionReflection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, name: ::windows::core::PCSTR) -> ::core::option::Option<ID3D11ShaderReflectionConstantBuffer> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetConstantBufferByName<Impl: ID3D11FunctionReflection_Impl>(this: *mut ::core::ffi::c_void, name: ::windows::core::PCSTR) -> ::core::option::Option<ID3D11ShaderReflectionConstantBuffer> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetConstantBufferByName(::core::mem::transmute(&name))
         }
-        unsafe extern "system" fn GetResourceBindingDesc<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D11FunctionReflection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, resourceindex: u32, pdesc: *mut D3D11_SHADER_INPUT_BIND_DESC) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetResourceBindingDesc<Impl: ID3D11FunctionReflection_Impl>(this: *mut ::core::ffi::c_void, resourceindex: u32, pdesc: *mut D3D11_SHADER_INPUT_BIND_DESC) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             match this.GetResourceBindingDesc(::core::mem::transmute_copy(&resourceindex)) {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
@@ -2584,14 +2592,14 @@ impl ID3D11FunctionReflection_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        unsafe extern "system" fn GetVariableByName<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D11FunctionReflection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, name: ::windows::core::PCSTR) -> ::core::option::Option<ID3D11ShaderReflectionVariable> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetVariableByName<Impl: ID3D11FunctionReflection_Impl>(this: *mut ::core::ffi::c_void, name: ::windows::core::PCSTR) -> ::core::option::Option<ID3D11ShaderReflectionVariable> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetVariableByName(::core::mem::transmute(&name))
         }
-        unsafe extern "system" fn GetResourceBindingDescByName<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D11FunctionReflection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, name: ::windows::core::PCSTR, pdesc: *mut D3D11_SHADER_INPUT_BIND_DESC) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetResourceBindingDescByName<Impl: ID3D11FunctionReflection_Impl>(this: *mut ::core::ffi::c_void, name: ::windows::core::PCSTR, pdesc: *mut D3D11_SHADER_INPUT_BIND_DESC) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             match this.GetResourceBindingDescByName(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
@@ -2600,23 +2608,35 @@ impl ID3D11FunctionReflection_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        unsafe extern "system" fn GetFunctionParameter<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D11FunctionReflection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, parameterindex: i32) -> ::core::option::Option<ID3D11FunctionParameterReflection> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetFunctionParameter<Impl: ID3D11FunctionReflection_Impl>(this: *mut ::core::ffi::c_void, parameterindex: i32) -> ::core::option::Option<ID3D11FunctionParameterReflection> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetFunctionParameter(::core::mem::transmute_copy(&parameterindex))
         }
         Self {
-            GetDesc: GetDesc::<Identity, Impl, OFFSET>,
-            GetConstantBufferByIndex: GetConstantBufferByIndex::<Identity, Impl, OFFSET>,
-            GetConstantBufferByName: GetConstantBufferByName::<Identity, Impl, OFFSET>,
-            GetResourceBindingDesc: GetResourceBindingDesc::<Identity, Impl, OFFSET>,
-            GetVariableByName: GetVariableByName::<Identity, Impl, OFFSET>,
-            GetResourceBindingDescByName: GetResourceBindingDescByName::<Identity, Impl, OFFSET>,
-            GetFunctionParameter: GetFunctionParameter::<Identity, Impl, OFFSET>,
+            GetDesc: GetDesc::<Impl>,
+            GetConstantBufferByIndex: GetConstantBufferByIndex::<Impl>,
+            GetConstantBufferByName: GetConstantBufferByName::<Impl>,
+            GetResourceBindingDesc: GetResourceBindingDesc::<Impl>,
+            GetVariableByName: GetVariableByName::<Impl>,
+            GetResourceBindingDescByName: GetResourceBindingDescByName::<Impl>,
+            GetFunctionParameter: GetFunctionParameter::<Impl>,
         }
     }
-    pub fn matches(iid: &windows::core::GUID) -> bool {
-        iid == &<ID3D11FunctionReflection as ::windows::core::Interface>::IID
+}
+#[doc(hidden)]
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D"))]
+struct ID3D11FunctionReflection_ImplVtbl<T: ID3D11FunctionReflection_Impl>(::std::marker::PhantomData<T>);
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D"))]
+impl<T: ID3D11FunctionReflection_Impl> ID3D11FunctionReflection_ImplVtbl<T> {
+    const VTABLE: ID3D11FunctionReflection_Vtbl = ID3D11FunctionReflection_Vtbl::new::<T>();
+}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D"))]
+impl ID3D11FunctionReflection {
+    pub fn new<'a, T: ID3D11FunctionReflection_Impl>(this: &'a T) -> ::windows::core::ScopedInterface<'a, Self> {
+        let this = ::windows::core::ScopedHeap { vtable: &ID3D11FunctionReflection_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
+        let this = ::std::mem::ManuallyDrop::new(::std::boxed::Box::new(this));
+        unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
 pub trait ID3D11GeometryShader_Impl: Sized + ID3D11DeviceChild_Impl {}
@@ -3577,33 +3597,39 @@ pub trait ID3D11ShaderReflectionConstantBuffer_Impl: Sized {
     fn GetVariableByName(&self, name: &::windows::core::PCSTR) -> ::core::option::Option<ID3D11ShaderReflectionVariable>;
 }
 #[cfg(feature = "Win32_Graphics_Direct3D")]
-impl ::windows::core::RuntimeName for ID3D11ShaderReflectionConstantBuffer {}
-#[cfg(feature = "Win32_Graphics_Direct3D")]
 impl ID3D11ShaderReflectionConstantBuffer_Vtbl {
-    pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D11ShaderReflectionConstantBuffer_Impl, const OFFSET: isize>() -> ID3D11ShaderReflectionConstantBuffer_Vtbl {
-        unsafe extern "system" fn GetDesc<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D11ShaderReflectionConstantBuffer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D11_SHADER_BUFFER_DESC) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+    pub const fn new<Impl: ID3D11ShaderReflectionConstantBuffer_Impl>() -> ID3D11ShaderReflectionConstantBuffer_Vtbl {
+        unsafe extern "system" fn GetDesc<Impl: ID3D11ShaderReflectionConstantBuffer_Impl>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D11_SHADER_BUFFER_DESC) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetDesc(::core::mem::transmute_copy(&pdesc)).into()
         }
-        unsafe extern "system" fn GetVariableByIndex<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D11ShaderReflectionConstantBuffer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: u32) -> ::core::option::Option<ID3D11ShaderReflectionVariable> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetVariableByIndex<Impl: ID3D11ShaderReflectionConstantBuffer_Impl>(this: *mut ::core::ffi::c_void, index: u32) -> ::core::option::Option<ID3D11ShaderReflectionVariable> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetVariableByIndex(::core::mem::transmute_copy(&index))
         }
-        unsafe extern "system" fn GetVariableByName<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D11ShaderReflectionConstantBuffer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, name: ::windows::core::PCSTR) -> ::core::option::Option<ID3D11ShaderReflectionVariable> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetVariableByName<Impl: ID3D11ShaderReflectionConstantBuffer_Impl>(this: *mut ::core::ffi::c_void, name: ::windows::core::PCSTR) -> ::core::option::Option<ID3D11ShaderReflectionVariable> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetVariableByName(::core::mem::transmute(&name))
         }
-        Self {
-            GetDesc: GetDesc::<Identity, Impl, OFFSET>,
-            GetVariableByIndex: GetVariableByIndex::<Identity, Impl, OFFSET>,
-            GetVariableByName: GetVariableByName::<Identity, Impl, OFFSET>,
-        }
+        Self { GetDesc: GetDesc::<Impl>, GetVariableByIndex: GetVariableByIndex::<Impl>, GetVariableByName: GetVariableByName::<Impl> }
     }
-    pub fn matches(iid: &windows::core::GUID) -> bool {
-        iid == &<ID3D11ShaderReflectionConstantBuffer as ::windows::core::Interface>::IID
+}
+#[doc(hidden)]
+#[cfg(feature = "Win32_Graphics_Direct3D")]
+struct ID3D11ShaderReflectionConstantBuffer_ImplVtbl<T: ID3D11ShaderReflectionConstantBuffer_Impl>(::std::marker::PhantomData<T>);
+#[cfg(feature = "Win32_Graphics_Direct3D")]
+impl<T: ID3D11ShaderReflectionConstantBuffer_Impl> ID3D11ShaderReflectionConstantBuffer_ImplVtbl<T> {
+    const VTABLE: ID3D11ShaderReflectionConstantBuffer_Vtbl = ID3D11ShaderReflectionConstantBuffer_Vtbl::new::<T>();
+}
+#[cfg(feature = "Win32_Graphics_Direct3D")]
+impl ID3D11ShaderReflectionConstantBuffer {
+    pub fn new<'a, T: ID3D11ShaderReflectionConstantBuffer_Impl>(this: &'a T) -> ::windows::core::ScopedInterface<'a, Self> {
+        let this = ::windows::core::ScopedHeap { vtable: &ID3D11ShaderReflectionConstantBuffer_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
+        let this = ::std::mem::ManuallyDrop::new(::std::boxed::Box::new(this));
+        unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D")]
@@ -3621,13 +3647,11 @@ pub trait ID3D11ShaderReflectionType_Impl: Sized {
     fn ImplementsInterface(&self, pbase: &::core::option::Option<ID3D11ShaderReflectionType>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Graphics_Direct3D")]
-impl ::windows::core::RuntimeName for ID3D11ShaderReflectionType {}
-#[cfg(feature = "Win32_Graphics_Direct3D")]
 impl ID3D11ShaderReflectionType_Vtbl {
-    pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D11ShaderReflectionType_Impl, const OFFSET: isize>() -> ID3D11ShaderReflectionType_Vtbl {
-        unsafe extern "system" fn GetDesc<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D11ShaderReflectionType_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D11_SHADER_TYPE_DESC) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+    pub const fn new<Impl: ID3D11ShaderReflectionType_Impl>() -> ID3D11ShaderReflectionType_Vtbl {
+        unsafe extern "system" fn GetDesc<Impl: ID3D11ShaderReflectionType_Impl>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D11_SHADER_TYPE_DESC) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             match this.GetDesc() {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
@@ -3636,72 +3660,84 @@ impl ID3D11ShaderReflectionType_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        unsafe extern "system" fn GetMemberTypeByIndex<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D11ShaderReflectionType_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: u32) -> ::core::option::Option<ID3D11ShaderReflectionType> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetMemberTypeByIndex<Impl: ID3D11ShaderReflectionType_Impl>(this: *mut ::core::ffi::c_void, index: u32) -> ::core::option::Option<ID3D11ShaderReflectionType> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetMemberTypeByIndex(::core::mem::transmute_copy(&index))
         }
-        unsafe extern "system" fn GetMemberTypeByName<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D11ShaderReflectionType_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, name: ::windows::core::PCSTR) -> ::core::option::Option<ID3D11ShaderReflectionType> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetMemberTypeByName<Impl: ID3D11ShaderReflectionType_Impl>(this: *mut ::core::ffi::c_void, name: ::windows::core::PCSTR) -> ::core::option::Option<ID3D11ShaderReflectionType> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetMemberTypeByName(::core::mem::transmute(&name))
         }
-        unsafe extern "system" fn GetMemberTypeName<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D11ShaderReflectionType_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: u32) -> ::windows::core::PSTR {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetMemberTypeName<Impl: ID3D11ShaderReflectionType_Impl>(this: *mut ::core::ffi::c_void, index: u32) -> ::windows::core::PSTR {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetMemberTypeName(::core::mem::transmute_copy(&index))
         }
-        unsafe extern "system" fn IsEqual<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D11ShaderReflectionType_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ptype: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn IsEqual<Impl: ID3D11ShaderReflectionType_Impl>(this: *mut ::core::ffi::c_void, ptype: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.IsEqual(::core::mem::transmute(&ptype)).into()
         }
-        unsafe extern "system" fn GetSubType<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D11ShaderReflectionType_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::core::option::Option<ID3D11ShaderReflectionType> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetSubType<Impl: ID3D11ShaderReflectionType_Impl>(this: *mut ::core::ffi::c_void) -> ::core::option::Option<ID3D11ShaderReflectionType> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetSubType()
         }
-        unsafe extern "system" fn GetBaseClass<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D11ShaderReflectionType_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::core::option::Option<ID3D11ShaderReflectionType> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetBaseClass<Impl: ID3D11ShaderReflectionType_Impl>(this: *mut ::core::ffi::c_void) -> ::core::option::Option<ID3D11ShaderReflectionType> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetBaseClass()
         }
-        unsafe extern "system" fn GetNumInterfaces<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D11ShaderReflectionType_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> u32 {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetNumInterfaces<Impl: ID3D11ShaderReflectionType_Impl>(this: *mut ::core::ffi::c_void) -> u32 {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetNumInterfaces()
         }
-        unsafe extern "system" fn GetInterfaceByIndex<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D11ShaderReflectionType_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, uindex: u32) -> ::core::option::Option<ID3D11ShaderReflectionType> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetInterfaceByIndex<Impl: ID3D11ShaderReflectionType_Impl>(this: *mut ::core::ffi::c_void, uindex: u32) -> ::core::option::Option<ID3D11ShaderReflectionType> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetInterfaceByIndex(::core::mem::transmute_copy(&uindex))
         }
-        unsafe extern "system" fn IsOfType<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D11ShaderReflectionType_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ptype: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn IsOfType<Impl: ID3D11ShaderReflectionType_Impl>(this: *mut ::core::ffi::c_void, ptype: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.IsOfType(::core::mem::transmute(&ptype)).into()
         }
-        unsafe extern "system" fn ImplementsInterface<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D11ShaderReflectionType_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbase: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn ImplementsInterface<Impl: ID3D11ShaderReflectionType_Impl>(this: *mut ::core::ffi::c_void, pbase: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.ImplementsInterface(::core::mem::transmute(&pbase)).into()
         }
         Self {
-            GetDesc: GetDesc::<Identity, Impl, OFFSET>,
-            GetMemberTypeByIndex: GetMemberTypeByIndex::<Identity, Impl, OFFSET>,
-            GetMemberTypeByName: GetMemberTypeByName::<Identity, Impl, OFFSET>,
-            GetMemberTypeName: GetMemberTypeName::<Identity, Impl, OFFSET>,
-            IsEqual: IsEqual::<Identity, Impl, OFFSET>,
-            GetSubType: GetSubType::<Identity, Impl, OFFSET>,
-            GetBaseClass: GetBaseClass::<Identity, Impl, OFFSET>,
-            GetNumInterfaces: GetNumInterfaces::<Identity, Impl, OFFSET>,
-            GetInterfaceByIndex: GetInterfaceByIndex::<Identity, Impl, OFFSET>,
-            IsOfType: IsOfType::<Identity, Impl, OFFSET>,
-            ImplementsInterface: ImplementsInterface::<Identity, Impl, OFFSET>,
+            GetDesc: GetDesc::<Impl>,
+            GetMemberTypeByIndex: GetMemberTypeByIndex::<Impl>,
+            GetMemberTypeByName: GetMemberTypeByName::<Impl>,
+            GetMemberTypeName: GetMemberTypeName::<Impl>,
+            IsEqual: IsEqual::<Impl>,
+            GetSubType: GetSubType::<Impl>,
+            GetBaseClass: GetBaseClass::<Impl>,
+            GetNumInterfaces: GetNumInterfaces::<Impl>,
+            GetInterfaceByIndex: GetInterfaceByIndex::<Impl>,
+            IsOfType: IsOfType::<Impl>,
+            ImplementsInterface: ImplementsInterface::<Impl>,
         }
     }
-    pub fn matches(iid: &windows::core::GUID) -> bool {
-        iid == &<ID3D11ShaderReflectionType as ::windows::core::Interface>::IID
+}
+#[doc(hidden)]
+#[cfg(feature = "Win32_Graphics_Direct3D")]
+struct ID3D11ShaderReflectionType_ImplVtbl<T: ID3D11ShaderReflectionType_Impl>(::std::marker::PhantomData<T>);
+#[cfg(feature = "Win32_Graphics_Direct3D")]
+impl<T: ID3D11ShaderReflectionType_Impl> ID3D11ShaderReflectionType_ImplVtbl<T> {
+    const VTABLE: ID3D11ShaderReflectionType_Vtbl = ID3D11ShaderReflectionType_Vtbl::new::<T>();
+}
+#[cfg(feature = "Win32_Graphics_Direct3D")]
+impl ID3D11ShaderReflectionType {
+    pub fn new<'a, T: ID3D11ShaderReflectionType_Impl>(this: &'a T) -> ::windows::core::ScopedInterface<'a, Self> {
+        let this = ::windows::core::ScopedHeap { vtable: &ID3D11ShaderReflectionType_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
+        let this = ::std::mem::ManuallyDrop::new(::std::boxed::Box::new(this));
+        unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
 pub trait ID3D11ShaderReflectionVariable_Impl: Sized {
@@ -3710,12 +3746,11 @@ pub trait ID3D11ShaderReflectionVariable_Impl: Sized {
     fn GetBuffer(&self) -> ::core::option::Option<ID3D11ShaderReflectionConstantBuffer>;
     fn GetInterfaceSlot(&self, uarrayindex: u32) -> u32;
 }
-impl ::windows::core::RuntimeName for ID3D11ShaderReflectionVariable {}
 impl ID3D11ShaderReflectionVariable_Vtbl {
-    pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D11ShaderReflectionVariable_Impl, const OFFSET: isize>() -> ID3D11ShaderReflectionVariable_Vtbl {
-        unsafe extern "system" fn GetDesc<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D11ShaderReflectionVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D11_SHADER_VARIABLE_DESC) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+    pub const fn new<Impl: ID3D11ShaderReflectionVariable_Impl>() -> ID3D11ShaderReflectionVariable_Vtbl {
+        unsafe extern "system" fn GetDesc<Impl: ID3D11ShaderReflectionVariable_Impl>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D11_SHADER_VARIABLE_DESC) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             match this.GetDesc() {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
@@ -3724,30 +3759,34 @@ impl ID3D11ShaderReflectionVariable_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        unsafe extern "system" fn GetType<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D11ShaderReflectionVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::core::option::Option<ID3D11ShaderReflectionType> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetType<Impl: ID3D11ShaderReflectionVariable_Impl>(this: *mut ::core::ffi::c_void) -> ::core::option::Option<ID3D11ShaderReflectionType> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetType()
         }
-        unsafe extern "system" fn GetBuffer<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D11ShaderReflectionVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::core::option::Option<ID3D11ShaderReflectionConstantBuffer> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetBuffer<Impl: ID3D11ShaderReflectionVariable_Impl>(this: *mut ::core::ffi::c_void) -> ::core::option::Option<ID3D11ShaderReflectionConstantBuffer> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetBuffer()
         }
-        unsafe extern "system" fn GetInterfaceSlot<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D11ShaderReflectionVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, uarrayindex: u32) -> u32 {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetInterfaceSlot<Impl: ID3D11ShaderReflectionVariable_Impl>(this: *mut ::core::ffi::c_void, uarrayindex: u32) -> u32 {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetInterfaceSlot(::core::mem::transmute_copy(&uarrayindex))
         }
-        Self {
-            GetDesc: GetDesc::<Identity, Impl, OFFSET>,
-            GetType: GetType::<Identity, Impl, OFFSET>,
-            GetBuffer: GetBuffer::<Identity, Impl, OFFSET>,
-            GetInterfaceSlot: GetInterfaceSlot::<Identity, Impl, OFFSET>,
-        }
+        Self { GetDesc: GetDesc::<Impl>, GetType: GetType::<Impl>, GetBuffer: GetBuffer::<Impl>, GetInterfaceSlot: GetInterfaceSlot::<Impl> }
     }
-    pub fn matches(iid: &windows::core::GUID) -> bool {
-        iid == &<ID3D11ShaderReflectionVariable as ::windows::core::Interface>::IID
+}
+#[doc(hidden)]
+struct ID3D11ShaderReflectionVariable_ImplVtbl<T: ID3D11ShaderReflectionVariable_Impl>(::std::marker::PhantomData<T>);
+impl<T: ID3D11ShaderReflectionVariable_Impl> ID3D11ShaderReflectionVariable_ImplVtbl<T> {
+    const VTABLE: ID3D11ShaderReflectionVariable_Vtbl = ID3D11ShaderReflectionVariable_Vtbl::new::<T>();
+}
+impl ID3D11ShaderReflectionVariable {
+    pub fn new<'a, T: ID3D11ShaderReflectionVariable_Impl>(this: &'a T) -> ::windows::core::ScopedInterface<'a, Self> {
+        let this = ::windows::core::ScopedHeap { vtable: &ID3D11ShaderReflectionVariable_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
+        let this = ::std::mem::ManuallyDrop::new(::std::boxed::Box::new(this));
+        unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D11/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D11/mod.rs
@@ -8229,7 +8229,16 @@ pub struct ID3D11FunctionLinkingGraph_Vtbl {
 }
 #[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`*"]
 #[repr(transparent)]
-pub struct ID3D11FunctionParameterReflection(::windows::core::IUnknown);
+pub struct ID3D11FunctionParameterReflection(::std::ptr::NonNull<::std::ffi::c_void>);
+unsafe impl ::windows::core::Abi for Option<ID3D11FunctionParameterReflection> {
+    type Abi = *mut ::std::ffi::c_void;
+}
+unsafe impl ::windows::core::Abi for ID3D11FunctionParameterReflection {
+    type Abi = *mut ::std::ffi::c_void;
+    fn abi_is_possibly_valid(abi: &Self::Abi) -> bool {
+        !abi.is_null()
+    }
+}
 impl ID3D11FunctionParameterReflection {
     #[doc = "*Required features: `\"Win32_Graphics_Direct3D\"`*"]
     #[cfg(feature = "Win32_Graphics_Direct3D")]
@@ -8259,9 +8268,6 @@ unsafe impl ::core::marker::Sync for ID3D11FunctionParameterReflection {}
 unsafe impl ::windows::core::Vtable for ID3D11FunctionParameterReflection {
     type Vtable = ID3D11FunctionParameterReflection_Vtbl;
 }
-unsafe impl ::windows::core::Interface for ID3D11FunctionParameterReflection {
-    const IID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x42757488_334f_47fe_982e_1a65d08cc462);
-}
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D11FunctionParameterReflection_Vtbl {
@@ -8272,7 +8278,16 @@ pub struct ID3D11FunctionParameterReflection_Vtbl {
 }
 #[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`*"]
 #[repr(transparent)]
-pub struct ID3D11FunctionReflection(::windows::core::IUnknown);
+pub struct ID3D11FunctionReflection(::std::ptr::NonNull<::std::ffi::c_void>);
+unsafe impl ::windows::core::Abi for Option<ID3D11FunctionReflection> {
+    type Abi = *mut ::std::ffi::c_void;
+}
+unsafe impl ::windows::core::Abi for ID3D11FunctionReflection {
+    type Abi = *mut ::std::ffi::c_void;
+    fn abi_is_possibly_valid(abi: &Self::Abi) -> bool {
+        !abi.is_null()
+    }
+}
 impl ID3D11FunctionReflection {
     #[doc = "*Required features: `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D\"`*"]
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D"))]
@@ -8334,9 +8349,6 @@ unsafe impl ::core::marker::Send for ID3D11FunctionReflection {}
 unsafe impl ::core::marker::Sync for ID3D11FunctionReflection {}
 unsafe impl ::windows::core::Vtable for ID3D11FunctionReflection {
     type Vtable = ID3D11FunctionReflection_Vtbl;
-}
-unsafe impl ::windows::core::Interface for ID3D11FunctionReflection {
-    const IID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x207bcecb_d683_4a06_a8a3_9b149b9f73a4);
 }
 #[repr(C)]
 #[doc(hidden)]
@@ -10699,7 +10711,16 @@ pub struct ID3D11ShaderReflection_Vtbl {
 }
 #[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`*"]
 #[repr(transparent)]
-pub struct ID3D11ShaderReflectionConstantBuffer(::windows::core::IUnknown);
+pub struct ID3D11ShaderReflectionConstantBuffer(::std::ptr::NonNull<::std::ffi::c_void>);
+unsafe impl ::windows::core::Abi for Option<ID3D11ShaderReflectionConstantBuffer> {
+    type Abi = *mut ::std::ffi::c_void;
+}
+unsafe impl ::windows::core::Abi for ID3D11ShaderReflectionConstantBuffer {
+    type Abi = *mut ::std::ffi::c_void;
+    fn abi_is_possibly_valid(abi: &Self::Abi) -> bool {
+        !abi.is_null()
+    }
+}
 impl ID3D11ShaderReflectionConstantBuffer {
     #[doc = "*Required features: `\"Win32_Graphics_Direct3D\"`*"]
     #[cfg(feature = "Win32_Graphics_Direct3D")]
@@ -10737,9 +10758,6 @@ unsafe impl ::core::marker::Sync for ID3D11ShaderReflectionConstantBuffer {}
 unsafe impl ::windows::core::Vtable for ID3D11ShaderReflectionConstantBuffer {
     type Vtable = ID3D11ShaderReflectionConstantBuffer_Vtbl;
 }
-unsafe impl ::windows::core::Interface for ID3D11ShaderReflectionConstantBuffer {
-    const IID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xeb62d63d_93dd_4318_8ae8_c6f83ad371b8);
-}
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D11ShaderReflectionConstantBuffer_Vtbl {
@@ -10752,7 +10770,16 @@ pub struct ID3D11ShaderReflectionConstantBuffer_Vtbl {
 }
 #[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`*"]
 #[repr(transparent)]
-pub struct ID3D11ShaderReflectionType(::windows::core::IUnknown);
+pub struct ID3D11ShaderReflectionType(::std::ptr::NonNull<::std::ffi::c_void>);
+unsafe impl ::windows::core::Abi for Option<ID3D11ShaderReflectionType> {
+    type Abi = *mut ::std::ffi::c_void;
+}
+unsafe impl ::windows::core::Abi for ID3D11ShaderReflectionType {
+    type Abi = *mut ::std::ffi::c_void;
+    fn abi_is_possibly_valid(abi: &Self::Abi) -> bool {
+        !abi.is_null()
+    }
+}
 impl ID3D11ShaderReflectionType {
     #[doc = "*Required features: `\"Win32_Graphics_Direct3D\"`*"]
     #[cfg(feature = "Win32_Graphics_Direct3D")]
@@ -10824,9 +10851,6 @@ unsafe impl ::core::marker::Sync for ID3D11ShaderReflectionType {}
 unsafe impl ::windows::core::Vtable for ID3D11ShaderReflectionType {
     type Vtable = ID3D11ShaderReflectionType_Vtbl;
 }
-unsafe impl ::windows::core::Interface for ID3D11ShaderReflectionType {
-    const IID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6e6ffa6a_9bae_4613_a51e_91652d508c21);
-}
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D11ShaderReflectionType_Vtbl {
@@ -10847,7 +10871,16 @@ pub struct ID3D11ShaderReflectionType_Vtbl {
 }
 #[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`*"]
 #[repr(transparent)]
-pub struct ID3D11ShaderReflectionVariable(::windows::core::IUnknown);
+pub struct ID3D11ShaderReflectionVariable(::std::ptr::NonNull<::std::ffi::c_void>);
+unsafe impl ::windows::core::Abi for Option<ID3D11ShaderReflectionVariable> {
+    type Abi = *mut ::std::ffi::c_void;
+}
+unsafe impl ::windows::core::Abi for ID3D11ShaderReflectionVariable {
+    type Abi = *mut ::std::ffi::c_void;
+    fn abi_is_possibly_valid(abi: &Self::Abi) -> bool {
+        !abi.is_null()
+    }
+}
 impl ID3D11ShaderReflectionVariable {
     pub unsafe fn GetDesc(&self) -> ::windows::core::Result<D3D11_SHADER_VARIABLE_DESC> {
         let mut result__ = ::core::mem::MaybeUninit::zeroed();
@@ -10883,9 +10916,6 @@ unsafe impl ::core::marker::Send for ID3D11ShaderReflectionVariable {}
 unsafe impl ::core::marker::Sync for ID3D11ShaderReflectionVariable {}
 unsafe impl ::windows::core::Vtable for ID3D11ShaderReflectionVariable {
     type Vtable = ID3D11ShaderReflectionVariable_Vtbl;
-}
-unsafe impl ::windows::core::Interface for ID3D11ShaderReflectionVariable {
-    const IID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x51f23923_f3e5_4bd1_91cb_606177d8db4c);
 }
 #[repr(C)]
 #[doc(hidden)]

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D12/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D12/impl.rs
@@ -1444,13 +1444,11 @@ pub trait ID3D12FunctionParameterReflection_Impl: Sized {
     fn GetDesc(&self) -> ::windows::core::Result<D3D12_PARAMETER_DESC>;
 }
 #[cfg(feature = "Win32_Graphics_Direct3D")]
-impl ::windows::core::RuntimeName for ID3D12FunctionParameterReflection {}
-#[cfg(feature = "Win32_Graphics_Direct3D")]
 impl ID3D12FunctionParameterReflection_Vtbl {
-    pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D12FunctionParameterReflection_Impl, const OFFSET: isize>() -> ID3D12FunctionParameterReflection_Vtbl {
-        unsafe extern "system" fn GetDesc<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D12FunctionParameterReflection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D12_PARAMETER_DESC) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+    pub const fn new<Impl: ID3D12FunctionParameterReflection_Impl>() -> ID3D12FunctionParameterReflection_Vtbl {
+        unsafe extern "system" fn GetDesc<Impl: ID3D12FunctionParameterReflection_Impl>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D12_PARAMETER_DESC) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             match this.GetDesc() {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
@@ -1459,10 +1457,22 @@ impl ID3D12FunctionParameterReflection_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { GetDesc: GetDesc::<Identity, Impl, OFFSET> }
+        Self { GetDesc: GetDesc::<Impl> }
     }
-    pub fn matches(iid: &windows::core::GUID) -> bool {
-        iid == &<ID3D12FunctionParameterReflection as ::windows::core::Interface>::IID
+}
+#[doc(hidden)]
+#[cfg(feature = "Win32_Graphics_Direct3D")]
+struct ID3D12FunctionParameterReflection_ImplVtbl<T: ID3D12FunctionParameterReflection_Impl>(::std::marker::PhantomData<T>);
+#[cfg(feature = "Win32_Graphics_Direct3D")]
+impl<T: ID3D12FunctionParameterReflection_Impl> ID3D12FunctionParameterReflection_ImplVtbl<T> {
+    const VTABLE: ID3D12FunctionParameterReflection_Vtbl = ID3D12FunctionParameterReflection_Vtbl::new::<T>();
+}
+#[cfg(feature = "Win32_Graphics_Direct3D")]
+impl ID3D12FunctionParameterReflection {
+    pub fn new<'a, T: ID3D12FunctionParameterReflection_Impl>(this: &'a T) -> ::windows::core::ScopedInterface<'a, Self> {
+        let this = ::windows::core::ScopedHeap { vtable: &ID3D12FunctionParameterReflection_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
+        let this = ::std::mem::ManuallyDrop::new(::std::boxed::Box::new(this));
+        unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D"))]
@@ -1476,13 +1486,11 @@ pub trait ID3D12FunctionReflection_Impl: Sized {
     fn GetFunctionParameter(&self, parameterindex: i32) -> ::core::option::Option<ID3D12FunctionParameterReflection>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D"))]
-impl ::windows::core::RuntimeName for ID3D12FunctionReflection {}
-#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D"))]
 impl ID3D12FunctionReflection_Vtbl {
-    pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D12FunctionReflection_Impl, const OFFSET: isize>() -> ID3D12FunctionReflection_Vtbl {
-        unsafe extern "system" fn GetDesc<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D12FunctionReflection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D12_FUNCTION_DESC) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+    pub const fn new<Impl: ID3D12FunctionReflection_Impl>() -> ID3D12FunctionReflection_Vtbl {
+        unsafe extern "system" fn GetDesc<Impl: ID3D12FunctionReflection_Impl>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D12_FUNCTION_DESC) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             match this.GetDesc() {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
@@ -1491,19 +1499,19 @@ impl ID3D12FunctionReflection_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        unsafe extern "system" fn GetConstantBufferByIndex<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D12FunctionReflection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bufferindex: u32) -> ::core::option::Option<ID3D12ShaderReflectionConstantBuffer> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetConstantBufferByIndex<Impl: ID3D12FunctionReflection_Impl>(this: *mut ::core::ffi::c_void, bufferindex: u32) -> ::core::option::Option<ID3D12ShaderReflectionConstantBuffer> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetConstantBufferByIndex(::core::mem::transmute_copy(&bufferindex))
         }
-        unsafe extern "system" fn GetConstantBufferByName<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D12FunctionReflection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, name: ::windows::core::PCSTR) -> ::core::option::Option<ID3D12ShaderReflectionConstantBuffer> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetConstantBufferByName<Impl: ID3D12FunctionReflection_Impl>(this: *mut ::core::ffi::c_void, name: ::windows::core::PCSTR) -> ::core::option::Option<ID3D12ShaderReflectionConstantBuffer> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetConstantBufferByName(::core::mem::transmute(&name))
         }
-        unsafe extern "system" fn GetResourceBindingDesc<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D12FunctionReflection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, resourceindex: u32, pdesc: *mut D3D12_SHADER_INPUT_BIND_DESC) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetResourceBindingDesc<Impl: ID3D12FunctionReflection_Impl>(this: *mut ::core::ffi::c_void, resourceindex: u32, pdesc: *mut D3D12_SHADER_INPUT_BIND_DESC) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             match this.GetResourceBindingDesc(::core::mem::transmute_copy(&resourceindex)) {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
@@ -1512,14 +1520,14 @@ impl ID3D12FunctionReflection_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        unsafe extern "system" fn GetVariableByName<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D12FunctionReflection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, name: ::windows::core::PCSTR) -> ::core::option::Option<ID3D12ShaderReflectionVariable> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetVariableByName<Impl: ID3D12FunctionReflection_Impl>(this: *mut ::core::ffi::c_void, name: ::windows::core::PCSTR) -> ::core::option::Option<ID3D12ShaderReflectionVariable> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetVariableByName(::core::mem::transmute(&name))
         }
-        unsafe extern "system" fn GetResourceBindingDescByName<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D12FunctionReflection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, name: ::windows::core::PCSTR, pdesc: *mut D3D12_SHADER_INPUT_BIND_DESC) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetResourceBindingDescByName<Impl: ID3D12FunctionReflection_Impl>(this: *mut ::core::ffi::c_void, name: ::windows::core::PCSTR, pdesc: *mut D3D12_SHADER_INPUT_BIND_DESC) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             match this.GetResourceBindingDescByName(::core::mem::transmute(&name)) {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
@@ -1528,23 +1536,35 @@ impl ID3D12FunctionReflection_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        unsafe extern "system" fn GetFunctionParameter<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D12FunctionReflection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, parameterindex: i32) -> ::core::option::Option<ID3D12FunctionParameterReflection> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetFunctionParameter<Impl: ID3D12FunctionReflection_Impl>(this: *mut ::core::ffi::c_void, parameterindex: i32) -> ::core::option::Option<ID3D12FunctionParameterReflection> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetFunctionParameter(::core::mem::transmute_copy(&parameterindex))
         }
         Self {
-            GetDesc: GetDesc::<Identity, Impl, OFFSET>,
-            GetConstantBufferByIndex: GetConstantBufferByIndex::<Identity, Impl, OFFSET>,
-            GetConstantBufferByName: GetConstantBufferByName::<Identity, Impl, OFFSET>,
-            GetResourceBindingDesc: GetResourceBindingDesc::<Identity, Impl, OFFSET>,
-            GetVariableByName: GetVariableByName::<Identity, Impl, OFFSET>,
-            GetResourceBindingDescByName: GetResourceBindingDescByName::<Identity, Impl, OFFSET>,
-            GetFunctionParameter: GetFunctionParameter::<Identity, Impl, OFFSET>,
+            GetDesc: GetDesc::<Impl>,
+            GetConstantBufferByIndex: GetConstantBufferByIndex::<Impl>,
+            GetConstantBufferByName: GetConstantBufferByName::<Impl>,
+            GetResourceBindingDesc: GetResourceBindingDesc::<Impl>,
+            GetVariableByName: GetVariableByName::<Impl>,
+            GetResourceBindingDescByName: GetResourceBindingDescByName::<Impl>,
+            GetFunctionParameter: GetFunctionParameter::<Impl>,
         }
     }
-    pub fn matches(iid: &windows::core::GUID) -> bool {
-        iid == &<ID3D12FunctionReflection as ::windows::core::Interface>::IID
+}
+#[doc(hidden)]
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D"))]
+struct ID3D12FunctionReflection_ImplVtbl<T: ID3D12FunctionReflection_Impl>(::std::marker::PhantomData<T>);
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D"))]
+impl<T: ID3D12FunctionReflection_Impl> ID3D12FunctionReflection_ImplVtbl<T> {
+    const VTABLE: ID3D12FunctionReflection_Vtbl = ID3D12FunctionReflection_Vtbl::new::<T>();
+}
+#[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D"))]
+impl ID3D12FunctionReflection {
+    pub fn new<'a, T: ID3D12FunctionReflection_Impl>(this: &'a T) -> ::windows::core::ScopedInterface<'a, Self> {
+        let this = ::windows::core::ScopedHeap { vtable: &ID3D12FunctionReflection_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
+        let this = ::std::mem::ManuallyDrop::new(::std::boxed::Box::new(this));
+        unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
@@ -3169,33 +3189,39 @@ pub trait ID3D12ShaderReflectionConstantBuffer_Impl: Sized {
     fn GetVariableByName(&self, name: &::windows::core::PCSTR) -> ::core::option::Option<ID3D12ShaderReflectionVariable>;
 }
 #[cfg(feature = "Win32_Graphics_Direct3D")]
-impl ::windows::core::RuntimeName for ID3D12ShaderReflectionConstantBuffer {}
-#[cfg(feature = "Win32_Graphics_Direct3D")]
 impl ID3D12ShaderReflectionConstantBuffer_Vtbl {
-    pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D12ShaderReflectionConstantBuffer_Impl, const OFFSET: isize>() -> ID3D12ShaderReflectionConstantBuffer_Vtbl {
-        unsafe extern "system" fn GetDesc<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D12ShaderReflectionConstantBuffer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D12_SHADER_BUFFER_DESC) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+    pub const fn new<Impl: ID3D12ShaderReflectionConstantBuffer_Impl>() -> ID3D12ShaderReflectionConstantBuffer_Vtbl {
+        unsafe extern "system" fn GetDesc<Impl: ID3D12ShaderReflectionConstantBuffer_Impl>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D12_SHADER_BUFFER_DESC) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetDesc(::core::mem::transmute_copy(&pdesc)).into()
         }
-        unsafe extern "system" fn GetVariableByIndex<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D12ShaderReflectionConstantBuffer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: u32) -> ::core::option::Option<ID3D12ShaderReflectionVariable> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetVariableByIndex<Impl: ID3D12ShaderReflectionConstantBuffer_Impl>(this: *mut ::core::ffi::c_void, index: u32) -> ::core::option::Option<ID3D12ShaderReflectionVariable> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetVariableByIndex(::core::mem::transmute_copy(&index))
         }
-        unsafe extern "system" fn GetVariableByName<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D12ShaderReflectionConstantBuffer_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, name: ::windows::core::PCSTR) -> ::core::option::Option<ID3D12ShaderReflectionVariable> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetVariableByName<Impl: ID3D12ShaderReflectionConstantBuffer_Impl>(this: *mut ::core::ffi::c_void, name: ::windows::core::PCSTR) -> ::core::option::Option<ID3D12ShaderReflectionVariable> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetVariableByName(::core::mem::transmute(&name))
         }
-        Self {
-            GetDesc: GetDesc::<Identity, Impl, OFFSET>,
-            GetVariableByIndex: GetVariableByIndex::<Identity, Impl, OFFSET>,
-            GetVariableByName: GetVariableByName::<Identity, Impl, OFFSET>,
-        }
+        Self { GetDesc: GetDesc::<Impl>, GetVariableByIndex: GetVariableByIndex::<Impl>, GetVariableByName: GetVariableByName::<Impl> }
     }
-    pub fn matches(iid: &windows::core::GUID) -> bool {
-        iid == &<ID3D12ShaderReflectionConstantBuffer as ::windows::core::Interface>::IID
+}
+#[doc(hidden)]
+#[cfg(feature = "Win32_Graphics_Direct3D")]
+struct ID3D12ShaderReflectionConstantBuffer_ImplVtbl<T: ID3D12ShaderReflectionConstantBuffer_Impl>(::std::marker::PhantomData<T>);
+#[cfg(feature = "Win32_Graphics_Direct3D")]
+impl<T: ID3D12ShaderReflectionConstantBuffer_Impl> ID3D12ShaderReflectionConstantBuffer_ImplVtbl<T> {
+    const VTABLE: ID3D12ShaderReflectionConstantBuffer_Vtbl = ID3D12ShaderReflectionConstantBuffer_Vtbl::new::<T>();
+}
+#[cfg(feature = "Win32_Graphics_Direct3D")]
+impl ID3D12ShaderReflectionConstantBuffer {
+    pub fn new<'a, T: ID3D12ShaderReflectionConstantBuffer_Impl>(this: &'a T) -> ::windows::core::ScopedInterface<'a, Self> {
+        let this = ::windows::core::ScopedHeap { vtable: &ID3D12ShaderReflectionConstantBuffer_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
+        let this = ::std::mem::ManuallyDrop::new(::std::boxed::Box::new(this));
+        unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
 #[cfg(feature = "Win32_Graphics_Direct3D")]
@@ -3213,13 +3239,11 @@ pub trait ID3D12ShaderReflectionType_Impl: Sized {
     fn ImplementsInterface(&self, pbase: &::core::option::Option<ID3D12ShaderReflectionType>) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Graphics_Direct3D")]
-impl ::windows::core::RuntimeName for ID3D12ShaderReflectionType {}
-#[cfg(feature = "Win32_Graphics_Direct3D")]
 impl ID3D12ShaderReflectionType_Vtbl {
-    pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D12ShaderReflectionType_Impl, const OFFSET: isize>() -> ID3D12ShaderReflectionType_Vtbl {
-        unsafe extern "system" fn GetDesc<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D12ShaderReflectionType_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D12_SHADER_TYPE_DESC) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+    pub const fn new<Impl: ID3D12ShaderReflectionType_Impl>() -> ID3D12ShaderReflectionType_Vtbl {
+        unsafe extern "system" fn GetDesc<Impl: ID3D12ShaderReflectionType_Impl>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D12_SHADER_TYPE_DESC) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             match this.GetDesc() {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
@@ -3228,72 +3252,84 @@ impl ID3D12ShaderReflectionType_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        unsafe extern "system" fn GetMemberTypeByIndex<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D12ShaderReflectionType_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: u32) -> ::core::option::Option<ID3D12ShaderReflectionType> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetMemberTypeByIndex<Impl: ID3D12ShaderReflectionType_Impl>(this: *mut ::core::ffi::c_void, index: u32) -> ::core::option::Option<ID3D12ShaderReflectionType> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetMemberTypeByIndex(::core::mem::transmute_copy(&index))
         }
-        unsafe extern "system" fn GetMemberTypeByName<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D12ShaderReflectionType_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, name: ::windows::core::PCSTR) -> ::core::option::Option<ID3D12ShaderReflectionType> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetMemberTypeByName<Impl: ID3D12ShaderReflectionType_Impl>(this: *mut ::core::ffi::c_void, name: ::windows::core::PCSTR) -> ::core::option::Option<ID3D12ShaderReflectionType> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetMemberTypeByName(::core::mem::transmute(&name))
         }
-        unsafe extern "system" fn GetMemberTypeName<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D12ShaderReflectionType_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: u32) -> ::windows::core::PSTR {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetMemberTypeName<Impl: ID3D12ShaderReflectionType_Impl>(this: *mut ::core::ffi::c_void, index: u32) -> ::windows::core::PSTR {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetMemberTypeName(::core::mem::transmute_copy(&index))
         }
-        unsafe extern "system" fn IsEqual<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D12ShaderReflectionType_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ptype: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn IsEqual<Impl: ID3D12ShaderReflectionType_Impl>(this: *mut ::core::ffi::c_void, ptype: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.IsEqual(::core::mem::transmute(&ptype)).into()
         }
-        unsafe extern "system" fn GetSubType<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D12ShaderReflectionType_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::core::option::Option<ID3D12ShaderReflectionType> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetSubType<Impl: ID3D12ShaderReflectionType_Impl>(this: *mut ::core::ffi::c_void) -> ::core::option::Option<ID3D12ShaderReflectionType> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetSubType()
         }
-        unsafe extern "system" fn GetBaseClass<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D12ShaderReflectionType_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::core::option::Option<ID3D12ShaderReflectionType> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetBaseClass<Impl: ID3D12ShaderReflectionType_Impl>(this: *mut ::core::ffi::c_void) -> ::core::option::Option<ID3D12ShaderReflectionType> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetBaseClass()
         }
-        unsafe extern "system" fn GetNumInterfaces<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D12ShaderReflectionType_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> u32 {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetNumInterfaces<Impl: ID3D12ShaderReflectionType_Impl>(this: *mut ::core::ffi::c_void) -> u32 {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetNumInterfaces()
         }
-        unsafe extern "system" fn GetInterfaceByIndex<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D12ShaderReflectionType_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, uindex: u32) -> ::core::option::Option<ID3D12ShaderReflectionType> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetInterfaceByIndex<Impl: ID3D12ShaderReflectionType_Impl>(this: *mut ::core::ffi::c_void, uindex: u32) -> ::core::option::Option<ID3D12ShaderReflectionType> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetInterfaceByIndex(::core::mem::transmute_copy(&uindex))
         }
-        unsafe extern "system" fn IsOfType<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D12ShaderReflectionType_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ptype: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn IsOfType<Impl: ID3D12ShaderReflectionType_Impl>(this: *mut ::core::ffi::c_void, ptype: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.IsOfType(::core::mem::transmute(&ptype)).into()
         }
-        unsafe extern "system" fn ImplementsInterface<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D12ShaderReflectionType_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbase: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn ImplementsInterface<Impl: ID3D12ShaderReflectionType_Impl>(this: *mut ::core::ffi::c_void, pbase: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.ImplementsInterface(::core::mem::transmute(&pbase)).into()
         }
         Self {
-            GetDesc: GetDesc::<Identity, Impl, OFFSET>,
-            GetMemberTypeByIndex: GetMemberTypeByIndex::<Identity, Impl, OFFSET>,
-            GetMemberTypeByName: GetMemberTypeByName::<Identity, Impl, OFFSET>,
-            GetMemberTypeName: GetMemberTypeName::<Identity, Impl, OFFSET>,
-            IsEqual: IsEqual::<Identity, Impl, OFFSET>,
-            GetSubType: GetSubType::<Identity, Impl, OFFSET>,
-            GetBaseClass: GetBaseClass::<Identity, Impl, OFFSET>,
-            GetNumInterfaces: GetNumInterfaces::<Identity, Impl, OFFSET>,
-            GetInterfaceByIndex: GetInterfaceByIndex::<Identity, Impl, OFFSET>,
-            IsOfType: IsOfType::<Identity, Impl, OFFSET>,
-            ImplementsInterface: ImplementsInterface::<Identity, Impl, OFFSET>,
+            GetDesc: GetDesc::<Impl>,
+            GetMemberTypeByIndex: GetMemberTypeByIndex::<Impl>,
+            GetMemberTypeByName: GetMemberTypeByName::<Impl>,
+            GetMemberTypeName: GetMemberTypeName::<Impl>,
+            IsEqual: IsEqual::<Impl>,
+            GetSubType: GetSubType::<Impl>,
+            GetBaseClass: GetBaseClass::<Impl>,
+            GetNumInterfaces: GetNumInterfaces::<Impl>,
+            GetInterfaceByIndex: GetInterfaceByIndex::<Impl>,
+            IsOfType: IsOfType::<Impl>,
+            ImplementsInterface: ImplementsInterface::<Impl>,
         }
     }
-    pub fn matches(iid: &windows::core::GUID) -> bool {
-        iid == &<ID3D12ShaderReflectionType as ::windows::core::Interface>::IID
+}
+#[doc(hidden)]
+#[cfg(feature = "Win32_Graphics_Direct3D")]
+struct ID3D12ShaderReflectionType_ImplVtbl<T: ID3D12ShaderReflectionType_Impl>(::std::marker::PhantomData<T>);
+#[cfg(feature = "Win32_Graphics_Direct3D")]
+impl<T: ID3D12ShaderReflectionType_Impl> ID3D12ShaderReflectionType_ImplVtbl<T> {
+    const VTABLE: ID3D12ShaderReflectionType_Vtbl = ID3D12ShaderReflectionType_Vtbl::new::<T>();
+}
+#[cfg(feature = "Win32_Graphics_Direct3D")]
+impl ID3D12ShaderReflectionType {
+    pub fn new<'a, T: ID3D12ShaderReflectionType_Impl>(this: &'a T) -> ::windows::core::ScopedInterface<'a, Self> {
+        let this = ::windows::core::ScopedHeap { vtable: &ID3D12ShaderReflectionType_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
+        let this = ::std::mem::ManuallyDrop::new(::std::boxed::Box::new(this));
+        unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
 pub trait ID3D12ShaderReflectionVariable_Impl: Sized {
@@ -3302,12 +3338,11 @@ pub trait ID3D12ShaderReflectionVariable_Impl: Sized {
     fn GetBuffer(&self) -> ::core::option::Option<ID3D12ShaderReflectionConstantBuffer>;
     fn GetInterfaceSlot(&self, uarrayindex: u32) -> u32;
 }
-impl ::windows::core::RuntimeName for ID3D12ShaderReflectionVariable {}
 impl ID3D12ShaderReflectionVariable_Vtbl {
-    pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D12ShaderReflectionVariable_Impl, const OFFSET: isize>() -> ID3D12ShaderReflectionVariable_Vtbl {
-        unsafe extern "system" fn GetDesc<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D12ShaderReflectionVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D12_SHADER_VARIABLE_DESC) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+    pub const fn new<Impl: ID3D12ShaderReflectionVariable_Impl>() -> ID3D12ShaderReflectionVariable_Vtbl {
+        unsafe extern "system" fn GetDesc<Impl: ID3D12ShaderReflectionVariable_Impl>(this: *mut ::core::ffi::c_void, pdesc: *mut D3D12_SHADER_VARIABLE_DESC) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             match this.GetDesc() {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(pdesc, ::core::mem::transmute(ok__));
@@ -3316,30 +3351,34 @@ impl ID3D12ShaderReflectionVariable_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        unsafe extern "system" fn GetType<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D12ShaderReflectionVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::core::option::Option<ID3D12ShaderReflectionType> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetType<Impl: ID3D12ShaderReflectionVariable_Impl>(this: *mut ::core::ffi::c_void) -> ::core::option::Option<ID3D12ShaderReflectionType> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetType()
         }
-        unsafe extern "system" fn GetBuffer<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D12ShaderReflectionVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::core::option::Option<ID3D12ShaderReflectionConstantBuffer> {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetBuffer<Impl: ID3D12ShaderReflectionVariable_Impl>(this: *mut ::core::ffi::c_void) -> ::core::option::Option<ID3D12ShaderReflectionConstantBuffer> {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetBuffer()
         }
-        unsafe extern "system" fn GetInterfaceSlot<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ID3D12ShaderReflectionVariable_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, uarrayindex: u32) -> u32 {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetInterfaceSlot<Impl: ID3D12ShaderReflectionVariable_Impl>(this: *mut ::core::ffi::c_void, uarrayindex: u32) -> u32 {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetInterfaceSlot(::core::mem::transmute_copy(&uarrayindex))
         }
-        Self {
-            GetDesc: GetDesc::<Identity, Impl, OFFSET>,
-            GetType: GetType::<Identity, Impl, OFFSET>,
-            GetBuffer: GetBuffer::<Identity, Impl, OFFSET>,
-            GetInterfaceSlot: GetInterfaceSlot::<Identity, Impl, OFFSET>,
-        }
+        Self { GetDesc: GetDesc::<Impl>, GetType: GetType::<Impl>, GetBuffer: GetBuffer::<Impl>, GetInterfaceSlot: GetInterfaceSlot::<Impl> }
     }
-    pub fn matches(iid: &windows::core::GUID) -> bool {
-        iid == &<ID3D12ShaderReflectionVariable as ::windows::core::Interface>::IID
+}
+#[doc(hidden)]
+struct ID3D12ShaderReflectionVariable_ImplVtbl<T: ID3D12ShaderReflectionVariable_Impl>(::std::marker::PhantomData<T>);
+impl<T: ID3D12ShaderReflectionVariable_Impl> ID3D12ShaderReflectionVariable_ImplVtbl<T> {
+    const VTABLE: ID3D12ShaderReflectionVariable_Vtbl = ID3D12ShaderReflectionVariable_Vtbl::new::<T>();
+}
+impl ID3D12ShaderReflectionVariable {
+    pub fn new<'a, T: ID3D12ShaderReflectionVariable_Impl>(this: &'a T) -> ::windows::core::ScopedInterface<'a, Self> {
+        let this = ::windows::core::ScopedHeap { vtable: &ID3D12ShaderReflectionVariable_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
+        let this = ::std::mem::ManuallyDrop::new(::std::boxed::Box::new(this));
+        unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
 #[cfg(feature = "Win32_Foundation")]

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D12/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D12/mod.rs
@@ -7615,7 +7615,16 @@ pub struct ID3D12Fence1_Vtbl {
 }
 #[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`*"]
 #[repr(transparent)]
-pub struct ID3D12FunctionParameterReflection(::windows::core::IUnknown);
+pub struct ID3D12FunctionParameterReflection(::std::ptr::NonNull<::std::ffi::c_void>);
+unsafe impl ::windows::core::Abi for Option<ID3D12FunctionParameterReflection> {
+    type Abi = *mut ::std::ffi::c_void;
+}
+unsafe impl ::windows::core::Abi for ID3D12FunctionParameterReflection {
+    type Abi = *mut ::std::ffi::c_void;
+    fn abi_is_possibly_valid(abi: &Self::Abi) -> bool {
+        !abi.is_null()
+    }
+}
 impl ID3D12FunctionParameterReflection {
     #[doc = "*Required features: `\"Win32_Graphics_Direct3D\"`*"]
     #[cfg(feature = "Win32_Graphics_Direct3D")]
@@ -7645,9 +7654,6 @@ unsafe impl ::core::marker::Sync for ID3D12FunctionParameterReflection {}
 unsafe impl ::windows::core::Vtable for ID3D12FunctionParameterReflection {
     type Vtable = ID3D12FunctionParameterReflection_Vtbl;
 }
-unsafe impl ::windows::core::Interface for ID3D12FunctionParameterReflection {
-    const IID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xec25f42d_7006_4f2b_b33e_02cc3375733f);
-}
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D12FunctionParameterReflection_Vtbl {
@@ -7658,7 +7664,16 @@ pub struct ID3D12FunctionParameterReflection_Vtbl {
 }
 #[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`*"]
 #[repr(transparent)]
-pub struct ID3D12FunctionReflection(::windows::core::IUnknown);
+pub struct ID3D12FunctionReflection(::std::ptr::NonNull<::std::ffi::c_void>);
+unsafe impl ::windows::core::Abi for Option<ID3D12FunctionReflection> {
+    type Abi = *mut ::std::ffi::c_void;
+}
+unsafe impl ::windows::core::Abi for ID3D12FunctionReflection {
+    type Abi = *mut ::std::ffi::c_void;
+    fn abi_is_possibly_valid(abi: &Self::Abi) -> bool {
+        !abi.is_null()
+    }
+}
 impl ID3D12FunctionReflection {
     #[doc = "*Required features: `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D\"`*"]
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D"))]
@@ -7720,9 +7735,6 @@ unsafe impl ::core::marker::Send for ID3D12FunctionReflection {}
 unsafe impl ::core::marker::Sync for ID3D12FunctionReflection {}
 unsafe impl ::windows::core::Vtable for ID3D12FunctionReflection {
     type Vtable = ID3D12FunctionReflection_Vtbl;
-}
-unsafe impl ::windows::core::Interface for ID3D12FunctionReflection {
-    const IID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1108795c_2772_4ba9_b2a8_d464dc7e2799);
 }
 #[repr(C)]
 #[doc(hidden)]
@@ -14307,7 +14319,16 @@ pub struct ID3D12ShaderReflection_Vtbl {
 }
 #[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`*"]
 #[repr(transparent)]
-pub struct ID3D12ShaderReflectionConstantBuffer(::windows::core::IUnknown);
+pub struct ID3D12ShaderReflectionConstantBuffer(::std::ptr::NonNull<::std::ffi::c_void>);
+unsafe impl ::windows::core::Abi for Option<ID3D12ShaderReflectionConstantBuffer> {
+    type Abi = *mut ::std::ffi::c_void;
+}
+unsafe impl ::windows::core::Abi for ID3D12ShaderReflectionConstantBuffer {
+    type Abi = *mut ::std::ffi::c_void;
+    fn abi_is_possibly_valid(abi: &Self::Abi) -> bool {
+        !abi.is_null()
+    }
+}
 impl ID3D12ShaderReflectionConstantBuffer {
     #[doc = "*Required features: `\"Win32_Graphics_Direct3D\"`*"]
     #[cfg(feature = "Win32_Graphics_Direct3D")]
@@ -14345,9 +14366,6 @@ unsafe impl ::core::marker::Sync for ID3D12ShaderReflectionConstantBuffer {}
 unsafe impl ::windows::core::Vtable for ID3D12ShaderReflectionConstantBuffer {
     type Vtable = ID3D12ShaderReflectionConstantBuffer_Vtbl;
 }
-unsafe impl ::windows::core::Interface for ID3D12ShaderReflectionConstantBuffer {
-    const IID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc59598b4_48b3_4869_b9b1_b1618b14a8b7);
-}
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D12ShaderReflectionConstantBuffer_Vtbl {
@@ -14360,7 +14378,16 @@ pub struct ID3D12ShaderReflectionConstantBuffer_Vtbl {
 }
 #[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`*"]
 #[repr(transparent)]
-pub struct ID3D12ShaderReflectionType(::windows::core::IUnknown);
+pub struct ID3D12ShaderReflectionType(::std::ptr::NonNull<::std::ffi::c_void>);
+unsafe impl ::windows::core::Abi for Option<ID3D12ShaderReflectionType> {
+    type Abi = *mut ::std::ffi::c_void;
+}
+unsafe impl ::windows::core::Abi for ID3D12ShaderReflectionType {
+    type Abi = *mut ::std::ffi::c_void;
+    fn abi_is_possibly_valid(abi: &Self::Abi) -> bool {
+        !abi.is_null()
+    }
+}
 impl ID3D12ShaderReflectionType {
     #[doc = "*Required features: `\"Win32_Graphics_Direct3D\"`*"]
     #[cfg(feature = "Win32_Graphics_Direct3D")]
@@ -14432,9 +14459,6 @@ unsafe impl ::core::marker::Sync for ID3D12ShaderReflectionType {}
 unsafe impl ::windows::core::Vtable for ID3D12ShaderReflectionType {
     type Vtable = ID3D12ShaderReflectionType_Vtbl;
 }
-unsafe impl ::windows::core::Interface for ID3D12ShaderReflectionType {
-    const IID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe913c351_783d_48ca_a1d1_4f306284ad56);
-}
 #[repr(C)]
 #[doc(hidden)]
 pub struct ID3D12ShaderReflectionType_Vtbl {
@@ -14455,7 +14479,16 @@ pub struct ID3D12ShaderReflectionType_Vtbl {
 }
 #[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`*"]
 #[repr(transparent)]
-pub struct ID3D12ShaderReflectionVariable(::windows::core::IUnknown);
+pub struct ID3D12ShaderReflectionVariable(::std::ptr::NonNull<::std::ffi::c_void>);
+unsafe impl ::windows::core::Abi for Option<ID3D12ShaderReflectionVariable> {
+    type Abi = *mut ::std::ffi::c_void;
+}
+unsafe impl ::windows::core::Abi for ID3D12ShaderReflectionVariable {
+    type Abi = *mut ::std::ffi::c_void;
+    fn abi_is_possibly_valid(abi: &Self::Abi) -> bool {
+        !abi.is_null()
+    }
+}
 impl ID3D12ShaderReflectionVariable {
     pub unsafe fn GetDesc(&self) -> ::windows::core::Result<D3D12_SHADER_VARIABLE_DESC> {
         let mut result__ = ::core::mem::MaybeUninit::zeroed();
@@ -14491,9 +14524,6 @@ unsafe impl ::core::marker::Send for ID3D12ShaderReflectionVariable {}
 unsafe impl ::core::marker::Sync for ID3D12ShaderReflectionVariable {}
 unsafe impl ::windows::core::Vtable for ID3D12ShaderReflectionVariable {
     type Vtable = ID3D12ShaderReflectionVariable_Vtbl;
-}
-unsafe impl ::windows::core::Interface for ID3D12ShaderReflectionVariable {
-    const IID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8337a8a6_a216_444a_b2f4_314733a73aea);
 }
 #[repr(C)]
 #[doc(hidden)]

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/XAudio2/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/XAudio2/impl.rs
@@ -261,32 +261,36 @@ pub trait IXAudio2EngineCallback_Impl: Sized {
     fn OnProcessingPassEnd(&self);
     fn OnCriticalError(&self, error: ::windows::core::HRESULT);
 }
-impl ::windows::core::RuntimeName for IXAudio2EngineCallback {}
 impl IXAudio2EngineCallback_Vtbl {
-    pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IXAudio2EngineCallback_Impl, const OFFSET: isize>() -> IXAudio2EngineCallback_Vtbl {
-        unsafe extern "system" fn OnProcessingPassStart<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IXAudio2EngineCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+    pub const fn new<Impl: IXAudio2EngineCallback_Impl>() -> IXAudio2EngineCallback_Vtbl {
+        unsafe extern "system" fn OnProcessingPassStart<Impl: IXAudio2EngineCallback_Impl>(this: *mut ::core::ffi::c_void) {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.OnProcessingPassStart()
         }
-        unsafe extern "system" fn OnProcessingPassEnd<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IXAudio2EngineCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn OnProcessingPassEnd<Impl: IXAudio2EngineCallback_Impl>(this: *mut ::core::ffi::c_void) {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.OnProcessingPassEnd()
         }
-        unsafe extern "system" fn OnCriticalError<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IXAudio2EngineCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, error: ::windows::core::HRESULT) {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn OnCriticalError<Impl: IXAudio2EngineCallback_Impl>(this: *mut ::core::ffi::c_void, error: ::windows::core::HRESULT) {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.OnCriticalError(::core::mem::transmute_copy(&error))
         }
-        Self {
-            OnProcessingPassStart: OnProcessingPassStart::<Identity, Impl, OFFSET>,
-            OnProcessingPassEnd: OnProcessingPassEnd::<Identity, Impl, OFFSET>,
-            OnCriticalError: OnCriticalError::<Identity, Impl, OFFSET>,
-        }
+        Self { OnProcessingPassStart: OnProcessingPassStart::<Impl>, OnProcessingPassEnd: OnProcessingPassEnd::<Impl>, OnCriticalError: OnCriticalError::<Impl> }
     }
-    pub fn matches(iid: &windows::core::GUID) -> bool {
-        iid == &<IXAudio2EngineCallback as ::windows::core::Interface>::IID
+}
+#[doc(hidden)]
+struct IXAudio2EngineCallback_ImplVtbl<T: IXAudio2EngineCallback_Impl>(::std::marker::PhantomData<T>);
+impl<T: IXAudio2EngineCallback_Impl> IXAudio2EngineCallback_ImplVtbl<T> {
+    const VTABLE: IXAudio2EngineCallback_Vtbl = IXAudio2EngineCallback_Vtbl::new::<T>();
+}
+impl IXAudio2EngineCallback {
+    pub fn new<'a, T: IXAudio2EngineCallback_Impl>(this: &'a T) -> ::windows::core::ScopedInterface<'a, Self> {
+        let this = ::windows::core::ScopedHeap { vtable: &IXAudio2EngineCallback_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
+        let this = ::std::mem::ManuallyDrop::new(::std::boxed::Box::new(this));
+        unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
 pub trait IXAudio2Extension_Impl: Sized {
@@ -321,13 +325,11 @@ pub trait IXAudio2MasteringVoice_Impl: Sized + IXAudio2Voice_Impl {
     fn GetChannelMask(&self) -> ::windows::core::Result<u32>;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::windows::core::RuntimeName for IXAudio2MasteringVoice {}
-#[cfg(feature = "Win32_Foundation")]
 impl IXAudio2MasteringVoice_Vtbl {
-    pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IXAudio2MasteringVoice_Impl, const OFFSET: isize>() -> IXAudio2MasteringVoice_Vtbl {
-        unsafe extern "system" fn GetChannelMask<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IXAudio2MasteringVoice_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pchannelmask: *mut u32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+    pub const fn new<Impl: IXAudio2MasteringVoice_Impl>() -> IXAudio2MasteringVoice_Vtbl {
+        unsafe extern "system" fn GetChannelMask<Impl: IXAudio2MasteringVoice_Impl>(this: *mut ::core::ffi::c_void, pchannelmask: *mut u32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             match this.GetChannelMask() {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(pchannelmask, ::core::mem::transmute(ok__));
@@ -336,10 +338,22 @@ impl IXAudio2MasteringVoice_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self { base__: IXAudio2Voice_Vtbl::new::<Identity, Impl, OFFSET>(), GetChannelMask: GetChannelMask::<Identity, Impl, OFFSET> }
+        Self { base__: IXAudio2Voice_Vtbl::new::<Impl>(), GetChannelMask: GetChannelMask::<Impl> }
     }
-    pub fn matches(iid: &windows::core::GUID) -> bool {
-        iid == &<IXAudio2MasteringVoice as ::windows::core::Interface>::IID || iid == &<IXAudio2Voice as ::windows::core::Interface>::IID
+}
+#[doc(hidden)]
+#[cfg(feature = "Win32_Foundation")]
+struct IXAudio2MasteringVoice_ImplVtbl<T: IXAudio2MasteringVoice_Impl>(::std::marker::PhantomData<T>);
+#[cfg(feature = "Win32_Foundation")]
+impl<T: IXAudio2MasteringVoice_Impl> IXAudio2MasteringVoice_ImplVtbl<T> {
+    const VTABLE: IXAudio2MasteringVoice_Vtbl = IXAudio2MasteringVoice_Vtbl::new::<T>();
+}
+#[cfg(feature = "Win32_Foundation")]
+impl IXAudio2MasteringVoice {
+    pub fn new<'a, T: IXAudio2MasteringVoice_Impl>(this: &'a T) -> ::windows::core::ScopedInterface<'a, Self> {
+        let this = ::windows::core::ScopedHeap { vtable: &IXAudio2MasteringVoice_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
+        let this = ::std::mem::ManuallyDrop::new(::std::boxed::Box::new(this));
+        unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -356,89 +370,109 @@ pub trait IXAudio2SourceVoice_Impl: Sized + IXAudio2Voice_Impl {
     fn SetSourceSampleRate(&self, newsourcesamplerate: u32) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::windows::core::RuntimeName for IXAudio2SourceVoice {}
-#[cfg(feature = "Win32_Foundation")]
 impl IXAudio2SourceVoice_Vtbl {
-    pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IXAudio2SourceVoice_Impl, const OFFSET: isize>() -> IXAudio2SourceVoice_Vtbl {
-        unsafe extern "system" fn Start<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IXAudio2SourceVoice_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, flags: u32, operationset: u32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+    pub const fn new<Impl: IXAudio2SourceVoice_Impl>() -> IXAudio2SourceVoice_Vtbl {
+        unsafe extern "system" fn Start<Impl: IXAudio2SourceVoice_Impl>(this: *mut ::core::ffi::c_void, flags: u32, operationset: u32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.Start(::core::mem::transmute_copy(&flags), ::core::mem::transmute_copy(&operationset)).into()
         }
-        unsafe extern "system" fn Stop<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IXAudio2SourceVoice_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, flags: u32, operationset: u32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn Stop<Impl: IXAudio2SourceVoice_Impl>(this: *mut ::core::ffi::c_void, flags: u32, operationset: u32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.Stop(::core::mem::transmute_copy(&flags), ::core::mem::transmute_copy(&operationset)).into()
         }
-        unsafe extern "system" fn SubmitSourceBuffer<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IXAudio2SourceVoice_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbuffer: *const XAUDIO2_BUFFER, pbufferwma: *const XAUDIO2_BUFFER_WMA) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn SubmitSourceBuffer<Impl: IXAudio2SourceVoice_Impl>(this: *mut ::core::ffi::c_void, pbuffer: *const XAUDIO2_BUFFER, pbufferwma: *const XAUDIO2_BUFFER_WMA) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.SubmitSourceBuffer(::core::mem::transmute_copy(&pbuffer), ::core::mem::transmute_copy(&pbufferwma)).into()
         }
-        unsafe extern "system" fn FlushSourceBuffers<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IXAudio2SourceVoice_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn FlushSourceBuffers<Impl: IXAudio2SourceVoice_Impl>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.FlushSourceBuffers().into()
         }
-        unsafe extern "system" fn Discontinuity<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IXAudio2SourceVoice_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn Discontinuity<Impl: IXAudio2SourceVoice_Impl>(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.Discontinuity().into()
         }
-        unsafe extern "system" fn ExitLoop<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IXAudio2SourceVoice_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, operationset: u32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn ExitLoop<Impl: IXAudio2SourceVoice_Impl>(this: *mut ::core::ffi::c_void, operationset: u32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.ExitLoop(::core::mem::transmute_copy(&operationset)).into()
         }
-        unsafe extern "system" fn GetState<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IXAudio2SourceVoice_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pvoicestate: *mut XAUDIO2_VOICE_STATE, flags: u32) {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetState<Impl: IXAudio2SourceVoice_Impl>(this: *mut ::core::ffi::c_void, pvoicestate: *mut XAUDIO2_VOICE_STATE, flags: u32) {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetState(::core::mem::transmute_copy(&pvoicestate), ::core::mem::transmute_copy(&flags))
         }
-        unsafe extern "system" fn SetFrequencyRatio<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IXAudio2SourceVoice_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ratio: f32, operationset: u32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn SetFrequencyRatio<Impl: IXAudio2SourceVoice_Impl>(this: *mut ::core::ffi::c_void, ratio: f32, operationset: u32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.SetFrequencyRatio(::core::mem::transmute_copy(&ratio), ::core::mem::transmute_copy(&operationset)).into()
         }
-        unsafe extern "system" fn GetFrequencyRatio<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IXAudio2SourceVoice_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pratio: *mut f32) {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetFrequencyRatio<Impl: IXAudio2SourceVoice_Impl>(this: *mut ::core::ffi::c_void, pratio: *mut f32) {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetFrequencyRatio(::core::mem::transmute_copy(&pratio))
         }
-        unsafe extern "system" fn SetSourceSampleRate<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IXAudio2SourceVoice_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, newsourcesamplerate: u32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn SetSourceSampleRate<Impl: IXAudio2SourceVoice_Impl>(this: *mut ::core::ffi::c_void, newsourcesamplerate: u32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.SetSourceSampleRate(::core::mem::transmute_copy(&newsourcesamplerate)).into()
         }
         Self {
-            base__: IXAudio2Voice_Vtbl::new::<Identity, Impl, OFFSET>(),
-            Start: Start::<Identity, Impl, OFFSET>,
-            Stop: Stop::<Identity, Impl, OFFSET>,
-            SubmitSourceBuffer: SubmitSourceBuffer::<Identity, Impl, OFFSET>,
-            FlushSourceBuffers: FlushSourceBuffers::<Identity, Impl, OFFSET>,
-            Discontinuity: Discontinuity::<Identity, Impl, OFFSET>,
-            ExitLoop: ExitLoop::<Identity, Impl, OFFSET>,
-            GetState: GetState::<Identity, Impl, OFFSET>,
-            SetFrequencyRatio: SetFrequencyRatio::<Identity, Impl, OFFSET>,
-            GetFrequencyRatio: GetFrequencyRatio::<Identity, Impl, OFFSET>,
-            SetSourceSampleRate: SetSourceSampleRate::<Identity, Impl, OFFSET>,
+            base__: IXAudio2Voice_Vtbl::new::<Impl>(),
+            Start: Start::<Impl>,
+            Stop: Stop::<Impl>,
+            SubmitSourceBuffer: SubmitSourceBuffer::<Impl>,
+            FlushSourceBuffers: FlushSourceBuffers::<Impl>,
+            Discontinuity: Discontinuity::<Impl>,
+            ExitLoop: ExitLoop::<Impl>,
+            GetState: GetState::<Impl>,
+            SetFrequencyRatio: SetFrequencyRatio::<Impl>,
+            GetFrequencyRatio: GetFrequencyRatio::<Impl>,
+            SetSourceSampleRate: SetSourceSampleRate::<Impl>,
         }
     }
-    pub fn matches(iid: &windows::core::GUID) -> bool {
-        iid == &<IXAudio2SourceVoice as ::windows::core::Interface>::IID || iid == &<IXAudio2Voice as ::windows::core::Interface>::IID
+}
+#[doc(hidden)]
+#[cfg(feature = "Win32_Foundation")]
+struct IXAudio2SourceVoice_ImplVtbl<T: IXAudio2SourceVoice_Impl>(::std::marker::PhantomData<T>);
+#[cfg(feature = "Win32_Foundation")]
+impl<T: IXAudio2SourceVoice_Impl> IXAudio2SourceVoice_ImplVtbl<T> {
+    const VTABLE: IXAudio2SourceVoice_Vtbl = IXAudio2SourceVoice_Vtbl::new::<T>();
+}
+#[cfg(feature = "Win32_Foundation")]
+impl IXAudio2SourceVoice {
+    pub fn new<'a, T: IXAudio2SourceVoice_Impl>(this: &'a T) -> ::windows::core::ScopedInterface<'a, Self> {
+        let this = ::windows::core::ScopedHeap { vtable: &IXAudio2SourceVoice_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
+        let this = ::std::mem::ManuallyDrop::new(::std::boxed::Box::new(this));
+        unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
 #[cfg(feature = "Win32_Foundation")]
 pub trait IXAudio2SubmixVoice_Impl: Sized + IXAudio2Voice_Impl {}
 #[cfg(feature = "Win32_Foundation")]
-impl ::windows::core::RuntimeName for IXAudio2SubmixVoice {}
-#[cfg(feature = "Win32_Foundation")]
 impl IXAudio2SubmixVoice_Vtbl {
-    pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IXAudio2SubmixVoice_Impl, const OFFSET: isize>() -> IXAudio2SubmixVoice_Vtbl {
-        Self { base__: IXAudio2Voice_Vtbl::new::<Identity, Impl, OFFSET>() }
+    pub const fn new<Impl: IXAudio2SubmixVoice_Impl>() -> IXAudio2SubmixVoice_Vtbl {
+        Self { base__: IXAudio2Voice_Vtbl::new::<Impl>() }
     }
-    pub fn matches(iid: &windows::core::GUID) -> bool {
-        iid == &<IXAudio2SubmixVoice as ::windows::core::Interface>::IID || iid == &<IXAudio2Voice as ::windows::core::Interface>::IID
+}
+#[doc(hidden)]
+#[cfg(feature = "Win32_Foundation")]
+struct IXAudio2SubmixVoice_ImplVtbl<T: IXAudio2SubmixVoice_Impl>(::std::marker::PhantomData<T>);
+#[cfg(feature = "Win32_Foundation")]
+impl<T: IXAudio2SubmixVoice_Impl> IXAudio2SubmixVoice_ImplVtbl<T> {
+    const VTABLE: IXAudio2SubmixVoice_Vtbl = IXAudio2SubmixVoice_Vtbl::new::<T>();
+}
+#[cfg(feature = "Win32_Foundation")]
+impl IXAudio2SubmixVoice {
+    pub fn new<'a, T: IXAudio2SubmixVoice_Impl>(this: &'a T) -> ::windows::core::ScopedInterface<'a, Self> {
+        let this = ::windows::core::ScopedHeap { vtable: &IXAudio2SubmixVoice_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
+        let this = ::std::mem::ManuallyDrop::new(::std::boxed::Box::new(this));
+        unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
 #[cfg(feature = "Win32_Foundation")]
@@ -464,129 +498,139 @@ pub trait IXAudio2Voice_Impl: Sized {
     fn DestroyVoice(&self);
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::windows::core::RuntimeName for IXAudio2Voice {}
-#[cfg(feature = "Win32_Foundation")]
 impl IXAudio2Voice_Vtbl {
-    pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IXAudio2Voice_Impl, const OFFSET: isize>() -> IXAudio2Voice_Vtbl {
-        unsafe extern "system" fn GetVoiceDetails<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IXAudio2Voice_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pvoicedetails: *mut XAUDIO2_VOICE_DETAILS) {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+    pub const fn new<Impl: IXAudio2Voice_Impl>() -> IXAudio2Voice_Vtbl {
+        unsafe extern "system" fn GetVoiceDetails<Impl: IXAudio2Voice_Impl>(this: *mut ::core::ffi::c_void, pvoicedetails: *mut XAUDIO2_VOICE_DETAILS) {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetVoiceDetails(::core::mem::transmute_copy(&pvoicedetails))
         }
-        unsafe extern "system" fn SetOutputVoices<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IXAudio2Voice_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, psendlist: *const XAUDIO2_VOICE_SENDS) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn SetOutputVoices<Impl: IXAudio2Voice_Impl>(this: *mut ::core::ffi::c_void, psendlist: *const XAUDIO2_VOICE_SENDS) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.SetOutputVoices(::core::mem::transmute_copy(&psendlist)).into()
         }
-        unsafe extern "system" fn SetEffectChain<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IXAudio2Voice_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, peffectchain: *const XAUDIO2_EFFECT_CHAIN) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn SetEffectChain<Impl: IXAudio2Voice_Impl>(this: *mut ::core::ffi::c_void, peffectchain: *const XAUDIO2_EFFECT_CHAIN) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.SetEffectChain(::core::mem::transmute_copy(&peffectchain)).into()
         }
-        unsafe extern "system" fn EnableEffect<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IXAudio2Voice_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, effectindex: u32, operationset: u32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn EnableEffect<Impl: IXAudio2Voice_Impl>(this: *mut ::core::ffi::c_void, effectindex: u32, operationset: u32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.EnableEffect(::core::mem::transmute_copy(&effectindex), ::core::mem::transmute_copy(&operationset)).into()
         }
-        unsafe extern "system" fn DisableEffect<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IXAudio2Voice_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, effectindex: u32, operationset: u32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn DisableEffect<Impl: IXAudio2Voice_Impl>(this: *mut ::core::ffi::c_void, effectindex: u32, operationset: u32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.DisableEffect(::core::mem::transmute_copy(&effectindex), ::core::mem::transmute_copy(&operationset)).into()
         }
-        unsafe extern "system" fn GetEffectState<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IXAudio2Voice_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, effectindex: u32, penabled: *mut super::super::super::Foundation::BOOL) {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetEffectState<Impl: IXAudio2Voice_Impl>(this: *mut ::core::ffi::c_void, effectindex: u32, penabled: *mut super::super::super::Foundation::BOOL) {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetEffectState(::core::mem::transmute_copy(&effectindex), ::core::mem::transmute_copy(&penabled))
         }
-        unsafe extern "system" fn SetEffectParameters<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IXAudio2Voice_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, effectindex: u32, pparameters: *const ::core::ffi::c_void, parametersbytesize: u32, operationset: u32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn SetEffectParameters<Impl: IXAudio2Voice_Impl>(this: *mut ::core::ffi::c_void, effectindex: u32, pparameters: *const ::core::ffi::c_void, parametersbytesize: u32, operationset: u32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.SetEffectParameters(::core::mem::transmute_copy(&effectindex), ::core::mem::transmute_copy(&pparameters), ::core::mem::transmute_copy(&parametersbytesize), ::core::mem::transmute_copy(&operationset)).into()
         }
-        unsafe extern "system" fn GetEffectParameters<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IXAudio2Voice_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, effectindex: u32, pparameters: *mut ::core::ffi::c_void, parametersbytesize: u32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetEffectParameters<Impl: IXAudio2Voice_Impl>(this: *mut ::core::ffi::c_void, effectindex: u32, pparameters: *mut ::core::ffi::c_void, parametersbytesize: u32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetEffectParameters(::core::mem::transmute_copy(&effectindex), ::core::mem::transmute_copy(&pparameters), ::core::mem::transmute_copy(&parametersbytesize)).into()
         }
-        unsafe extern "system" fn SetFilterParameters<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IXAudio2Voice_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pparameters: *const XAUDIO2_FILTER_PARAMETERS, operationset: u32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn SetFilterParameters<Impl: IXAudio2Voice_Impl>(this: *mut ::core::ffi::c_void, pparameters: *const XAUDIO2_FILTER_PARAMETERS, operationset: u32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.SetFilterParameters(::core::mem::transmute_copy(&pparameters), ::core::mem::transmute_copy(&operationset)).into()
         }
-        unsafe extern "system" fn GetFilterParameters<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IXAudio2Voice_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pparameters: *mut XAUDIO2_FILTER_PARAMETERS) {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetFilterParameters<Impl: IXAudio2Voice_Impl>(this: *mut ::core::ffi::c_void, pparameters: *mut XAUDIO2_FILTER_PARAMETERS) {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetFilterParameters(::core::mem::transmute_copy(&pparameters))
         }
-        unsafe extern "system" fn SetOutputFilterParameters<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IXAudio2Voice_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdestinationvoice: *mut ::core::ffi::c_void, pparameters: *const XAUDIO2_FILTER_PARAMETERS, operationset: u32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn SetOutputFilterParameters<Impl: IXAudio2Voice_Impl>(this: *mut ::core::ffi::c_void, pdestinationvoice: *mut ::core::ffi::c_void, pparameters: *const XAUDIO2_FILTER_PARAMETERS, operationset: u32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.SetOutputFilterParameters(::core::mem::transmute(&pdestinationvoice), ::core::mem::transmute_copy(&pparameters), ::core::mem::transmute_copy(&operationset)).into()
         }
-        unsafe extern "system" fn GetOutputFilterParameters<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IXAudio2Voice_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdestinationvoice: *mut ::core::ffi::c_void, pparameters: *mut XAUDIO2_FILTER_PARAMETERS) {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetOutputFilterParameters<Impl: IXAudio2Voice_Impl>(this: *mut ::core::ffi::c_void, pdestinationvoice: *mut ::core::ffi::c_void, pparameters: *mut XAUDIO2_FILTER_PARAMETERS) {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetOutputFilterParameters(::core::mem::transmute(&pdestinationvoice), ::core::mem::transmute_copy(&pparameters))
         }
-        unsafe extern "system" fn SetVolume<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IXAudio2Voice_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, volume: f32, operationset: u32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn SetVolume<Impl: IXAudio2Voice_Impl>(this: *mut ::core::ffi::c_void, volume: f32, operationset: u32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.SetVolume(::core::mem::transmute_copy(&volume), ::core::mem::transmute_copy(&operationset)).into()
         }
-        unsafe extern "system" fn GetVolume<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IXAudio2Voice_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pvolume: *mut f32) {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetVolume<Impl: IXAudio2Voice_Impl>(this: *mut ::core::ffi::c_void, pvolume: *mut f32) {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetVolume(::core::mem::transmute_copy(&pvolume))
         }
-        unsafe extern "system" fn SetChannelVolumes<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IXAudio2Voice_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, channels: u32, pvolumes: *const f32, operationset: u32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn SetChannelVolumes<Impl: IXAudio2Voice_Impl>(this: *mut ::core::ffi::c_void, channels: u32, pvolumes: *const f32, operationset: u32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.SetChannelVolumes(::core::mem::transmute_copy(&channels), ::core::mem::transmute_copy(&pvolumes), ::core::mem::transmute_copy(&operationset)).into()
         }
-        unsafe extern "system" fn GetChannelVolumes<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IXAudio2Voice_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, channels: u32, pvolumes: *mut f32) {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetChannelVolumes<Impl: IXAudio2Voice_Impl>(this: *mut ::core::ffi::c_void, channels: u32, pvolumes: *mut f32) {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetChannelVolumes(::core::mem::transmute_copy(&channels), ::core::mem::transmute_copy(&pvolumes))
         }
-        unsafe extern "system" fn SetOutputMatrix<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IXAudio2Voice_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdestinationvoice: *mut ::core::ffi::c_void, sourcechannels: u32, destinationchannels: u32, plevelmatrix: *const f32, operationset: u32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn SetOutputMatrix<Impl: IXAudio2Voice_Impl>(this: *mut ::core::ffi::c_void, pdestinationvoice: *mut ::core::ffi::c_void, sourcechannels: u32, destinationchannels: u32, plevelmatrix: *const f32, operationset: u32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.SetOutputMatrix(::core::mem::transmute(&pdestinationvoice), ::core::mem::transmute_copy(&sourcechannels), ::core::mem::transmute_copy(&destinationchannels), ::core::mem::transmute_copy(&plevelmatrix), ::core::mem::transmute_copy(&operationset)).into()
         }
-        unsafe extern "system" fn GetOutputMatrix<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IXAudio2Voice_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdestinationvoice: *mut ::core::ffi::c_void, sourcechannels: u32, destinationchannels: u32, plevelmatrix: *mut f32) {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetOutputMatrix<Impl: IXAudio2Voice_Impl>(this: *mut ::core::ffi::c_void, pdestinationvoice: *mut ::core::ffi::c_void, sourcechannels: u32, destinationchannels: u32, plevelmatrix: *mut f32) {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetOutputMatrix(::core::mem::transmute(&pdestinationvoice), ::core::mem::transmute_copy(&sourcechannels), ::core::mem::transmute_copy(&destinationchannels), ::core::mem::transmute_copy(&plevelmatrix))
         }
-        unsafe extern "system" fn DestroyVoice<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IXAudio2Voice_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn DestroyVoice<Impl: IXAudio2Voice_Impl>(this: *mut ::core::ffi::c_void) {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.DestroyVoice()
         }
         Self {
-            GetVoiceDetails: GetVoiceDetails::<Identity, Impl, OFFSET>,
-            SetOutputVoices: SetOutputVoices::<Identity, Impl, OFFSET>,
-            SetEffectChain: SetEffectChain::<Identity, Impl, OFFSET>,
-            EnableEffect: EnableEffect::<Identity, Impl, OFFSET>,
-            DisableEffect: DisableEffect::<Identity, Impl, OFFSET>,
-            GetEffectState: GetEffectState::<Identity, Impl, OFFSET>,
-            SetEffectParameters: SetEffectParameters::<Identity, Impl, OFFSET>,
-            GetEffectParameters: GetEffectParameters::<Identity, Impl, OFFSET>,
-            SetFilterParameters: SetFilterParameters::<Identity, Impl, OFFSET>,
-            GetFilterParameters: GetFilterParameters::<Identity, Impl, OFFSET>,
-            SetOutputFilterParameters: SetOutputFilterParameters::<Identity, Impl, OFFSET>,
-            GetOutputFilterParameters: GetOutputFilterParameters::<Identity, Impl, OFFSET>,
-            SetVolume: SetVolume::<Identity, Impl, OFFSET>,
-            GetVolume: GetVolume::<Identity, Impl, OFFSET>,
-            SetChannelVolumes: SetChannelVolumes::<Identity, Impl, OFFSET>,
-            GetChannelVolumes: GetChannelVolumes::<Identity, Impl, OFFSET>,
-            SetOutputMatrix: SetOutputMatrix::<Identity, Impl, OFFSET>,
-            GetOutputMatrix: GetOutputMatrix::<Identity, Impl, OFFSET>,
-            DestroyVoice: DestroyVoice::<Identity, Impl, OFFSET>,
+            GetVoiceDetails: GetVoiceDetails::<Impl>,
+            SetOutputVoices: SetOutputVoices::<Impl>,
+            SetEffectChain: SetEffectChain::<Impl>,
+            EnableEffect: EnableEffect::<Impl>,
+            DisableEffect: DisableEffect::<Impl>,
+            GetEffectState: GetEffectState::<Impl>,
+            SetEffectParameters: SetEffectParameters::<Impl>,
+            GetEffectParameters: GetEffectParameters::<Impl>,
+            SetFilterParameters: SetFilterParameters::<Impl>,
+            GetFilterParameters: GetFilterParameters::<Impl>,
+            SetOutputFilterParameters: SetOutputFilterParameters::<Impl>,
+            GetOutputFilterParameters: GetOutputFilterParameters::<Impl>,
+            SetVolume: SetVolume::<Impl>,
+            GetVolume: GetVolume::<Impl>,
+            SetChannelVolumes: SetChannelVolumes::<Impl>,
+            GetChannelVolumes: GetChannelVolumes::<Impl>,
+            SetOutputMatrix: SetOutputMatrix::<Impl>,
+            GetOutputMatrix: GetOutputMatrix::<Impl>,
+            DestroyVoice: DestroyVoice::<Impl>,
         }
     }
-    pub fn matches(iid: &windows::core::GUID) -> bool {
-        iid == &<IXAudio2Voice as ::windows::core::Interface>::IID
+}
+#[doc(hidden)]
+#[cfg(feature = "Win32_Foundation")]
+struct IXAudio2Voice_ImplVtbl<T: IXAudio2Voice_Impl>(::std::marker::PhantomData<T>);
+#[cfg(feature = "Win32_Foundation")]
+impl<T: IXAudio2Voice_Impl> IXAudio2Voice_ImplVtbl<T> {
+    const VTABLE: IXAudio2Voice_Vtbl = IXAudio2Voice_Vtbl::new::<T>();
+}
+#[cfg(feature = "Win32_Foundation")]
+impl IXAudio2Voice {
+    pub fn new<'a, T: IXAudio2Voice_Impl>(this: &'a T) -> ::windows::core::ScopedInterface<'a, Self> {
+        let this = ::windows::core::ScopedHeap { vtable: &IXAudio2Voice_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
+        let this = ::std::mem::ManuallyDrop::new(::std::boxed::Box::new(this));
+        unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
 pub trait IXAudio2VoiceCallback_Impl: Sized {
@@ -598,55 +642,63 @@ pub trait IXAudio2VoiceCallback_Impl: Sized {
     fn OnLoopEnd(&self, pbuffercontext: *mut ::core::ffi::c_void);
     fn OnVoiceError(&self, pbuffercontext: *mut ::core::ffi::c_void, error: ::windows::core::HRESULT);
 }
-impl ::windows::core::RuntimeName for IXAudio2VoiceCallback {}
 impl IXAudio2VoiceCallback_Vtbl {
-    pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IXAudio2VoiceCallback_Impl, const OFFSET: isize>() -> IXAudio2VoiceCallback_Vtbl {
-        unsafe extern "system" fn OnVoiceProcessingPassStart<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IXAudio2VoiceCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bytesrequired: u32) {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+    pub const fn new<Impl: IXAudio2VoiceCallback_Impl>() -> IXAudio2VoiceCallback_Vtbl {
+        unsafe extern "system" fn OnVoiceProcessingPassStart<Impl: IXAudio2VoiceCallback_Impl>(this: *mut ::core::ffi::c_void, bytesrequired: u32) {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.OnVoiceProcessingPassStart(::core::mem::transmute_copy(&bytesrequired))
         }
-        unsafe extern "system" fn OnVoiceProcessingPassEnd<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IXAudio2VoiceCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn OnVoiceProcessingPassEnd<Impl: IXAudio2VoiceCallback_Impl>(this: *mut ::core::ffi::c_void) {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.OnVoiceProcessingPassEnd()
         }
-        unsafe extern "system" fn OnStreamEnd<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IXAudio2VoiceCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn OnStreamEnd<Impl: IXAudio2VoiceCallback_Impl>(this: *mut ::core::ffi::c_void) {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.OnStreamEnd()
         }
-        unsafe extern "system" fn OnBufferStart<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IXAudio2VoiceCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbuffercontext: *mut ::core::ffi::c_void) {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn OnBufferStart<Impl: IXAudio2VoiceCallback_Impl>(this: *mut ::core::ffi::c_void, pbuffercontext: *mut ::core::ffi::c_void) {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.OnBufferStart(::core::mem::transmute_copy(&pbuffercontext))
         }
-        unsafe extern "system" fn OnBufferEnd<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IXAudio2VoiceCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbuffercontext: *mut ::core::ffi::c_void) {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn OnBufferEnd<Impl: IXAudio2VoiceCallback_Impl>(this: *mut ::core::ffi::c_void, pbuffercontext: *mut ::core::ffi::c_void) {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.OnBufferEnd(::core::mem::transmute_copy(&pbuffercontext))
         }
-        unsafe extern "system" fn OnLoopEnd<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IXAudio2VoiceCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbuffercontext: *mut ::core::ffi::c_void) {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn OnLoopEnd<Impl: IXAudio2VoiceCallback_Impl>(this: *mut ::core::ffi::c_void, pbuffercontext: *mut ::core::ffi::c_void) {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.OnLoopEnd(::core::mem::transmute_copy(&pbuffercontext))
         }
-        unsafe extern "system" fn OnVoiceError<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IXAudio2VoiceCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbuffercontext: *mut ::core::ffi::c_void, error: ::windows::core::HRESULT) {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn OnVoiceError<Impl: IXAudio2VoiceCallback_Impl>(this: *mut ::core::ffi::c_void, pbuffercontext: *mut ::core::ffi::c_void, error: ::windows::core::HRESULT) {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.OnVoiceError(::core::mem::transmute_copy(&pbuffercontext), ::core::mem::transmute_copy(&error))
         }
         Self {
-            OnVoiceProcessingPassStart: OnVoiceProcessingPassStart::<Identity, Impl, OFFSET>,
-            OnVoiceProcessingPassEnd: OnVoiceProcessingPassEnd::<Identity, Impl, OFFSET>,
-            OnStreamEnd: OnStreamEnd::<Identity, Impl, OFFSET>,
-            OnBufferStart: OnBufferStart::<Identity, Impl, OFFSET>,
-            OnBufferEnd: OnBufferEnd::<Identity, Impl, OFFSET>,
-            OnLoopEnd: OnLoopEnd::<Identity, Impl, OFFSET>,
-            OnVoiceError: OnVoiceError::<Identity, Impl, OFFSET>,
+            OnVoiceProcessingPassStart: OnVoiceProcessingPassStart::<Impl>,
+            OnVoiceProcessingPassEnd: OnVoiceProcessingPassEnd::<Impl>,
+            OnStreamEnd: OnStreamEnd::<Impl>,
+            OnBufferStart: OnBufferStart::<Impl>,
+            OnBufferEnd: OnBufferEnd::<Impl>,
+            OnLoopEnd: OnLoopEnd::<Impl>,
+            OnVoiceError: OnVoiceError::<Impl>,
         }
     }
-    pub fn matches(iid: &windows::core::GUID) -> bool {
-        iid == &<IXAudio2VoiceCallback as ::windows::core::Interface>::IID
+}
+#[doc(hidden)]
+struct IXAudio2VoiceCallback_ImplVtbl<T: IXAudio2VoiceCallback_Impl>(::std::marker::PhantomData<T>);
+impl<T: IXAudio2VoiceCallback_Impl> IXAudio2VoiceCallback_ImplVtbl<T> {
+    const VTABLE: IXAudio2VoiceCallback_Vtbl = IXAudio2VoiceCallback_Vtbl::new::<T>();
+}
+impl IXAudio2VoiceCallback {
+    pub fn new<'a, T: IXAudio2VoiceCallback_Impl>(this: &'a T) -> ::windows::core::ScopedInterface<'a, Self> {
+        let this = ::windows::core::ScopedHeap { vtable: &IXAudio2VoiceCallback_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
+        let this = ::std::mem::ManuallyDrop::new(::std::boxed::Box::new(this));
+        unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/XAudio2/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/XAudio2/mod.rs
@@ -383,7 +383,16 @@ pub struct IXAudio2_Vtbl {
 }
 #[doc = "*Required features: `\"Win32_Media_Audio_XAudio2\"`*"]
 #[repr(transparent)]
-pub struct IXAudio2EngineCallback(::windows::core::IUnknown);
+pub struct IXAudio2EngineCallback(::std::ptr::NonNull<::std::ffi::c_void>);
+unsafe impl ::windows::core::Abi for Option<IXAudio2EngineCallback> {
+    type Abi = *mut ::std::ffi::c_void;
+}
+unsafe impl ::windows::core::Abi for IXAudio2EngineCallback {
+    type Abi = *mut ::std::ffi::c_void;
+    fn abi_is_possibly_valid(abi: &Self::Abi) -> bool {
+        !abi.is_null()
+    }
+}
 impl IXAudio2EngineCallback {
     pub unsafe fn OnProcessingPassStart(&self) {
         (::windows::core::Vtable::vtable(self).OnProcessingPassStart)(::windows::core::Vtable::as_raw(self))
@@ -413,9 +422,6 @@ impl ::core::fmt::Debug for IXAudio2EngineCallback {
 }
 unsafe impl ::windows::core::Vtable for IXAudio2EngineCallback {
     type Vtable = IXAudio2EngineCallback_Vtbl;
-}
-unsafe impl ::windows::core::Interface for IXAudio2EngineCallback {
-    const IID: ::windows::core::GUID = ::windows::core::GUID::zeroed();
 }
 #[repr(C)]
 #[doc(hidden)]
@@ -481,7 +487,16 @@ pub struct IXAudio2Extension_Vtbl {
 }
 #[doc = "*Required features: `\"Win32_Media_Audio_XAudio2\"`*"]
 #[repr(transparent)]
-pub struct IXAudio2MasteringVoice(::windows::core::IUnknown);
+pub struct IXAudio2MasteringVoice(::std::ptr::NonNull<::std::ffi::c_void>);
+unsafe impl ::windows::core::Abi for Option<IXAudio2MasteringVoice> {
+    type Abi = *mut ::std::ffi::c_void;
+}
+unsafe impl ::windows::core::Abi for IXAudio2MasteringVoice {
+    type Abi = *mut ::std::ffi::c_void;
+    fn abi_is_possibly_valid(abi: &Self::Abi) -> bool {
+        !abi.is_null()
+    }
+}
 impl IXAudio2MasteringVoice {
     pub unsafe fn GetVoiceDetails(&self, pvoicedetails: *mut XAUDIO2_VOICE_DETAILS) {
         (::windows::core::Vtable::vtable(self).base__.GetVoiceDetails)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pvoicedetails))
@@ -595,9 +610,6 @@ impl ::core::fmt::Debug for IXAudio2MasteringVoice {
 unsafe impl ::windows::core::Vtable for IXAudio2MasteringVoice {
     type Vtable = IXAudio2MasteringVoice_Vtbl;
 }
-unsafe impl ::windows::core::Interface for IXAudio2MasteringVoice {
-    const IID: ::windows::core::GUID = ::windows::core::GUID::zeroed();
-}
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXAudio2MasteringVoice_Vtbl {
@@ -606,7 +618,16 @@ pub struct IXAudio2MasteringVoice_Vtbl {
 }
 #[doc = "*Required features: `\"Win32_Media_Audio_XAudio2\"`*"]
 #[repr(transparent)]
-pub struct IXAudio2SourceVoice(::windows::core::IUnknown);
+pub struct IXAudio2SourceVoice(::std::ptr::NonNull<::std::ffi::c_void>);
+unsafe impl ::windows::core::Abi for Option<IXAudio2SourceVoice> {
+    type Abi = *mut ::std::ffi::c_void;
+}
+unsafe impl ::windows::core::Abi for IXAudio2SourceVoice {
+    type Abi = *mut ::std::ffi::c_void;
+    fn abi_is_possibly_valid(abi: &Self::Abi) -> bool {
+        !abi.is_null()
+    }
+}
 impl IXAudio2SourceVoice {
     pub unsafe fn GetVoiceDetails(&self, pvoicedetails: *mut XAUDIO2_VOICE_DETAILS) {
         (::windows::core::Vtable::vtable(self).base__.GetVoiceDetails)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pvoicedetails))
@@ -746,9 +767,6 @@ impl ::core::fmt::Debug for IXAudio2SourceVoice {
 unsafe impl ::windows::core::Vtable for IXAudio2SourceVoice {
     type Vtable = IXAudio2SourceVoice_Vtbl;
 }
-unsafe impl ::windows::core::Interface for IXAudio2SourceVoice {
-    const IID: ::windows::core::GUID = ::windows::core::GUID::zeroed();
-}
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXAudio2SourceVoice_Vtbl {
@@ -766,7 +784,16 @@ pub struct IXAudio2SourceVoice_Vtbl {
 }
 #[doc = "*Required features: `\"Win32_Media_Audio_XAudio2\"`*"]
 #[repr(transparent)]
-pub struct IXAudio2SubmixVoice(::windows::core::IUnknown);
+pub struct IXAudio2SubmixVoice(::std::ptr::NonNull<::std::ffi::c_void>);
+unsafe impl ::windows::core::Abi for Option<IXAudio2SubmixVoice> {
+    type Abi = *mut ::std::ffi::c_void;
+}
+unsafe impl ::windows::core::Abi for IXAudio2SubmixVoice {
+    type Abi = *mut ::std::ffi::c_void;
+    fn abi_is_possibly_valid(abi: &Self::Abi) -> bool {
+        !abi.is_null()
+    }
+}
 impl IXAudio2SubmixVoice {
     pub unsafe fn GetVoiceDetails(&self, pvoicedetails: *mut XAUDIO2_VOICE_DETAILS) {
         (::windows::core::Vtable::vtable(self).base__.GetVoiceDetails)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pvoicedetails))
@@ -876,9 +903,6 @@ impl ::core::fmt::Debug for IXAudio2SubmixVoice {
 unsafe impl ::windows::core::Vtable for IXAudio2SubmixVoice {
     type Vtable = IXAudio2SubmixVoice_Vtbl;
 }
-unsafe impl ::windows::core::Interface for IXAudio2SubmixVoice {
-    const IID: ::windows::core::GUID = ::windows::core::GUID::zeroed();
-}
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXAudio2SubmixVoice_Vtbl {
@@ -886,7 +910,16 @@ pub struct IXAudio2SubmixVoice_Vtbl {
 }
 #[doc = "*Required features: `\"Win32_Media_Audio_XAudio2\"`*"]
 #[repr(transparent)]
-pub struct IXAudio2Voice(::windows::core::IUnknown);
+pub struct IXAudio2Voice(::std::ptr::NonNull<::std::ffi::c_void>);
+unsafe impl ::windows::core::Abi for Option<IXAudio2Voice> {
+    type Abi = *mut ::std::ffi::c_void;
+}
+unsafe impl ::windows::core::Abi for IXAudio2Voice {
+    type Abi = *mut ::std::ffi::c_void;
+    fn abi_is_possibly_valid(abi: &Self::Abi) -> bool {
+        !abi.is_null()
+    }
+}
 impl IXAudio2Voice {
     pub unsafe fn GetVoiceDetails(&self, pvoicedetails: *mut XAUDIO2_VOICE_DETAILS) {
         (::windows::core::Vtable::vtable(self).GetVoiceDetails)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pvoicedetails))
@@ -981,9 +1014,6 @@ impl ::core::fmt::Debug for IXAudio2Voice {
 unsafe impl ::windows::core::Vtable for IXAudio2Voice {
     type Vtable = IXAudio2Voice_Vtbl;
 }
-unsafe impl ::windows::core::Interface for IXAudio2Voice {
-    const IID: ::windows::core::GUID = ::windows::core::GUID::zeroed();
-}
 #[repr(C)]
 #[doc(hidden)]
 pub struct IXAudio2Voice_Vtbl {
@@ -1015,7 +1045,16 @@ pub struct IXAudio2Voice_Vtbl {
 }
 #[doc = "*Required features: `\"Win32_Media_Audio_XAudio2\"`*"]
 #[repr(transparent)]
-pub struct IXAudio2VoiceCallback(::windows::core::IUnknown);
+pub struct IXAudio2VoiceCallback(::std::ptr::NonNull<::std::ffi::c_void>);
+unsafe impl ::windows::core::Abi for Option<IXAudio2VoiceCallback> {
+    type Abi = *mut ::std::ffi::c_void;
+}
+unsafe impl ::windows::core::Abi for IXAudio2VoiceCallback {
+    type Abi = *mut ::std::ffi::c_void;
+    fn abi_is_possibly_valid(abi: &Self::Abi) -> bool {
+        !abi.is_null()
+    }
+}
 impl IXAudio2VoiceCallback {
     pub unsafe fn OnVoiceProcessingPassStart(&self, bytesrequired: u32) {
         (::windows::core::Vtable::vtable(self).OnVoiceProcessingPassStart)(::windows::core::Vtable::as_raw(self), bytesrequired)
@@ -1057,9 +1096,6 @@ impl ::core::fmt::Debug for IXAudio2VoiceCallback {
 }
 unsafe impl ::windows::core::Vtable for IXAudio2VoiceCallback {
     type Vtable = IXAudio2VoiceCallback_Vtbl;
-}
-unsafe impl ::windows::core::Interface for IXAudio2VoiceCallback {
-    const IID: ::windows::core::GUID = ::windows::core::GUID::zeroed();
 }
 #[repr(C)]
 #[doc(hidden)]

--- a/crates/libs/windows/src/Windows/Win32/Media/Speech/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Speech/impl.rs
@@ -653,19 +653,29 @@ pub trait ISpNotifyCallback_Impl: Sized {
     fn NotifyCallback(&self, wparam: super::super::Foundation::WPARAM, lparam: super::super::Foundation::LPARAM) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::windows::core::RuntimeName for ISpNotifyCallback {}
-#[cfg(feature = "Win32_Foundation")]
 impl ISpNotifyCallback_Vtbl {
-    pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ISpNotifyCallback_Impl, const OFFSET: isize>() -> ISpNotifyCallback_Vtbl {
-        unsafe extern "system" fn NotifyCallback<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: ISpNotifyCallback_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, wparam: super::super::Foundation::WPARAM, lparam: super::super::Foundation::LPARAM) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+    pub const fn new<Impl: ISpNotifyCallback_Impl>() -> ISpNotifyCallback_Vtbl {
+        unsafe extern "system" fn NotifyCallback<Impl: ISpNotifyCallback_Impl>(this: *mut ::core::ffi::c_void, wparam: super::super::Foundation::WPARAM, lparam: super::super::Foundation::LPARAM) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.NotifyCallback(::core::mem::transmute_copy(&wparam), ::core::mem::transmute_copy(&lparam)).into()
         }
-        Self { NotifyCallback: NotifyCallback::<Identity, Impl, OFFSET> }
+        Self { NotifyCallback: NotifyCallback::<Impl> }
     }
-    pub fn matches(iid: &windows::core::GUID) -> bool {
-        iid == &<ISpNotifyCallback as ::windows::core::Interface>::IID
+}
+#[doc(hidden)]
+#[cfg(feature = "Win32_Foundation")]
+struct ISpNotifyCallback_ImplVtbl<T: ISpNotifyCallback_Impl>(::std::marker::PhantomData<T>);
+#[cfg(feature = "Win32_Foundation")]
+impl<T: ISpNotifyCallback_Impl> ISpNotifyCallback_ImplVtbl<T> {
+    const VTABLE: ISpNotifyCallback_Vtbl = ISpNotifyCallback_Vtbl::new::<T>();
+}
+#[cfg(feature = "Win32_Foundation")]
+impl ISpNotifyCallback {
+    pub fn new<'a, T: ISpNotifyCallback_Impl>(this: &'a T) -> ::windows::core::ScopedInterface<'a, Self> {
+        let this = ::windows::core::ScopedHeap { vtable: &ISpNotifyCallback_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
+        let this = ::std::mem::ManuallyDrop::new(::std::boxed::Box::new(this));
+        unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
 pub trait ISpNotifySink_Impl: Sized {

--- a/crates/libs/windows/src/Windows/Win32/Media/Speech/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Speech/mod.rs
@@ -1486,7 +1486,16 @@ pub struct ISpMMSysAudio_Vtbl {
 }
 #[doc = "*Required features: `\"Win32_Media_Speech\"`*"]
 #[repr(transparent)]
-pub struct ISpNotifyCallback(::windows::core::IUnknown);
+pub struct ISpNotifyCallback(::std::ptr::NonNull<::std::ffi::c_void>);
+unsafe impl ::windows::core::Abi for Option<ISpNotifyCallback> {
+    type Abi = *mut ::std::ffi::c_void;
+}
+unsafe impl ::windows::core::Abi for ISpNotifyCallback {
+    type Abi = *mut ::std::ffi::c_void;
+    fn abi_is_possibly_valid(abi: &Self::Abi) -> bool {
+        !abi.is_null()
+    }
+}
 impl ISpNotifyCallback {
     #[doc = "*Required features: `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
@@ -1516,9 +1525,6 @@ impl ::core::fmt::Debug for ISpNotifyCallback {
 }
 unsafe impl ::windows::core::Vtable for ISpNotifyCallback {
     type Vtable = ISpNotifyCallback_Vtbl;
-}
-unsafe impl ::windows::core::Interface for ISpNotifyCallback {
-    const IID: ::windows::core::GUID = ::windows::core::GUID::zeroed();
 }
 #[repr(C)]
 #[doc(hidden)]

--- a/crates/libs/windows/src/Windows/Win32/Storage/Vss/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Vss/impl.rs
@@ -623,64 +623,62 @@ pub trait IVssCreateWriterMetadata_Impl: Sized {
     fn SaveAsXML(&self, pbstrxml: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
 }
 #[cfg(all(feature = "Win32_Data_Xml_MsXml", feature = "Win32_System_Com"))]
-impl ::windows::core::RuntimeName for IVssCreateWriterMetadata {}
-#[cfg(all(feature = "Win32_Data_Xml_MsXml", feature = "Win32_System_Com"))]
 impl IVssCreateWriterMetadata_Vtbl {
-    pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IVssCreateWriterMetadata_Impl, const OFFSET: isize>() -> IVssCreateWriterMetadata_Vtbl {
-        unsafe extern "system" fn AddIncludeFiles<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IVssCreateWriterMetadata_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, wszpath: ::windows::core::PCWSTR, wszfilespec: ::windows::core::PCWSTR, brecursive: u8, wszalternatelocation: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+    pub const fn new<Impl: IVssCreateWriterMetadata_Impl>() -> IVssCreateWriterMetadata_Vtbl {
+        unsafe extern "system" fn AddIncludeFiles<Impl: IVssCreateWriterMetadata_Impl>(this: *mut ::core::ffi::c_void, wszpath: ::windows::core::PCWSTR, wszfilespec: ::windows::core::PCWSTR, brecursive: u8, wszalternatelocation: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.AddIncludeFiles(::core::mem::transmute(&wszpath), ::core::mem::transmute(&wszfilespec), ::core::mem::transmute_copy(&brecursive), ::core::mem::transmute(&wszalternatelocation)).into()
         }
-        unsafe extern "system" fn AddExcludeFiles<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IVssCreateWriterMetadata_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, wszpath: ::windows::core::PCWSTR, wszfilespec: ::windows::core::PCWSTR, brecursive: u8) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn AddExcludeFiles<Impl: IVssCreateWriterMetadata_Impl>(this: *mut ::core::ffi::c_void, wszpath: ::windows::core::PCWSTR, wszfilespec: ::windows::core::PCWSTR, brecursive: u8) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.AddExcludeFiles(::core::mem::transmute(&wszpath), ::core::mem::transmute(&wszfilespec), ::core::mem::transmute_copy(&brecursive)).into()
         }
-        unsafe extern "system" fn AddComponent<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IVssCreateWriterMetadata_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ct: VSS_COMPONENT_TYPE, wszlogicalpath: ::windows::core::PCWSTR, wszcomponentname: ::windows::core::PCWSTR, wszcaption: ::windows::core::PCWSTR, pbicon: *const u8, cbicon: u32, brestoremetadata: u8, bnotifyonbackupcomplete: u8, bselectable: u8, bselectableforrestore: u8, dwcomponentflags: u32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn AddComponent<Impl: IVssCreateWriterMetadata_Impl>(this: *mut ::core::ffi::c_void, ct: VSS_COMPONENT_TYPE, wszlogicalpath: ::windows::core::PCWSTR, wszcomponentname: ::windows::core::PCWSTR, wszcaption: ::windows::core::PCWSTR, pbicon: *const u8, cbicon: u32, brestoremetadata: u8, bnotifyonbackupcomplete: u8, bselectable: u8, bselectableforrestore: u8, dwcomponentflags: u32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.AddComponent(::core::mem::transmute_copy(&ct), ::core::mem::transmute(&wszlogicalpath), ::core::mem::transmute(&wszcomponentname), ::core::mem::transmute(&wszcaption), ::core::mem::transmute_copy(&pbicon), ::core::mem::transmute_copy(&cbicon), ::core::mem::transmute_copy(&brestoremetadata), ::core::mem::transmute_copy(&bnotifyonbackupcomplete), ::core::mem::transmute_copy(&bselectable), ::core::mem::transmute_copy(&bselectableforrestore), ::core::mem::transmute_copy(&dwcomponentflags))
                 .into()
         }
-        unsafe extern "system" fn AddDatabaseFiles<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IVssCreateWriterMetadata_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, wszlogicalpath: ::windows::core::PCWSTR, wszdatabasename: ::windows::core::PCWSTR, wszpath: ::windows::core::PCWSTR, wszfilespec: ::windows::core::PCWSTR, dwbackuptypemask: u32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn AddDatabaseFiles<Impl: IVssCreateWriterMetadata_Impl>(this: *mut ::core::ffi::c_void, wszlogicalpath: ::windows::core::PCWSTR, wszdatabasename: ::windows::core::PCWSTR, wszpath: ::windows::core::PCWSTR, wszfilespec: ::windows::core::PCWSTR, dwbackuptypemask: u32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.AddDatabaseFiles(::core::mem::transmute(&wszlogicalpath), ::core::mem::transmute(&wszdatabasename), ::core::mem::transmute(&wszpath), ::core::mem::transmute(&wszfilespec), ::core::mem::transmute_copy(&dwbackuptypemask)).into()
         }
-        unsafe extern "system" fn AddDatabaseLogFiles<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IVssCreateWriterMetadata_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, wszlogicalpath: ::windows::core::PCWSTR, wszdatabasename: ::windows::core::PCWSTR, wszpath: ::windows::core::PCWSTR, wszfilespec: ::windows::core::PCWSTR, dwbackuptypemask: u32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn AddDatabaseLogFiles<Impl: IVssCreateWriterMetadata_Impl>(this: *mut ::core::ffi::c_void, wszlogicalpath: ::windows::core::PCWSTR, wszdatabasename: ::windows::core::PCWSTR, wszpath: ::windows::core::PCWSTR, wszfilespec: ::windows::core::PCWSTR, dwbackuptypemask: u32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.AddDatabaseLogFiles(::core::mem::transmute(&wszlogicalpath), ::core::mem::transmute(&wszdatabasename), ::core::mem::transmute(&wszpath), ::core::mem::transmute(&wszfilespec), ::core::mem::transmute_copy(&dwbackuptypemask)).into()
         }
-        unsafe extern "system" fn AddFilesToFileGroup<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IVssCreateWriterMetadata_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, wszlogicalpath: ::windows::core::PCWSTR, wszgroupname: ::windows::core::PCWSTR, wszpath: ::windows::core::PCWSTR, wszfilespec: ::windows::core::PCWSTR, brecursive: u8, wszalternatelocation: ::windows::core::PCWSTR, dwbackuptypemask: u32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn AddFilesToFileGroup<Impl: IVssCreateWriterMetadata_Impl>(this: *mut ::core::ffi::c_void, wszlogicalpath: ::windows::core::PCWSTR, wszgroupname: ::windows::core::PCWSTR, wszpath: ::windows::core::PCWSTR, wszfilespec: ::windows::core::PCWSTR, brecursive: u8, wszalternatelocation: ::windows::core::PCWSTR, dwbackuptypemask: u32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.AddFilesToFileGroup(::core::mem::transmute(&wszlogicalpath), ::core::mem::transmute(&wszgroupname), ::core::mem::transmute(&wszpath), ::core::mem::transmute(&wszfilespec), ::core::mem::transmute_copy(&brecursive), ::core::mem::transmute(&wszalternatelocation), ::core::mem::transmute_copy(&dwbackuptypemask)).into()
         }
-        unsafe extern "system" fn SetRestoreMethod<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IVssCreateWriterMetadata_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, method: VSS_RESTOREMETHOD_ENUM, wszservice: ::windows::core::PCWSTR, wszuserprocedure: ::windows::core::PCWSTR, writerrestore: VSS_WRITERRESTORE_ENUM, brebootrequired: u8) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn SetRestoreMethod<Impl: IVssCreateWriterMetadata_Impl>(this: *mut ::core::ffi::c_void, method: VSS_RESTOREMETHOD_ENUM, wszservice: ::windows::core::PCWSTR, wszuserprocedure: ::windows::core::PCWSTR, writerrestore: VSS_WRITERRESTORE_ENUM, brebootrequired: u8) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.SetRestoreMethod(::core::mem::transmute_copy(&method), ::core::mem::transmute(&wszservice), ::core::mem::transmute(&wszuserprocedure), ::core::mem::transmute_copy(&writerrestore), ::core::mem::transmute_copy(&brebootrequired)).into()
         }
-        unsafe extern "system" fn AddAlternateLocationMapping<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IVssCreateWriterMetadata_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, wszsourcepath: ::windows::core::PCWSTR, wszsourcefilespec: ::windows::core::PCWSTR, brecursive: u8, wszdestination: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn AddAlternateLocationMapping<Impl: IVssCreateWriterMetadata_Impl>(this: *mut ::core::ffi::c_void, wszsourcepath: ::windows::core::PCWSTR, wszsourcefilespec: ::windows::core::PCWSTR, brecursive: u8, wszdestination: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.AddAlternateLocationMapping(::core::mem::transmute(&wszsourcepath), ::core::mem::transmute(&wszsourcefilespec), ::core::mem::transmute_copy(&brecursive), ::core::mem::transmute(&wszdestination)).into()
         }
-        unsafe extern "system" fn AddComponentDependency<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IVssCreateWriterMetadata_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, wszforlogicalpath: ::windows::core::PCWSTR, wszforcomponentname: ::windows::core::PCWSTR, onwriterid: ::windows::core::GUID, wszonlogicalpath: ::windows::core::PCWSTR, wszoncomponentname: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn AddComponentDependency<Impl: IVssCreateWriterMetadata_Impl>(this: *mut ::core::ffi::c_void, wszforlogicalpath: ::windows::core::PCWSTR, wszforcomponentname: ::windows::core::PCWSTR, onwriterid: ::windows::core::GUID, wszonlogicalpath: ::windows::core::PCWSTR, wszoncomponentname: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.AddComponentDependency(::core::mem::transmute(&wszforlogicalpath), ::core::mem::transmute(&wszforcomponentname), ::core::mem::transmute(&onwriterid), ::core::mem::transmute(&wszonlogicalpath), ::core::mem::transmute(&wszoncomponentname)).into()
         }
-        unsafe extern "system" fn SetBackupSchema<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IVssCreateWriterMetadata_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwschemamask: u32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn SetBackupSchema<Impl: IVssCreateWriterMetadata_Impl>(this: *mut ::core::ffi::c_void, dwschemamask: u32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.SetBackupSchema(::core::mem::transmute_copy(&dwschemamask)).into()
         }
-        unsafe extern "system" fn GetDocument<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IVssCreateWriterMetadata_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdoc: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetDocument<Impl: IVssCreateWriterMetadata_Impl>(this: *mut ::core::ffi::c_void, pdoc: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             match this.GetDocument() {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(pdoc, ::core::mem::transmute(ok__));
@@ -689,28 +687,40 @@ impl IVssCreateWriterMetadata_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        unsafe extern "system" fn SaveAsXML<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IVssCreateWriterMetadata_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbstrxml: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn SaveAsXML<Impl: IVssCreateWriterMetadata_Impl>(this: *mut ::core::ffi::c_void, pbstrxml: *mut ::core::mem::ManuallyDrop<::windows::core::BSTR>) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.SaveAsXML(::core::mem::transmute_copy(&pbstrxml)).into()
         }
         Self {
-            AddIncludeFiles: AddIncludeFiles::<Identity, Impl, OFFSET>,
-            AddExcludeFiles: AddExcludeFiles::<Identity, Impl, OFFSET>,
-            AddComponent: AddComponent::<Identity, Impl, OFFSET>,
-            AddDatabaseFiles: AddDatabaseFiles::<Identity, Impl, OFFSET>,
-            AddDatabaseLogFiles: AddDatabaseLogFiles::<Identity, Impl, OFFSET>,
-            AddFilesToFileGroup: AddFilesToFileGroup::<Identity, Impl, OFFSET>,
-            SetRestoreMethod: SetRestoreMethod::<Identity, Impl, OFFSET>,
-            AddAlternateLocationMapping: AddAlternateLocationMapping::<Identity, Impl, OFFSET>,
-            AddComponentDependency: AddComponentDependency::<Identity, Impl, OFFSET>,
-            SetBackupSchema: SetBackupSchema::<Identity, Impl, OFFSET>,
-            GetDocument: GetDocument::<Identity, Impl, OFFSET>,
-            SaveAsXML: SaveAsXML::<Identity, Impl, OFFSET>,
+            AddIncludeFiles: AddIncludeFiles::<Impl>,
+            AddExcludeFiles: AddExcludeFiles::<Impl>,
+            AddComponent: AddComponent::<Impl>,
+            AddDatabaseFiles: AddDatabaseFiles::<Impl>,
+            AddDatabaseLogFiles: AddDatabaseLogFiles::<Impl>,
+            AddFilesToFileGroup: AddFilesToFileGroup::<Impl>,
+            SetRestoreMethod: SetRestoreMethod::<Impl>,
+            AddAlternateLocationMapping: AddAlternateLocationMapping::<Impl>,
+            AddComponentDependency: AddComponentDependency::<Impl>,
+            SetBackupSchema: SetBackupSchema::<Impl>,
+            GetDocument: GetDocument::<Impl>,
+            SaveAsXML: SaveAsXML::<Impl>,
         }
     }
-    pub fn matches(iid: &windows::core::GUID) -> bool {
-        iid == &<IVssCreateWriterMetadata as ::windows::core::Interface>::IID
+}
+#[doc(hidden)]
+#[cfg(all(feature = "Win32_Data_Xml_MsXml", feature = "Win32_System_Com"))]
+struct IVssCreateWriterMetadata_ImplVtbl<T: IVssCreateWriterMetadata_Impl>(::std::marker::PhantomData<T>);
+#[cfg(all(feature = "Win32_Data_Xml_MsXml", feature = "Win32_System_Com"))]
+impl<T: IVssCreateWriterMetadata_Impl> IVssCreateWriterMetadata_ImplVtbl<T> {
+    const VTABLE: IVssCreateWriterMetadata_Vtbl = IVssCreateWriterMetadata_Vtbl::new::<T>();
+}
+#[cfg(all(feature = "Win32_Data_Xml_MsXml", feature = "Win32_System_Com"))]
+impl IVssCreateWriterMetadata {
+    pub fn new<'a, T: IVssCreateWriterMetadata_Impl>(this: &'a T) -> ::windows::core::ScopedInterface<'a, Self> {
+        let this = ::windows::core::ScopedHeap { vtable: &IVssCreateWriterMetadata_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
+        let this = ::std::mem::ManuallyDrop::new(::std::boxed::Box::new(this));
+        unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
 pub trait IVssDifferentialSoftwareSnapshotMgmt_Impl: Sized {
@@ -1626,22 +1636,21 @@ pub trait IVssWriterComponents_Impl: Sized {
     fn GetWriterInfo(&self, pidinstance: *mut ::windows::core::GUID, pidwriter: *mut ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn GetComponent(&self, icomponent: u32) -> ::windows::core::Result<IVssComponent>;
 }
-impl ::windows::core::RuntimeName for IVssWriterComponents {}
 impl IVssWriterComponents_Vtbl {
-    pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IVssWriterComponents_Impl, const OFFSET: isize>() -> IVssWriterComponents_Vtbl {
-        unsafe extern "system" fn GetComponentCount<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IVssWriterComponents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pccomponents: *mut u32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+    pub const fn new<Impl: IVssWriterComponents_Impl>() -> IVssWriterComponents_Vtbl {
+        unsafe extern "system" fn GetComponentCount<Impl: IVssWriterComponents_Impl>(this: *mut ::core::ffi::c_void, pccomponents: *mut u32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetComponentCount(::core::mem::transmute_copy(&pccomponents)).into()
         }
-        unsafe extern "system" fn GetWriterInfo<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IVssWriterComponents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pidinstance: *mut ::windows::core::GUID, pidwriter: *mut ::windows::core::GUID) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetWriterInfo<Impl: IVssWriterComponents_Impl>(this: *mut ::core::ffi::c_void, pidinstance: *mut ::windows::core::GUID, pidwriter: *mut ::windows::core::GUID) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetWriterInfo(::core::mem::transmute_copy(&pidinstance), ::core::mem::transmute_copy(&pidwriter)).into()
         }
-        unsafe extern "system" fn GetComponent<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IVssWriterComponents_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, icomponent: u32, ppcomponent: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetComponent<Impl: IVssWriterComponents_Impl>(this: *mut ::core::ffi::c_void, icomponent: u32, ppcomponent: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             match this.GetComponent(::core::mem::transmute_copy(&icomponent)) {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(ppcomponent, ::core::mem::transmute(ok__));
@@ -1650,14 +1659,19 @@ impl IVssWriterComponents_Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        Self {
-            GetComponentCount: GetComponentCount::<Identity, Impl, OFFSET>,
-            GetWriterInfo: GetWriterInfo::<Identity, Impl, OFFSET>,
-            GetComponent: GetComponent::<Identity, Impl, OFFSET>,
-        }
+        Self { GetComponentCount: GetComponentCount::<Impl>, GetWriterInfo: GetWriterInfo::<Impl>, GetComponent: GetComponent::<Impl> }
     }
-    pub fn matches(iid: &windows::core::GUID) -> bool {
-        iid == &<IVssWriterComponents as ::windows::core::Interface>::IID
+}
+#[doc(hidden)]
+struct IVssWriterComponents_ImplVtbl<T: IVssWriterComponents_Impl>(::std::marker::PhantomData<T>);
+impl<T: IVssWriterComponents_Impl> IVssWriterComponents_ImplVtbl<T> {
+    const VTABLE: IVssWriterComponents_Vtbl = IVssWriterComponents_Vtbl::new::<T>();
+}
+impl IVssWriterComponents {
+    pub fn new<'a, T: IVssWriterComponents_Impl>(this: &'a T) -> ::windows::core::ScopedInterface<'a, Self> {
+        let this = ::windows::core::ScopedHeap { vtable: &IVssWriterComponents_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
+        let this = ::std::mem::ManuallyDrop::new(::std::boxed::Box::new(this));
+        unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
 pub trait IVssWriterImpl_Impl: Sized {

--- a/crates/libs/windows/src/Windows/Win32/Storage/Vss/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Vss/mod.rs
@@ -1120,7 +1120,16 @@ pub struct IVssCreateExpressWriterMetadata_Vtbl {
 }
 #[doc = "*Required features: `\"Win32_Storage_Vss\"`*"]
 #[repr(transparent)]
-pub struct IVssCreateWriterMetadata(::windows::core::IUnknown);
+pub struct IVssCreateWriterMetadata(::std::ptr::NonNull<::std::ffi::c_void>);
+unsafe impl ::windows::core::Abi for Option<IVssCreateWriterMetadata> {
+    type Abi = *mut ::std::ffi::c_void;
+}
+unsafe impl ::windows::core::Abi for IVssCreateWriterMetadata {
+    type Abi = *mut ::std::ffi::c_void;
+    fn abi_is_possibly_valid(abi: &Self::Abi) -> bool {
+        !abi.is_null()
+    }
+}
 impl IVssCreateWriterMetadata {
     pub unsafe fn AddIncludeFiles<'a, P0, P1, P2>(&self, wszpath: P0, wszfilespec: P1, brecursive: u8, wszalternatelocation: P2) -> ::windows::core::Result<()>
     where
@@ -1228,9 +1237,6 @@ impl ::core::fmt::Debug for IVssCreateWriterMetadata {
 }
 unsafe impl ::windows::core::Vtable for IVssCreateWriterMetadata {
     type Vtable = IVssCreateWriterMetadata_Vtbl;
-}
-unsafe impl ::windows::core::Interface for IVssCreateWriterMetadata {
-    const IID: ::windows::core::GUID = ::windows::core::GUID::zeroed();
 }
 #[repr(C)]
 #[doc(hidden)]
@@ -2613,7 +2619,16 @@ pub struct IVssWMFiledesc_Vtbl {
 }
 #[doc = "*Required features: `\"Win32_Storage_Vss\"`*"]
 #[repr(transparent)]
-pub struct IVssWriterComponents(::windows::core::IUnknown);
+pub struct IVssWriterComponents(::std::ptr::NonNull<::std::ffi::c_void>);
+unsafe impl ::windows::core::Abi for Option<IVssWriterComponents> {
+    type Abi = *mut ::std::ffi::c_void;
+}
+unsafe impl ::windows::core::Abi for IVssWriterComponents {
+    type Abi = *mut ::std::ffi::c_void;
+    fn abi_is_possibly_valid(abi: &Self::Abi) -> bool {
+        !abi.is_null()
+    }
+}
 impl IVssWriterComponents {
     pub unsafe fn GetComponentCount(&self, pccomponents: *mut u32) -> ::windows::core::Result<()> {
         (::windows::core::Vtable::vtable(self).GetComponentCount)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(pccomponents)).ok()
@@ -2644,9 +2659,6 @@ impl ::core::fmt::Debug for IVssWriterComponents {
 }
 unsafe impl ::windows::core::Vtable for IVssWriterComponents {
     type Vtable = IVssWriterComponents_Vtbl;
-}
-unsafe impl ::windows::core::Interface for IVssWriterComponents {
-    const IID: ::windows::core::GUID = ::windows::core::GUID::zeroed();
 }
 #[repr(C)]
 #[doc(hidden)]

--- a/crates/libs/windows/src/Windows/Win32/System/AddressBook/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/AddressBook/impl.rs
@@ -1346,68 +1346,66 @@ pub trait IWABOBJECT__Impl: Sized {
     fn SetMe(&self, lpiab: &::core::option::Option<IAddrBook>, ulflags: u32, sbeid: &SBinary, hwnd: super::super::Foundation::HWND) -> ::windows::core::Result<()>;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::windows::core::RuntimeName for IWABOBJECT_ {}
-#[cfg(feature = "Win32_Foundation")]
 impl IWABOBJECT__Vtbl {
-    pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IWABOBJECT__Impl, const OFFSET: isize>() -> IWABOBJECT__Vtbl {
-        unsafe extern "system" fn QueryInterface<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IWABOBJECT__Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppvobj: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+    pub const fn new<Impl: IWABOBJECT__Impl>() -> IWABOBJECT__Vtbl {
+        unsafe extern "system" fn QueryInterface<Impl: IWABOBJECT__Impl>(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppvobj: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.QueryInterface(::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppvobj)).into()
         }
-        unsafe extern "system" fn AddRef<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IWABOBJECT__Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> u32 {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn AddRef<Impl: IWABOBJECT__Impl>(this: *mut ::core::ffi::c_void) -> u32 {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.AddRef()
         }
-        unsafe extern "system" fn Release<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IWABOBJECT__Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> u32 {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn Release<Impl: IWABOBJECT__Impl>(this: *mut ::core::ffi::c_void) -> u32 {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.Release()
         }
-        unsafe extern "system" fn GetLastError<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IWABOBJECT__Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, hresult: ::windows::core::HRESULT, ulflags: u32, lppmapierror: *mut *mut MAPIERROR) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetLastError<Impl: IWABOBJECT__Impl>(this: *mut ::core::ffi::c_void, hresult: ::windows::core::HRESULT, ulflags: u32, lppmapierror: *mut *mut MAPIERROR) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetLastError(::core::mem::transmute_copy(&hresult), ::core::mem::transmute_copy(&ulflags), ::core::mem::transmute_copy(&lppmapierror)).into()
         }
-        unsafe extern "system" fn AllocateBuffer<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IWABOBJECT__Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cbsize: u32, lppbuffer: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn AllocateBuffer<Impl: IWABOBJECT__Impl>(this: *mut ::core::ffi::c_void, cbsize: u32, lppbuffer: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.AllocateBuffer(::core::mem::transmute_copy(&cbsize), ::core::mem::transmute_copy(&lppbuffer)).into()
         }
-        unsafe extern "system" fn AllocateMore<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IWABOBJECT__Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cbsize: u32, lpobject: *const ::core::ffi::c_void, lppbuffer: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn AllocateMore<Impl: IWABOBJECT__Impl>(this: *mut ::core::ffi::c_void, cbsize: u32, lpobject: *const ::core::ffi::c_void, lppbuffer: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.AllocateMore(::core::mem::transmute_copy(&cbsize), ::core::mem::transmute_copy(&lpobject), ::core::mem::transmute_copy(&lppbuffer)).into()
         }
-        unsafe extern "system" fn FreeBuffer<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IWABOBJECT__Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lpbuffer: *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn FreeBuffer<Impl: IWABOBJECT__Impl>(this: *mut ::core::ffi::c_void, lpbuffer: *const ::core::ffi::c_void) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.FreeBuffer(::core::mem::transmute_copy(&lpbuffer)).into()
         }
-        unsafe extern "system" fn Backup<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IWABOBJECT__Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lpfilename: ::windows::core::PCSTR) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn Backup<Impl: IWABOBJECT__Impl>(this: *mut ::core::ffi::c_void, lpfilename: ::windows::core::PCSTR) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.Backup(::core::mem::transmute(&lpfilename)).into()
         }
-        unsafe extern "system" fn Import<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IWABOBJECT__Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lpwip: ::windows::core::PCSTR) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn Import<Impl: IWABOBJECT__Impl>(this: *mut ::core::ffi::c_void, lpwip: ::windows::core::PCSTR) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.Import(::core::mem::transmute(&lpwip)).into()
         }
-        unsafe extern "system" fn Find<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IWABOBJECT__Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lpiab: *mut ::core::ffi::c_void, hwnd: super::super::Foundation::HWND) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn Find<Impl: IWABOBJECT__Impl>(this: *mut ::core::ffi::c_void, lpiab: *mut ::core::ffi::c_void, hwnd: super::super::Foundation::HWND) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.Find(::core::mem::transmute(&lpiab), ::core::mem::transmute_copy(&hwnd)).into()
         }
-        unsafe extern "system" fn VCardDisplay<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IWABOBJECT__Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lpiab: *mut ::core::ffi::c_void, hwnd: super::super::Foundation::HWND, lpszfilename: ::windows::core::PCSTR) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn VCardDisplay<Impl: IWABOBJECT__Impl>(this: *mut ::core::ffi::c_void, lpiab: *mut ::core::ffi::c_void, hwnd: super::super::Foundation::HWND, lpszfilename: ::windows::core::PCSTR) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.VCardDisplay(::core::mem::transmute(&lpiab), ::core::mem::transmute_copy(&hwnd), ::core::mem::transmute(&lpszfilename)).into()
         }
-        unsafe extern "system" fn LDAPUrl<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IWABOBJECT__Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lpiab: *mut ::core::ffi::c_void, hwnd: super::super::Foundation::HWND, ulflags: u32, lpszurl: ::windows::core::PCSTR, lppmailuser: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn LDAPUrl<Impl: IWABOBJECT__Impl>(this: *mut ::core::ffi::c_void, lpiab: *mut ::core::ffi::c_void, hwnd: super::super::Foundation::HWND, ulflags: u32, lpszurl: ::windows::core::PCSTR, lppmailuser: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             match this.LDAPUrl(::core::mem::transmute(&lpiab), ::core::mem::transmute_copy(&hwnd), ::core::mem::transmute_copy(&ulflags), ::core::mem::transmute(&lpszurl)) {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(lppmailuser, ::core::mem::transmute(ok__));
@@ -1416,14 +1414,14 @@ impl IWABOBJECT__Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        unsafe extern "system" fn VCardCreate<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IWABOBJECT__Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lpiab: *mut ::core::ffi::c_void, ulflags: u32, lpszvcard: ::windows::core::PCSTR, lpmailuser: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn VCardCreate<Impl: IWABOBJECT__Impl>(this: *mut ::core::ffi::c_void, lpiab: *mut ::core::ffi::c_void, ulflags: u32, lpszvcard: ::windows::core::PCSTR, lpmailuser: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.VCardCreate(::core::mem::transmute(&lpiab), ::core::mem::transmute_copy(&ulflags), ::core::mem::transmute(&lpszvcard), ::core::mem::transmute(&lpmailuser)).into()
         }
-        unsafe extern "system" fn VCardRetrieve<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IWABOBJECT__Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lpiab: *mut ::core::ffi::c_void, ulflags: u32, lpszvcard: ::windows::core::PCSTR, lppmailuser: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn VCardRetrieve<Impl: IWABOBJECT__Impl>(this: *mut ::core::ffi::c_void, lpiab: *mut ::core::ffi::c_void, ulflags: u32, lpszvcard: ::windows::core::PCSTR, lppmailuser: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             match this.VCardRetrieve(::core::mem::transmute(&lpiab), ::core::mem::transmute_copy(&ulflags), ::core::mem::transmute(&lpszvcard)) {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(lppmailuser, ::core::mem::transmute(ok__));
@@ -1432,37 +1430,49 @@ impl IWABOBJECT__Vtbl {
                 ::core::result::Result::Err(err) => err.into(),
             }
         }
-        unsafe extern "system" fn GetMe<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IWABOBJECT__Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lpiab: *mut ::core::ffi::c_void, ulflags: u32, lpdwaction: *mut u32, lpsbeid: *mut SBinary, hwnd: super::super::Foundation::HWND) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn GetMe<Impl: IWABOBJECT__Impl>(this: *mut ::core::ffi::c_void, lpiab: *mut ::core::ffi::c_void, ulflags: u32, lpdwaction: *mut u32, lpsbeid: *mut SBinary, hwnd: super::super::Foundation::HWND) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.GetMe(::core::mem::transmute(&lpiab), ::core::mem::transmute_copy(&ulflags), ::core::mem::transmute_copy(&lpdwaction), ::core::mem::transmute_copy(&lpsbeid), ::core::mem::transmute_copy(&hwnd)).into()
         }
-        unsafe extern "system" fn SetMe<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IWABOBJECT__Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lpiab: *mut ::core::ffi::c_void, ulflags: u32, sbeid: SBinary, hwnd: super::super::Foundation::HWND) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn SetMe<Impl: IWABOBJECT__Impl>(this: *mut ::core::ffi::c_void, lpiab: *mut ::core::ffi::c_void, ulflags: u32, sbeid: SBinary, hwnd: super::super::Foundation::HWND) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.SetMe(::core::mem::transmute(&lpiab), ::core::mem::transmute_copy(&ulflags), ::core::mem::transmute(&sbeid), ::core::mem::transmute_copy(&hwnd)).into()
         }
         Self {
-            QueryInterface: QueryInterface::<Identity, Impl, OFFSET>,
-            AddRef: AddRef::<Identity, Impl, OFFSET>,
-            Release: Release::<Identity, Impl, OFFSET>,
-            GetLastError: GetLastError::<Identity, Impl, OFFSET>,
-            AllocateBuffer: AllocateBuffer::<Identity, Impl, OFFSET>,
-            AllocateMore: AllocateMore::<Identity, Impl, OFFSET>,
-            FreeBuffer: FreeBuffer::<Identity, Impl, OFFSET>,
-            Backup: Backup::<Identity, Impl, OFFSET>,
-            Import: Import::<Identity, Impl, OFFSET>,
-            Find: Find::<Identity, Impl, OFFSET>,
-            VCardDisplay: VCardDisplay::<Identity, Impl, OFFSET>,
-            LDAPUrl: LDAPUrl::<Identity, Impl, OFFSET>,
-            VCardCreate: VCardCreate::<Identity, Impl, OFFSET>,
-            VCardRetrieve: VCardRetrieve::<Identity, Impl, OFFSET>,
-            GetMe: GetMe::<Identity, Impl, OFFSET>,
-            SetMe: SetMe::<Identity, Impl, OFFSET>,
+            QueryInterface: QueryInterface::<Impl>,
+            AddRef: AddRef::<Impl>,
+            Release: Release::<Impl>,
+            GetLastError: GetLastError::<Impl>,
+            AllocateBuffer: AllocateBuffer::<Impl>,
+            AllocateMore: AllocateMore::<Impl>,
+            FreeBuffer: FreeBuffer::<Impl>,
+            Backup: Backup::<Impl>,
+            Import: Import::<Impl>,
+            Find: Find::<Impl>,
+            VCardDisplay: VCardDisplay::<Impl>,
+            LDAPUrl: LDAPUrl::<Impl>,
+            VCardCreate: VCardCreate::<Impl>,
+            VCardRetrieve: VCardRetrieve::<Impl>,
+            GetMe: GetMe::<Impl>,
+            SetMe: SetMe::<Impl>,
         }
     }
-    pub fn matches(iid: &windows::core::GUID) -> bool {
-        iid == &<IWABOBJECT_ as ::windows::core::Interface>::IID
+}
+#[doc(hidden)]
+#[cfg(feature = "Win32_Foundation")]
+struct IWABOBJECT__ImplVtbl<T: IWABOBJECT__Impl>(::std::marker::PhantomData<T>);
+#[cfg(feature = "Win32_Foundation")]
+impl<T: IWABOBJECT__Impl> IWABOBJECT__ImplVtbl<T> {
+    const VTABLE: IWABOBJECT__Vtbl = IWABOBJECT__Vtbl::new::<T>();
+}
+#[cfg(feature = "Win32_Foundation")]
+impl IWABOBJECT_ {
+    pub fn new<'a, T: IWABOBJECT__Impl>(this: &'a T) -> ::windows::core::ScopedInterface<'a, Self> {
+        let this = ::windows::core::ScopedHeap { vtable: &IWABOBJECT__ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
+        let this = ::std::mem::ManuallyDrop::new(::std::boxed::Box::new(this));
+        unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
 #[cfg(feature = "Win32_Foundation")]

--- a/crates/libs/windows/src/Windows/Win32/System/AddressBook/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/AddressBook/mod.rs
@@ -3071,7 +3071,16 @@ pub struct IWABExtInit_Vtbl {
 }
 #[doc = "*Required features: `\"Win32_System_AddressBook\"`*"]
 #[repr(transparent)]
-pub struct IWABOBJECT_(::windows::core::IUnknown);
+pub struct IWABOBJECT_(::std::ptr::NonNull<::std::ffi::c_void>);
+unsafe impl ::windows::core::Abi for Option<IWABOBJECT_> {
+    type Abi = *mut ::std::ffi::c_void;
+}
+unsafe impl ::windows::core::Abi for IWABOBJECT_ {
+    type Abi = *mut ::std::ffi::c_void;
+    fn abi_is_possibly_valid(abi: &Self::Abi) -> bool {
+        !abi.is_null()
+    }
+}
 impl IWABOBJECT_ {
     pub unsafe fn QueryInterface(&self, riid: *const ::windows::core::GUID, ppvobj: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()> {
         (::windows::core::Vtable::vtable(self).QueryInterface)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(riid), ::core::mem::transmute(ppvobj)).ok()
@@ -3189,9 +3198,6 @@ impl ::core::fmt::Debug for IWABOBJECT_ {
 }
 unsafe impl ::windows::core::Vtable for IWABOBJECT_ {
     type Vtable = IWABOBJECT__Vtbl;
-}
-unsafe impl ::windows::core::Interface for IWABOBJECT_ {
-    const IID: ::windows::core::GUID = ::windows::core::GUID::zeroed();
 }
 #[repr(C)]
 #[doc(hidden)]

--- a/crates/libs/windows/src/Windows/Win32/System/Search/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Search/impl.rs
@@ -6802,45 +6802,55 @@ pub trait IUMS_Impl: Sized {
     fn SqlUmsFIsPremptive(&self) -> super::super::Foundation::BOOL;
 }
 #[cfg(feature = "Win32_Foundation")]
-impl ::windows::core::RuntimeName for IUMS {}
-#[cfg(feature = "Win32_Foundation")]
 impl IUMS_Vtbl {
-    pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IUMS_Impl, const OFFSET: isize>() -> IUMS_Vtbl {
-        unsafe extern "system" fn SqlUmsSuspend<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IUMS_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ticks: u32) {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+    pub const fn new<Impl: IUMS_Impl>() -> IUMS_Vtbl {
+        unsafe extern "system" fn SqlUmsSuspend<Impl: IUMS_Impl>(this: *mut ::core::ffi::c_void, ticks: u32) {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.SqlUmsSuspend(::core::mem::transmute_copy(&ticks))
         }
-        unsafe extern "system" fn SqlUmsYield<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IUMS_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ticks: u32) {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn SqlUmsYield<Impl: IUMS_Impl>(this: *mut ::core::ffi::c_void, ticks: u32) {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.SqlUmsYield(::core::mem::transmute_copy(&ticks))
         }
-        unsafe extern "system" fn SqlUmsSwitchPremptive<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IUMS_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn SqlUmsSwitchPremptive<Impl: IUMS_Impl>(this: *mut ::core::ffi::c_void) {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.SqlUmsSwitchPremptive()
         }
-        unsafe extern "system" fn SqlUmsSwitchNonPremptive<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IUMS_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn SqlUmsSwitchNonPremptive<Impl: IUMS_Impl>(this: *mut ::core::ffi::c_void) {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.SqlUmsSwitchNonPremptive()
         }
-        unsafe extern "system" fn SqlUmsFIsPremptive<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IUMS_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> super::super::Foundation::BOOL {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn SqlUmsFIsPremptive<Impl: IUMS_Impl>(this: *mut ::core::ffi::c_void) -> super::super::Foundation::BOOL {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.SqlUmsFIsPremptive()
         }
         Self {
-            SqlUmsSuspend: SqlUmsSuspend::<Identity, Impl, OFFSET>,
-            SqlUmsYield: SqlUmsYield::<Identity, Impl, OFFSET>,
-            SqlUmsSwitchPremptive: SqlUmsSwitchPremptive::<Identity, Impl, OFFSET>,
-            SqlUmsSwitchNonPremptive: SqlUmsSwitchNonPremptive::<Identity, Impl, OFFSET>,
-            SqlUmsFIsPremptive: SqlUmsFIsPremptive::<Identity, Impl, OFFSET>,
+            SqlUmsSuspend: SqlUmsSuspend::<Impl>,
+            SqlUmsYield: SqlUmsYield::<Impl>,
+            SqlUmsSwitchPremptive: SqlUmsSwitchPremptive::<Impl>,
+            SqlUmsSwitchNonPremptive: SqlUmsSwitchNonPremptive::<Impl>,
+            SqlUmsFIsPremptive: SqlUmsFIsPremptive::<Impl>,
         }
     }
-    pub fn matches(iid: &windows::core::GUID) -> bool {
-        iid == &<IUMS as ::windows::core::Interface>::IID
+}
+#[doc(hidden)]
+#[cfg(feature = "Win32_Foundation")]
+struct IUMS_ImplVtbl<T: IUMS_Impl>(::std::marker::PhantomData<T>);
+#[cfg(feature = "Win32_Foundation")]
+impl<T: IUMS_Impl> IUMS_ImplVtbl<T> {
+    const VTABLE: IUMS_Vtbl = IUMS_Vtbl::new::<T>();
+}
+#[cfg(feature = "Win32_Foundation")]
+impl IUMS {
+    pub fn new<'a, T: IUMS_Impl>(this: &'a T) -> ::windows::core::ScopedInterface<'a, Self> {
+        let this = ::windows::core::ScopedHeap { vtable: &IUMS_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
+        let this = ::std::mem::ManuallyDrop::new(::std::boxed::Box::new(this));
+        unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
 pub trait IUMSInitialize_Impl: Sized {

--- a/crates/libs/windows/src/Windows/Win32/System/Search/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Search/mod.rs
@@ -15316,7 +15316,16 @@ pub struct ITrusteeGroupAdmin_Vtbl {
 }
 #[doc = "*Required features: `\"Win32_System_Search\"`*"]
 #[repr(transparent)]
-pub struct IUMS(::windows::core::IUnknown);
+pub struct IUMS(::std::ptr::NonNull<::std::ffi::c_void>);
+unsafe impl ::windows::core::Abi for Option<IUMS> {
+    type Abi = *mut ::std::ffi::c_void;
+}
+unsafe impl ::windows::core::Abi for IUMS {
+    type Abi = *mut ::std::ffi::c_void;
+    fn abi_is_possibly_valid(abi: &Self::Abi) -> bool {
+        !abi.is_null()
+    }
+}
 impl IUMS {
     pub unsafe fn SqlUmsSuspend(&self, ticks: u32) {
         (::windows::core::Vtable::vtable(self).SqlUmsSuspend)(::windows::core::Vtable::as_raw(self), ticks)
@@ -15354,9 +15363,6 @@ impl ::core::fmt::Debug for IUMS {
 }
 unsafe impl ::windows::core::Vtable for IUMS {
     type Vtable = IUMS_Vtbl;
-}
-unsafe impl ::windows::core::Interface for IUMS {
-    const IID: ::windows::core::GUID = ::windows::core::GUID::zeroed();
 }
 #[repr(C)]
 #[doc(hidden)]

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/impl.rs
@@ -818,18 +818,26 @@ impl IRestrictedErrorInfo_Vtbl {
 pub trait IRoMetaDataLocator_Impl: Sized {
     fn Locate(&self, nameelement: &::windows::core::PCWSTR, metadatadestination: &::core::option::Option<IRoSimpleMetaDataBuilder>) -> ::windows::core::Result<()>;
 }
-impl ::windows::core::RuntimeName for IRoMetaDataLocator {}
 impl IRoMetaDataLocator_Vtbl {
-    pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IRoMetaDataLocator_Impl, const OFFSET: isize>() -> IRoMetaDataLocator_Vtbl {
-        unsafe extern "system" fn Locate<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IRoMetaDataLocator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, nameelement: ::windows::core::PCWSTR, metadatadestination: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+    pub const fn new<Impl: IRoMetaDataLocator_Impl>() -> IRoMetaDataLocator_Vtbl {
+        unsafe extern "system" fn Locate<Impl: IRoMetaDataLocator_Impl>(this: *mut ::core::ffi::c_void, nameelement: ::windows::core::PCWSTR, metadatadestination: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.Locate(::core::mem::transmute(&nameelement), ::core::mem::transmute(&metadatadestination)).into()
         }
-        Self { Locate: Locate::<Identity, Impl, OFFSET> }
+        Self { Locate: Locate::<Impl> }
     }
-    pub fn matches(iid: &windows::core::GUID) -> bool {
-        iid == &<IRoMetaDataLocator as ::windows::core::Interface>::IID
+}
+#[doc(hidden)]
+struct IRoMetaDataLocator_ImplVtbl<T: IRoMetaDataLocator_Impl>(::std::marker::PhantomData<T>);
+impl<T: IRoMetaDataLocator_Impl> IRoMetaDataLocator_ImplVtbl<T> {
+    const VTABLE: IRoMetaDataLocator_Vtbl = IRoMetaDataLocator_Vtbl::new::<T>();
+}
+impl IRoMetaDataLocator {
+    pub fn new<'a, T: IRoMetaDataLocator_Impl>(this: &'a T) -> ::windows::core::ScopedInterface<'a, Self> {
+        let this = ::windows::core::ScopedHeap { vtable: &IRoMetaDataLocator_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
+        let this = ::std::mem::ManuallyDrop::new(::std::boxed::Box::new(this));
+        unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
 pub trait IRoSimpleMetaDataBuilder_Impl: Sized {
@@ -844,74 +852,82 @@ pub trait IRoSimpleMetaDataBuilder_Impl: Sized {
     fn SetParameterizedInterface(&self, piid: &::windows::core::GUID, numargs: u32) -> ::windows::core::Result<()>;
     fn SetParameterizedDelegate(&self, piid: &::windows::core::GUID, numargs: u32) -> ::windows::core::Result<()>;
 }
-impl ::windows::core::RuntimeName for IRoSimpleMetaDataBuilder {}
 impl IRoSimpleMetaDataBuilder_Vtbl {
-    pub const fn new<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IRoSimpleMetaDataBuilder_Impl, const OFFSET: isize>() -> IRoSimpleMetaDataBuilder_Vtbl {
-        unsafe extern "system" fn SetWinRtInterface<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IRoSimpleMetaDataBuilder_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, iid: ::windows::core::GUID) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+    pub const fn new<Impl: IRoSimpleMetaDataBuilder_Impl>() -> IRoSimpleMetaDataBuilder_Vtbl {
+        unsafe extern "system" fn SetWinRtInterface<Impl: IRoSimpleMetaDataBuilder_Impl>(this: *mut ::core::ffi::c_void, iid: ::windows::core::GUID) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.SetWinRtInterface(::core::mem::transmute(&iid)).into()
         }
-        unsafe extern "system" fn SetDelegate<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IRoSimpleMetaDataBuilder_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, iid: ::windows::core::GUID) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn SetDelegate<Impl: IRoSimpleMetaDataBuilder_Impl>(this: *mut ::core::ffi::c_void, iid: ::windows::core::GUID) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.SetDelegate(::core::mem::transmute(&iid)).into()
         }
-        unsafe extern "system" fn SetInterfaceGroupSimpleDefault<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IRoSimpleMetaDataBuilder_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, name: ::windows::core::PCWSTR, defaultinterfacename: ::windows::core::PCWSTR, defaultinterfaceiid: *const ::windows::core::GUID) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn SetInterfaceGroupSimpleDefault<Impl: IRoSimpleMetaDataBuilder_Impl>(this: *mut ::core::ffi::c_void, name: ::windows::core::PCWSTR, defaultinterfacename: ::windows::core::PCWSTR, defaultinterfaceiid: *const ::windows::core::GUID) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.SetInterfaceGroupSimpleDefault(::core::mem::transmute(&name), ::core::mem::transmute(&defaultinterfacename), ::core::mem::transmute_copy(&defaultinterfaceiid)).into()
         }
-        unsafe extern "system" fn SetInterfaceGroupParameterizedDefault<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IRoSimpleMetaDataBuilder_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, name: ::windows::core::PCWSTR, elementcount: u32, defaultinterfacenameelements: *const ::windows::core::PWSTR) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn SetInterfaceGroupParameterizedDefault<Impl: IRoSimpleMetaDataBuilder_Impl>(this: *mut ::core::ffi::c_void, name: ::windows::core::PCWSTR, elementcount: u32, defaultinterfacenameelements: *const ::windows::core::PWSTR) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.SetInterfaceGroupParameterizedDefault(::core::mem::transmute(&name), ::core::mem::transmute_copy(&elementcount), ::core::mem::transmute_copy(&defaultinterfacenameelements)).into()
         }
-        unsafe extern "system" fn SetRuntimeClassSimpleDefault<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IRoSimpleMetaDataBuilder_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, name: ::windows::core::PCWSTR, defaultinterfacename: ::windows::core::PCWSTR, defaultinterfaceiid: *const ::windows::core::GUID) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn SetRuntimeClassSimpleDefault<Impl: IRoSimpleMetaDataBuilder_Impl>(this: *mut ::core::ffi::c_void, name: ::windows::core::PCWSTR, defaultinterfacename: ::windows::core::PCWSTR, defaultinterfaceiid: *const ::windows::core::GUID) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.SetRuntimeClassSimpleDefault(::core::mem::transmute(&name), ::core::mem::transmute(&defaultinterfacename), ::core::mem::transmute_copy(&defaultinterfaceiid)).into()
         }
-        unsafe extern "system" fn SetRuntimeClassParameterizedDefault<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IRoSimpleMetaDataBuilder_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, name: ::windows::core::PCWSTR, elementcount: u32, defaultinterfacenameelements: *const ::windows::core::PWSTR) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn SetRuntimeClassParameterizedDefault<Impl: IRoSimpleMetaDataBuilder_Impl>(this: *mut ::core::ffi::c_void, name: ::windows::core::PCWSTR, elementcount: u32, defaultinterfacenameelements: *const ::windows::core::PWSTR) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.SetRuntimeClassParameterizedDefault(::core::mem::transmute(&name), ::core::mem::transmute_copy(&elementcount), ::core::mem::transmute_copy(&defaultinterfacenameelements)).into()
         }
-        unsafe extern "system" fn SetStruct<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IRoSimpleMetaDataBuilder_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, name: ::windows::core::PCWSTR, numfields: u32, fieldtypenames: *const ::windows::core::PWSTR) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn SetStruct<Impl: IRoSimpleMetaDataBuilder_Impl>(this: *mut ::core::ffi::c_void, name: ::windows::core::PCWSTR, numfields: u32, fieldtypenames: *const ::windows::core::PWSTR) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.SetStruct(::core::mem::transmute(&name), ::core::mem::transmute_copy(&numfields), ::core::mem::transmute_copy(&fieldtypenames)).into()
         }
-        unsafe extern "system" fn SetEnum<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IRoSimpleMetaDataBuilder_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, name: ::windows::core::PCWSTR, basetype: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn SetEnum<Impl: IRoSimpleMetaDataBuilder_Impl>(this: *mut ::core::ffi::c_void, name: ::windows::core::PCWSTR, basetype: ::windows::core::PCWSTR) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.SetEnum(::core::mem::transmute(&name), ::core::mem::transmute(&basetype)).into()
         }
-        unsafe extern "system" fn SetParameterizedInterface<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IRoSimpleMetaDataBuilder_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, piid: ::windows::core::GUID, numargs: u32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn SetParameterizedInterface<Impl: IRoSimpleMetaDataBuilder_Impl>(this: *mut ::core::ffi::c_void, piid: ::windows::core::GUID, numargs: u32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.SetParameterizedInterface(::core::mem::transmute(&piid), ::core::mem::transmute_copy(&numargs)).into()
         }
-        unsafe extern "system" fn SetParameterizedDelegate<Identity: ::windows::core::IUnknownImpl<Impl = Impl>, Impl: IRoSimpleMetaDataBuilder_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, piid: ::windows::core::GUID, numargs: u32) -> ::windows::core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        unsafe extern "system" fn SetParameterizedDelegate<Impl: IRoSimpleMetaDataBuilder_Impl>(this: *mut ::core::ffi::c_void, piid: ::windows::core::GUID, numargs: u32) -> ::windows::core::HRESULT {
+            let this = (this as *mut *mut ::core::ffi::c_void) as *const ::windows::core::ScopedHeap;
+            let this = &*((*this).this as *const Impl);
             this.SetParameterizedDelegate(::core::mem::transmute(&piid), ::core::mem::transmute_copy(&numargs)).into()
         }
         Self {
-            SetWinRtInterface: SetWinRtInterface::<Identity, Impl, OFFSET>,
-            SetDelegate: SetDelegate::<Identity, Impl, OFFSET>,
-            SetInterfaceGroupSimpleDefault: SetInterfaceGroupSimpleDefault::<Identity, Impl, OFFSET>,
-            SetInterfaceGroupParameterizedDefault: SetInterfaceGroupParameterizedDefault::<Identity, Impl, OFFSET>,
-            SetRuntimeClassSimpleDefault: SetRuntimeClassSimpleDefault::<Identity, Impl, OFFSET>,
-            SetRuntimeClassParameterizedDefault: SetRuntimeClassParameterizedDefault::<Identity, Impl, OFFSET>,
-            SetStruct: SetStruct::<Identity, Impl, OFFSET>,
-            SetEnum: SetEnum::<Identity, Impl, OFFSET>,
-            SetParameterizedInterface: SetParameterizedInterface::<Identity, Impl, OFFSET>,
-            SetParameterizedDelegate: SetParameterizedDelegate::<Identity, Impl, OFFSET>,
+            SetWinRtInterface: SetWinRtInterface::<Impl>,
+            SetDelegate: SetDelegate::<Impl>,
+            SetInterfaceGroupSimpleDefault: SetInterfaceGroupSimpleDefault::<Impl>,
+            SetInterfaceGroupParameterizedDefault: SetInterfaceGroupParameterizedDefault::<Impl>,
+            SetRuntimeClassSimpleDefault: SetRuntimeClassSimpleDefault::<Impl>,
+            SetRuntimeClassParameterizedDefault: SetRuntimeClassParameterizedDefault::<Impl>,
+            SetStruct: SetStruct::<Impl>,
+            SetEnum: SetEnum::<Impl>,
+            SetParameterizedInterface: SetParameterizedInterface::<Impl>,
+            SetParameterizedDelegate: SetParameterizedDelegate::<Impl>,
         }
     }
-    pub fn matches(iid: &windows::core::GUID) -> bool {
-        iid == &<IRoSimpleMetaDataBuilder as ::windows::core::Interface>::IID
+}
+#[doc(hidden)]
+struct IRoSimpleMetaDataBuilder_ImplVtbl<T: IRoSimpleMetaDataBuilder_Impl>(::std::marker::PhantomData<T>);
+impl<T: IRoSimpleMetaDataBuilder_Impl> IRoSimpleMetaDataBuilder_ImplVtbl<T> {
+    const VTABLE: IRoSimpleMetaDataBuilder_Vtbl = IRoSimpleMetaDataBuilder_Vtbl::new::<T>();
+}
+impl IRoSimpleMetaDataBuilder {
+    pub fn new<'a, T: IRoSimpleMetaDataBuilder_Impl>(this: &'a T) -> ::windows::core::ScopedInterface<'a, Self> {
+        let this = ::windows::core::ScopedHeap { vtable: &IRoSimpleMetaDataBuilder_ImplVtbl::<T>::VTABLE as *const _ as *const _, this: this as *const _ as *const _ };
+        let this = ::std::mem::ManuallyDrop::new(::std::boxed::Box::new(this));
+        unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
 #[cfg(feature = "Win32_Foundation")]

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/mod.rs
@@ -2487,7 +2487,16 @@ pub struct IRestrictedErrorInfo_Vtbl {
 }
 #[doc = "*Required features: `\"Win32_System_WinRT\"`*"]
 #[repr(transparent)]
-pub struct IRoMetaDataLocator(::windows::core::IUnknown);
+pub struct IRoMetaDataLocator(::std::ptr::NonNull<::std::ffi::c_void>);
+unsafe impl ::windows::core::Abi for Option<IRoMetaDataLocator> {
+    type Abi = *mut ::std::ffi::c_void;
+}
+unsafe impl ::windows::core::Abi for IRoMetaDataLocator {
+    type Abi = *mut ::std::ffi::c_void;
+    fn abi_is_possibly_valid(abi: &Self::Abi) -> bool {
+        !abi.is_null()
+    }
+}
 impl IRoMetaDataLocator {
     pub unsafe fn Locate<'a, P0, P1>(&self, nameelement: P0, metadatadestination: P1) -> ::windows::core::Result<()>
     where
@@ -2516,9 +2525,6 @@ impl ::core::fmt::Debug for IRoMetaDataLocator {
 unsafe impl ::windows::core::Vtable for IRoMetaDataLocator {
     type Vtable = IRoMetaDataLocator_Vtbl;
 }
-unsafe impl ::windows::core::Interface for IRoMetaDataLocator {
-    const IID: ::windows::core::GUID = ::windows::core::GUID::zeroed();
-}
 #[repr(C)]
 #[doc(hidden)]
 pub struct IRoMetaDataLocator_Vtbl {
@@ -2526,7 +2532,16 @@ pub struct IRoMetaDataLocator_Vtbl {
 }
 #[doc = "*Required features: `\"Win32_System_WinRT\"`*"]
 #[repr(transparent)]
-pub struct IRoSimpleMetaDataBuilder(::windows::core::IUnknown);
+pub struct IRoSimpleMetaDataBuilder(::std::ptr::NonNull<::std::ffi::c_void>);
+unsafe impl ::windows::core::Abi for Option<IRoSimpleMetaDataBuilder> {
+    type Abi = *mut ::std::ffi::c_void;
+}
+unsafe impl ::windows::core::Abi for IRoSimpleMetaDataBuilder {
+    type Abi = *mut ::std::ffi::c_void;
+    fn abi_is_possibly_valid(abi: &Self::Abi) -> bool {
+        !abi.is_null()
+    }
+}
 impl IRoSimpleMetaDataBuilder {
     pub unsafe fn SetWinRtInterface(&self, iid: ::windows::core::GUID) -> ::windows::core::Result<()> {
         (::windows::core::Vtable::vtable(self).SetWinRtInterface)(::windows::core::Vtable::as_raw(self), ::core::mem::transmute(iid)).ok()
@@ -2598,9 +2613,6 @@ impl ::core::fmt::Debug for IRoSimpleMetaDataBuilder {
 }
 unsafe impl ::windows::core::Vtable for IRoSimpleMetaDataBuilder {
     type Vtable = IRoSimpleMetaDataBuilder_Vtbl;
-}
-unsafe impl ::windows::core::Interface for IRoSimpleMetaDataBuilder {
-    const IID: ::windows::core::GUID = ::windows::core::GUID::zeroed();
 }
 #[repr(C)]
 #[doc(hidden)]

--- a/crates/libs/windows/src/core/mod.rs
+++ b/crates/libs/windows/src/core/mod.rs
@@ -26,7 +26,9 @@ mod vtable;
 mod waiter;
 mod weak;
 mod weak_ref_count;
+mod scoped_interface;
 
+pub use scoped_interface::*;
 #[doc(hidden)]
 pub use abi::*;
 pub use agile_reference::*;

--- a/crates/libs/windows/src/core/mod.rs
+++ b/crates/libs/windows/src/core/mod.rs
@@ -19,6 +19,7 @@ mod param;
 mod ref_count;
 mod runtime_name;
 mod runtime_type;
+mod scoped_interface;
 mod sha1;
 mod strings;
 mod unknown;
@@ -26,9 +27,7 @@ mod vtable;
 mod waiter;
 mod weak;
 mod weak_ref_count;
-mod scoped_interface;
 
-pub use scoped_interface::*;
 #[doc(hidden)]
 pub use abi::*;
 pub use agile_reference::*;
@@ -56,6 +55,7 @@ pub use ref_count::*;
 pub use runtime_name::*;
 #[doc(hidden)]
 pub use runtime_type::*;
+pub use scoped_interface::*;
 #[doc(hidden)]
 pub use sha1::*;
 pub use strings::*;

--- a/crates/libs/windows/src/core/scoped_interface.rs
+++ b/crates/libs/windows/src/core/scoped_interface.rs
@@ -29,6 +29,8 @@ impl<'a, T: Vtable> std::ops::Deref for ScopedInterface<'a, T> {
 
 impl<'a, T: Vtable> Drop for ScopedInterface<'a, T> {
     fn drop(&mut self) {
-        unsafe { let _ = ::std::boxed::Box::from_raw(self.interface.as_raw() as *const _ as *mut ScopedHeap); }
+        unsafe {
+            let _ = ::std::boxed::Box::from_raw(self.interface.as_raw() as *const _ as *mut ScopedHeap);
+        }
     }
 }

--- a/crates/libs/windows/src/core/scoped_interface.rs
+++ b/crates/libs/windows/src/core/scoped_interface.rs
@@ -1,0 +1,34 @@
+use super::*;
+
+#[doc(hidden)]
+#[repr(C)]
+pub struct ScopedHeap {
+    pub vtable: *const std::ffi::c_void,
+    pub this: *const std::ffi::c_void,
+}
+
+#[doc(hidden)]
+pub struct ScopedInterface<'a, T: Vtable> {
+    interface: T,
+    lifetime: std::marker::PhantomData<&'a T>,
+}
+
+impl<'a, T: Vtable> ScopedInterface<'a, T> {
+    pub fn new(interface: T) -> Self {
+        Self { interface, lifetime: std::marker::PhantomData }
+    }
+}
+
+impl<'a, T: Vtable> std::ops::Deref for ScopedInterface<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &self.interface
+    }
+}
+
+impl<'a, T: Vtable> Drop for ScopedInterface<'a, T> {
+    fn drop(&mut self) {
+        unsafe { let _ = ::std::boxed::Box::from_raw(self.interface.as_raw() as *const _ as *mut ScopedHeap); }
+    }
+}

--- a/crates/tests/interface/Cargo.toml
+++ b/crates/tests/interface/Cargo.toml
@@ -11,4 +11,7 @@ features = [
     "Win32_System_Com",
     "interface",
     "implement",
+    "Win32_Graphics_Direct3D12",
+    "Win32_Graphics_Direct3D",
+    "Win32_Graphics_Direct3D10",
 ]

--- a/crates/tests/interface/tests/non_com_existing.rs
+++ b/crates/tests/interface/tests/non_com_existing.rs
@@ -1,0 +1,76 @@
+use windows::{core::*, Win32::Foundation::*, Win32::Graphics::Direct3D12::*, Win32::Graphics::Direct3D10::*};
+
+struct Reflection;
+
+impl ID3D12FunctionParameterReflection_Impl for Reflection {
+    fn GetDesc(&self) -> Result<D3D12_PARAMETER_DESC> {
+        Ok(D3D12_PARAMETER_DESC { Name: s!("test"), ..Default::default() })
+    }
+}
+
+struct Variable(u128);
+
+impl Default for Variable {
+    fn default() -> Self {
+        Self(0x00000000_0000_0000_c000_000000000046)
+    }
+}
+
+impl ID3D10EffectBlendVariable_Impl for Variable {
+    fn GetBlendState(&self, _: u32) -> Result<ID3D10BlendState> {
+        todo!();
+    }
+    fn GetBackingStore(&self, _: u32,_: *mut D3D10_BLEND_DESC) -> Result<()> {
+        todo!();
+    }
+}
+
+impl ID3D10EffectVariable_Impl for Variable {
+    fn IsValid(&self) -> BOOL {  
+        assert_eq!(self.0, 0x00000000_0000_0000_c000_000000000046);
+        true.into()
+    }
+    fn GetType(&self) -> ::core::option::Option<ID3D10EffectType> { todo!(); }
+    fn GetDesc(&self) -> ::windows::core::Result<D3D10_EFFECT_VARIABLE_DESC> { todo!(); }
+    fn GetAnnotationByIndex(&self, _: u32) -> ::core::option::Option<ID3D10EffectVariable> { todo!(); }
+    fn GetAnnotationByName(&self, _: &::windows::core::PCSTR) -> ::core::option::Option<ID3D10EffectVariable> { todo!(); }
+    fn GetMemberByIndex(&self, _: u32) -> ::core::option::Option<ID3D10EffectVariable> { todo!(); }
+    fn GetMemberByName(&self, _: &::windows::core::PCSTR) -> ::core::option::Option<ID3D10EffectVariable> { todo!(); }
+    fn GetMemberBySemantic(&self, _: &::windows::core::PCSTR) -> ::core::option::Option<ID3D10EffectVariable> { todo!(); }
+    fn GetElement(&self, _: u32) -> ::core::option::Option<ID3D10EffectVariable> { todo!(); }
+    fn GetParentConstantBuffer(&self) -> ::core::option::Option<ID3D10EffectConstantBuffer> { todo!(); }
+    fn AsScalar(&self) -> ::core::option::Option<ID3D10EffectScalarVariable> { todo!(); }
+    fn AsVector(&self) -> ::core::option::Option<ID3D10EffectVectorVariable> { todo!(); }
+    fn AsMatrix(&self) -> ::core::option::Option<ID3D10EffectMatrixVariable> { todo!(); }
+    fn AsString(&self) -> ::core::option::Option<ID3D10EffectStringVariable> { todo!(); }
+    fn AsShaderResource(&self) -> ::core::option::Option<ID3D10EffectShaderResourceVariable> { todo!(); }
+    fn AsRenderTargetView(&self) -> ::core::option::Option<ID3D10EffectRenderTargetViewVariable> { todo!(); }
+    fn AsDepthStencilView(&self) -> ::core::option::Option<ID3D10EffectDepthStencilViewVariable> { todo!(); }
+    fn AsConstantBuffer(&self) -> ::core::option::Option<ID3D10EffectConstantBuffer> { todo!(); }
+    fn AsShader(&self) -> ::core::option::Option<ID3D10EffectShaderVariable> { todo!(); }
+    fn AsBlend(&self) -> ::core::option::Option<ID3D10EffectBlendVariable> { todo!(); }
+    fn AsDepthStencil(&self) -> ::core::option::Option<ID3D10EffectDepthStencilVariable> { todo!(); }
+    fn AsRasterizer(&self) -> ::core::option::Option<ID3D10EffectRasterizerVariable> { todo!(); }
+    fn AsSampler(&self) -> ::core::option::Option<ID3D10EffectSamplerVariable> { todo!(); }
+    fn SetRawValue(&self, _: *const ::core::ffi::c_void,_: u32, _: u32) -> ::windows::core::Result<()> { todo!(); }
+    fn GetRawValue(&self, _: *mut ::core::ffi::c_void, _: u32, _: u32) -> ::windows::core::Result<()> { todo!(); }
+}
+
+#[test]
+fn test() -> Result<()> {
+    unsafe {
+        let reflection = ID3D12FunctionParameterReflection::new(&Reflection);
+        let desc = reflection.GetDesc()?;
+        assert_eq!("test", desc.Name.to_string().unwrap());
+
+        let variable = Variable::default();
+        let interface_variable = ID3D10EffectVariable::new(&variable);
+        assert_eq!(interface_variable.IsValid(), true);
+
+        let variable = Variable::default();
+        let interface_variable = ID3D10EffectBlendVariable::new(&variable);
+        assert_eq!(interface_variable.IsValid(), true);
+
+        Ok(())
+    }
+}

--- a/crates/tests/interface/tests/non_com_existing.rs
+++ b/crates/tests/interface/tests/non_com_existing.rs
@@ -1,4 +1,4 @@
-use windows::{core::*, Win32::Foundation::*, Win32::Graphics::Direct3D12::*, Win32::Graphics::Direct3D10::*};
+use windows::{core::*, Win32::Foundation::*, Win32::Graphics::Direct3D10::*, Win32::Graphics::Direct3D12::*};
 
 struct Reflection;
 
@@ -20,40 +20,88 @@ impl ID3D10EffectBlendVariable_Impl for Variable {
     fn GetBlendState(&self, _: u32) -> Result<ID3D10BlendState> {
         todo!();
     }
-    fn GetBackingStore(&self, _: u32,_: *mut D3D10_BLEND_DESC) -> Result<()> {
+    fn GetBackingStore(&self, _: u32, _: *mut D3D10_BLEND_DESC) -> Result<()> {
         todo!();
     }
 }
 
 impl ID3D10EffectVariable_Impl for Variable {
-    fn IsValid(&self) -> BOOL {  
+    fn IsValid(&self) -> BOOL {
         assert_eq!(self.0, 0x00000000_0000_0000_c000_000000000046);
         true.into()
     }
-    fn GetType(&self) -> ::core::option::Option<ID3D10EffectType> { todo!(); }
-    fn GetDesc(&self) -> ::windows::core::Result<D3D10_EFFECT_VARIABLE_DESC> { todo!(); }
-    fn GetAnnotationByIndex(&self, _: u32) -> ::core::option::Option<ID3D10EffectVariable> { todo!(); }
-    fn GetAnnotationByName(&self, _: &::windows::core::PCSTR) -> ::core::option::Option<ID3D10EffectVariable> { todo!(); }
-    fn GetMemberByIndex(&self, _: u32) -> ::core::option::Option<ID3D10EffectVariable> { todo!(); }
-    fn GetMemberByName(&self, _: &::windows::core::PCSTR) -> ::core::option::Option<ID3D10EffectVariable> { todo!(); }
-    fn GetMemberBySemantic(&self, _: &::windows::core::PCSTR) -> ::core::option::Option<ID3D10EffectVariable> { todo!(); }
-    fn GetElement(&self, _: u32) -> ::core::option::Option<ID3D10EffectVariable> { todo!(); }
-    fn GetParentConstantBuffer(&self) -> ::core::option::Option<ID3D10EffectConstantBuffer> { todo!(); }
-    fn AsScalar(&self) -> ::core::option::Option<ID3D10EffectScalarVariable> { todo!(); }
-    fn AsVector(&self) -> ::core::option::Option<ID3D10EffectVectorVariable> { todo!(); }
-    fn AsMatrix(&self) -> ::core::option::Option<ID3D10EffectMatrixVariable> { todo!(); }
-    fn AsString(&self) -> ::core::option::Option<ID3D10EffectStringVariable> { todo!(); }
-    fn AsShaderResource(&self) -> ::core::option::Option<ID3D10EffectShaderResourceVariable> { todo!(); }
-    fn AsRenderTargetView(&self) -> ::core::option::Option<ID3D10EffectRenderTargetViewVariable> { todo!(); }
-    fn AsDepthStencilView(&self) -> ::core::option::Option<ID3D10EffectDepthStencilViewVariable> { todo!(); }
-    fn AsConstantBuffer(&self) -> ::core::option::Option<ID3D10EffectConstantBuffer> { todo!(); }
-    fn AsShader(&self) -> ::core::option::Option<ID3D10EffectShaderVariable> { todo!(); }
-    fn AsBlend(&self) -> ::core::option::Option<ID3D10EffectBlendVariable> { todo!(); }
-    fn AsDepthStencil(&self) -> ::core::option::Option<ID3D10EffectDepthStencilVariable> { todo!(); }
-    fn AsRasterizer(&self) -> ::core::option::Option<ID3D10EffectRasterizerVariable> { todo!(); }
-    fn AsSampler(&self) -> ::core::option::Option<ID3D10EffectSamplerVariable> { todo!(); }
-    fn SetRawValue(&self, _: *const ::core::ffi::c_void,_: u32, _: u32) -> ::windows::core::Result<()> { todo!(); }
-    fn GetRawValue(&self, _: *mut ::core::ffi::c_void, _: u32, _: u32) -> ::windows::core::Result<()> { todo!(); }
+    fn GetType(&self) -> ::core::option::Option<ID3D10EffectType> {
+        todo!();
+    }
+    fn GetDesc(&self) -> ::windows::core::Result<D3D10_EFFECT_VARIABLE_DESC> {
+        todo!();
+    }
+    fn GetAnnotationByIndex(&self, _: u32) -> ::core::option::Option<ID3D10EffectVariable> {
+        todo!();
+    }
+    fn GetAnnotationByName(&self, _: &::windows::core::PCSTR) -> ::core::option::Option<ID3D10EffectVariable> {
+        todo!();
+    }
+    fn GetMemberByIndex(&self, _: u32) -> ::core::option::Option<ID3D10EffectVariable> {
+        todo!();
+    }
+    fn GetMemberByName(&self, _: &::windows::core::PCSTR) -> ::core::option::Option<ID3D10EffectVariable> {
+        todo!();
+    }
+    fn GetMemberBySemantic(&self, _: &::windows::core::PCSTR) -> ::core::option::Option<ID3D10EffectVariable> {
+        todo!();
+    }
+    fn GetElement(&self, _: u32) -> ::core::option::Option<ID3D10EffectVariable> {
+        todo!();
+    }
+    fn GetParentConstantBuffer(&self) -> ::core::option::Option<ID3D10EffectConstantBuffer> {
+        todo!();
+    }
+    fn AsScalar(&self) -> ::core::option::Option<ID3D10EffectScalarVariable> {
+        todo!();
+    }
+    fn AsVector(&self) -> ::core::option::Option<ID3D10EffectVectorVariable> {
+        todo!();
+    }
+    fn AsMatrix(&self) -> ::core::option::Option<ID3D10EffectMatrixVariable> {
+        todo!();
+    }
+    fn AsString(&self) -> ::core::option::Option<ID3D10EffectStringVariable> {
+        todo!();
+    }
+    fn AsShaderResource(&self) -> ::core::option::Option<ID3D10EffectShaderResourceVariable> {
+        todo!();
+    }
+    fn AsRenderTargetView(&self) -> ::core::option::Option<ID3D10EffectRenderTargetViewVariable> {
+        todo!();
+    }
+    fn AsDepthStencilView(&self) -> ::core::option::Option<ID3D10EffectDepthStencilViewVariable> {
+        todo!();
+    }
+    fn AsConstantBuffer(&self) -> ::core::option::Option<ID3D10EffectConstantBuffer> {
+        todo!();
+    }
+    fn AsShader(&self) -> ::core::option::Option<ID3D10EffectShaderVariable> {
+        todo!();
+    }
+    fn AsBlend(&self) -> ::core::option::Option<ID3D10EffectBlendVariable> {
+        todo!();
+    }
+    fn AsDepthStencil(&self) -> ::core::option::Option<ID3D10EffectDepthStencilVariable> {
+        todo!();
+    }
+    fn AsRasterizer(&self) -> ::core::option::Option<ID3D10EffectRasterizerVariable> {
+        todo!();
+    }
+    fn AsSampler(&self) -> ::core::option::Option<ID3D10EffectSamplerVariable> {
+        todo!();
+    }
+    fn SetRawValue(&self, _: *const ::core::ffi::c_void, _: u32, _: u32) -> ::windows::core::Result<()> {
+        todo!();
+    }
+    fn GetRawValue(&self, _: *mut ::core::ffi::c_void, _: u32, _: u32) -> ::windows::core::Result<()> {
+        todo!();
+    }
 }
 
 #[test]

--- a/crates/tests/interface/tests/non_com_new.rs
+++ b/crates/tests/interface/tests/non_com_new.rs
@@ -2,7 +2,7 @@
 
 use windows::core::*;
 
-// The `interface` macro defines a new local interface that does not derive from `IUnknown` and thus is not a COM interface at all. 
+// The `interface` macro defines a new local interface that does not derive from `IUnknown` and thus is not a COM interface at all.
 #[interface]
 unsafe trait IBase {
     unsafe fn BaseValue(&self) -> i32;
@@ -24,7 +24,7 @@ unsafe fn base_value(test: &IBase) -> i32 {
 fn base() {
     unsafe {
         // Since the interface is not rooted in `IUnknown`, there's no COM-style lifetime and the resulting implementation merely
-        // exists for the lifetime of the referenced implementation. 
+        // exists for the lifetime of the referenced implementation.
         let test = Base(456);
         let interface = IBase::new(&test);
         assert_eq!(base_value(&interface), 456);

--- a/crates/tests/interface/tests/non_com_new.rs
+++ b/crates/tests/interface/tests/non_com_new.rs
@@ -1,0 +1,33 @@
+#![allow(non_snake_case, non_camel_case_types)]
+
+use windows::core::*;
+
+// The `interface` macro defines a new local interface that does not derive from `IUnknown` and thus is not a COM interface at all. 
+#[interface]
+unsafe trait IBase {
+    unsafe fn BaseValue(&self) -> i32;
+}
+
+struct Base(i32);
+
+impl IBase_Impl for Base {
+    unsafe fn BaseValue(&self) -> i32 {
+        self.0
+    }
+}
+
+unsafe fn base_value(test: &IBase) -> i32 {
+    test.BaseValue()
+}
+
+#[test]
+fn base() {
+    unsafe {
+        // Since the interface is not rooted in `IUnknown`, there's no COM-style lifetime and the resulting implementation merely
+        // exists for the lifetime of the referenced implementation. 
+        let test = Base(456);
+        let interface = IBase::new(&test);
+        assert_eq!(base_value(&interface), 456);
+        assert_eq!(interface.BaseValue(), 456);
+    }
+}


### PR DESCRIPTION
Well, this was a lot more complicated than I'd hoped! I'm not a big fan of interfaces that sort of pretend to be COM interfaces but don't actually inherit from `IUnknown`. The thing is that `IUnknown` addresses a number of fundamental problems with lifetime and discovery that are just left in question without it. The solution here isn't perfect but it's a start and builds on a number of PRs that have already been completed. Here's what's new:

1. You can use the `interface` macro to declare a (new) interface that derives from an existing interface defined by the `windows` crate. The `implement` macro can implement COM interfaces regardless of how they were declared. 

2. You cannot implement non-COM interfaces with the `implement` macro. Since `IUnknown` is not available to reason about lifetime, the `implement` macro isn't much use, but you can simply use the `new` method on the interface to "wrap" an implementation of the interface's trait (or traits) with a scoped implementation. 

```rust
struct Reflection;

impl ID3D12FunctionParameterReflection_Impl for Reflection {
    fn GetDesc(&self) -> Result<D3D12_PARAMETER_DESC> {
        todo!();
    }
}

let reflection = ID3D12FunctionParameterReflection::new(&Reflection);
let desc = reflection.GetDesc()?;
```

3. You can use the `interface` macro to declare a (new) interface that does not derive from `IUnknown`. This too can be implemented in the same way:

```rust
#[interface]
unsafe trait IValuable {
    unsafe fn Value(&self) -> i32;
}

struct Valuable(i32);

impl IValuable_Impl for Valuable {
    unsafe fn Value(&self) -> i32 {
        self.0
    }
}

unsafe fn call_value(test: &IValuable) -> i32 {
    test.Value()
}

#[test]
fn main {
    unsafe {
        // Since the interface is not rooted in `IUnknown`, there's no COM-style lifetime and the 
        // resulting implementation merely exists for the lifetime of the referenced implementation. 
        let test = Valuable(456);
        let interface = IValuable::new(&test);
        assert_eq!(call_value(&interface), 456);
        assert_eq!(interface.Value(), 456);
    }
}
```

4. Non-COM interfaces no longer hold a private `IUnknown` pointer so you don't have to worry about them doing bad things when dropped. 

Fixes: #453 