### PR TITLE
Fix a few new `clippy` warnings

### DIFF
--- a/crates/libs/metadata/src/reader/mod.rs
+++ b/crates/libs/metadata/src/reader/mod.rs
@@ -260,7 +260,7 @@ impl<'a> Reader<'a> {
         let _this_and_gen_param_count = sig.read_usize();
         let fixed_arg_count = sig.read_usize();
         let _ret_type = sig.read_usize();
-        let mut args: Vec<(String, Value)> = Vec::with_capacity(fixed_arg_count as usize);
+        let mut args: Vec<(String, Value)> = Vec::with_capacity(fixed_arg_count);
 
         for _ in 0..fixed_arg_count {
             let arg = match self.type_from_blob(&mut sig, None, &[]).expect("Type not found") {
@@ -1512,7 +1512,7 @@ impl<'a> Reader<'a> {
 
         match code {
             0x11 | 0x12 => self.type_from_ref(TypeDefOrRef::decode(blob.file, blob.read_usize()), enclosing, generics),
-            0x13 => generics.get(blob.read_usize() as usize).unwrap_or(&Type::Void).clone(),
+            0x13 => generics.get(blob.read_usize()).unwrap_or(&Type::Void).clone(),
             0x14 => {
                 let kind = self.type_from_blob(blob, enclosing, generics).unwrap();
                 let _rank = blob.read_usize();

--- a/crates/samples/create_window/src/main.rs
+++ b/crates/samples/create_window/src/main.rs
@@ -34,7 +34,7 @@ fn main() -> Result<()> {
 
 extern "system" fn wndproc(window: HWND, message: u32, wparam: WPARAM, lparam: LPARAM) -> LRESULT {
     unsafe {
-        match message as u32 {
+        match message {
             WM_PAINT => {
                 println!("WM_PAINT");
                 ValidateRect(window, None);

--- a/crates/samples/create_window_sys/src/main.rs
+++ b/crates/samples/create_window_sys/src/main.rs
@@ -35,7 +35,7 @@ fn main() {
 
 extern "system" fn wndproc(window: HWND, message: u32, wparam: WPARAM, lparam: LPARAM) -> LRESULT {
     unsafe {
-        match message as u32 {
+        match message {
             WM_PAINT => {
                 println!("WM_PAINT");
                 ValidateRect(window, std::ptr::null());

--- a/crates/samples/direct2d/src/main.rs
+++ b/crates/samples/direct2d/src/main.rs
@@ -179,6 +179,7 @@ impl Window {
 
         let size = unsafe { target.GetSize() };
 
+        #[allow(clippy::manual_clamp)]
         let radius = size.width.min(size.height).max(200.0) / 2.0 - 50.0;
         let translation = Matrix3x2::translation(size.width / 2.0, size.height / 2.0);
         unsafe { target.SetTransform(&translation) };


### PR DESCRIPTION
removed some unnecessary casts (`clippy::unnecessary-cast`) and ignored another warning (`clippy::manual_clamp`)
