### PR TITLE
Don't require files for reading/writing

### DIFF
--- a/crates/libs/metadata/src/reader/file.rs
+++ b/crates/libs/metadata/src/reader/file.rs
@@ -55,7 +55,14 @@ impl File {
     pub fn new(path: &str) -> Result<Self> {
         let path = std::path::Path::new(path);
 
-        let mut result = File { bytes: std::fs::read(path)?, ..Default::default() };
+        let buffer = std::fs::read(&path)?;
+        let name = path.file_name().unwrap().to_string_lossy().into_owned();
+
+        Self::from_buffer(buffer, name)
+    }
+
+    pub fn from_buffer(buffer: Vec<u8>, name: String) -> Result<Self> {
+        let mut result = File { bytes: buffer, name, ..Default::default() };
 
         let dos = result.bytes.view_as::<IMAGE_DOS_HEADER>(0);
 
@@ -312,8 +319,6 @@ impl File {
         result.tables[TABLE_NESTEDCLASS].set_data(&mut view);
         result.tables[TABLE_GENERICPARAM].set_data(&mut view);
 
-        // Since the file was read successfully, we just assume it has a valid file name.
-        result.name = path.file_name().unwrap().to_string_lossy().to_string();
         Ok(result)
     }
 

--- a/crates/libs/metadata/src/reader/file.rs
+++ b/crates/libs/metadata/src/reader/file.rs
@@ -55,7 +55,7 @@ impl File {
     pub fn new(path: &str) -> Result<Self> {
         let path = std::path::Path::new(path);
 
-        let buffer = std::fs::read(&path)?;
+        let buffer = std::fs::read(path)?;
         let name = path.file_name().unwrap().to_string_lossy().into_owned();
 
         Self::from_buffer(buffer, name)

--- a/crates/libs/metadata/src/writer/file.rs
+++ b/crates/libs/metadata/src/writer/file.rs
@@ -1,6 +1,11 @@
 use super::*;
 
 pub fn write(filename: &str, tables: Tables) {
+    let buffer = write_to_buffer(tables);
+    std::fs::write(filename, buffer).unwrap();
+}
+
+pub fn write_to_buffer(tables: Tables) -> Vec<u8> {
     let mut dos: IMAGE_DOS_HEADER = unsafe { zeroed() };
     dos.e_magic = IMAGE_DOS_SIGNATURE as _;
     dos.e_lfarlc = 64;
@@ -108,7 +113,7 @@ pub fn write(filename: &str, tables: Tables) {
     assert_eq!(clr.MetaData.Size as usize, buffer.len() - metadata_offset);
     assert_eq!(size_of_image, buffer.len());
 
-    std::fs::write(filename, buffer).unwrap();
+    buffer
 }
 
 const SECTION_ALIGNMENT: u32 = 4096;


### PR DESCRIPTION
The reader/writer implementations in `windows-metadata` only supported reading/writing directly to files, which makes them cumbersome to use if you want to do anything with buffers before/after reading or writing (eg compression), this just adds a `windows_metdata::reader::Reader::from_buffer` and `windows_metadata::writer::file::write_to_buffer` method/function to not require a file on disk.