### PR TITLE
Remove unsafe conversion for PCWSTR

### DIFF
--- a/crates/libs/windows/src/core/strings/pcwstr.rs
+++ b/crates/libs/windows/src/core/strings/pcwstr.rs
@@ -59,12 +59,6 @@ unsafe impl Abi for PCWSTR {
     type Abi = Self;
 }
 
-impl From<&HSTRING> for PCWSTR {
-    fn from(hstring: &HSTRING) -> Self {
-        Self(hstring.as_ptr())
-    }
-}
-
 // This just ensures that `None` can be used for optional PCWSTR parameters, which can be quite common
 // with some Windows APIs.
 impl From<Option<PCWSTR>> for PCWSTR {


### PR DESCRIPTION
As @michaelwoerister pointed out this conversion, while safe, makes it *very* easy to write incorrect code. I think we should avoid such code.

Here's an example of some code that uses safe Rust but creates a dangling pointer:

```rust
fn create_dangling_pcwstr_pointer() -> PCWSTR {
    let s = HSTRING::from("abc");
    PCWSTR::from(&s)
}
```