### PR TITLE
Test `DEVMODEA`/`DEVMODEW` struct sizes are correct

### DIFF
--- a/crates/tests/metadata/Cargo.toml
+++ b/crates/tests/metadata/Cargo.toml
@@ -6,3 +6,19 @@ edition = "2018"
 
 [dependencies]
 metadata = { package = "windows-metadata", path = "../../libs/metadata" }
+
+[dependencies.windows]
+path = "../../libs/windows"
+features = [
+    "Win32_Graphics_Gdi",
+    "Win32_System_SystemServices",
+    "Win32_Foundation",
+]
+
+[dependencies.windows-sys]
+path = "../../libs/sys"
+features = [
+    "Win32_Graphics_Gdi",
+    "Win32_System_SystemServices",
+    "Win32_Foundation",
+]

--- a/crates/tests/metadata/tests/struct_size.rs
+++ b/crates/tests/metadata/tests/struct_size.rs
@@ -1,0 +1,15 @@
+#[test]
+fn test_windows() {
+    use windows::Win32::Graphics::Gdi::*;
+
+    assert_eq!(156, std::mem::size_of::<DEVMODEA>());
+    assert_eq!(220, std::mem::size_of::<DEVMODEW>());
+}
+
+#[test]
+fn test_sys() {
+    use windows_sys::Win32::Graphics::Gdi::*;
+
+    assert_eq!(156, std::mem::size_of::<DEVMODEA>());
+    assert_eq!(220, std::mem::size_of::<DEVMODEW>());
+}


### PR DESCRIPTION
Since this was a regression in the win32 metadata and these structs are pretty complex, I thought it prudent to add a test to avoid further surprises. 

Fixes #2138