### PR TITLE
Switch debugger visualizer from crate feature to build option

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,4 @@
+[build]
+rustflags = [
+    # "--cfg", "windows_debugger_visualizer",
+]

--- a/.github/workflows/debugger_visualizer.yml
+++ b/.github/workflows/debugger_visualizer.yml
@@ -7,7 +7,7 @@ on:
       - master
 
 env:
-  RUSTFLAGS: -Dwarnings
+  RUSTFLAGS: -Dwarnings --cfg windows_debugger_visualizer
 
 jobs:
   test:

--- a/crates/libs/windows/Cargo.toml
+++ b/crates/libs/windows/Cargo.toml
@@ -689,7 +689,3 @@ Win32_UI_WindowsAndMessaging = ["Win32_UI"]
 Win32_UI_Wpf = ["Win32_UI"]
 Win32_UI_Xaml = ["Win32_UI"]
 Win32_UI_Xaml_Diagnostics = ["Win32_UI_Xaml"]
-
-# These features are unstable and require Rust nightly:
-debugger_visualizer = []
-

--- a/crates/libs/windows/src/lib.rs
+++ b/crates/libs/windows/src/lib.rs
@@ -4,7 +4,7 @@ Learn more about Rust for Windows here: <https://github.com/microsoft/windows-rs
 
 #![doc(html_no_source)]
 #![allow(non_snake_case, clashing_extern_declarations)]
-#![cfg_attr(feature = "debugger_visualizer", feature(debugger_visualizer), debugger_visualizer(natvis_file = "../windows.natvis"))]
+#![cfg_attr(windows_debugger_visualizer, feature(debugger_visualizer), debugger_visualizer(natvis_file = "../windows.natvis"))]
 
 extern crate self as windows;
 mod Windows;

--- a/crates/tests/debugger_visualizer/Cargo.toml
+++ b/crates/tests/debugger_visualizer/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 [dependencies.windows]
 path = "../../libs/windows"
 features = [
-    "debugger_visualizer",
     "implement",
     "Win32_System_Com",
     "Win32_Foundation",

--- a/crates/tools/windows/src/main.rs
+++ b/crates/tools/windows/src/main.rs
@@ -81,16 +81,6 @@ interface = ["windows-interface"]
         }
     }
 
-    file.write_all(
-        r#"
-# These features are unstable and require Rust nightly:
-debugger_visualizer = []
-
-"#
-        .as_bytes(),
-    )
-    .unwrap();
-
     std::fs::copy("license-mit", "crates/libs/windows/license-mit").unwrap();
     std::fs::copy("license-apache-2.0", "crates/libs/windows/license-apache-2.0").unwrap();
 }


### PR DESCRIPTION
As [suggested here](https://github.com/microsoft/windows-rs/pull/2149#discussion_r1019678713), I'm switching nightly features and features that might change behavior from using crate features to using build cfg options. First up is the debugger_visualizer support. 

cc @ridwanabdillahi