### PR TITLE
Use more readable formatting for samples

### DIFF
--- a/crates/samples/consent/src/main.rs
+++ b/crates/samples/consent/src/main.rs
@@ -1,4 +1,7 @@
-use windows::{core::*, Foundation::*, Security::Credentials::UI::*, Win32::Foundation::*, Win32::System::WinRT::*};
+use windows::{
+    core::*, Foundation::*, Security::Credentials::UI::*, Win32::Foundation::*,
+    Win32::System::WinRT::*,
+};
 
 fn main() -> Result<()> {
     unsafe {
@@ -6,7 +9,8 @@ fn main() -> Result<()> {
 
         let window = HWND(0); // <== replace with your app's window handle
 
-        let operation: IAsyncOperation<UserConsentVerificationResult> = interop.RequestVerificationForWindowAsync(window, h!("Hello from Rust"))?;
+        let operation: IAsyncOperation<UserConsentVerificationResult> =
+            interop.RequestVerificationForWindowAsync(window, h!("Hello from Rust"))?;
 
         let result: UserConsentVerificationResult = operation.get()?;
 

--- a/crates/samples/core_app/src/main.rs
+++ b/crates/samples/core_app/src/main.rs
@@ -58,7 +58,12 @@ fn main() -> Result<()> {
         CoInitializeEx(None, COINIT_MULTITHREADED)?;
 
         if let Err(result) = Package::Current() {
-            MessageBoxW(None, w!("This sample must be registered (via register.cmd) and launched from Start."), w!("Error"), MB_ICONSTOP | MB_OK);
+            MessageBoxW(
+                None,
+                w!("This sample must be registered (via register.cmd) and launched from Start."),
+                w!("Error"),
+                MB_ICONSTOP | MB_OK,
+            );
             return Err(result);
         }
     }

--- a/crates/samples/counter/src/main.rs
+++ b/crates/samples/counter/src/main.rs
@@ -6,7 +6,12 @@ fn main() {
         PdhOpenQueryW(None, 0, &mut query);
 
         let mut counter = 0;
-        PdhAddCounterW(query, w!("\\Processor(0)\\% Processor Time"), 0, &mut counter);
+        PdhAddCounterW(
+            query,
+            w!("\\Processor(0)\\% Processor Time"),
+            0,
+            &mut counter,
+        );
 
         loop {
             std::thread::sleep(std::time::Duration::new(1, 0));

--- a/crates/samples/counter_sys/src/main.rs
+++ b/crates/samples/counter_sys/src/main.rs
@@ -6,14 +6,24 @@ fn main() {
         PdhOpenQueryW(std::ptr::null(), 0, &mut query);
 
         let mut counter = 0;
-        PdhAddCounterW(query, w!("\\Processor(0)\\% Processor Time"), 0, &mut counter);
+        PdhAddCounterW(
+            query,
+            w!("\\Processor(0)\\% Processor Time"),
+            0,
+            &mut counter,
+        );
 
         loop {
             std::thread::sleep(std::time::Duration::new(1, 0));
             PdhCollectQueryData(query);
 
             let mut value = std::mem::zeroed();
-            if 0 == PdhGetFormattedCounterValue(counter, PDH_FMT_DOUBLE, std::ptr::null_mut(), &mut value) {
+            if 0 == PdhGetFormattedCounterValue(
+                counter,
+                PDH_FMT_DOUBLE,
+                std::ptr::null_mut(),
+                &mut value,
+            ) {
                 println!("{:.2}", value.Anonymous.doubleValue);
             }
         }

--- a/crates/samples/create_window/src/main.rs
+++ b/crates/samples/create_window/src/main.rs
@@ -1,4 +1,7 @@
-use windows::{core::*, Win32::Foundation::*, Win32::Graphics::Gdi::ValidateRect, Win32::System::LibraryLoader::GetModuleHandleA, Win32::UI::WindowsAndMessaging::*};
+use windows::{
+    core::*, Win32::Foundation::*, Win32::Graphics::Gdi::ValidateRect,
+    Win32::System::LibraryLoader::GetModuleHandleA, Win32::UI::WindowsAndMessaging::*,
+};
 
 fn main() -> Result<()> {
     unsafe {
@@ -20,7 +23,20 @@ fn main() -> Result<()> {
         let atom = RegisterClassA(&wc);
         debug_assert!(atom != 0);
 
-        CreateWindowExA(WINDOW_EX_STYLE::default(), window_class, s!("This is a sample window"), WS_OVERLAPPEDWINDOW | WS_VISIBLE, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, None, None, instance, None);
+        CreateWindowExA(
+            WINDOW_EX_STYLE::default(),
+            window_class,
+            s!("This is a sample window"),
+            WS_OVERLAPPEDWINDOW | WS_VISIBLE,
+            CW_USEDEFAULT,
+            CW_USEDEFAULT,
+            CW_USEDEFAULT,
+            CW_USEDEFAULT,
+            None,
+            None,
+            instance,
+            None,
+        );
 
         let mut message = MSG::default();
 

--- a/crates/samples/create_window_sys/src/main.rs
+++ b/crates/samples/create_window_sys/src/main.rs
@@ -1,4 +1,7 @@
-use windows_sys::{core::*, Win32::Foundation::*, Win32::Graphics::Gdi::ValidateRect, Win32::System::LibraryLoader::GetModuleHandleA, Win32::UI::WindowsAndMessaging::*};
+use windows_sys::{
+    core::*, Win32::Foundation::*, Win32::Graphics::Gdi::ValidateRect,
+    Win32::System::LibraryLoader::GetModuleHandleA, Win32::UI::WindowsAndMessaging::*,
+};
 
 fn main() {
     unsafe {
@@ -23,7 +26,20 @@ fn main() {
         let atom = RegisterClassA(&wc);
         debug_assert!(atom != 0);
 
-        CreateWindowExA(0, window_class, s!("This is a sample window"), WS_OVERLAPPEDWINDOW | WS_VISIBLE, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, 0, 0, instance, std::ptr::null());
+        CreateWindowExA(
+            0,
+            window_class,
+            s!("This is a sample window"),
+            WS_OVERLAPPEDWINDOW | WS_VISIBLE,
+            CW_USEDEFAULT,
+            CW_USEDEFAULT,
+            CW_USEDEFAULT,
+            CW_USEDEFAULT,
+            0,
+            0,
+            instance,
+            std::ptr::null(),
+        );
 
         let mut message = std::mem::zeroed();
 

--- a/crates/samples/data_protection/src/main.rs
+++ b/crates/samples/data_protection/src/main.rs
@@ -1,8 +1,12 @@
-use windows::{core::*, Security::Cryptography::DataProtection::*, Security::Cryptography::*, Storage::Streams::*, Win32::System::WinRT::*};
+use windows::{
+    core::*, Security::Cryptography::DataProtection::*, Security::Cryptography::*,
+    Storage::Streams::*, Win32::System::WinRT::*,
+};
 
 fn main() -> std::io::Result<()> {
     let provider = DataProtectionProvider::CreateOverloadExplicit(h!("LOCAL=user"))?;
-    let unprotected = CryptographicBuffer::ConvertStringToBinary(h!("Hello world"), BinaryStringEncoding::Utf8)?;
+    let unprotected =
+        CryptographicBuffer::ConvertStringToBinary(h!("Hello world"), BinaryStringEncoding::Utf8)?;
 
     let protected = provider.ProtectAsync(&unprotected)?.get()?;
     let protected_bytes = unsafe { as_mut_bytes(&protected)? };
@@ -12,7 +16,8 @@ fn main() -> std::io::Result<()> {
     let protected = CryptographicBuffer::CreateFromByteArray(&protected_bytes)?;
     let unprotected = provider.UnprotectAsync(&protected)?.get()?;
 
-    let message = CryptographicBuffer::ConvertBinaryToString(BinaryStringEncoding::Utf8, &unprotected)?;
+    let message =
+        CryptographicBuffer::ConvertBinaryToString(BinaryStringEncoding::Utf8, &unprotected)?;
     println!("{message}");
     Ok(())
 }

--- a/crates/samples/direct2d/src/main.rs
+++ b/crates/samples/direct2d/src/main.rs
@@ -1,4 +1,11 @@
-use windows::{core::*, Foundation::Numerics::*, Win32::Foundation::*, Win32::Graphics::Direct2D::Common::*, Win32::Graphics::Direct2D::*, Win32::Graphics::Direct3D::*, Win32::Graphics::Direct3D11::*, Win32::Graphics::Dxgi::Common::*, Win32::Graphics::Dxgi::*, Win32::Graphics::Gdi::*, Win32::System::Com::*, Win32::System::LibraryLoader::*, Win32::System::Performance::*, Win32::System::SystemInformation::GetLocalTime, Win32::UI::Animation::*, Win32::UI::WindowsAndMessaging::*};
+use windows::{
+    core::*, Foundation::Numerics::*, Win32::Foundation::*, Win32::Graphics::Direct2D::Common::*,
+    Win32::Graphics::Direct2D::*, Win32::Graphics::Direct3D::*, Win32::Graphics::Direct3D11::*,
+    Win32::Graphics::Dxgi::Common::*, Win32::Graphics::Dxgi::*, Win32::Graphics::Gdi::*,
+    Win32::System::Com::*, Win32::System::LibraryLoader::*, Win32::System::Performance::*,
+    Win32::System::SystemInformation::GetLocalTime, Win32::UI::Animation::*,
+    Win32::UI::WindowsAndMessaging::*,
+};
 
 fn main() -> Result<()> {
     unsafe {
@@ -44,7 +51,11 @@ impl Angles {
         let minute = time.wMinute as f32 * 6.0 + second / 60.0;
         let hour = (time.wHour % 12) as f32 * 30.0 + minute / 12.0;
 
-        Self { second, minute, hour }
+        Self {
+            second,
+            minute,
+            hour,
+        }
     }
 }
 
@@ -53,7 +64,8 @@ impl Window {
         let factory = create_factory()?;
         let dxfactory: IDXGIFactory2 = unsafe { CreateDXGIFactory1()? };
         let style = create_style(&factory)?;
-        let manager: IUIAnimationManager = unsafe { CoCreateInstance(&UIAnimationManager, None, CLSCTX_ALL)? };
+        let manager: IUIAnimationManager =
+            unsafe { CoCreateInstance(&UIAnimationManager, None, CLSCTX_ALL)? };
         let transition = create_transition()?;
 
         let mut dpi = 0.0;
@@ -116,7 +128,10 @@ impl Window {
 
         if let Err(error) = self.present(1, 0) {
             if error.code() == DXGI_STATUS_OCCLUDED {
-                self.occlusion = unsafe { self.dxfactory.RegisterOcclusionStatusWindow(self.handle, WM_USER)? };
+                self.occlusion = unsafe {
+                    self.dxfactory
+                        .RegisterOcclusionStatusWindow(self.handle, WM_USER)?
+                };
                 self.visible = false;
             } else {
                 self.release_device();
@@ -149,7 +164,12 @@ impl Window {
         unsafe {
             self.manager.Update(get_time(self.frequency)?)?;
 
-            target.Clear(Some(&D2D1_COLOR_F { r: 1.0, g: 1.0, b: 1.0, a: 1.0 }));
+            target.Clear(Some(&D2D1_COLOR_F {
+                r: 1.0,
+                g: 1.0,
+                b: 1.0,
+                a: 1.0,
+            }));
 
             let mut previous = None;
             // TODO: workaround for https://github.com/microsoft/win32metadata/issues/1005
@@ -163,11 +183,23 @@ impl Window {
             let mut output = None;
             shadow.GetOutput(&mut output);
 
-            target.DrawImage(output.as_ref(), None, None, D2D1_INTERPOLATION_MODE_LINEAR, D2D1_COMPOSITE_MODE_SOURCE_OVER);
+            target.DrawImage(
+                output.as_ref(),
+                None,
+                None,
+                D2D1_INTERPOLATION_MODE_LINEAR,
+                D2D1_COMPOSITE_MODE_SOURCE_OVER,
+            );
 
             target.SetTransform(&Matrix3x2::identity());
 
-            target.DrawImage(clock, None, None, D2D1_INTERPOLATION_MODE_LINEAR, D2D1_COMPOSITE_MODE_SOURCE_OVER);
+            target.DrawImage(
+                clock,
+                None,
+                None,
+                D2D1_INTERPOLATION_MODE_LINEAR,
+                D2D1_COMPOSITE_MODE_SOURCE_OVER,
+            );
         }
 
         Ok(())
@@ -184,7 +216,11 @@ impl Window {
         let translation = Matrix3x2::translation(size.width / 2.0, size.height / 2.0);
         unsafe { target.SetTransform(&translation) };
 
-        let ellipse = D2D1_ELLIPSE { point: D2D_POINT_2F::default(), radiusX: radius, radiusY: radius };
+        let ellipse = D2D1_ELLIPSE {
+            point: D2D_POINT_2F::default(),
+            radiusX: radius,
+            radiusY: radius,
+        };
 
         let swing = unsafe {
             target.DrawEllipse(&ellipse, brush, radius / 20.0, None);
@@ -211,15 +247,42 @@ impl Window {
         unsafe {
             target.SetTransform(&(Matrix3x2::rotation(angles.second, 0.0, 0.0) * translation));
 
-            target.DrawLine(D2D_POINT_2F::default(), D2D_POINT_2F { x: 0.0, y: -(radius * 0.75) }, brush, radius / 25.0, &self.style);
+            target.DrawLine(
+                D2D_POINT_2F::default(),
+                D2D_POINT_2F {
+                    x: 0.0,
+                    y: -(radius * 0.75),
+                },
+                brush,
+                radius / 25.0,
+                &self.style,
+            );
 
             target.SetTransform(&(Matrix3x2::rotation(angles.minute, 0.0, 0.0) * translation));
 
-            target.DrawLine(D2D_POINT_2F::default(), D2D_POINT_2F { x: 0.0, y: -(radius * 0.75) }, brush, radius / 15.0, &self.style);
+            target.DrawLine(
+                D2D_POINT_2F::default(),
+                D2D_POINT_2F {
+                    x: 0.0,
+                    y: -(radius * 0.75),
+                },
+                brush,
+                radius / 15.0,
+                &self.style,
+            );
 
             target.SetTransform(&(Matrix3x2::rotation(angles.hour, 0.0, 0.0) * translation));
 
-            target.DrawLine(D2D_POINT_2F::default(), D2D_POINT_2F { x: 0.0, y: -(radius * 0.5) }, brush, radius / 10.0, &self.style);
+            target.DrawLine(
+                D2D_POINT_2F::default(),
+                D2D_POINT_2F {
+                    x: 0.0,
+                    y: -(radius * 0.5),
+                },
+                brush,
+                radius / 10.0,
+                &self.style,
+            );
         }
 
         Ok(())
@@ -237,10 +300,16 @@ impl Window {
     fn create_clock(&self, target: &ID2D1DeviceContext) -> Result<ID2D1Bitmap1> {
         let size_f = unsafe { target.GetSize() };
 
-        let size_u = D2D_SIZE_U { width: (size_f.width * self.dpi / 96.0) as u32, height: (size_f.height * self.dpi / 96.0) as u32 };
+        let size_u = D2D_SIZE_U {
+            width: (size_f.width * self.dpi / 96.0) as u32,
+            height: (size_f.height * self.dpi / 96.0) as u32,
+        };
 
         let properties = D2D1_BITMAP_PROPERTIES1 {
-            pixelFormat: D2D1_PIXEL_FORMAT { format: DXGI_FORMAT_B8G8R8A8_UNORM, alphaMode: D2D1_ALPHA_MODE_PREMULTIPLIED },
+            pixelFormat: D2D1_PIXEL_FORMAT {
+                format: DXGI_FORMAT_B8G8R8A8_UNORM,
+                alphaMode: D2D1_ALPHA_MODE_PREMULTIPLIED,
+            },
             dpiX: self.dpi,
             dpiY: self.dpi,
             bitmapOptions: D2D1_BITMAP_OPTIONS_TARGET,
@@ -255,7 +324,11 @@ impl Window {
             let swapchain = self.swapchain.as_ref().unwrap();
             unsafe { target.SetTarget(None) };
 
-            if unsafe { swapchain.ResizeBuffers(0, 0, 0, DXGI_FORMAT_UNKNOWN, 0).is_ok() } {
+            if unsafe {
+                swapchain
+                    .ResizeBuffers(0, 0, 0, DXGI_FORMAT_UNKNOWN, 0)
+                    .is_ok()
+            } {
                 create_swapchain_bitmap(swapchain, target)?;
                 self.create_device_size_resources()?;
             } else {
@@ -328,7 +401,20 @@ impl Window {
             let atom = RegisterClassA(&wc);
             debug_assert!(atom != 0);
 
-            let handle = CreateWindowExA(WINDOW_EX_STYLE::default(), window_class, s!("Sample Window"), WS_OVERLAPPEDWINDOW | WS_VISIBLE, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, None, None, instance, Some(self as *mut _ as _));
+            let handle = CreateWindowExA(
+                WINDOW_EX_STYLE::default(),
+                window_class,
+                s!("Sample Window"),
+                WS_OVERLAPPEDWINDOW | WS_VISIBLE,
+                CW_USEDEFAULT,
+                CW_USEDEFAULT,
+                CW_USEDEFAULT,
+                CW_USEDEFAULT,
+                None,
+                None,
+                instance,
+                Some(self as *mut _ as _),
+            );
 
             debug_assert!(handle.0 != 0);
             debug_assert!(handle == self.handle);
@@ -357,7 +443,12 @@ impl Window {
         }
     }
 
-    extern "system" fn wndproc(window: HWND, message: u32, wparam: WPARAM, lparam: LPARAM) -> LRESULT {
+    extern "system" fn wndproc(
+        window: HWND,
+        message: u32,
+        wparam: WPARAM,
+        lparam: LPARAM,
+    ) -> LRESULT {
         unsafe {
             if message == WM_NCCREATE {
                 let cs = lparam.0 as *const CREATESTRUCTA;
@@ -387,9 +478,17 @@ fn get_time(frequency: i64) -> Result<f64> {
 }
 
 fn create_brush(target: &ID2D1DeviceContext) -> Result<ID2D1SolidColorBrush> {
-    let color = D2D1_COLOR_F { r: 0.92, g: 0.38, b: 0.208, a: 1.0 };
+    let color = D2D1_COLOR_F {
+        r: 0.92,
+        g: 0.38,
+        b: 0.208,
+        a: 1.0,
+    };
 
-    let properties = D2D1_BRUSH_PROPERTIES { opacity: 0.8, transform: Matrix3x2::identity() };
+    let properties = D2D1_BRUSH_PROPERTIES {
+        opacity: 0.8,
+        transform: Matrix3x2::identity(),
+    };
 
     unsafe { target.CreateSolidColorBrush(&color, Some(&properties)) }
 }
@@ -414,14 +513,19 @@ fn create_factory() -> Result<ID2D1Factory1> {
 }
 
 fn create_style(factory: &ID2D1Factory1) -> Result<ID2D1StrokeStyle> {
-    let props = D2D1_STROKE_STYLE_PROPERTIES { startCap: D2D1_CAP_STYLE_ROUND, endCap: D2D1_CAP_STYLE_TRIANGLE, ..Default::default() };
+    let props = D2D1_STROKE_STYLE_PROPERTIES {
+        startCap: D2D1_CAP_STYLE_ROUND,
+        endCap: D2D1_CAP_STYLE_TRIANGLE,
+        ..Default::default()
+    };
 
     unsafe { factory.CreateStrokeStyle(&props, None) }
 }
 
 fn create_transition() -> Result<IUIAnimationTransition> {
     unsafe {
-        let library: IUIAnimationTransitionLibrary = CoCreateInstance(&UIAnimationTransitionLibrary, None, CLSCTX_ALL)?;
+        let library: IUIAnimationTransitionLibrary =
+            CoCreateInstance(&UIAnimationTransitionLibrary, None, CLSCTX_ALL)?;
         library.CreateAccelerateDecelerateTransition(5.0, 1.0, 0.2, 0.8)
     }
 }
@@ -435,7 +539,20 @@ fn create_device_with_type(drive_type: D3D_DRIVER_TYPE) -> Result<ID3D11Device> 
 
     let mut device = None;
 
-    unsafe { D3D11CreateDevice(None, drive_type, None, flags, None, D3D11_SDK_VERSION, Some(&mut device), None, None).map(|()| device.unwrap()) }
+    unsafe {
+        D3D11CreateDevice(
+            None,
+            drive_type,
+            None,
+            flags,
+            None,
+            D3D11_SDK_VERSION,
+            Some(&mut device),
+            None,
+            None,
+        )
+        .map(|()| device.unwrap())
+    }
 }
 
 fn create_device() -> Result<ID3D11Device> {
@@ -450,7 +567,10 @@ fn create_device() -> Result<ID3D11Device> {
     result
 }
 
-fn create_render_target(factory: &ID2D1Factory1, device: &ID3D11Device) -> Result<ID2D1DeviceContext> {
+fn create_render_target(
+    factory: &ID2D1Factory1,
+    device: &ID3D11Device,
+) -> Result<ID2D1DeviceContext> {
     unsafe {
         let d2device = factory.CreateDevice(&device.cast::<IDXGIDevice>()?)?;
 
@@ -471,7 +591,10 @@ fn create_swapchain_bitmap(swapchain: &IDXGISwapChain1, target: &ID2D1DeviceCont
     let surface: IDXGISurface = unsafe { swapchain.GetBuffer(0)? };
 
     let props = D2D1_BITMAP_PROPERTIES1 {
-        pixelFormat: D2D1_PIXEL_FORMAT { format: DXGI_FORMAT_B8G8R8A8_UNORM, alphaMode: D2D1_ALPHA_MODE_IGNORE },
+        pixelFormat: D2D1_PIXEL_FORMAT {
+            format: DXGI_FORMAT_B8G8R8A8_UNORM,
+            alphaMode: D2D1_ALPHA_MODE_IGNORE,
+        },
         dpiX: 96.0,
         dpiY: 96.0,
         bitmapOptions: D2D1_BITMAP_OPTIONS_TARGET | D2D1_BITMAP_OPTIONS_CANNOT_DRAW,
@@ -491,7 +614,10 @@ fn create_swapchain(device: &ID3D11Device, window: HWND) -> Result<IDXGISwapChai
 
     let props = DXGI_SWAP_CHAIN_DESC1 {
         Format: DXGI_FORMAT_B8G8R8A8_UNORM,
-        SampleDesc: DXGI_SAMPLE_DESC { Count: 1, Quality: 0 },
+        SampleDesc: DXGI_SAMPLE_DESC {
+            Count: 1,
+            Quality: 0,
+        },
         BufferUsage: DXGI_USAGE_RENDER_TARGET_OUTPUT,
         BufferCount: 2,
         SwapEffect: DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL,

--- a/crates/samples/direct3d12/build.rs
+++ b/crates/samples/direct3d12/build.rs
@@ -1,4 +1,8 @@
 fn main() {
     println!("!cargo:rerun-if-changed=src/shaders.hlsl");
-    std::fs::copy("src/shaders.hlsl", std::env::var("OUT_DIR").unwrap() + "/../../../shaders.hlsl").expect("Copy");
+    std::fs::copy(
+        "src/shaders.hlsl",
+        std::env::var("OUT_DIR").unwrap() + "/../../../shaders.hlsl",
+    )
+    .expect("Copy");
 }

--- a/crates/samples/direct3d12/src/main.rs
+++ b/crates/samples/direct3d12/src/main.rs
@@ -1,4 +1,9 @@
-use windows::{core::*, Win32::Foundation::*, Win32::Graphics::Direct3D::Fxc::*, Win32::Graphics::Direct3D::*, Win32::Graphics::Direct3D12::*, Win32::Graphics::Dxgi::Common::*, Win32::Graphics::Dxgi::*, Win32::System::LibraryLoader::*, Win32::System::Threading::*, Win32::System::WindowsProgramming::*, Win32::UI::WindowsAndMessaging::*};
+use windows::{
+    core::*, Win32::Foundation::*, Win32::Graphics::Direct3D::Fxc::*, Win32::Graphics::Direct3D::*,
+    Win32::Graphics::Direct3D12::*, Win32::Graphics::Dxgi::Common::*, Win32::Graphics::Dxgi::*,
+    Win32::System::LibraryLoader::*, Win32::System::Threading::*,
+    Win32::System::WindowsProgramming::*, Win32::UI::WindowsAndMessaging::*,
+};
 
 use std::mem::transmute;
 
@@ -64,7 +69,12 @@ where
     let atom = unsafe { RegisterClassExA(&wc) };
     debug_assert_ne!(atom, 0);
 
-    let mut window_rect = RECT { left: 0, top: 0, right: size.0, bottom: size.1 };
+    let mut window_rect = RECT {
+        left: 0,
+        top: 0,
+        right: size.0,
+        bottom: size.1,
+    };
     unsafe { AdjustWindowRect(&mut window_rect, WS_OVERLAPPEDWINDOW, false) };
 
     let mut title = sample.title();
@@ -132,7 +142,12 @@ fn sample_wndproc<S: DXSample>(sample: &mut S, message: u32, wparam: WPARAM) -> 
     }
 }
 
-extern "system" fn wndproc<S: DXSample>(window: HWND, message: u32, wparam: WPARAM, lparam: LPARAM) -> LRESULT {
+extern "system" fn wndproc<S: DXSample>(
+    window: HWND,
+    message: u32,
+    wparam: WPARAM,
+    lparam: LPARAM,
+) -> LRESULT {
     match message {
         WM_CREATE => {
             unsafe {
@@ -148,7 +163,9 @@ extern "system" fn wndproc<S: DXSample>(window: HWND, message: u32, wparam: WPAR
         _ => {
             let user_data = unsafe { GetWindowLongPtrA(window, GWLP_USERDATA) };
             let sample = std::ptr::NonNull::<S>::new(user_data as _);
-            let handled = sample.map_or(false, |mut s| sample_wndproc(unsafe { s.as_mut() }, message, wparam));
+            let handled = sample.map_or(false, |mut s| {
+                sample_wndproc(unsafe { s.as_mut() }, message, wparam)
+            });
 
             if handled {
                 LRESULT::default()
@@ -173,7 +190,15 @@ fn get_hardware_adapter(factory: &IDXGIFactory4) -> Result<IDXGIAdapter1> {
 
         // Check to see whether the adapter supports Direct3D 12, but don't
         // create the actual device yet.
-        if unsafe { D3D12CreateDevice(&adapter, D3D_FEATURE_LEVEL_11_0, std::ptr::null_mut::<Option<ID3D12Device>>()) }.is_ok() {
+        if unsafe {
+            D3D12CreateDevice(
+                &adapter,
+                D3D_FEATURE_LEVEL_11_0,
+                std::ptr::null_mut::<Option<ID3D12Device>>(),
+            )
+        }
+        .is_ok()
+        {
             return Ok(adapter);
         }
     }
@@ -221,11 +246,20 @@ mod d3d12_hello_triangle {
         fn new(command_line: &SampleCommandLine) -> Result<Self> {
             let (dxgi_factory, device) = create_device(command_line)?;
 
-            Ok(Sample { dxgi_factory, device, resources: None })
+            Ok(Sample {
+                dxgi_factory,
+                device,
+                resources: None,
+            })
         }
 
         fn bind_to_window(&mut self, hwnd: &HWND) -> Result<()> {
-            let command_queue: ID3D12CommandQueue = unsafe { self.device.CreateCommandQueue(&D3D12_COMMAND_QUEUE_DESC { Type: D3D12_COMMAND_LIST_TYPE_DIRECT, ..Default::default() })? };
+            let command_queue: ID3D12CommandQueue = unsafe {
+                self.device.CreateCommandQueue(&D3D12_COMMAND_QUEUE_DESC {
+                    Type: D3D12_COMMAND_LIST_TYPE_DIRECT,
+                    ..Default::default()
+                })?
+            };
 
             let (width, height) = self.window_size();
 
@@ -236,40 +270,94 @@ mod d3d12_hello_triangle {
                 Format: DXGI_FORMAT_R8G8B8A8_UNORM,
                 BufferUsage: DXGI_USAGE_RENDER_TARGET_OUTPUT,
                 SwapEffect: DXGI_SWAP_EFFECT_FLIP_DISCARD,
-                SampleDesc: DXGI_SAMPLE_DESC { Count: 1, ..Default::default() },
+                SampleDesc: DXGI_SAMPLE_DESC {
+                    Count: 1,
+                    ..Default::default()
+                },
                 ..Default::default()
             };
 
-            let swap_chain: IDXGISwapChain3 = unsafe { self.dxgi_factory.CreateSwapChainForHwnd(&command_queue, *hwnd, &swap_chain_desc, None, None)? }.cast()?;
+            let swap_chain: IDXGISwapChain3 = unsafe {
+                self.dxgi_factory.CreateSwapChainForHwnd(
+                    &command_queue,
+                    *hwnd,
+                    &swap_chain_desc,
+                    None,
+                    None,
+                )?
+            }
+            .cast()?;
 
             // This sample does not support fullscreen transitions
             unsafe {
-                self.dxgi_factory.MakeWindowAssociation(*hwnd, DXGI_MWA_NO_ALT_ENTER)?;
+                self.dxgi_factory
+                    .MakeWindowAssociation(*hwnd, DXGI_MWA_NO_ALT_ENTER)?;
             }
 
             let frame_index = unsafe { swap_chain.GetCurrentBackBufferIndex() };
 
-            let rtv_heap: ID3D12DescriptorHeap = unsafe { self.device.CreateDescriptorHeap(&D3D12_DESCRIPTOR_HEAP_DESC { NumDescriptors: FRAME_COUNT, Type: D3D12_DESCRIPTOR_HEAP_TYPE_RTV, ..Default::default() }) }?;
+            let rtv_heap: ID3D12DescriptorHeap = unsafe {
+                self.device
+                    .CreateDescriptorHeap(&D3D12_DESCRIPTOR_HEAP_DESC {
+                        NumDescriptors: FRAME_COUNT,
+                        Type: D3D12_DESCRIPTOR_HEAP_TYPE_RTV,
+                        ..Default::default()
+                    })
+            }?;
 
-            let rtv_descriptor_size = unsafe { self.device.GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV) } as usize;
+            let rtv_descriptor_size = unsafe {
+                self.device
+                    .GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV)
+            } as usize;
             let rtv_handle = unsafe { rtv_heap.GetCPUDescriptorHandleForHeapStart() };
 
-            let render_targets: [ID3D12Resource; FRAME_COUNT as usize] = array_init::try_array_init(|i: usize| -> Result<ID3D12Resource> {
-                let render_target: ID3D12Resource = unsafe { swap_chain.GetBuffer(i as u32) }?;
-                unsafe { self.device.CreateRenderTargetView(&render_target, None, D3D12_CPU_DESCRIPTOR_HANDLE { ptr: rtv_handle.ptr + i * rtv_descriptor_size }) };
-                Ok(render_target)
-            })?;
+            let render_targets: [ID3D12Resource; FRAME_COUNT as usize] =
+                array_init::try_array_init(|i: usize| -> Result<ID3D12Resource> {
+                    let render_target: ID3D12Resource = unsafe { swap_chain.GetBuffer(i as u32) }?;
+                    unsafe {
+                        self.device.CreateRenderTargetView(
+                            &render_target,
+                            None,
+                            D3D12_CPU_DESCRIPTOR_HANDLE {
+                                ptr: rtv_handle.ptr + i * rtv_descriptor_size,
+                            },
+                        )
+                    };
+                    Ok(render_target)
+                })?;
 
-            let viewport = D3D12_VIEWPORT { TopLeftX: 0.0, TopLeftY: 0.0, Width: width as f32, Height: height as f32, MinDepth: D3D12_MIN_DEPTH, MaxDepth: D3D12_MAX_DEPTH };
+            let viewport = D3D12_VIEWPORT {
+                TopLeftX: 0.0,
+                TopLeftY: 0.0,
+                Width: width as f32,
+                Height: height as f32,
+                MinDepth: D3D12_MIN_DEPTH,
+                MaxDepth: D3D12_MAX_DEPTH,
+            };
 
-            let scissor_rect = RECT { left: 0, top: 0, right: width, bottom: height };
+            let scissor_rect = RECT {
+                left: 0,
+                top: 0,
+                right: width,
+                bottom: height,
+            };
 
-            let command_allocator = unsafe { self.device.CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT) }?;
+            let command_allocator = unsafe {
+                self.device
+                    .CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT)
+            }?;
 
             let root_signature = create_root_signature(&self.device)?;
             let pso = create_pipeline_state(&self.device, &root_signature)?;
 
-            let command_list: ID3D12GraphicsCommandList = unsafe { self.device.CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, &command_allocator, &pso) }?;
+            let command_list: ID3D12GraphicsCommandList = unsafe {
+                self.device.CreateCommandList(
+                    0,
+                    D3D12_COMMAND_LIST_TYPE_DIRECT,
+                    &command_allocator,
+                    &pso,
+                )
+            }?;
             unsafe {
                 command_list.Close()?;
             };
@@ -321,7 +409,11 @@ mod d3d12_hello_triangle {
 
                 // Execute the command list.
                 let command_list = ID3D12CommandList::from(&resources.command_list);
-                unsafe { resources.command_queue.ExecuteCommandLists(&[Some(command_list)]) };
+                unsafe {
+                    resources
+                        .command_queue
+                        .ExecuteCommandLists(&[Some(command_list)])
+                };
 
                 // Present the frame.
                 unsafe { resources.swap_chain.Present(1, 0) }.ok().unwrap();
@@ -356,34 +448,58 @@ mod d3d12_hello_triangle {
         }
 
         // Indicate that the back buffer will be used as a render target.
-        let barrier = transition_barrier(&resources.render_targets[resources.frame_index as usize], D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET);
+        let barrier = transition_barrier(
+            &resources.render_targets[resources.frame_index as usize],
+            D3D12_RESOURCE_STATE_PRESENT,
+            D3D12_RESOURCE_STATE_RENDER_TARGET,
+        );
         unsafe { command_list.ResourceBarrier(&[barrier]) };
 
-        let rtv_handle = D3D12_CPU_DESCRIPTOR_HANDLE { ptr: unsafe { resources.rtv_heap.GetCPUDescriptorHandleForHeapStart() }.ptr + resources.frame_index as usize * resources.rtv_descriptor_size };
+        let rtv_handle = D3D12_CPU_DESCRIPTOR_HANDLE {
+            ptr: unsafe { resources.rtv_heap.GetCPUDescriptorHandleForHeapStart() }.ptr
+                + resources.frame_index as usize * resources.rtv_descriptor_size,
+        };
 
         unsafe { command_list.OMSetRenderTargets(1, Some(&rtv_handle), false, None) };
 
         // Record commands.
         unsafe {
             // TODO: workaround for https://github.com/microsoft/win32metadata/issues/1006
-            command_list.ClearRenderTargetView(rtv_handle, &*[0.0_f32, 0.2_f32, 0.4_f32, 1.0_f32].as_ptr(), &[]);
+            command_list.ClearRenderTargetView(
+                rtv_handle,
+                &*[0.0_f32, 0.2_f32, 0.4_f32, 1.0_f32].as_ptr(),
+                &[],
+            );
             command_list.IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
             command_list.IASetVertexBuffers(0, Some(&[resources.vbv]));
             command_list.DrawInstanced(3, 1, 0, 0);
 
             // Indicate that the back buffer will now be used to present.
-            command_list.ResourceBarrier(&[transition_barrier(&resources.render_targets[resources.frame_index as usize], D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT)]);
+            command_list.ResourceBarrier(&[transition_barrier(
+                &resources.render_targets[resources.frame_index as usize],
+                D3D12_RESOURCE_STATE_RENDER_TARGET,
+                D3D12_RESOURCE_STATE_PRESENT,
+            )]);
         }
 
         unsafe { command_list.Close() }
     }
 
-    fn transition_barrier(resource: &ID3D12Resource, state_before: D3D12_RESOURCE_STATES, state_after: D3D12_RESOURCE_STATES) -> D3D12_RESOURCE_BARRIER {
+    fn transition_barrier(
+        resource: &ID3D12Resource,
+        state_before: D3D12_RESOURCE_STATES,
+        state_after: D3D12_RESOURCE_STATES,
+    ) -> D3D12_RESOURCE_BARRIER {
         D3D12_RESOURCE_BARRIER {
             Type: D3D12_RESOURCE_BARRIER_TYPE_TRANSITION,
             Flags: D3D12_RESOURCE_BARRIER_FLAG_NONE,
             Anonymous: D3D12_RESOURCE_BARRIER_0 {
-                Transition: std::mem::ManuallyDrop::new(D3D12_RESOURCE_TRANSITION_BARRIER { pResource: Some(resource.clone()), StateBefore: state_before, StateAfter: state_after, Subresource: D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES }),
+                Transition: std::mem::ManuallyDrop::new(D3D12_RESOURCE_TRANSITION_BARRIER {
+                    pResource: Some(resource.clone()),
+                    StateBefore: state_before,
+                    StateAfter: state_after,
+                    Subresource: D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES,
+                }),
             },
         }
     }
@@ -398,11 +514,19 @@ mod d3d12_hello_triangle {
             }
         }
 
-        let dxgi_factory_flags = if cfg!(debug_assertions) { DXGI_CREATE_FACTORY_DEBUG } else { 0 };
+        let dxgi_factory_flags = if cfg!(debug_assertions) {
+            DXGI_CREATE_FACTORY_DEBUG
+        } else {
+            0
+        };
 
         let dxgi_factory: IDXGIFactory4 = unsafe { CreateDXGIFactory2(dxgi_factory_flags) }?;
 
-        let adapter = if command_line.use_warp_device { unsafe { dxgi_factory.EnumWarpAdapter() } } else { get_hardware_adapter(&dxgi_factory) }?;
+        let adapter = if command_line.use_warp_device {
+            unsafe { dxgi_factory.EnumWarpAdapter() }
+        } else {
+            get_hardware_adapter(&dxgi_factory)
+        }?;
 
         let mut device: Option<ID3D12Device> = None;
         unsafe { D3D12CreateDevice(&adapter, D3D_FEATURE_LEVEL_11_0, &mut device) }?;
@@ -410,17 +534,38 @@ mod d3d12_hello_triangle {
     }
 
     fn create_root_signature(device: &ID3D12Device) -> Result<ID3D12RootSignature> {
-        let desc = D3D12_ROOT_SIGNATURE_DESC { Flags: D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT, ..Default::default() };
+        let desc = D3D12_ROOT_SIGNATURE_DESC {
+            Flags: D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT,
+            ..Default::default()
+        };
 
         let mut signature = None;
 
-        let signature = unsafe { D3D12SerializeRootSignature(&desc, D3D_ROOT_SIGNATURE_VERSION_1, &mut signature, None) }.map(|()| signature.unwrap())?;
+        let signature = unsafe {
+            D3D12SerializeRootSignature(&desc, D3D_ROOT_SIGNATURE_VERSION_1, &mut signature, None)
+        }
+        .map(|()| signature.unwrap())?;
 
-        unsafe { device.CreateRootSignature(0, std::slice::from_raw_parts(signature.GetBufferPointer() as _, signature.GetBufferSize())) }
+        unsafe {
+            device.CreateRootSignature(
+                0,
+                std::slice::from_raw_parts(
+                    signature.GetBufferPointer() as _,
+                    signature.GetBufferSize(),
+                ),
+            )
+        }
     }
 
-    fn create_pipeline_state(device: &ID3D12Device, root_signature: &ID3D12RootSignature) -> Result<ID3D12PipelineState> {
-        let compile_flags = if cfg!(debug_assertions) { D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION } else { 0 };
+    fn create_pipeline_state(
+        device: &ID3D12Device,
+        root_signature: &ID3D12RootSignature,
+    ) -> Result<ID3D12PipelineState> {
+        let compile_flags = if cfg!(debug_assertions) {
+            D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION
+        } else {
+            0
+        };
 
         let exe_path = std::env::current_exe().ok().unwrap();
         let asset_path = exe_path.parent().unwrap();
@@ -429,10 +574,36 @@ mod d3d12_hello_triangle {
         let shaders_hlsl: HSTRING = shaders_hlsl.into();
 
         let mut vertex_shader = None;
-        let vertex_shader = unsafe { D3DCompileFromFile(&shaders_hlsl, None, None, s!("VSMain"), s!("vs_5_0"), compile_flags, 0, &mut vertex_shader, None) }.map(|()| vertex_shader.unwrap())?;
+        let vertex_shader = unsafe {
+            D3DCompileFromFile(
+                &shaders_hlsl,
+                None,
+                None,
+                s!("VSMain"),
+                s!("vs_5_0"),
+                compile_flags,
+                0,
+                &mut vertex_shader,
+                None,
+            )
+        }
+        .map(|()| vertex_shader.unwrap())?;
 
         let mut pixel_shader = None;
-        let pixel_shader = unsafe { D3DCompileFromFile(&shaders_hlsl, None, None, s!("PSMain"), s!("ps_5_0"), compile_flags, 0, &mut pixel_shader, None) }.map(|()| pixel_shader.unwrap())?;
+        let pixel_shader = unsafe {
+            D3DCompileFromFile(
+                &shaders_hlsl,
+                None,
+                None,
+                s!("PSMain"),
+                s!("ps_5_0"),
+                compile_flags,
+                0,
+                &mut pixel_shader,
+                None,
+            )
+        }
+        .map(|()| pixel_shader.unwrap())?;
 
         let mut input_element_descs: [D3D12_INPUT_ELEMENT_DESC; 2] = [
             D3D12_INPUT_ELEMENT_DESC {
@@ -456,11 +627,24 @@ mod d3d12_hello_triangle {
         ];
 
         let mut desc = D3D12_GRAPHICS_PIPELINE_STATE_DESC {
-            InputLayout: D3D12_INPUT_LAYOUT_DESC { pInputElementDescs: input_element_descs.as_mut_ptr(), NumElements: input_element_descs.len() as u32 },
+            InputLayout: D3D12_INPUT_LAYOUT_DESC {
+                pInputElementDescs: input_element_descs.as_mut_ptr(),
+                NumElements: input_element_descs.len() as u32,
+            },
             pRootSignature: Some(root_signature.clone()), // << https://github.com/microsoft/windows-rs/discussions/623
-            VS: D3D12_SHADER_BYTECODE { pShaderBytecode: unsafe { vertex_shader.GetBufferPointer() }, BytecodeLength: unsafe { vertex_shader.GetBufferSize() } },
-            PS: D3D12_SHADER_BYTECODE { pShaderBytecode: unsafe { pixel_shader.GetBufferPointer() }, BytecodeLength: unsafe { pixel_shader.GetBufferSize() } },
-            RasterizerState: D3D12_RASTERIZER_DESC { FillMode: D3D12_FILL_MODE_SOLID, CullMode: D3D12_CULL_MODE_NONE, ..Default::default() },
+            VS: D3D12_SHADER_BYTECODE {
+                pShaderBytecode: unsafe { vertex_shader.GetBufferPointer() },
+                BytecodeLength: unsafe { vertex_shader.GetBufferSize() },
+            },
+            PS: D3D12_SHADER_BYTECODE {
+                pShaderBytecode: unsafe { pixel_shader.GetBufferPointer() },
+                BytecodeLength: unsafe { pixel_shader.GetBufferSize() },
+            },
+            RasterizerState: D3D12_RASTERIZER_DESC {
+                FillMode: D3D12_FILL_MODE_SOLID,
+                CullMode: D3D12_CULL_MODE_NONE,
+                ..Default::default()
+            },
             BlendState: D3D12_BLEND_DESC {
                 AlphaToCoverageEnable: false.into(),
                 IndependentBlendEnable: false.into(),
@@ -490,7 +674,10 @@ mod d3d12_hello_triangle {
             SampleMask: u32::max_value(),
             PrimitiveTopologyType: D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE,
             NumRenderTargets: 1,
-            SampleDesc: DXGI_SAMPLE_DESC { Count: 1, ..Default::default() },
+            SampleDesc: DXGI_SAMPLE_DESC {
+                Count: 1,
+                ..Default::default()
+            },
             ..Default::default()
         };
         desc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
@@ -498,8 +685,24 @@ mod d3d12_hello_triangle {
         unsafe { device.CreateGraphicsPipelineState(&desc) }
     }
 
-    fn create_vertex_buffer(device: &ID3D12Device, aspect_ratio: f32) -> Result<(ID3D12Resource, D3D12_VERTEX_BUFFER_VIEW)> {
-        let vertices = [Vertex { position: [0.0, 0.25 * aspect_ratio, 0.0], color: [1.0, 0.0, 0.0, 1.0] }, Vertex { position: [0.25, -0.25 * aspect_ratio, 0.0], color: [0.0, 1.0, 0.0, 1.0] }, Vertex { position: [-0.25, -0.25 * aspect_ratio, 0.0], color: [0.0, 0.0, 1.0, 1.0] }];
+    fn create_vertex_buffer(
+        device: &ID3D12Device,
+        aspect_ratio: f32,
+    ) -> Result<(ID3D12Resource, D3D12_VERTEX_BUFFER_VIEW)> {
+        let vertices = [
+            Vertex {
+                position: [0.0, 0.25 * aspect_ratio, 0.0],
+                color: [1.0, 0.0, 0.0, 1.0],
+            },
+            Vertex {
+                position: [0.25, -0.25 * aspect_ratio, 0.0],
+                color: [0.0, 1.0, 0.0, 1.0],
+            },
+            Vertex {
+                position: [-0.25, -0.25 * aspect_ratio, 0.0],
+                color: [0.0, 0.0, 1.0, 1.0],
+            },
+        ];
 
         // Note: using upload heaps to transfer static data like vert buffers is
         // not recommended. Every time the GPU needs it, the upload heap will be
@@ -509,7 +712,10 @@ mod d3d12_hello_triangle {
         let mut vertex_buffer: Option<ID3D12Resource> = None;
         unsafe {
             device.CreateCommittedResource(
-                &D3D12_HEAP_PROPERTIES { Type: D3D12_HEAP_TYPE_UPLOAD, ..Default::default() },
+                &D3D12_HEAP_PROPERTIES {
+                    Type: D3D12_HEAP_TYPE_UPLOAD,
+                    ..Default::default()
+                },
                 D3D12_HEAP_FLAG_NONE,
                 &D3D12_RESOURCE_DESC {
                     Dimension: D3D12_RESOURCE_DIMENSION_BUFFER,
@@ -517,7 +723,10 @@ mod d3d12_hello_triangle {
                     Height: 1,
                     DepthOrArraySize: 1,
                     MipLevels: 1,
-                    SampleDesc: DXGI_SAMPLE_DESC { Count: 1, Quality: 0 },
+                    SampleDesc: DXGI_SAMPLE_DESC {
+                        Count: 1,
+                        Quality: 0,
+                    },
                     Layout: D3D12_TEXTURE_LAYOUT_ROW_MAJOR,
                     ..Default::default()
                 },
@@ -532,7 +741,11 @@ mod d3d12_hello_triangle {
         unsafe {
             let mut data = std::ptr::null_mut();
             vertex_buffer.Map(0, None, Some(&mut data))?;
-            std::ptr::copy_nonoverlapping(vertices.as_ptr(), data as *mut Vertex, std::mem::size_of_val(&vertices));
+            std::ptr::copy_nonoverlapping(
+                vertices.as_ptr(),
+                data as *mut Vertex,
+                std::mem::size_of_val(&vertices),
+            );
             vertex_buffer.Unmap(0, None);
         }
 
@@ -560,13 +773,21 @@ mod d3d12_hello_triangle {
         // Signal and increment the fence value.
         let fence = resources.fence_value;
 
-        unsafe { resources.command_queue.Signal(&resources.fence, fence) }.ok().unwrap();
+        unsafe { resources.command_queue.Signal(&resources.fence, fence) }
+            .ok()
+            .unwrap();
 
         resources.fence_value += 1;
 
         // Wait until the previous frame is finished.
         if unsafe { resources.fence.GetCompletedValue() } < fence {
-            unsafe { resources.fence.SetEventOnCompletion(fence, resources.fence_event) }.ok().unwrap();
+            unsafe {
+                resources
+                    .fence
+                    .SetEventOnCompletion(fence, resources.fence_event)
+            }
+            .ok()
+            .unwrap();
 
             unsafe { WaitForSingleObject(resources.fence_event, INFINITE) };
         }

--- a/crates/samples/ocr/src/main.rs
+++ b/crates/samples/ocr/src/main.rs
@@ -13,7 +13,8 @@ async fn main_async() -> Result<()> {
     let mut message = std::env::current_dir().unwrap();
     message.push("message.png");
 
-    let file = StorageFile::GetFileFromPathAsync(&HSTRING::from(message.to_str().unwrap()))?.await?;
+    let file =
+        StorageFile::GetFileFromPathAsync(&HSTRING::from(message.to_str().unwrap()))?.await?;
     let stream = file.OpenAsync(FileAccessMode::Read)?.await?;
 
     let decode = BitmapDecoder::CreateAsync(&stream)?.await?;

--- a/crates/samples/overlapped/src/main.rs
+++ b/crates/samples/overlapped/src/main.rs
@@ -1,4 +1,7 @@
-use windows::{core::*, Win32::Foundation::*, Win32::Storage::FileSystem::*, Win32::System::Threading::*, Win32::System::IO::*};
+use windows::{
+    core::*, Win32::Foundation::*, Win32::Storage::FileSystem::*, Win32::System::Threading::*,
+    Win32::System::IO::*,
+};
 
 fn main() -> Result<()> {
     unsafe {
@@ -7,10 +10,23 @@ fn main() -> Result<()> {
 
         let mut string = filename.as_path().to_str().unwrap().to_owned();
         string.push('\0');
-        let file = CreateFileA(PCSTR(string.as_ptr()), FILE_GENERIC_READ, FILE_SHARE_READ, None, OPEN_EXISTING, FILE_FLAG_OVERLAPPED, None)?;
+        let file = CreateFileA(
+            PCSTR(string.as_ptr()),
+            FILE_GENERIC_READ,
+            FILE_SHARE_READ,
+            None,
+            OPEN_EXISTING,
+            FILE_FLAG_OVERLAPPED,
+            None,
+        )?;
 
         let mut overlapped = OVERLAPPED {
-            Anonymous: OVERLAPPED_0 { Anonymous: OVERLAPPED_0_0 { Offset: 9, OffsetHigh: 0 } },
+            Anonymous: OVERLAPPED_0 {
+                Anonymous: OVERLAPPED_0_0 {
+                    Offset: 9,
+                    OffsetHigh: 0,
+                },
+            },
             hEvent: CreateEventA(None, true, false, None)?,
             Internal: 0,
             InternalHigh: 0,
@@ -18,7 +34,13 @@ fn main() -> Result<()> {
 
         let mut buffer: [u8; 12] = Default::default();
 
-        let read_ok = ReadFile(file, Some(buffer.as_mut_ptr() as _), buffer.len() as _, None, Some(&mut overlapped));
+        let read_ok = ReadFile(
+            file,
+            Some(buffer.as_mut_ptr() as _),
+            buffer.len() as _,
+            None,
+            Some(&mut overlapped),
+        );
 
         if !read_ok.as_bool() {
             assert_eq!(GetLastError(), ERROR_IO_PENDING);

--- a/crates/samples/readme.md
+++ b/crates/samples/readme.md
@@ -1,3 +1,5 @@
+Many of the samples were inspired or originally appeared in [my articles](https://kennykerr.ca/articles/) and [courses on Pluralsight](https://kennykerr.ca/courses/). 
+
 The samples in the repo compile with the latest, usually pre-release, version of the `windows` or `windows-sys` crate. 
 To find the samples for a particular release you can use a specific release tag. For example:
 

--- a/crates/samples/rustfmt.toml
+++ b/crates/samples/rustfmt.toml
@@ -1,0 +1,1 @@
+newline_style = "Unix"

--- a/crates/samples/spellchecker/src/main.rs
+++ b/crates/samples/spellchecker/src/main.rs
@@ -1,14 +1,17 @@
 use windows::{core::*, Win32::Globalization::*, Win32::System::Com::*};
 
 fn main() -> Result<()> {
-    let input = std::env::args().nth(1).expect("Expected one command line argument for text to be spell-corrected");
+    let input = std::env::args()
+        .nth(1)
+        .expect("Expected one command line argument for text to be spell-corrected");
     // Initialize the COM runtime for this thread
     unsafe {
         CoInitializeEx(None, COINIT_MULTITHREADED)?;
     }
 
     // Create ISpellCheckerFactory
-    let factory: ISpellCheckerFactory = unsafe { CoCreateInstance(&SpellCheckerFactory, None, CLSCTX_ALL)? };
+    let factory: ISpellCheckerFactory =
+        unsafe { CoCreateInstance(&SpellCheckerFactory, None, CLSCTX_ALL)? };
 
     // Make sure that the "en-US" locale is supported
     let locale = w!("en-US");
@@ -43,7 +46,9 @@ fn main() -> Result<()> {
                 // Get the replacement as a widestring and convert to a Rust String
                 let replacement = unsafe { error.Replacement()? };
 
-                println!("Replace: {substring} with {}", unsafe { replacement.display() });
+                println!("Replace: {substring} with {}", unsafe {
+                    replacement.display()
+                });
 
                 unsafe { CoTaskMemFree(Some(replacement.as_ptr() as *mut _)) };
             }
@@ -62,7 +67,9 @@ fn main() -> Result<()> {
                         break;
                     }
 
-                    println!("Maybe replace: {substring} with {}", unsafe { suggestion[0].display() });
+                    println!("Maybe replace: {substring} with {}", unsafe {
+                        suggestion[0].display()
+                    });
 
                     unsafe { CoTaskMemFree(Some(suggestion[0].as_ptr() as *mut _)) };
                 }

--- a/crates/samples/uiautomation/src/main.rs
+++ b/crates/samples/uiautomation/src/main.rs
@@ -1,4 +1,7 @@
-use windows::{core::*, Win32::System::Com::*, Win32::UI::Accessibility::*, Win32::UI::WindowsAndMessaging::*, UI::UIAutomation::*};
+use windows::{
+    core::*, Win32::System::Com::*, Win32::UI::Accessibility::*, Win32::UI::WindowsAndMessaging::*,
+    UI::UIAutomation::*,
+};
 
 fn main() -> Result<()> {
     unsafe {

--- a/crates/samples/wmi/src/main.rs
+++ b/crates/samples/wmi/src/main.rs
@@ -1,16 +1,42 @@
-use windows::{core::*, Win32::Security::*, Win32::System::Com::*, Win32::System::Ole::*, Win32::System::Wmi::*};
+use windows::{
+    core::*, Win32::Security::*, Win32::System::Com::*, Win32::System::Ole::*,
+    Win32::System::Wmi::*,
+};
 
 fn main() -> Result<()> {
     unsafe {
         CoInitializeEx(None, COINIT_MULTITHREADED)?;
 
-        CoInitializeSecurity(PSECURITY_DESCRIPTOR::default(), -1, None, None, RPC_C_AUTHN_LEVEL_DEFAULT, RPC_C_IMP_LEVEL_IMPERSONATE, None, EOAC_NONE, None)?;
+        CoInitializeSecurity(
+            PSECURITY_DESCRIPTOR::default(),
+            -1,
+            None,
+            None,
+            RPC_C_AUTHN_LEVEL_DEFAULT,
+            RPC_C_IMP_LEVEL_IMPERSONATE,
+            None,
+            EOAC_NONE,
+            None,
+        )?;
 
         let locator: IWbemLocator = CoCreateInstance(&WbemLocator, None, CLSCTX_INPROC_SERVER)?;
 
-        let server = locator.ConnectServer(&BSTR::from("root\\cimv2"), &BSTR::new(), &BSTR::new(), &BSTR::new(), 0, &BSTR::new(), None)?;
+        let server = locator.ConnectServer(
+            &BSTR::from("root\\cimv2"),
+            &BSTR::new(),
+            &BSTR::new(),
+            &BSTR::new(),
+            0,
+            &BSTR::new(),
+            None,
+        )?;
 
-        let query = server.ExecQuery(&BSTR::from("WQL"), &BSTR::from("select Caption from Win32_LogicalDisk"), WBEM_FLAG_FORWARD_ONLY | WBEM_FLAG_RETURN_IMMEDIATELY, None)?;
+        let query = server.ExecQuery(
+            &BSTR::from("WQL"),
+            &BSTR::from("select Caption from Win32_LogicalDisk"),
+            WBEM_FLAG_FORWARD_ONLY | WBEM_FLAG_RETURN_IMMEDIATELY,
+            None,
+        )?;
 
         loop {
             let mut row = [None; 1];
@@ -19,8 +45,23 @@ fn main() -> Result<()> {
 
             if let Some(row) = &row[0] {
                 let mut value = Default::default();
-                row.Get(w!("Caption"), 0, &mut value, std::ptr::null_mut(), std::ptr::null_mut())?;
-                println!("{}", VarFormat(&value, None, VARFORMAT_FIRST_DAY_SYSTEMDEFAULT, VARFORMAT_FIRST_WEEK_SYSTEMDEFAULT, 0)?);
+                row.Get(
+                    w!("Caption"),
+                    0,
+                    &mut value,
+                    std::ptr::null_mut(),
+                    std::ptr::null_mut(),
+                )?;
+                println!(
+                    "{}",
+                    VarFormat(
+                        &value,
+                        None,
+                        VARFORMAT_FIRST_DAY_SYSTEMDEFAULT,
+                        VARFORMAT_FIRST_WEEK_SYSTEMDEFAULT,
+                        0
+                    )?
+                );
 
                 // TODO: workaround for https://github.com/microsoft/windows-rs/issues/539
                 VariantClear(&mut value)?;


### PR DESCRIPTION
This repo uses a very long line width to improve crate compression, but it does make the code a little harder to read. This update just tweaks the line width for samples to improve readability. 