### PR TITLE
Version 0.43

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run cargo fmt
         run: cargo fmt --all -- --check
 
@@ -24,7 +24,7 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run cargo doc
         run: cargo doc --no-deps -p windows
 
@@ -36,7 +36,7 @@ jobs:
         generator: [windows, sys, yml]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run tool_${{ matrix.generator }}
         run: cargo run -p tool_${{ matrix.generator }}
       - name: Compare
@@ -54,7 +54,7 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Update toolchain
         run: rustup update --no-self-update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
       - name: Run cargo check
@@ -71,7 +71,7 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Update toolchain
         run: rustup update --no-self-update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
       - name: Run cargo check
@@ -82,7 +82,7 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Update toolchain
         run: rustup update --no-self-update nightly && rustup default nightly-x86_64-pc-windows-msvc
       - name: Install clippy

--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Add toolchain target
         run: rustup target add ${{ matrix.target }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Update toolchain
         run: rustup update --no-self-update ${{ matrix.version }} && rustup default ${{ matrix.version }}-${{ matrix.target }}
       - name: Add toolchain target

--- a/crates/libs/bindgen/Cargo.toml
+++ b/crates/libs/bindgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows-bindgen"
-version = "0.42.0"
+version = "0.43.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -13,4 +13,4 @@ targets = []
 
 [dependencies]
 tokens = { package = "windows-tokens", path = "../tokens", version = "0.42.0" }
-metadata = { package = "windows-metadata", path = "../metadata", version = "0.42.0" }
+metadata = { package = "windows-metadata", path = "../metadata", version = "0.43.0" }

--- a/crates/libs/implement/Cargo.toml
+++ b/crates/libs/implement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows-implement"
-version = "0.42.0"
+version = "0.43.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/libs/interface/Cargo.toml
+++ b/crates/libs/interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows-interface"
-version = "0.42.0"
+version = "0.43.0"
 edition = "2018"
 authors = ["Microsoft"]
 license = "MIT OR Apache-2.0"

--- a/crates/libs/metadata/Cargo.toml
+++ b/crates/libs/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows-metadata"
-version = "0.42.0"
+version = "0.43.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/libs/windows/Cargo.toml
+++ b/crates/libs/windows/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "windows"
-version = "0.42.0"
+version = "0.43.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -52,8 +52,8 @@ windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.42.0" }
 windows_x86_64_gnullvm = { path = "../../targets/x86_64_gnullvm", version = "0.42.0" }
 
 [dependencies]
-windows-implement = { path = "../implement",  version = "0.42.0", optional = true }
-windows-interface = { path = "../interface",  version = "0.42.0", optional = true }
+windows-implement = { path = "../implement",  version = "0.43.0", optional = true }
+windows-interface = { path = "../interface",  version = "0.43.0", optional = true }
 
 [features]
 default = []

--- a/crates/tools/windows/src/main.rs
+++ b/crates/tools/windows/src/main.rs
@@ -39,7 +39,7 @@ fn main() {
         r#"
 [package]
 name = "windows"
-version = "0.42.0"
+version = "0.43.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -90,8 +90,8 @@ windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.42.0" }
 windows_x86_64_gnullvm = { path = "../../targets/x86_64_gnullvm", version = "0.42.0" }
 
 [dependencies]
-windows-implement = { path = "../implement",  version = "0.42.0", optional = true }
-windows-interface = { path = "../interface",  version = "0.42.0", optional = true }
+windows-implement = { path = "../implement",  version = "0.43.0", optional = true }
+windows-interface = { path = "../interface",  version = "0.43.0", optional = true }
 
 [features]
 default = []

--- a/crates/tools/yml/src/main.rs
+++ b/crates/tools/yml/src/main.rs
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Update toolchain
         run: rustup update --no-self-update ${{ matrix.version }} && rustup default ${{ matrix.version }}-${{ matrix.target }}
       - name: Add toolchain target
@@ -166,7 +166,7 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run cargo fmt
         run: cargo fmt --all -- --check
 
@@ -175,7 +175,7 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run cargo doc
         run: cargo doc --no-deps -p windows
 
@@ -187,7 +187,7 @@ jobs:
         generator: [windows, sys, yml]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run tool_${{ matrix.generator }}
         run: cargo run -p tool_${{ matrix.generator }}
       - name: Compare
@@ -205,7 +205,7 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Update toolchain
         run: rustup update --no-self-update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
       - name: Run cargo check
@@ -222,7 +222,7 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Update toolchain
         run: rustup update --no-self-update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
       - name: Run cargo check
@@ -233,7 +233,7 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Update toolchain
         run: rustup update --no-self-update nightly && rustup default nightly-x86_64-pc-windows-msvc
       - name: Install clippy

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -13,7 +13,7 @@ Start by adding the following to your Cargo.toml file:
 
 ```toml
 [dependencies.windows]
-version = "0.42.0"
+version = "0.43.0"
 features = [
     "Data_Xml_Dom",
     "Win32_Foundation",


### PR DESCRIPTION
* Bumps the version in anticipation of the 0.43 release of the `windows` crate.
* Updates the build to use `actions/checkout@v3` to avoid build warnings.