### PR TITLE
Make more of the `HSTRING` methods `const`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
     name: Check windows
     strategy:
       matrix:
-        rust: [1.59.0, stable, nightly]
+        rust: [1.64.0, stable, nightly]
         runs-on:
           - windows-2019
           - ubuntu-latest

--- a/crates/libs/implement/Cargo.toml
+++ b/crates/libs/implement/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "The implement macro for the windows crate"
 repository = "https://github.com/microsoft/windows-rs"
-rust-version = "1.61"
+rust-version = "1.64"
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"

--- a/crates/libs/interface/Cargo.toml
+++ b/crates/libs/interface/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Microsoft"]
 license = "MIT OR Apache-2.0"
 description = "The interface macro for the windows crate"
 repository = "https://github.com/microsoft/windows-rs"
-rust-version = "1.61"
+rust-version = "1.64"
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"

--- a/crates/libs/windows/Cargo.toml
+++ b/crates/libs/windows/Cargo.toml
@@ -9,7 +9,7 @@ description = "Rust for Windows"
 repository = "https://github.com/microsoft/windows-rs"
 documentation = "https://microsoft.github.io/windows-docs-rs/"
 readme = "../../../docs/readme.md"
-rust-version = "1.59"
+rust-version = "1.64"
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"

--- a/crates/libs/windows/src/core/strings/hstring.rs
+++ b/crates/libs/windows/src/core/strings/hstring.rs
@@ -115,7 +115,7 @@ impl Clone for HSTRING {
         if let Some(header) = self.get_header() {
             unsafe { Self(std::mem::transmute(header.duplicate())) }
         } else {
-            return Self::new();
+            Self::new()
         }
     }
 }

--- a/crates/libs/windows/src/core/weak_ref_count.rs
+++ b/crates/libs/windows/src/core/weak_ref_count.rs
@@ -13,11 +13,11 @@ impl WeakRefCount {
     }
 
     pub fn add_ref(&self) -> u32 {
-        self.0.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |count_or_pointer| (!is_weak_ref(count_or_pointer)).then(|| count_or_pointer + 1)).map(|u| u as u32 + 1).unwrap_or_else(|pointer| unsafe { TearOff::decode(pointer).strong_count.add_ref() })
+        self.0.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |count_or_pointer| (!is_weak_ref(count_or_pointer)).then_some(count_or_pointer + 1)).map(|u| u as u32 + 1).unwrap_or_else(|pointer| unsafe { TearOff::decode(pointer).strong_count.add_ref() })
     }
 
     pub fn release(&self) -> u32 {
-        self.0.fetch_update(Ordering::Release, Ordering::Relaxed, |count_or_pointer| (!is_weak_ref(count_or_pointer)).then(|| count_or_pointer - 1)).map(|u| u as u32 - 1).unwrap_or_else(|pointer| unsafe {
+        self.0.fetch_update(Ordering::Release, Ordering::Relaxed, |count_or_pointer| (!is_weak_ref(count_or_pointer)).then_some(count_or_pointer - 1)).map(|u| u as u32 - 1).unwrap_or_else(|pointer| unsafe {
             let tear_off = TearOff::decode(pointer);
             let remaining = tear_off.strong_count.release();
 
@@ -214,7 +214,7 @@ impl TearOff {
             .fetch_update(Ordering::Acquire, Ordering::Relaxed, |count| {
                 // Attempt to acquire a strong reference count to stabilize the object for the duration
                 // of the `QueryInterface` call.
-                (count != 0).then(|| count + 1)
+                (count != 0).then_some(count + 1)
             })
             .map(|_| {
                 // Let the object respond to the upgrade query.

--- a/crates/tests/core/tests/hstring.rs
+++ b/crates/tests/core/tests/hstring.rs
@@ -3,6 +3,7 @@ use windows::core::*;
 
 #[test]
 fn hstring_works() {
+    assert_eq!(std::mem::size_of::<HSTRING>(), std::mem::size_of::<usize>());
     let empty = HSTRING::new();
     assert!(empty.is_empty());
     assert!(empty.is_empty());

--- a/crates/tools/windows/src/main.rs
+++ b/crates/tools/windows/src/main.rs
@@ -47,7 +47,7 @@ description = "Rust for Windows"
 repository = "https://github.com/microsoft/windows-rs"
 documentation = "https://microsoft.github.io/windows-docs-rs/"
 readme = "../../../docs/readme.md"
-rust-version = "1.59"
+rust-version = "1.64"
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"

--- a/crates/tools/yml/src/main.rs
+++ b/crates/tools/yml/src/main.rs
@@ -215,7 +215,7 @@ jobs:
     name: Check windows
     strategy:
       matrix:
-        rust: [1.59.0, stable, nightly]
+        rust: [1.64.0, stable, nightly]
         runs-on:
           - windows-2019
           - ubuntu-latest


### PR DESCRIPTION
Based on a suggestion by @ChrisDenton, I've made more of the `HSTRING` methods `const`. In theory I could apply the same technique to `BSTR` if desired. I'm reluctant to mess with `PCWSTR` and friends as they're used in more unorthodox ways. 

Fixes: #2049