### PR TITLE
Simplify yml generation

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -32,13 +32,6 @@ jobs:
             >> $env:GITHUB_ENV
       - name: Run cargo clippy
         run: |
-          cargo clippy -p windows-bindgen &&
-          cargo clippy -p windows-implement &&
-          cargo clippy -p windows-interface &&
-          cargo clippy -p windows-metadata &&
-          cargo clippy -p windows-sys &&
-          cargo clippy -p windows-tokens &&
-          cargo clippy -p windows &&
           cargo clippy -p sample_com_uri &&
           cargo clippy -p sample_consent &&
           cargo clippy -p sample_core_app &&
@@ -64,13 +57,6 @@ jobs:
           cargo clippy -p sample_uiautomation &&
           cargo clippy -p sample_wmi &&
           cargo clippy -p sample_xml &&
-          cargo clippy -p windows_aarch64_gnullvm &&
-          cargo clippy -p windows_aarch64_msvc &&
-          cargo clippy -p windows_i686_gnu &&
-          cargo clippy -p windows_i686_msvc &&
-          cargo clippy -p windows_x86_64_gnu &&
-          cargo clippy -p windows_x86_64_gnullvm &&
-          cargo clippy -p windows_x86_64_msvc &&
           cargo clippy -p test_agile &&
           cargo clippy -p test_agile_reference &&
           cargo clippy -p test_alternate_success_code &&
@@ -125,4 +111,18 @@ jobs:
           cargo clippy -p tool_sys &&
           cargo clippy -p tool_windows &&
           cargo clippy -p tool_yml &&
+          cargo clippy -p windows &&
+          cargo clippy -p windows-bindgen &&
+          cargo clippy -p windows-implement &&
+          cargo clippy -p windows-interface &&
+          cargo clippy -p windows-metadata &&
+          cargo clippy -p windows-sys &&
+          cargo clippy -p windows-tokens &&
+          cargo clippy -p windows_aarch64_gnullvm &&
+          cargo clippy -p windows_aarch64_msvc &&
+          cargo clippy -p windows_i686_gnu &&
+          cargo clippy -p windows_i686_msvc &&
+          cargo clippy -p windows_x86_64_gnu &&
+          cargo clippy -p windows_x86_64_gnullvm &&
+          cargo clippy -p windows_x86_64_msvc &&
           cargo clippy -p test_debugger_visualizer

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -71,6 +71,7 @@ jobs:
           cargo clippy -p test_const_fields &&
           cargo clippy -p test_core &&
           cargo clippy -p test_debug &&
+          cargo clippy -p test_debugger_visualizer_x &&
           cargo clippy -p test_deprecated &&
           cargo clippy -p test_dispatch &&
           cargo clippy -p test_does_not_return &&
@@ -124,5 +125,4 @@ jobs:
           cargo clippy -p windows_i686_msvc &&
           cargo clippy -p windows_x86_64_gnu &&
           cargo clippy -p windows_x86_64_gnullvm &&
-          cargo clippy -p windows_x86_64_msvc &&
-          cargo clippy -p test_debugger_visualizer
+          cargo clippy -p windows_x86_64_msvc

--- a/.github/workflows/debugger_visualizer.yml
+++ b/.github/workflows/debugger_visualizer.yml
@@ -1,0 +1,31 @@
+name: debugger_visualizer
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+env:
+  RUSTFLAGS: -Dwarnings
+
+jobs:
+  test:
+    name: Test
+    runs-on: windows-2019
+
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-pc-windows-msvc
+          - target: i686-pc-windows-msvc
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Update toolchain
+        run: rustup update --no-self-update nightly && rustup default nightly-${{ matrix.target }}
+      - name: Add toolchain target
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Test
+        run: cargo test -p test_debugger_visualizer_x -- --test-threads=1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -177,10 +177,6 @@ jobs:
           cargo test --target ${{ matrix.target }} -p windows_x86_64_gnullvm &&
           cargo test --target ${{ matrix.target }} -p windows_x86_64_msvc
 
-      - name: Test debugger_visualizer feature
-        run: cargo test --target ${{ matrix.target }} -p test_debugger_visualizer -- --test-threads=1
-        if: matrix.version == 'nightly' && endsWith(matrix.target, '-msvc')
-
       - name: Check import libs
         shell: pwsh
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,13 +82,6 @@ jobs:
           }
       - name: Test
         run: >
-          cargo test --target ${{ matrix.target }} -p windows-bindgen &&
-          cargo test --target ${{ matrix.target }} -p windows-implement &&
-          cargo test --target ${{ matrix.target }} -p windows-interface &&
-          cargo test --target ${{ matrix.target }} -p windows-metadata &&
-          cargo test --target ${{ matrix.target }} -p windows-sys &&
-          cargo test --target ${{ matrix.target }} -p windows-tokens &&
-          cargo test --target ${{ matrix.target }} -p windows &&
           cargo test --target ${{ matrix.target }} -p sample_com_uri &&
           cargo test --target ${{ matrix.target }} -p sample_consent &&
           cargo test --target ${{ matrix.target }} -p sample_core_app &&
@@ -114,13 +107,6 @@ jobs:
           cargo test --target ${{ matrix.target }} -p sample_uiautomation &&
           cargo test --target ${{ matrix.target }} -p sample_wmi &&
           cargo test --target ${{ matrix.target }} -p sample_xml &&
-          cargo test --target ${{ matrix.target }} -p windows_aarch64_gnullvm &&
-          cargo test --target ${{ matrix.target }} -p windows_aarch64_msvc &&
-          cargo test --target ${{ matrix.target }} -p windows_i686_gnu &&
-          cargo test --target ${{ matrix.target }} -p windows_i686_msvc &&
-          cargo test --target ${{ matrix.target }} -p windows_x86_64_gnu &&
-          cargo test --target ${{ matrix.target }} -p windows_x86_64_gnullvm &&
-          cargo test --target ${{ matrix.target }} -p windows_x86_64_msvc &&
           cargo test --target ${{ matrix.target }} -p test_agile &&
           cargo test --target ${{ matrix.target }} -p test_agile_reference &&
           cargo test --target ${{ matrix.target }} -p test_alternate_success_code &&
@@ -128,7 +114,6 @@ jobs:
           cargo test --target ${{ matrix.target }} -p test_arch_feature &&
           cargo test --target ${{ matrix.target }} -p test_bcrypt &&
           cargo test --target ${{ matrix.target }} -p test_bstr &&
-          cargo clean &&
           cargo test --target ${{ matrix.target }} -p test_calling_convention &&
           cargo test --target ${{ matrix.target }} -p test_cfg_generic &&
           cargo test --target ${{ matrix.target }} -p test_component &&
@@ -143,6 +128,7 @@ jobs:
           cargo test --target ${{ matrix.target }} -p test_error &&
           cargo test --target ${{ matrix.target }} -p test_event &&
           cargo test --target ${{ matrix.target }} -p test_extensions &&
+          cargo clean &&
           cargo test --target ${{ matrix.target }} -p test_handles &&
           cargo test --target ${{ matrix.target }} -p test_helpers &&
           cargo test --target ${{ matrix.target }} -p test_implement &&
@@ -175,7 +161,21 @@ jobs:
           cargo test --target ${{ matrix.target }} -p tool_msvc &&
           cargo test --target ${{ matrix.target }} -p tool_sys &&
           cargo test --target ${{ matrix.target }} -p tool_windows &&
-          cargo test --target ${{ matrix.target }} -p tool_yml
+          cargo test --target ${{ matrix.target }} -p tool_yml &&
+          cargo test --target ${{ matrix.target }} -p windows &&
+          cargo test --target ${{ matrix.target }} -p windows-bindgen &&
+          cargo test --target ${{ matrix.target }} -p windows-implement &&
+          cargo test --target ${{ matrix.target }} -p windows-interface &&
+          cargo test --target ${{ matrix.target }} -p windows-metadata &&
+          cargo test --target ${{ matrix.target }} -p windows-sys &&
+          cargo test --target ${{ matrix.target }} -p windows-tokens &&
+          cargo test --target ${{ matrix.target }} -p windows_aarch64_gnullvm &&
+          cargo test --target ${{ matrix.target }} -p windows_aarch64_msvc &&
+          cargo test --target ${{ matrix.target }} -p windows_i686_gnu &&
+          cargo test --target ${{ matrix.target }} -p windows_i686_msvc &&
+          cargo test --target ${{ matrix.target }} -p windows_x86_64_gnu &&
+          cargo test --target ${{ matrix.target }} -p windows_x86_64_gnullvm &&
+          cargo test --target ${{ matrix.target }} -p windows_x86_64_msvc
 
       - name: Test debugger_visualizer feature
         run: cargo test --target ${{ matrix.target }} -p test_debugger_visualizer -- --test-threads=1

--- a/crates/tests/debugger_visualizer/Cargo.toml
+++ b/crates/tests/debugger_visualizer/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "test_debugger_visualizer"
+name = "test_debugger_visualizer_x"
 version = "0.0.0"
 authors = ["Microsoft"]
 edition = "2018"

--- a/crates/tools/yml/Cargo.toml
+++ b/crates/tools/yml/Cargo.toml
@@ -6,3 +6,4 @@ publish = false
 
 [dependencies]
 metadata = { package = "windows-metadata", path = "../../libs/metadata" }
+regex = "1.7.0"


### PR DESCRIPTION
The current yml generator depends on the directory structure to infer the names of the crates. This update avoids this dependency by using regex to read the crate names directly. Crates that need custom testing can be excluded by using the `_x` suffix as is the case for `debugger_visualizer`. 