### PR TITLE
Streamline delay load core implementation

### DIFF
--- a/crates/libs/windows/src/core/bindings.rs
+++ b/crates/libs/windows/src/core/bindings.rs
@@ -13,9 +13,6 @@ link!("oleaut32.dll" "system" fn GetErrorInfo(reserved: u32, info: *mut *mut c_v
 link!("oleaut32.dll" "system" fn SetErrorInfo(reserved: u32, info: *const c_void) -> HRESULT);
 link!("kernel32.dll" "system" fn EncodePointer(ptr: *const c_void) -> *mut c_void);
 link!("kernel32.dll" "system" fn FormatMessageW(flags: u32, source: *const c_void, code: u32, lang: u32, buffer: PWSTR, len: u32, args: *const *const i8) -> u32);
-link!("kernel32.dll" "system" fn FreeLibrary(library: isize) -> i32);
-link!("kernel32.dll" "system" fn GetProcAddress(library: isize, name: PCSTR) -> *const c_void);
-link!("kernel32.dll" "system" fn LoadLibraryA(name: PCSTR) -> isize);
 link!("kernel32.dll" "system" fn GetProcessHeap() -> isize);
 link!("kernel32.dll" "system" fn HeapAlloc(heap: isize, flags: u32, len: usize) -> *mut c_void);
 link!("kernel32.dll" "system" fn HeapFree(heap: isize, flags: u32, ptr: *const c_void) -> i32);

--- a/crates/libs/windows/src/core/error.rs
+++ b/crates/libs/windows/src/core/error.rs
@@ -16,8 +16,7 @@ impl Error {
     /// point of failure.
     pub fn new(code: HRESULT, message: HSTRING) -> Self {
         unsafe {
-            if let Ok(function) = delay_load(s!("combase.dll"), s!("RoOriginateError")) {
-                let function: RoOriginateError = std::mem::transmute(function);
+            if let Some(function) = delay_load::<RoOriginateError>(s!("combase.dll"), s!("RoOriginateError")) {
                 function(code, std::mem::transmute_copy(&message));
             }
             let info = GetErrorInfo().and_then(|e| e.cast()).ok();

--- a/crates/libs/windows/src/core/factory_cache.rs
+++ b/crates/libs/windows/src/core/factory_cache.rs
@@ -53,16 +53,14 @@ pub fn factory<C: RuntimeName, I: Interface>() -> Result<I> {
     let mut factory: Option<I> = None;
     let name = HSTRING::from(C::NAME);
 
-    let code = if let Ok(function) = unsafe { delay_load(s!("combase.dll"), s!("RoGetActivationFactory")) } {
+    let code = if let Some(function) = unsafe { delay_load::<RoGetActivationFactory>(s!("combase.dll"), s!("RoGetActivationFactory")) } {
         unsafe {
-            let function: RoGetActivationFactory = std::mem::transmute(function);
             let mut code = function(std::mem::transmute_copy(&name), &I::IID, &mut factory as *mut _ as *mut _);
 
             // If RoGetActivationFactory fails because combase hasn't been loaded yet then load combase
             // automatically so that it "just works" for apartment-agnostic code.
             if code == CO_E_NOTINITIALIZED {
-                if let Ok(mta) = delay_load(s!("ole32.dll"), s!("CoIncrementMTAUsage")) {
-                    let mta: CoIncrementMTAUsage = std::mem::transmute(mta);
+                if let Some(mta) = delay_load::<CoIncrementMTAUsage>(s!("ole32.dll"), s!("CoIncrementMTAUsage")) {
                     let mut cookie = std::ptr::null_mut();
                     let _ = mta(&mut cookie);
                 }
@@ -121,8 +119,7 @@ where
 }
 
 unsafe fn get_activation_factory(library: PCSTR, name: &HSTRING) -> Result<IGenericFactory> {
-    let function = delay_load(library, s!("DllGetActivationFactory"))?;
-    let function: DllGetActivationFactory = std::mem::transmute(function);
+    let function = delay_load::<DllGetActivationFactory>(library, s!("DllGetActivationFactory")).ok_or_else(Error::from_win32)?;
     let mut abi = std::mem::MaybeUninit::zeroed();
     function(std::mem::transmute_copy(name), abi.as_mut_ptr()).from_abi(abi)
 }


### PR DESCRIPTION
This is the core delay load support from #2161 that can be merged in without necessarily including the full/implicit delay load support in #2161.