### PR TITLE
Improve `windows::core::Error` formatting

### DIFF
--- a/crates/libs/windows/src/core/error.rs
+++ b/crates/libs/windows/src/core/error.rs
@@ -132,13 +132,18 @@ impl std::convert::From<HRESULT> for Error {
 impl std::fmt::Debug for Error {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut debug = fmt.debug_struct("Error");
-        debug.field("code", &format_args!("{:#010X}", self.code.0)).field("message", &self.message()).finish()
+        debug.field("code", &self.code).field("message", &self.message()).finish()
     }
 }
 
 impl std::fmt::Display for Error {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        std::write!(fmt, "{}", self.message())
+        let message = self.message();
+        if message.is_empty() {
+            std::write!(fmt, "{}", self.code())
+        } else {
+            std::write!(fmt, "{} ({})", self.message(), self.code())
+        }
     }
 }
 

--- a/crates/libs/windows/src/core/hresult.rs
+++ b/crates/libs/windows/src/core/hresult.rs
@@ -120,9 +120,15 @@ impl<T> std::convert::From<Result<T>> for HRESULT {
     }
 }
 
+impl std::fmt::Display for HRESULT {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!("{:#010X}", self.0))
+    }
+}
+
 impl std::fmt::Debug for HRESULT {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_fmt(format_args!("HRESULT(0x{:08X})", self.0))
+        f.write_fmt(format_args!("HRESULT({})", self))
     }
 }
 

--- a/crates/libs/windows/src/core/strings/hstring.rs
+++ b/crates/libs/windows/src/core/strings/hstring.rs
@@ -140,7 +140,7 @@ impl std::fmt::Display for HSTRING {
 
 impl std::fmt::Debug for HSTRING {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self)
+        write!(f, "\"{}\"", self)
     }
 }
 

--- a/crates/tests/core/Cargo.toml
+++ b/crates/tests/core/Cargo.toml
@@ -11,6 +11,7 @@ features = [
     "interface",
     "Win32_Foundation",
     "Win32_System_WinRT",
+    "Win32_Media_Audio",
 ]
 
 [dependencies.windows-sys]

--- a/crates/tests/core/tests/error.rs
+++ b/crates/tests/core/tests/error.rs
@@ -1,0 +1,14 @@
+#[test]
+fn test() {
+    let e = windows::core::Error::from(windows::Win32::Foundation::ERROR_NO_UNICODE_TRANSLATION);
+    let display = format!("{}", e);
+    let debug = format!("{:?}", e);
+    assert_eq!(display, "No mapping for the Unicode character exists in the target multi-byte code page. (0x80070459)");
+    assert_eq!(debug, r#"Error { code: HRESULT(0x80070459), message: "No mapping for the Unicode character exists in the target multi-byte code page." }"#);
+
+    let e = windows::core::Error::from(windows::Win32::Media::Audio::AUDCLNT_E_UNSUPPORTED_FORMAT);
+    let display = format!("{}", e);
+    let debug = format!("{:?}", e);
+    assert_eq!(display, "0x88890008");
+    assert_eq!(debug, r#"Error { code: HRESULT(0x88890008), message: "" }"#);
+}

--- a/crates/tests/core/tests/hstring.rs
+++ b/crates/tests/core/tests/hstring.rs
@@ -46,7 +46,7 @@ fn display_invalid_format() {
 #[test]
 fn debug_format() {
     let value = HSTRING::from("Hello world");
-    assert!(format!("{:?}", value) == "Hello world");
+    assert!(format!("{:?}", value) == r#""Hello world""#);
 }
 
 #[test]

--- a/crates/tests/enums/tests/win.rs
+++ b/crates/tests/enums/tests/win.rs
@@ -36,7 +36,7 @@ fn win32_error() {
     assert!("WIN32_ERROR(5)" == format!("{:?}", e));
 
     let e: Error = h.into();
-    assert_eq!("Error { code: 0x80070005, message: Access is denied. }", format!("{:?}", e));
+    assert_eq!(r#"Error { code: HRESULT(0x80070005), message: "Access is denied." }"#, format!("{:?}", e));
     let e = WIN32_ERROR::from_error(&e).unwrap();
     assert!(e == ERROR_ACCESS_DENIED);
 }

--- a/crates/tests/winrt/tests/error.rs
+++ b/crates/tests/winrt/tests/error.rs
@@ -52,5 +52,5 @@ fn convertible() {
     let result = convertible_error();
     let format = format!("{:?}", result);
 
-    assert_eq!(format, "Err(Error { code: 0x80004002, message: test message })");
+    assert_eq!(format, r#"Err(Error { code: HRESULT(0x80004002), message: "test message" })"#);
 }


### PR DESCRIPTION
The `Display` and `Debug` formatting for the `windows::core::Error` type is refined to make it more consistent with `std` error types and provides meaningful output in the event that an error message is not available.

Fixes: #2059 