### PR TITLE
Allow fewer warnings

### DIFF
--- a/crates/libs/bindgen/src/lib.rs
+++ b/crates/libs/bindgen/src/lib.rs
@@ -25,7 +25,7 @@ pub fn namespace(gen: &Gen, tree: &Tree) -> String {
 
     if tree.namespace == "Windows" {
         tokens.combine(&quote! {
-            #![allow(non_snake_case, non_upper_case_globals, non_camel_case_types, clashing_extern_declarations, unused_variables, dead_code, clippy::all)]
+            #![allow(non_upper_case_globals, non_camel_case_types, clippy::all)]
         });
     }
 

--- a/crates/libs/sys/src/Windows/mod.rs
+++ b/crates/libs/sys/src/Windows/mod.rs
@@ -1,3 +1,3 @@
-#![allow(non_snake_case, non_upper_case_globals, non_camel_case_types, clashing_extern_declarations, unused_variables, dead_code, clippy::all)]
+#![allow(non_upper_case_globals, non_camel_case_types, clippy::all)]
 #[cfg(feature = "Win32")]
 pub mod Win32;

--- a/crates/libs/windows/src/Windows/mod.rs
+++ b/crates/libs/windows/src/Windows/mod.rs
@@ -1,4 +1,4 @@
-#![allow(non_snake_case, non_upper_case_globals, non_camel_case_types, clashing_extern_declarations, unused_variables, dead_code, clippy::all)]
+#![allow(non_upper_case_globals, non_camel_case_types, clippy::all)]
 #[cfg(feature = "AI")]
 pub mod AI;
 #[cfg(feature = "ApplicationModel")]


### PR DESCRIPTION
This update reduces the number of Rust compiler warnings that the generated code automatically suppresses. A few of these are no longer required. The clippy warnings will still require more effort to sort through as there are many. 