### PR TITLE
Improve samples and tests for validating calling conventions

### DIFF
--- a/crates/samples/dcomp/Cargo.toml
+++ b/crates/samples/dcomp/Cargo.toml
@@ -27,4 +27,5 @@ features = [
     "Win32_UI_Animation",
     "Win32_UI_HiDpi",
     "Win32_UI_WindowsAndMessaging",
+    "Win32_UI_Shell",
 ]

--- a/crates/samples/dcomp/src/main.rs
+++ b/crates/samples/dcomp/src/main.rs
@@ -6,7 +6,7 @@ use windows::{
         Graphics::Direct3D11::*, Graphics::DirectComposition::*, Graphics::DirectWrite::*,
         Graphics::Dxgi::Common::*, Graphics::Dxgi::*, Graphics::Gdi::*, Graphics::Imaging::D2D::*,
         Graphics::Imaging::*, System::Com::*, System::LibraryLoader::*, System::SystemServices::*,
-        UI::Animation::*, UI::HiDpi::*, UI::WindowsAndMessaging::*,
+        UI::Animation::*, UI::HiDpi::*, UI::Shell::*, UI::WindowsAndMessaging::*,
     },
 };
 
@@ -513,8 +513,15 @@ fn create_image() -> Result<IWICFormatConverter> {
         let factory: IWICImagingFactory2 =
             CoCreateInstance(&CLSID_WICImagingFactory, None, CLSCTX_INPROC_SERVER)?;
 
+        // Just a little hack to make it simpler to run the sample from the root of the workspace.
+        let path = if PathFileExistsW(w!("image.jpg")).into() {
+            w!("image.jpg")
+        } else {
+            w!("crates/samples/dcomp/image.jpg")
+        };
+
         let decoder = factory.CreateDecoderFromFilename(
-            w!("image.jpg"),
+            path,
             None,
             GENERIC_READ,
             WICDecodeMetadataCacheOnDemand,

--- a/crates/samples/message_box/Cargo.toml
+++ b/crates/samples/message_box/Cargo.toml
@@ -8,4 +8,5 @@ path = "../../libs/windows"
 features = [
     "Win32_Foundation",
     "Win32_UI_WindowsAndMessaging",
+    "Win32_UI_Shell",
 ]

--- a/crates/samples/message_box/src/main.rs
+++ b/crates/samples/message_box/src/main.rs
@@ -1,10 +1,8 @@
-use windows::core::*;
-use windows::Win32::UI::WindowsAndMessaging::*;
+use windows::{core::*, Win32::UI::Shell::*, Win32::UI::WindowsAndMessaging::*};
 
 fn main() {
     unsafe {
         MessageBoxA(None, s!("Ansi"), s!("World"), MB_OK);
-        MessageBoxW(None, w!("Wide"), w!("World"), MB_OK);
-        MessageBoxW(None, h!("WinRT"), h!("World"), MB_OK);
+        ShellMessageBoxW(None, None, w!("Wide"), w!("World"), MB_ICONERROR.0);
     }
 }

--- a/crates/samples/message_box_sys/Cargo.toml
+++ b/crates/samples/message_box_sys/Cargo.toml
@@ -8,4 +8,5 @@ path = "../../libs/sys"
 features = [
     "Win32_Foundation",
     "Win32_UI_WindowsAndMessaging",
+    "Win32_UI_Shell",
 ]

--- a/crates/samples/message_box_sys/src/main.rs
+++ b/crates/samples/message_box_sys/src/main.rs
@@ -1,8 +1,8 @@
-use windows_sys::{core::*, Win32::UI::WindowsAndMessaging::*};
+use windows_sys::{core::*, Win32::UI::Shell::*, Win32::UI::WindowsAndMessaging::*};
 
 fn main() {
     unsafe {
         MessageBoxA(0, s!("Ansi"), s!("World"), MB_OK);
-        MessageBoxW(0, w!("Wide"), w!("World"), MB_OK);
+        ShellMessageBoxW(0, 0, w!("Wide"), w!("World"), MB_ICONERROR);
     }
 }

--- a/crates/tests/calling_convention/Cargo.toml
+++ b/crates/tests/calling_convention/Cargo.toml
@@ -9,6 +9,7 @@ path = "../../libs/windows"
 features = [
     "Win32_Foundation",
     "Win32_Networking_Ldap",
+    "Win32_System_SystemInformation",
 ]
 
 [dependencies.windows-sys]
@@ -16,4 +17,5 @@ path = "../../libs/sys"
 features = [
     "Win32_Foundation",
     "Win32_Networking_Ldap",
+    "Win32_System_SystemInformation",
 ]

--- a/crates/tests/calling_convention/tests/sys.rs
+++ b/crates/tests/calling_convention/tests/sys.rs
@@ -1,8 +1,12 @@
-use windows_sys::{Win32::Foundation::*, Win32::Networking::Ldap::*};
+use windows_sys::{Win32::Foundation::*, Win32::Networking::Ldap::*, Win32::System::SystemInformation::*};
 
 #[test]
-fn test() {
+fn calling_convention() {
     unsafe {
+        // This function requires cdecl on x86.
         assert_eq!(ERROR_BUSY, LdapMapErrorToWin32(LDAP_BUSY));
+
+        // This function requires stdcall on x86.
+        GetTickCount();
     }
 }

--- a/crates/tests/calling_convention/tests/win.rs
+++ b/crates/tests/calling_convention/tests/win.rs
@@ -1,8 +1,12 @@
-use windows::{Win32::Foundation::*, Win32::Networking::Ldap::*};
+use windows::{Win32::Foundation::*, Win32::Networking::Ldap::*, Win32::System::SystemInformation::*};
 
 #[test]
-fn test() {
+fn calling_convention() {
     unsafe {
+        // This function requires cdecl on x86.
         assert_eq!(ERROR_BUSY, LdapMapErrorToWin32(LDAP_BUSY));
+
+        // This function requires stdcall on x86.
+        GetTickCount();
     }
 }


### PR DESCRIPTION
Just a few tweaks to improve coverage of `cdecl` and `stdcall` APIs in tests and samples. 