### PR TITLE
Use `std` consistently in the `windows` crate

### DIFF
--- a/crates/libs/metadata/src/reader/blob.rs
+++ b/crates/libs/metadata/src/reader/blob.rs
@@ -62,11 +62,11 @@ impl<'a> Blob<'a> {
     }
     pub fn read_string(self) -> String {
         let slice = self.slice;
-        if slice.as_ptr().align_offset(core::mem::align_of::<u16>()) > 0 {
+        if slice.as_ptr().align_offset(std::mem::align_of::<u16>()) > 0 {
             let slice = slice.chunks_exact(2).take(slice.len() / 2).map(|chunk| u16::from_le_bytes(chunk.try_into().unwrap())).collect::<Vec<u16>>();
             String::from_utf16_lossy(&slice)
         } else {
-            let slice = unsafe { core::slice::from_raw_parts(slice.as_ptr() as *const u16, slice.len() / 2) };
+            let slice = unsafe { std::slice::from_raw_parts(slice.as_ptr() as *const u16, slice.len() / 2) };
             String::from_utf16_lossy(slice)
         }
     }

--- a/crates/libs/metadata/src/reader/guid.rs
+++ b/crates/libs/metadata/src/reader/guid.rs
@@ -30,7 +30,7 @@ impl GUID {
 }
 
 impl std::fmt::Debug for GUID {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> core::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:08x?}-{:04x?}-{:04x?}-{:02x?}{:02x?}-{:02x?}{:02x?}{:02x?}{:02x?}{:02x?}{:02x?}", self.0, self.1, self.2, self.3, self.4, self.5, self.6, self.7, self.8, self.9, self.10)
     }
 }

--- a/crates/libs/windows/src/core/abi.rs
+++ b/crates/libs/windows/src/core/abi.rs
@@ -21,7 +21,7 @@ pub unsafe trait Abi: Sized {
     /// Note: `Self::Abi` is only valid for however long `&self` lives for
     fn abi(&self) -> Self::Abi {
         // SAFETY: the `Abi` trait ensures that `Self` can be memcopied into `Self::Abi`
-        unsafe { core::mem::transmute_copy(self) }
+        unsafe { std::mem::transmute_copy(self) }
     }
 
     /// Converts an abi value to `Self` or fails if we can determine `abi` is not valid.
@@ -32,7 +32,7 @@ pub unsafe trait Abi: Sized {
     /// if `abi_is_possibly_valid` returns true.
     unsafe fn from_abi(abi: Self::Abi) -> Result<Self> {
         if Self::abi_is_possibly_valid(&abi) {
-            Ok(core::mem::transmute_copy(&abi))
+            Ok(std::mem::transmute_copy(&abi))
         } else {
             Err(Error::OK)
         }
@@ -46,7 +46,7 @@ pub unsafe trait Abi: Sized {
     /// if `abi_is_possibly_valid` returns true.
     unsafe fn from_abi_ref(abi: &Self::Abi) -> Result<&Self> {
         if Self::abi_is_possibly_valid(abi) {
-            Ok(core::mem::transmute(abi))
+            Ok(std::mem::transmute(abi))
         } else {
             Err(Error::OK)
         }
@@ -61,11 +61,11 @@ pub unsafe trait Abi: Sized {
 }
 
 unsafe impl<T: Interface> Abi for Option<T> {
-    type Abi = *mut core::ffi::c_void;
+    type Abi = *mut std::ffi::c_void;
 }
 
 unsafe impl<T: Interface> Abi for T {
-    type Abi = *mut core::ffi::c_void;
+    type Abi = *mut std::ffi::c_void;
 
     fn abi_is_possibly_valid(abi: &Self::Abi) -> bool {
         !abi.is_null()

--- a/crates/libs/windows/src/core/agile_reference.rs
+++ b/crates/libs/windows/src/core/agile_reference.rs
@@ -1,6 +1,6 @@
 use super::*;
 use bindings::*;
-use core::marker::PhantomData;
+use std::marker::PhantomData;
 
 /// A type representing an agile reference to a COM/WinRT object.
 #[repr(transparent)]

--- a/crates/libs/windows/src/core/array.rs
+++ b/crates/libs/windows/src/core/array.rs
@@ -9,7 +9,7 @@ pub struct Array<T: RuntimeType> {
 
 impl<T: RuntimeType> Default for Array<T> {
     fn default() -> Self {
-        Array { data: core::ptr::null_mut(), len: 0 }
+        Array { data: std::ptr::null_mut(), len: 0 }
     }
 }
 
@@ -21,8 +21,8 @@ impl<T: RuntimeType> Array<T> {
 
     /// Creates an array of the given length with default values.
     pub fn with_len(len: usize) -> Self {
-        assert!(len < core::u32::MAX as usize);
-        let bytes_amount = len.checked_mul(core::mem::size_of::<T>()).expect("Attempted to allocate too large an Array");
+        assert!(len < std::u32::MAX as usize);
+        let bytes_amount = len.checked_mul(std::mem::size_of::<T>()).expect("Attempted to allocate too large an Array");
 
         // WinRT arrays must be allocated with CoTaskMemAlloc.
         // SAFETY: the call to CoTaskMemAlloc is safe to perform
@@ -37,7 +37,7 @@ impl<T: RuntimeType> Array<T> {
         // bytes making the entire array zero initialized. We have assured
         // above that the data ptr is not null.
         unsafe {
-            core::ptr::write_bytes(data, 0, len);
+            std::ptr::write_bytes(data, 0, len);
         }
 
         let len = len as u32;
@@ -70,18 +70,18 @@ impl<T: RuntimeType> Array<T> {
             return;
         }
 
-        let mut data = core::ptr::null_mut();
+        let mut data = std::ptr::null_mut();
         let mut len = 0;
 
-        core::mem::swap(&mut data, &mut self.data);
-        core::mem::swap(&mut len, &mut self.len);
+        std::mem::swap(&mut data, &mut self.data);
+        std::mem::swap(&mut len, &mut self.len);
 
         // SAFETY: At this point, self has been reset to zero so any panics in T's destructor would
         // only leak data not leave the array in bad state.
         unsafe {
             // Call the destructors of all the elements of the old array
             // SAFETY: the slice cannot be used after the call to `drop_in_place`
-            core::ptr::drop_in_place(core::slice::from_raw_parts_mut(data, len as usize));
+            std::ptr::drop_in_place(std::slice::from_raw_parts_mut(data, len as usize));
             // Free the data memory where the elements were
             // SAFETY: we have unique access to the data pointer at this point
             // so freeing it is the right thing to do
@@ -102,12 +102,12 @@ impl<T: RuntimeType> Array<T> {
     /// Turn the array into a pointer to its data and its length
     pub fn into_abi(self) -> (*mut T::Abi, u32) {
         let abi = (self.data as *mut _, self.len);
-        core::mem::forget(self);
+        std::mem::forget(self);
         abi
     }
 }
 
-impl<T: RuntimeType> core::ops::Deref for Array<T> {
+impl<T: RuntimeType> std::ops::Deref for Array<T> {
     type Target = [T::DefaultType];
 
     fn deref(&self) -> &[T::DefaultType] {
@@ -116,18 +116,18 @@ impl<T: RuntimeType> core::ops::Deref for Array<T> {
         }
 
         // SAFETY: data must not be null if the array is not empty
-        unsafe { core::slice::from_raw_parts(self.data, self.len as usize) }
+        unsafe { std::slice::from_raw_parts(self.data, self.len as usize) }
     }
 }
 
-impl<T: RuntimeType> core::ops::DerefMut for Array<T> {
+impl<T: RuntimeType> std::ops::DerefMut for Array<T> {
     fn deref_mut(&mut self) -> &mut [T::DefaultType] {
         if self.is_empty() {
             return &mut [];
         }
 
         // SAFETY: data must not be null if the array is not empty
-        unsafe { core::slice::from_raw_parts_mut(self.data, self.len as usize) }
+        unsafe { std::slice::from_raw_parts_mut(self.data, self.len as usize) }
     }
 }
 
@@ -141,12 +141,12 @@ impl<T: RuntimeType> Drop for Array<T> {
 pub struct ArrayProxy<T: RuntimeType> {
     data: *mut *mut T::DefaultType,
     len: *mut u32,
-    temp: core::mem::ManuallyDrop<Array<T>>,
+    temp: std::mem::ManuallyDrop<Array<T>>,
 }
 
 impl<T: RuntimeType> ArrayProxy<T> {
     pub fn from_raw_parts(data: *mut *mut T::DefaultType, len: *mut u32) -> Self {
-        Self { data, len, temp: core::mem::ManuallyDrop::new(Array::new()) }
+        Self { data, len, temp: std::mem::ManuallyDrop::new(Array::new()) }
     }
 
     pub fn as_array(&mut self) -> &mut Array<T> {

--- a/crates/libs/windows/src/core/bindings.rs
+++ b/crates/libs/windows/src/core/bindings.rs
@@ -406,7 +406,7 @@ impl ILanguageExceptionErrorInfo2 {
     }
     pub unsafe fn CapturePropagationContext<'a, P0>(&self, languageexception: P0) -> Result<()>
     where
-        P0: ::std::convert::Into<InParam<'a, IUnknown>>,
+        P0: std::convert::Into<InParam<'a, IUnknown>>,
     {
         (Vtable::vtable(self).CapturePropagationContext)(Vtable::as_raw(self), languageexception.into().abi()).ok()
     }

--- a/crates/libs/windows/src/core/borrowed.rs
+++ b/crates/libs/windows/src/core/borrowed.rs
@@ -12,7 +12,7 @@
 #[repr(transparent)]
 pub struct Borrowed<'a, T: super::Abi> {
     item: T::Abi,
-    lifetime: core::marker::PhantomData<&'a ()>,
+    lifetime: std::marker::PhantomData<&'a ()>,
 }
 
 impl<'a, T: super::Abi> Borrowed<'a, T> {
@@ -22,15 +22,15 @@ impl<'a, T: super::Abi> Borrowed<'a, T> {
     /// that allows you to call `.into` to safely create a `Borrowed` value.
     pub fn new(item: Option<&'a T>) -> Self {
         // SAFETY: The `Abi` trait ensures `T::Abi` is safe to zero initialize
-        let item = item.map(|i| i.abi()).unwrap_or_else(|| unsafe { core::mem::MaybeUninit::zeroed().assume_init() });
-        Self { item, lifetime: core::marker::PhantomData }
+        let item = item.map(|i| i.abi()).unwrap_or_else(|| unsafe { std::mem::MaybeUninit::zeroed().assume_init() });
+        Self { item, lifetime: std::marker::PhantomData }
     }
 
     /// Create a new null `Borrowed` value.
     pub fn none() -> Self {
         // SAFETY: The `Abi` trait ensures `T::Abi` is safe to zero initialize
-        let item = unsafe { core::mem::MaybeUninit::zeroed().assume_init() };
-        Self { item, lifetime: core::marker::PhantomData }
+        let item = unsafe { std::mem::MaybeUninit::zeroed().assume_init() };
+        Self { item, lifetime: std::marker::PhantomData }
     }
 
     /// Get the abi representation for this param
@@ -38,7 +38,7 @@ impl<'a, T: super::Abi> Borrowed<'a, T> {
     /// Note: the return value is only guranteed to be valid for the lifetime of `&self`
     pub fn abi(&self) -> T::Abi {
         // SAFETY: The `Abi` trait ensures `T::Abi` is safe to memcopy
-        unsafe { core::mem::transmute_copy(&self.item) }
+        unsafe { std::mem::transmute_copy(&self.item) }
     }
 
     /// Get an optional reference to the underlying value
@@ -52,7 +52,7 @@ impl<'a, T: super::Abi> Borrowed<'a, T> {
 impl<'a, T: super::Abi + Copy> Borrowed<'a, T> {
     /// Creates an `Borrowed` type from a `Copy` type meaning we don't need to borrow `item` like in `Borrowed::new`
     pub(crate) fn new_from_owned(item: T) -> Self {
-        Self { item: item.abi(), lifetime: core::marker::PhantomData }
+        Self { item: item.abi(), lifetime: std::marker::PhantomData }
     }
 }
 
@@ -90,8 +90,8 @@ where
     }
 }
 
-impl<'a, T: super::Abi + core::fmt::Debug> core::fmt::Debug for Borrowed<'a, T> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+impl<'a, T: super::Abi + std::fmt::Debug> std::fmt::Debug for Borrowed<'a, T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:?}", self.as_ref())
     }
 }
@@ -99,6 +99,6 @@ impl<'a, T: super::Abi + core::fmt::Debug> core::fmt::Debug for Borrowed<'a, T> 
 impl<'a, T: super::Abi> Clone for Borrowed<'a, T> {
     fn clone(&self) -> Self {
         // SAFETY: it is safe to alias `Borrow<'a, T>` for the lifetime `'a`
-        unsafe { core::mem::transmute_copy(self) }
+        unsafe { std::mem::transmute_copy(self) }
     }
 }

--- a/crates/libs/windows/src/core/delay_load.rs
+++ b/crates/libs/windows/src/core/delay_load.rs
@@ -8,7 +8,7 @@ use bindings::*;
 /// # Safety
 ///
 /// * Both the library and function names must be valid PCSTR representations
-pub unsafe fn delay_load(library: PCSTR, function: PCSTR) -> Result<*const core::ffi::c_void> {
+pub unsafe fn delay_load(library: PCSTR, function: PCSTR) -> Result<*const std::ffi::c_void> {
     let library = LoadLibraryA(library);
 
     if library == 0 {

--- a/crates/libs/windows/src/core/error.rs
+++ b/crates/libs/windows/src/core/error.rs
@@ -17,8 +17,8 @@ impl Error {
     pub fn new(code: HRESULT, message: HSTRING) -> Self {
         unsafe {
             if let Ok(function) = delay_load(s!("combase.dll"), s!("RoOriginateError")) {
-                let function: RoOriginateError = core::mem::transmute(function);
-                function(code, core::mem::transmute_copy(&message));
+                let function: RoOriginateError = std::mem::transmute(function);
+                function(code, std::mem::transmute_copy(&message));
             }
             let info = GetErrorInfo().and_then(|e| e.cast()).ok();
             Self { code, info }
@@ -62,7 +62,7 @@ impl Error {
     }
 }
 
-impl core::convert::From<Error> for HRESULT {
+impl std::convert::From<Error> for HRESULT {
     fn from(error: Error) -> Self {
         let code = error.code;
         let info: Option<IErrorInfo> = error.info.and_then(|info| info.cast().ok());
@@ -75,7 +75,7 @@ impl core::convert::From<Error> for HRESULT {
     }
 }
 
-impl core::convert::From<Error> for std::io::Error {
+impl std::convert::From<Error> for std::io::Error {
     fn from(from: Error) -> Self {
         Self::from_raw_os_error(from.code.0)
     }
@@ -85,13 +85,13 @@ impl core::convert::From<Error> for std::io::Error {
 // not know the `Infallible` can never be constructed. This code needs to be here
 // to satesify the type checker but it will never be run. Once `!` is stabilizied
 // this can be removed.
-impl core::convert::From<core::convert::Infallible> for Error {
-    fn from(from: core::convert::Infallible) -> Self {
+impl std::convert::From<std::convert::Infallible> for Error {
+    fn from(from: std::convert::Infallible) -> Self {
         unreachable!()
     }
 }
 
-impl core::convert::From<HRESULT> for Error {
+impl std::convert::From<HRESULT> for Error {
     fn from(code: HRESULT) -> Self {
         let info: Option<IRestrictedErrorInfo> = GetErrorInfo().and_then(|e| e.cast()).ok();
 
@@ -117,22 +117,22 @@ impl core::convert::From<HRESULT> for Error {
     }
 }
 
-impl core::fmt::Debug for Error {
-    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+impl std::fmt::Debug for Error {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug = fmt.debug_struct("Error");
         debug.field("code", &format_args!("{:#010X}", self.code.0)).field("message", &self.message()).finish()
     }
 }
 
-impl core::fmt::Display for Error {
-    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::write!(fmt, "{}", self.message())
+impl std::fmt::Display for Error {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::write!(fmt, "{}", self.message())
     }
 }
 
 impl std::error::Error for Error {}
 
-type RoOriginateError = extern "system" fn(code: HRESULT, message: core::mem::ManuallyDrop<HSTRING>) -> i32;
+type RoOriginateError = extern "system" fn(code: HRESULT, message: std::mem::ManuallyDrop<HSTRING>) -> i32;
 
 fn GetErrorInfo() -> Result<IErrorInfo> {
     let mut result = std::mem::MaybeUninit::zeroed();

--- a/crates/libs/windows/src/core/guid.rs
+++ b/crates/libs/windows/src/core/guid.rs
@@ -71,13 +71,13 @@ unsafe impl RuntimeType for GUID {
     }
 }
 
-impl core::fmt::Debug for GUID {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+impl std::fmt::Debug for GUID {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:08X?}-{:04X?}-{:04X?}-{:02X?}{:02X?}-{:02X?}{:02X?}{:02X?}{:02X?}{:02X?}{:02X?}", self.data1, self.data2, self.data3, self.data4[0], self.data4[1], self.data4[2], self.data4[3], self.data4[4], self.data4[5], self.data4[6], self.data4[7])
     }
 }
 
-impl core::convert::From<&str> for GUID {
+impl std::convert::From<&str> for GUID {
     fn from(value: &str) -> Self {
         assert!(value.len() == 36, "Invalid GUID string");
         let mut bytes = value.bytes();
@@ -103,13 +103,13 @@ impl core::convert::From<&str> for GUID {
     }
 }
 
-impl core::convert::From<u128> for GUID {
+impl std::convert::From<u128> for GUID {
     fn from(value: u128) -> Self {
         Self::from_u128(value)
     }
 }
 
-impl core::convert::From<GUID> for u128 {
+impl std::convert::From<GUID> for u128 {
     fn from(value: GUID) -> Self {
         value.to_u128()
     }
@@ -121,7 +121,7 @@ trait HexReader {
     fn next_u32(&mut self) -> u32;
 }
 
-impl HexReader for core::str::Bytes<'_> {
+impl HexReader for std::str::Bytes<'_> {
     fn next_u8(&mut self) -> u8 {
         let value = self.next().unwrap();
         match value {

--- a/crates/libs/windows/src/core/heap.rs
+++ b/crates/libs/windows/src/core/heap.rs
@@ -7,7 +7,7 @@ use bindings::*;
 ///
 /// This function will fail in OOM situations, if the heap is otherwise corrupt,
 /// or if getting a handle to the process heap fails.
-pub fn heap_alloc(bytes: usize) -> Result<*mut core::ffi::c_void> {
+pub fn heap_alloc(bytes: usize) -> Result<*mut std::ffi::c_void> {
     let ptr = unsafe { HeapAlloc(GetProcessHeap(), 0, bytes) };
 
     if ptr.is_null() {
@@ -31,6 +31,6 @@ pub fn heap_alloc(bytes: usize) -> Result<*mut core::ffi::c_void> {
 /// # Safety
 ///
 /// `ptr` must be a valid pointer to memory allocated by `HeapAlloc` or `HeapReAlloc`
-pub unsafe fn heap_free(ptr: *mut core::ffi::c_void) {
+pub unsafe fn heap_free(ptr: *mut std::ffi::c_void) {
     HeapFree(GetProcessHeap(), 0, ptr);
 }

--- a/crates/libs/windows/src/core/hresult.rs
+++ b/crates/libs/windows/src/core/hresult.rs
@@ -73,7 +73,7 @@ impl HRESULT {
     /// Safe to call if
     /// * `abi` is initialized if `self` is `Ok`
     /// * `abi` can be safely transmuted to `T`
-    pub unsafe fn from_abi<T: Abi>(self, abi: core::mem::MaybeUninit<T::Abi>) -> Result<T> {
+    pub unsafe fn from_abi<T: Abi>(self, abi: std::mem::MaybeUninit<T::Abi>) -> Result<T> {
         if self.is_ok() {
             T::from_abi(abi.assume_init())
         } else {
@@ -83,12 +83,12 @@ impl HRESULT {
 
     /// The error message describing the error.
     pub fn message(&self) -> HSTRING {
-        let mut message = HeapString(core::ptr::null_mut());
+        let mut message = HeapString(std::ptr::null_mut());
 
         unsafe {
-            let size = FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, std::ptr::null(), self.0 as _, 0, PWSTR(core::mem::transmute(&mut message.0)), 0, std::ptr::null());
+            let size = FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, std::ptr::null(), self.0 as _, 0, PWSTR(std::mem::transmute(&mut message.0)), 0, std::ptr::null());
 
-            HSTRING::from_wide(wide_trim_end(core::slice::from_raw_parts(message.0 as *const u16, size as usize)))
+            HSTRING::from_wide(wide_trim_end(std::slice::from_raw_parts(message.0 as *const u16, size as usize)))
         }
     }
 
@@ -110,7 +110,7 @@ unsafe impl RuntimeType for HRESULT {
     }
 }
 
-impl<T> core::convert::From<Result<T>> for HRESULT {
+impl<T> std::convert::From<Result<T>> for HRESULT {
     fn from(result: Result<T>) -> Self {
         if let Err(error) = result {
             return error.into();
@@ -120,8 +120,8 @@ impl<T> core::convert::From<Result<T>> for HRESULT {
     }
 }
 
-impl core::fmt::Debug for HRESULT {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+impl std::fmt::Debug for HRESULT {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_fmt(format_args!("HRESULT(0x{:08X})", self.0))
     }
 }

--- a/crates/libs/windows/src/core/inspectable.rs
+++ b/crates/libs/windows/src/core/inspectable.rs
@@ -13,9 +13,9 @@ impl IInspectable {
     /// Returns the canonical type name for the underlying object.
     pub fn GetRuntimeClassName(&self) -> Result<HSTRING> {
         unsafe {
-            let mut abi = core::ptr::null_mut();
-            (self.vtable().GetRuntimeClassName)(core::mem::transmute_copy(self), &mut abi).ok()?;
-            Ok(core::mem::transmute(abi))
+            let mut abi = std::ptr::null_mut();
+            (self.vtable().GetRuntimeClassName)(std::mem::transmute_copy(self), &mut abi).ok()?;
+            Ok(std::mem::transmute(abi))
         }
     }
 }
@@ -24,9 +24,9 @@ impl IInspectable {
 #[repr(C)]
 pub struct IInspectable_Vtbl {
     pub base: IUnknown_Vtbl,
-    pub GetIids: unsafe extern "system" fn(this: *mut core::ffi::c_void, count: *mut u32, values: *mut *mut GUID) -> HRESULT,
-    pub GetRuntimeClassName: unsafe extern "system" fn(this: *mut core::ffi::c_void, value: *mut *mut core::ffi::c_void) -> HRESULT,
-    pub GetTrustLevel: unsafe extern "system" fn(this: *mut core::ffi::c_void, value: *mut i32) -> HRESULT,
+    pub GetIids: unsafe extern "system" fn(this: *mut std::ffi::c_void, count: *mut u32, values: *mut *mut GUID) -> HRESULT,
+    pub GetRuntimeClassName: unsafe extern "system" fn(this: *mut std::ffi::c_void, value: *mut *mut std::ffi::c_void) -> HRESULT,
+    pub GetTrustLevel: unsafe extern "system" fn(this: *mut std::ffi::c_void, value: *mut i32) -> HRESULT,
 }
 
 unsafe impl Vtable for IInspectable {
@@ -47,8 +47,8 @@ unsafe impl RuntimeType for IInspectable {
 
 impl RuntimeName for IInspectable {}
 
-impl core::fmt::Debug for IInspectable {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+impl std::fmt::Debug for IInspectable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // Attempts to retrieve the string representation of the object via the
         // IStringable interface. If that fails, it will use the canonical type
         // name to give some idea of what the object represents. This implementation
@@ -63,19 +63,19 @@ impl core::fmt::Debug for IInspectable {
 
 macro_rules! primitive_boxed_type {
     ($(($t:ty, $m:ident)),+) => {
-        $(impl core::convert::TryFrom<$t> for IInspectable {
+        $(impl std::convert::TryFrom<$t> for IInspectable {
             type Error = Error;
             fn try_from(value: $t) -> Result<Self> {
                 PropertyValue::$m(value)
             }
         }
-        impl core::convert::TryFrom<IInspectable> for $t {
+        impl std::convert::TryFrom<IInspectable> for $t {
             type Error = Error;
             fn try_from(value: IInspectable) -> Result<Self> {
                 <IInspectable as Interface>::cast::<IReference<$t>>(&value)?.Value()
             }
         }
-        impl core::convert::TryFrom<&IInspectable> for $t {
+        impl std::convert::TryFrom<&IInspectable> for $t {
             type Error = Error;
             fn try_from(value: &IInspectable) -> Result<Self> {
                 <IInspectable as Interface>::cast::<IReference<$t>>(value)?.Value()
@@ -97,32 +97,32 @@ primitive_boxed_type! {
     (f64, CreateDouble)
 }
 
-impl core::convert::TryFrom<&str> for IInspectable {
+impl std::convert::TryFrom<&str> for IInspectable {
     type Error = Error;
     fn try_from(value: &str) -> Result<Self> {
         let value: HSTRING = value.into();
         PropertyValue::CreateString(&value)
     }
 }
-impl core::convert::TryFrom<HSTRING> for IInspectable {
+impl std::convert::TryFrom<HSTRING> for IInspectable {
     type Error = Error;
     fn try_from(value: HSTRING) -> Result<Self> {
         PropertyValue::CreateString(&value)
     }
 }
-impl core::convert::TryFrom<&HSTRING> for IInspectable {
+impl std::convert::TryFrom<&HSTRING> for IInspectable {
     type Error = Error;
     fn try_from(value: &HSTRING) -> Result<Self> {
         PropertyValue::CreateString(value)
     }
 }
-impl core::convert::TryFrom<IInspectable> for HSTRING {
+impl std::convert::TryFrom<IInspectable> for HSTRING {
     type Error = Error;
     fn try_from(value: IInspectable) -> Result<Self> {
         <IInspectable as Interface>::cast::<IReference<HSTRING>>(&value)?.Value()
     }
 }
-impl core::convert::TryFrom<&IInspectable> for HSTRING {
+impl std::convert::TryFrom<&IInspectable> for HSTRING {
     type Error = Error;
     fn try_from(value: &IInspectable) -> Result<Self> {
         <IInspectable as Interface>::cast::<IReference<HSTRING>>(value)?.Value()
@@ -132,20 +132,20 @@ impl core::convert::TryFrom<&IInspectable> for HSTRING {
 #[cfg(feature = "implement")]
 impl IInspectable_Vtbl {
     pub const fn new<Identity: IUnknownImpl, Name: RuntimeName, const OFFSET: isize>() -> Self {
-        unsafe extern "system" fn GetIids(_: *mut core::ffi::c_void, count: *mut u32, values: *mut *mut GUID) -> ::windows::core::HRESULT {
+        unsafe extern "system" fn GetIids(_: *mut std::ffi::c_void, count: *mut u32, values: *mut *mut GUID) -> windows::core::HRESULT {
             // Note: even if we end up implementing this in future, it still doesn't need a this pointer
             // since the data to be returned is type- not instance-specific so can be shared for all
             // interfaces.
             *count = 0;
-            *values = core::ptr::null_mut();
+            *values = std::ptr::null_mut();
             HRESULT(0)
         }
-        unsafe extern "system" fn GetRuntimeClassName<T: RuntimeName>(_: *mut core::ffi::c_void, value: *mut *mut core::ffi::c_void) -> HRESULT {
+        unsafe extern "system" fn GetRuntimeClassName<T: RuntimeName>(_: *mut std::ffi::c_void, value: *mut *mut std::ffi::c_void) -> HRESULT {
             let h: HSTRING = T::NAME.into(); // TODO: should be try_into
-            *value = ::core::mem::transmute(h);
+            *value = std::mem::transmute(h);
             HRESULT(0)
         }
-        unsafe extern "system" fn GetTrustLevel(_: *mut core::ffi::c_void, value: *mut i32) -> HRESULT {
+        unsafe extern "system" fn GetTrustLevel(_: *mut std::ffi::c_void, value: *mut i32) -> HRESULT {
             // Note: even if we end up implementing this in future, it still doesn't need a this pointer
             // since the data to be returned is type- not instance-specific so can be shared for all
             // interfaces.

--- a/crates/libs/windows/src/core/interface.rs
+++ b/crates/libs/windows/src/core/interface.rs
@@ -40,7 +40,7 @@ pub unsafe trait Interface: Vtable {
     ///
     /// `interface` must be a non-null, valid pointer for writing an interface pointer
     #[doc(hidden)]
-    unsafe fn query(&self, iid: &GUID, interface: *mut *const core::ffi::c_void) -> HRESULT {
+    unsafe fn query(&self, iid: &GUID, interface: *mut *const std::ffi::c_void) -> HRESULT {
         (self.assume_vtable::<IUnknown>().QueryInterface)(self.as_raw(), iid, interface)
     }
 }

--- a/crates/libs/windows/src/core/mod.rs
+++ b/crates/libs/windows/src/core/mod.rs
@@ -65,7 +65,7 @@ pub use weak::*;
 pub use weak_ref_count::*;
 
 /// A specialized [`Result`] type that provides Windows error information.
-pub type Result<T> = core::result::Result<T, Error>;
+pub type Result<T> = std::result::Result<T, Error>;
 
 #[doc(hidden)]
 pub use bindings::IAgileObject;
@@ -80,7 +80,7 @@ pub use windows_interface::interface;
 
 extern "C" {
     #[doc(hidden)]
-    pub fn memcmp(left: *const core::ffi::c_void, right: *const core::ffi::c_void, len: usize) -> i32;
+    pub fn memcmp(left: *const std::ffi::c_void, right: *const std::ffi::c_void, len: usize) -> i32;
 }
 
 #[doc(hidden)]

--- a/crates/libs/windows/src/core/ref_count.rs
+++ b/crates/libs/windows/src/core/ref_count.rs
@@ -1,4 +1,4 @@
-use core::sync::atomic::{fence, AtomicI32, Ordering};
+use std::sync::atomic::{fence, AtomicI32, Ordering};
 
 #[doc(hidden)]
 #[repr(transparent)]
@@ -24,9 +24,9 @@ impl RefCount {
         let remaining = self.0.fetch_sub(1, Ordering::Release) - 1;
 
         match remaining.cmp(&0) {
-            core::cmp::Ordering::Equal => fence(Ordering::Acquire),
-            core::cmp::Ordering::Less => panic!("Object has been over-released."),
-            core::cmp::Ordering::Greater => {}
+            std::cmp::Ordering::Equal => fence(Ordering::Acquire),
+            std::cmp::Ordering::Less => panic!("Object has been over-released."),
+            std::cmp::Ordering::Greater => {}
         }
 
         remaining as u32

--- a/crates/libs/windows/src/core/scoped_interface.rs
+++ b/crates/libs/windows/src/core/scoped_interface.rs
@@ -30,7 +30,7 @@ impl<'a, T: Vtable> std::ops::Deref for ScopedInterface<'a, T> {
 impl<'a, T: Vtable> Drop for ScopedInterface<'a, T> {
     fn drop(&mut self) {
         unsafe {
-            let _ = ::std::boxed::Box::from_raw(self.interface.as_raw() as *const _ as *mut ScopedHeap);
+            let _ = std::boxed::Box::from_raw(self.interface.as_raw() as *const _ as *mut ScopedHeap);
         }
     }
 }

--- a/crates/libs/windows/src/core/sha1.rs
+++ b/crates/libs/windows/src/core/sha1.rs
@@ -323,8 +323,8 @@ impl Digest {
     }
 }
 
-impl core::fmt::Display for Digest {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+impl std::fmt::Display for Digest {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         for i in self.data.iter() {
             write!(f, "{:08x}", i)?;
         }

--- a/crates/libs/windows/src/core/strings/bstr.rs
+++ b/crates/libs/windows/src/core/strings/bstr.rs
@@ -6,7 +6,7 @@ pub struct BSTR(*const u16);
 
 impl BSTR {
     pub const fn new() -> Self {
-        Self(core::ptr::null_mut())
+        Self(std::ptr::null_mut())
     }
 
     pub fn is_empty(&self) -> bool {
@@ -23,7 +23,7 @@ impl BSTR {
 
     pub fn from_wide(value: &[u16]) -> Self {
         if value.is_empty() {
-            return Self(::core::ptr::null_mut());
+            return Self(std::ptr::null_mut());
         }
 
         unsafe { Self(SysAllocStringLen(value.as_ptr(), value.len() as _)) }
@@ -34,7 +34,7 @@ impl BSTR {
             return &[];
         }
 
-        unsafe { ::core::slice::from_raw_parts(self.0, self.len()) }
+        unsafe { std::slice::from_raw_parts(self.0, self.len()) }
     }
 
     pub unsafe fn from_raw(raw: *const u16) -> Self {
@@ -45,90 +45,90 @@ impl BSTR {
         unsafe { std::mem::transmute(self) }
     }
 }
-impl ::core::clone::Clone for BSTR {
+impl std::clone::Clone for BSTR {
     fn clone(&self) -> Self {
         Self::from_wide(self.as_wide())
     }
 }
-impl ::core::convert::From<&str> for BSTR {
+impl std::convert::From<&str> for BSTR {
     fn from(value: &str) -> Self {
-        let value: ::windows::core::alloc::vec::Vec<u16> = value.encode_utf16().collect();
+        let value: windows::core::alloc::vec::Vec<u16> = value.encode_utf16().collect();
         Self::from_wide(&value)
     }
 }
-impl ::core::convert::From<::windows::core::alloc::string::String> for BSTR {
-    fn from(value: ::windows::core::alloc::string::String) -> Self {
+impl std::convert::From<windows::core::alloc::string::String> for BSTR {
+    fn from(value: windows::core::alloc::string::String) -> Self {
         value.as_str().into()
     }
 }
-impl ::core::convert::From<&::windows::core::alloc::string::String> for BSTR {
-    fn from(value: &::windows::core::alloc::string::String) -> Self {
+impl std::convert::From<&windows::core::alloc::string::String> for BSTR {
+    fn from(value: &windows::core::alloc::string::String) -> Self {
         value.as_str().into()
     }
 }
-impl<'a> ::core::convert::TryFrom<&'a BSTR> for ::windows::core::alloc::string::String {
-    type Error = ::windows::core::alloc::string::FromUtf16Error;
+impl<'a> std::convert::TryFrom<&'a BSTR> for windows::core::alloc::string::String {
+    type Error = windows::core::alloc::string::FromUtf16Error;
 
-    fn try_from(value: &BSTR) -> ::core::result::Result<Self, Self::Error> {
-        ::windows::core::alloc::string::String::from_utf16(value.as_wide())
+    fn try_from(value: &BSTR) -> std::result::Result<Self, Self::Error> {
+        windows::core::alloc::string::String::from_utf16(value.as_wide())
     }
 }
-impl ::core::convert::TryFrom<BSTR> for ::windows::core::alloc::string::String {
-    type Error = ::windows::core::alloc::string::FromUtf16Error;
+impl std::convert::TryFrom<BSTR> for windows::core::alloc::string::String {
+    type Error = windows::core::alloc::string::FromUtf16Error;
 
-    fn try_from(value: BSTR) -> ::core::result::Result<Self, Self::Error> {
-        ::windows::core::alloc::string::String::try_from(&value)
+    fn try_from(value: BSTR) -> std::result::Result<Self, Self::Error> {
+        windows::core::alloc::string::String::try_from(&value)
     }
 }
-impl ::core::default::Default for BSTR {
+impl std::default::Default for BSTR {
     fn default() -> Self {
-        Self(::core::ptr::null_mut())
+        Self(std::ptr::null_mut())
     }
 }
-impl ::core::fmt::Display for BSTR {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        ::core::write!(f, "{}", ::windows::core::Decode(|| ::core::char::decode_utf16(self.as_wide().iter().cloned())))
+impl std::fmt::Display for BSTR {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::write!(f, "{}", windows::core::Decode(|| std::char::decode_utf16(self.as_wide().iter().cloned())))
     }
 }
-impl ::core::fmt::Debug for BSTR {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        ::core::write!(f, "{}", self)
+impl std::fmt::Debug for BSTR {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::write!(f, "{}", self)
     }
 }
-impl ::core::cmp::PartialEq for BSTR {
+impl std::cmp::PartialEq for BSTR {
     fn eq(&self, other: &Self) -> bool {
         self.as_wide() == other.as_wide()
     }
 }
-impl ::core::cmp::Eq for BSTR {}
-impl ::core::cmp::PartialEq<::windows::core::alloc::string::String> for BSTR {
-    fn eq(&self, other: &::windows::core::alloc::string::String) -> bool {
+impl std::cmp::Eq for BSTR {}
+impl std::cmp::PartialEq<windows::core::alloc::string::String> for BSTR {
+    fn eq(&self, other: &windows::core::alloc::string::String) -> bool {
         self == other.as_str()
     }
 }
-impl ::core::cmp::PartialEq<str> for BSTR {
+impl std::cmp::PartialEq<str> for BSTR {
     fn eq(&self, other: &str) -> bool {
         self == other
     }
 }
-impl ::core::cmp::PartialEq<&str> for BSTR {
+impl std::cmp::PartialEq<&str> for BSTR {
     fn eq(&self, other: &&str) -> bool {
         self.as_wide().iter().copied().eq(other.encode_utf16())
     }
 }
 
-impl ::core::cmp::PartialEq<BSTR> for &str {
+impl std::cmp::PartialEq<BSTR> for &str {
     fn eq(&self, other: &BSTR) -> bool {
         other == self
     }
 }
-impl ::core::ops::Drop for BSTR {
+impl std::ops::Drop for BSTR {
     fn drop(&mut self) {
         if !self.0.is_null() {
             unsafe { SysFreeString(self.0) }
         }
     }
 }
-unsafe impl ::windows::core::Abi for BSTR {
-    type Abi = ::core::mem::ManuallyDrop<Self>;
+unsafe impl windows::core::Abi for BSTR {
+    type Abi = std::mem::ManuallyDrop<Self>;
 }

--- a/crates/libs/windows/src/core/strings/mod.rs
+++ b/crates/libs/windows/src/core/strings/mod.rs
@@ -28,13 +28,13 @@ extern "C" {
 #[doc(hidden)]
 pub struct Decode<F>(pub F);
 
-impl<F, R, E> core::fmt::Display for Decode<F>
+impl<F, R, E> std::fmt::Display for Decode<F>
 where
     F: Clone + FnOnce() -> R,
-    R: IntoIterator<Item = core::result::Result<char, E>>,
+    R: IntoIterator<Item = std::result::Result<char, E>>,
 {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        use core::fmt::Write;
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use std::fmt::Write;
         let iter = self.0.clone();
         for c in iter().into_iter() {
             f.write_char(c.unwrap_or_else(|_| std::char::REPLACEMENT_CHARACTER))?
@@ -44,7 +44,7 @@ where
 }
 
 /// Mirror of `std::char::decode_utf16` for utf-8.
-fn decode_utf8<'a>(mut buffer: &'a [u8]) -> impl Iterator<Item = core::result::Result<char, std::str::Utf8Error>> + 'a {
+fn decode_utf8<'a>(mut buffer: &'a [u8]) -> impl Iterator<Item = std::result::Result<char, std::str::Utf8Error>> + 'a {
     let mut current = "".chars();
     let mut previous_error = None;
     std::iter::from_fn(move || {

--- a/crates/libs/windows/src/core/strings/pcstr.rs
+++ b/crates/libs/windows/src/core/strings/pcstr.rs
@@ -13,7 +13,7 @@ impl PCSTR {
 
     /// Construct a null `PCSTR`
     pub fn null() -> Self {
-        Self(core::ptr::null())
+        Self(std::ptr::null())
     }
 
     /// Returns a raw pointer to the `PCSTR`
@@ -41,7 +41,7 @@ impl PCSTR {
     /// # Safety
     ///
     /// See the safety information for `PCSTR::as_bytes`.
-    pub unsafe fn to_string(&self) -> core::result::Result<String, std::string::FromUtf8Error> {
+    pub unsafe fn to_string(&self) -> std::result::Result<String, std::string::FromUtf8Error> {
         String::from_utf8(self.as_bytes().into())
     }
 
@@ -50,7 +50,7 @@ impl PCSTR {
     /// # Safety
     ///
     /// See the safety information for `PCSTR::as_bytes`.
-    pub unsafe fn display<'a>(&'a self) -> impl core::fmt::Display + 'a {
+    pub unsafe fn display<'a>(&'a self) -> impl std::fmt::Display + 'a {
         Decode(move || decode_utf8(self.as_bytes()))
     }
 }

--- a/crates/libs/windows/src/core/strings/pcwstr.rs
+++ b/crates/libs/windows/src/core/strings/pcwstr.rs
@@ -13,7 +13,7 @@ impl PCWSTR {
 
     /// Construct a null `PCWSTR`
     pub fn null() -> Self {
-        Self(core::ptr::null())
+        Self(std::ptr::null())
     }
 
     /// Returns a raw pointer to the `PCWSTR`
@@ -41,7 +41,7 @@ impl PCWSTR {
     /// # Safety
     ///
     /// See the safety information for `PCWSTR::as_wide`.
-    pub unsafe fn to_string(&self) -> core::result::Result<String, std::string::FromUtf16Error> {
+    pub unsafe fn to_string(&self) -> std::result::Result<String, std::string::FromUtf16Error> {
         String::from_utf16(self.as_wide())
     }
 
@@ -50,8 +50,8 @@ impl PCWSTR {
     /// # Safety
     ///
     /// See the safety information for `PCWSTR::as_wide`.
-    pub unsafe fn display<'a>(&'a self) -> impl core::fmt::Display + 'a {
-        Decode(move || core::char::decode_utf16(self.as_wide().iter().cloned()))
+    pub unsafe fn display<'a>(&'a self) -> impl std::fmt::Display + 'a {
+        Decode(move || std::char::decode_utf16(self.as_wide().iter().cloned()))
     }
 }
 

--- a/crates/libs/windows/src/core/strings/pstr.rs
+++ b/crates/libs/windows/src/core/strings/pstr.rs
@@ -13,7 +13,7 @@ impl PSTR {
 
     /// Construct a null `PSTR`
     pub fn null() -> Self {
-        Self(core::ptr::null_mut())
+        Self(std::ptr::null_mut())
     }
 
     /// Returns a raw pointer to the `PSTR`
@@ -41,7 +41,7 @@ impl PSTR {
     /// # Safety
     ///
     /// See the safety information for `PSTR::as_bytes`.
-    pub unsafe fn to_string(&self) -> core::result::Result<String, std::string::FromUtf8Error> {
+    pub unsafe fn to_string(&self) -> std::result::Result<String, std::string::FromUtf8Error> {
         String::from_utf8(self.as_bytes().into())
     }
 
@@ -50,7 +50,7 @@ impl PSTR {
     /// # Safety
     ///
     /// See the safety information for `PSTR::as_bytes`.
-    pub unsafe fn display<'a>(&'a self) -> impl core::fmt::Display + 'a {
+    pub unsafe fn display<'a>(&'a self) -> impl std::fmt::Display + 'a {
         Decode(move || decode_utf8(self.as_bytes()))
     }
 }

--- a/crates/libs/windows/src/core/strings/pwstr.rs
+++ b/crates/libs/windows/src/core/strings/pwstr.rs
@@ -13,7 +13,7 @@ impl PWSTR {
 
     /// Construct a null `PWSTR`.
     pub fn null() -> Self {
-        Self(core::ptr::null_mut())
+        Self(std::ptr::null_mut())
     }
 
     /// Returns a raw pointer to the `PWSTR`.
@@ -41,7 +41,7 @@ impl PWSTR {
     /// # Safety
     ///
     /// See the safety information for `PWSTR::as_wide`.
-    pub unsafe fn to_string(&self) -> core::result::Result<String, std::string::FromUtf16Error> {
+    pub unsafe fn to_string(&self) -> std::result::Result<String, std::string::FromUtf16Error> {
         String::from_utf16(self.as_wide().into())
     }
 
@@ -50,8 +50,8 @@ impl PWSTR {
     /// # Safety
     ///
     /// See the safety information for `PWSTR::as_wide`.
-    pub unsafe fn display<'a>(&'a self) -> impl core::fmt::Display + 'a {
-        Decode(move || core::char::decode_utf16(self.as_wide().iter().cloned()))
+    pub unsafe fn display<'a>(&'a self) -> impl std::fmt::Display + 'a {
+        Decode(move || std::char::decode_utf16(self.as_wide().iter().cloned()))
     }
 }
 

--- a/crates/libs/windows/src/core/unknown.rs
+++ b/crates/libs/windows/src/core/unknown.rs
@@ -5,14 +5,14 @@ use super::*;
 /// under the hood to provide reference-counted lifetime management as well as the ability
 /// to query for additional interfaces that the object may implement.
 #[repr(transparent)]
-pub struct IUnknown(core::ptr::NonNull<core::ffi::c_void>);
+pub struct IUnknown(std::ptr::NonNull<std::ffi::c_void>);
 
 #[doc(hidden)]
 #[repr(C)]
 pub struct IUnknown_Vtbl {
-    pub QueryInterface: unsafe extern "system" fn(this: *mut core::ffi::c_void, iid: &GUID, interface: *mut *const core::ffi::c_void) -> HRESULT,
-    pub AddRef: unsafe extern "system" fn(this: *mut core::ffi::c_void) -> u32,
-    pub Release: unsafe extern "system" fn(this: *mut core::ffi::c_void) -> u32,
+    pub QueryInterface: unsafe extern "system" fn(this: *mut std::ffi::c_void, iid: &GUID, interface: *mut *const std::ffi::c_void) -> HRESULT,
+    pub AddRef: unsafe extern "system" fn(this: *mut std::ffi::c_void) -> u32,
+    pub Release: unsafe extern "system" fn(this: *mut std::ffi::c_void) -> u32,
 }
 
 unsafe impl Vtable for IUnknown {
@@ -26,7 +26,7 @@ unsafe impl Interface for IUnknown {
 impl Clone for IUnknown {
     fn clone(&self) -> Self {
         unsafe {
-            (self.vtable().AddRef)(core::mem::transmute_copy(self));
+            (self.vtable().AddRef)(std::mem::transmute_copy(self));
         }
 
         Self(self.0)
@@ -36,7 +36,7 @@ impl Clone for IUnknown {
 impl Drop for IUnknown {
     fn drop(&mut self) {
         unsafe {
-            (self.vtable().Release)(core::mem::transmute_copy(self));
+            (self.vtable().Release)(std::mem::transmute_copy(self));
         }
     }
 }
@@ -53,8 +53,8 @@ impl PartialEq for IUnknown {
 
 impl Eq for IUnknown {}
 
-impl core::fmt::Debug for IUnknown {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+impl std::fmt::Debug for IUnknown {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_tuple("IUnknown").field(&self.0).finish()
     }
 }
@@ -71,7 +71,7 @@ pub trait IUnknownImpl {
     ///
     /// This function is safe to call as long as the interface pointer is non-null and valid for writes
     /// of an interface pointer.
-    unsafe fn QueryInterface(&self, iid: &GUID, interface: *mut *const core::ffi::c_void) -> HRESULT;
+    unsafe fn QueryInterface(&self, iid: &GUID, interface: *mut *const std::ffi::c_void) -> HRESULT;
     /// Increments the reference count of the interface
     fn AddRef(&self) -> u32;
     /// Decrements the reference count causing the interface's memory to be freed when the count is 0
@@ -86,16 +86,16 @@ pub trait IUnknownImpl {
 #[cfg(any(feature = "interface", feature = "implement"))]
 impl IUnknown_Vtbl {
     pub const fn new<T: IUnknownImpl, const OFFSET: isize>() -> Self {
-        unsafe extern "system" fn QueryInterface<T: IUnknownImpl, const OFFSET: isize>(this: *mut core::ffi::c_void, iid: &GUID, interface: *mut *const core::ffi::c_void) -> HRESULT {
-            let this = (this as *mut *mut core::ffi::c_void).offset(OFFSET) as *mut T;
+        unsafe extern "system" fn QueryInterface<T: IUnknownImpl, const OFFSET: isize>(this: *mut std::ffi::c_void, iid: &GUID, interface: *mut *const std::ffi::c_void) -> HRESULT {
+            let this = (this as *mut *mut std::ffi::c_void).offset(OFFSET) as *mut T;
             (*this).QueryInterface(iid, interface)
         }
-        unsafe extern "system" fn AddRef<T: IUnknownImpl, const OFFSET: isize>(this: *mut core::ffi::c_void) -> u32 {
-            let this = (this as *mut *mut core::ffi::c_void).offset(OFFSET) as *mut T;
+        unsafe extern "system" fn AddRef<T: IUnknownImpl, const OFFSET: isize>(this: *mut std::ffi::c_void) -> u32 {
+            let this = (this as *mut *mut std::ffi::c_void).offset(OFFSET) as *mut T;
             (*this).AddRef()
         }
-        unsafe extern "system" fn Release<T: IUnknownImpl, const OFFSET: isize>(this: *mut core::ffi::c_void) -> u32 {
-            let this = (this as *mut *mut core::ffi::c_void).offset(OFFSET) as *mut T;
+        unsafe extern "system" fn Release<T: IUnknownImpl, const OFFSET: isize>(this: *mut std::ffi::c_void) -> u32 {
+            let this = (this as *mut *mut std::ffi::c_void).offset(OFFSET) as *mut T;
             (*this).Release()
         }
         Self { QueryInterface: QueryInterface::<T, OFFSET>, AddRef: AddRef::<T, OFFSET>, Release: Release::<T, OFFSET> }

--- a/crates/libs/windows/src/core/vtable.rs
+++ b/crates/libs/windows/src/core/vtable.rs
@@ -25,13 +25,13 @@ pub unsafe trait Vtable: Sized {
 
     /// Returns the raw COM interface pointer. The resulting pointer continues to be owned by the `Interface` implementation.
     #[inline(always)]
-    fn as_raw(&self) -> *mut core::ffi::c_void {
+    fn as_raw(&self) -> *mut std::ffi::c_void {
         // SAFETY: implementors of this trait must guarantee that the implementing type has a pointer in-memory representation
-        unsafe { core::mem::transmute_copy(self) }
+        unsafe { std::mem::transmute_copy(self) }
     }
 
     /// Returns the raw COM interface pointer and releases ownership. It the caller's responsibility to release the COM interface pointer.
-    fn into_raw(self) -> *mut core::ffi::c_void {
+    fn into_raw(self) -> *mut std::ffi::c_void {
         // SAFETY: implementors of this trait must guarantee that the implementing type has a pointer in-memory representation
         let raw = self.as_raw();
         std::mem::forget(self);
@@ -44,7 +44,7 @@ pub unsafe trait Vtable: Sized {
     ///
     /// The `raw` pointer must be owned by the caller and represent a valid COM interface pointer. In other words,
     /// it must point to a vtable beginning with the `IUnknown` function pointers and match the vtable of `Interface`.
-    unsafe fn from_raw(raw: *mut core::ffi::c_void) -> Self {
+    unsafe fn from_raw(raw: *mut std::ffi::c_void) -> Self {
         std::mem::transmute_copy(&raw)
     }
 
@@ -54,7 +54,7 @@ pub unsafe trait Vtable: Sized {
     ///
     /// The `raw` pointer must be a valid COM interface pointer. In other words, it must point to a vtable
     /// beginning with the `IUnknown` function pointers and match the vtable of `Interface`.
-    unsafe fn from_raw_borrowed<'a>(raw: &'a *mut core::ffi::c_void) -> &'a Self {
+    unsafe fn from_raw_borrowed<'a>(raw: &'a *mut std::ffi::c_void) -> &'a Self {
         std::mem::transmute_copy(&raw)
     }
 }

--- a/crates/libs/windows/src/core/weak.rs
+++ b/crates/libs/windows/src/core/weak.rs
@@ -1,6 +1,6 @@
 use super::*;
 use bindings::*;
-use core::marker::PhantomData;
+use std::marker::PhantomData;
 
 /// `Weak` holds a non-owning reference to an object.
 #[derive(Clone, PartialEq, Eq, Default)]


### PR DESCRIPTION
While the `windows-sys` crate supports `no_std`, the `windows` crate uses the `std` library but has been using `std` and `core` interchangeably. Here I'm just switching to use `std` consistently throughout. 