### PR TITLE
Fix example

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -33,7 +33,7 @@ use windows::{
 
 fn main() -> Result<()> {
     let doc = XmlDocument::new()?;
-    doc.LoadXml(h!("<html>hello world</html>"))?;
+    doc.LoadXml(w!("<html>hello world</html>"))?;
 
     let root = doc.DocumentElement()?;
     assert!(root.NodeName()? == "html");


### PR DESCRIPTION
Fixes error inside readme example: 

```
error: cannot find macro `h` in this scope
 --> src\main.rs:8:17
  |
8 |     doc.LoadXml(h!("<html>hello world</html>"))?;
  |                 ^ help: a macro with a similar name exists: `s`
  |
 ::: windows-0.42.0\src\core\strings\literals.rs:3:1
  |
3 | macro_rules! s {
  | -------------- similarly named macro `s` defined here
```
